### PR TITLE
Add Saudi Riyal to list of selectable currencies

### DIFF
--- a/config-sample.php
+++ b/config-sample.php
@@ -33,7 +33,7 @@ $guid="" ;
 
 
 /**
- * Sets system-wide caching factor, used to baalance performance and freshness. Value represents number of page loads between cache refresh. Must be posititve integer. 1 means no caching.
+ * Sets system-wide caching factor, used to balance performance and freshness. Value represents number of page loads between cache refresh. Must be positive integer. 1 means no caching.
  */
 $caching=10 ; 
 

--- a/installer/install.php
+++ b/installer/install.php
@@ -905,6 +905,7 @@ include "../functions.php" ;
 																		<option value='IDR Rp'>Indonesian Rupiah (Rp)</option>
 																		<option value='NGN ₦'>Nigerian Naira (₦)</option>
 																		<option value='KES KSh'>Kenyan Shilling (KSh)</option>
+																		<option value='SAR ﷼‎'>Saudi Riyal (﷼‎)</option>
 																	</optgroup>
 																</select>
 															</td>

--- a/modules/System Admin/systemSettings.php
+++ b/modules/System Admin/systemSettings.php
@@ -899,6 +899,7 @@ else {
 							<option <?php if ($row["value"]=="IDR Rp") { print "selected" ; } ?> value='IDR Rp'>Indonesian Rupiah (Rp)</option>
 							<option <?php if ($row["value"]=="NGN ₦") { print "selected" ; } ?> value='NGN ₦'>Nigerian Naira (₦)</option>
 							<option <?php if ($row["value"]=="KES KSh") { print "selected" ; } ?> value='KES KSh'>Kenyan Shilling (KSh)</option>
+							<option <?php if ($row["value"]=="SAR ﷼‎") { print "selected" ; } ?> value='SAR ﷼‎'>Saudi Riyal (﷼‎)</option>
 						</optgroup>
 					</select>
 				</td>


### PR DESCRIPTION
Currently evaluating Gibbon for a school in Saudi Arabia; rather delicious that I saw it a few days back (v9.X) but when I came around to downloading it, v10 with the Arabic translation had come out the day before: شكرا!!

Bit of a shame that Saudi Riyal wasn't available but simple enough to add in - that's if I've got it right!  It's worked so far during installation and initial testing but do let me know if I'm missing something important...

I've sneaked in a little typo-correction (x2) along the way.