### PR TITLE
Markbook: Updated use of empty to improve backwards compatibility

### DIFF
--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -324,7 +324,7 @@
             $info .= '<li>'.__($guid, 'Type').' - '.$markbook->getTypeDescription( $columnType ) .'</li>';
 
             $weightInfo = '';
-            $includeMarks = !empty($column->getData('completeDate'));
+            $includeMarks = ($column->getData('completeDate') != false);
 
             if (isset($unit[0])) {
                 $info .= '<li>'.__($guid, 'Unit').' - '. $unit[0] .'</li>';
@@ -354,7 +354,7 @@
             if ($markbook->getSetting('enableTypeWeighting') == 'Y' ) {
                 $info .= '<li>'. __($guid, 'Type Weighting').' '.floatval( $markbook->getWeightingByType($columnType) ).'</li>';
 
-                if ( empty($markbook->getWeightingByType($columnType))) {
+                if ( $markbook->getWeightingByType($columnType) == false ) {
                     $weightInfo .= __($guid, 'Type Weighting').' '.floatval( $markbook->getWeightingByType($columnType) ).'<br/>';
                     $includeMarks = false;
                 }

--- a/modules/Markbook/src/markbookView.php
+++ b/modules/Markbook/src/markbookView.php
@@ -279,7 +279,7 @@ class markbookView
                 $this->columns[ $i ] = $column;
 
                 //WORK OUT IF THERE IS SUBMISSION
-                if ( !empty($column->getData('gibbonPlannerEntryID'))) {
+                if ( $column->getData('gibbonPlannerEntryID') != false ) {
                     try {
                         $dataSub=array("gibbonPlannerEntryID"=>$column->getData('gibbonPlannerEntryID') ); 
                         $sqlSub="SELECT homeworkDueDateTime, date FROM gibbonPlannerEntry WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID AND homeworkSubmission='Y' LIMIT 1" ;


### PR DESCRIPTION
Updated a few instances of the empty() function to conform to pre-PHP 5.5

>     Note:
>     Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error. In other words, the following will not work: empty(trim($name)). Instead, use trim($name) == false.

from http://us3.php.net/empty