### PR TITLE
Markbook Copy Tools

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -448,5 +448,6 @@ INSERT INTO `gibbonSetting` (`gibbonSystemSettingsID` ,`scope` ,`name` ,`nameDis
 INSERT INTO `gibbonSetting` (`gibbonSystemSettingsID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES (NULL , 'System', 'mailerSMTPPassword', 'SMTP Password', 'Password to use for SMTP authentication. Leave blank for no authentication.', '');end
 ALTER TABLE `gibbonUnit` ADD `tags` TEXT NOT NULL AFTER `description`;end
 UPDATE gibbonAction SET URLList = 'markbook_edit.php, markbook_edit_add.php, markbook_edit_edit.php, markbook_edit_delete.php,markbook_edit_data.php,markbook_edit_targets.php,markbook_edit_copy.php' WHERE (name='Edit Markbook_singleClass' OR name='Edit Markbook_multipleClassesInDepartment' OR name='Edit Markbook_multipleClassesAcrossSchool' OR name='Edit Markbook_everything') AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Markbook');end
+UPDATE gibbonAction SET precedence=0 WHERE gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Markbook') AND name='Manage Weightings_singleClass';end
 
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -447,4 +447,6 @@ INSERT INTO `gibbonSetting` (`gibbonSystemSettingsID` ,`scope` ,`name` ,`nameDis
 INSERT INTO `gibbonSetting` (`gibbonSystemSettingsID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES (NULL , 'System', 'mailerSMTPUsername', 'SMTP Username', 'Username to use for SMTP authentication. Leave blank for no authentication.', '');end
 INSERT INTO `gibbonSetting` (`gibbonSystemSettingsID` ,`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES (NULL , 'System', 'mailerSMTPPassword', 'SMTP Password', 'Password to use for SMTP authentication. Leave blank for no authentication.', '');end
 ALTER TABLE `gibbonUnit` ADD `tags` TEXT NOT NULL AFTER `description`;end
+UPDATE gibbonAction SET URLList = 'markbook_edit.php, markbook_edit_add.php, markbook_edit_edit.php, markbook_edit_delete.php,markbook_edit_data.php,markbook_edit_targets.php,markbook_edit_copy.php' WHERE (name='Edit Markbook_singleClass' OR name='Edit Markbook_multipleClassesInDepartment' OR name='Edit Markbook_multipleClassesAcrossSchool' OR name='Edit Markbook_everything') AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Markbook');end
+
 ";

--- a/modules/Markbook/markbook_edit.php
+++ b/modules/Markbook/markbook_edit.php
@@ -68,9 +68,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
         }
         //Check existence of and access to this class.
         else {
+
+            $highestAction2 = getHighestGroupedAction($guid, '/modules/Markbook/markbook_edit.php', $connection2);
+
             try {
-                $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $gibbonCourseClassID);
-                $sql = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID FROM gibbonCourse, gibbonCourseClass, gibbonCourseClassPerson WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND role='Teacher' AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID ORDER BY course, class";
+                if ($highestAction == 'Edit Markbook_everything') {
+                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
+                    $sql = 'SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID, gibbonCourse.gibbonDepartmentID, gibbonYearGroupIDList FROM gibbonCourse, gibbonCourseClass WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID ORDER BY course, class';
+                } else {
+                    $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $gibbonCourseClassID);
+                    $sql = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID, gibbonCourse.gibbonDepartmentID, gibbonYearGroupIDList FROM gibbonCourse, gibbonCourseClass, gibbonCourseClassPerson WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND role='Teacher' AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID ORDER BY course, class";
+                }
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -92,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
 
                 //Add multiple columns
                 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php')) {
-                    $highestAction2 = getHighestGroupedAction($guid, '/modules/Markbook/markbook_edit.php', $connection2);
+                    
                     if ($highestAction2 == 'Edit Markbook_multipleClassesAcrossSchool' or $highestAction2 == 'Edit Markbook_multipleClassesInDepartment' or $highestAction2 == 'Edit Markbook_everything') {
 
                         //Check highest role in any department

--- a/modules/Markbook/markbook_edit.php
+++ b/modules/Markbook/markbook_edit.php
@@ -98,6 +98,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
                 echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > </div><div class='trailEnd'>".__($guid, 'Edit').' '.$row['course'].'.'.$row['class'].' '.__($guid, 'Markbook').'</div>';
                 echo '</div>';
 
+                if (isset($_GET['return'])) {
+                    returnProcess($guid, $_GET['return'], null, null);
+                }
+
                 //Add multiple columns
                 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php')) {
                     
@@ -116,6 +120,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
                 //Get teacher list
                 $teacherList = getTeacherList( $pdo, $gibbonCourseClassID );
                 $teaching = (isset($teacherList[ $_SESSION[$guid]['gibbonPersonID'] ]) );
+
+                $canEditThisClass = ($teaching == true || $isCoordinator == true or $highestAction2 == 'Edit Markbook_multipleClassesAcrossSchool' or $highestAction2 == 'Edit Markbook_everything');
 
                 if (!empty($teacherList)) {
                     echo '<h3>';
@@ -151,7 +157,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
                     echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
-                if ($teaching) {
+                if ($canEditThisClass) {
                     echo "<div class='linkTop'>";
                     echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/markbook_edit_add.php&gibbonCourseClassID=$gibbonCourseClassID'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
 
@@ -244,6 +250,58 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
 
                         ++$count;
                     }
+                    echo '</table>';
+                }
+
+                echo '<br/>&nbsp;<br/>';
+
+                if ($canEditThisClass) {
+                    echo '<h3>';
+                    echo __($guid, 'Copy Markbook Columns');
+                    echo '</h1>';
+
+                    echo "<table cellspacing='0' class='noIntBorder' style='width: 100%; margin: 10px 0 10px 0'>";
+                    echo '<tr>';
+                    echo "<td style='vertical-align: top'>";
+
+                    echo '</td>';
+                    echo "<td style='vertical-align: top; text-align: right'>";
+                    echo "<form method='post' action='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Markbook/markbook_edit_copy.php&gibbonCourseClassID=$gibbonCourseClassID'>";
+
+                    echo "&nbsp;&nbsp;&nbsp;<span>".__($guid, 'Copy from')." ".__($guid, 'Class').": </span>";
+                    echo "<select name='gibbonMarkbookCopyClassID' id='gibbonMarkbookCopyClassID' style='width:193px; float: none;'>";
+                    echo "<option value=''></option>";
+                    try {
+                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+                        $sqlSelect = 'SELECT DISTINCT gibbonCourseClass.gibbonCourseClassID, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonMarkbookColumn ON (gibbonMarkbookColumn.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID ORDER BY course, class';
+                        $resultSelect = $pdo->executeQuery($dataSelect, $sqlSelect);
+                    } catch (PDOException $e) {
+                    }
+                    $selectCount = 0;
+
+                    echo "<optgroup label='--".__($guid, 'My Classes')."--'>";
+                    while ($rowSelect = $resultSelect->fetch()) {
+                        if ($rowSelect['gibbonCourseClassID'] == $gibbonCourseClassID) continue; // Skip the current class
+                        echo "<option value='".$rowSelect['gibbonCourseClassID']."'>".htmlPrep($rowSelect['course']).'.'.htmlPrep($rowSelect['class']).'</option>';
+                    }
+                    echo '</optgroup>';
+                    try {
+                        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                        $sqlSelect = 'SELECT DISTINCT gibbonCourseClass.gibbonCourseClassID, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonMarkbookColumn ON (gibbonMarkbookColumn.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY course, class';
+                        $resultSelect = $pdo->executeQuery($dataSelect, $sqlSelect);
+                    } catch (PDOException $e) {
+                    }
+                    echo "<optgroup label='--".__($guid, 'All Classes')."--'>";
+                    while ($rowSelect = $resultSelect->fetch()) {
+                        if ($rowSelect['gibbonCourseClassID'] == $gibbonCourseClassID) continue; // Skip the current class
+                        echo "<option value='".$rowSelect['gibbonCourseClassID']."'>".htmlPrep($rowSelect['course']).'.'.htmlPrep($rowSelect['class']).'</option>';
+                    }
+                    echo '</optgroup>';
+                    echo '</select>';
+                    echo "<input type='submit' value='".__($guid, 'Go')."'>";
+                    echo '</form>';
+                    echo '</td>';
+                    echo '</tr>';
                     echo '</table>';
                 }
             }

--- a/modules/Markbook/markbook_edit_copy.php
+++ b/modules/Markbook/markbook_edit_copy.php
@@ -1,0 +1,204 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+@session_start();
+
+//Set timezone from session variable
+date_default_timezone_set($_SESSION[$guid]['timezone']);
+
+//Module includes
+include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_copy.php') == false) {
+    //Acess denied
+    echo "<div class='error'>";
+    echo __($guid, 'You do not have access to this action.');
+    echo '</div>';
+} else {
+    $highestAction = getHighestGroupedAction($guid, $_GET['q'], $connection2);
+    if ($highestAction == false) {
+        echo "<div class='error'>";
+        echo __($guid, 'The highest grouped action cannot be determined.');
+        echo '</div>';
+    } else {
+        //Check if school year specified
+        $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
+        $gibbonMarkbookCopyClassID = (isset($_POST['gibbonMarkbookCopyClassID']))? $_POST['gibbonMarkbookCopyClassID'] : null;
+
+        if ( empty($gibbonCourseClassID) or empty($gibbonMarkbookCopyClassID) ) {
+            echo "<div class='error'>";
+            echo __($guid, 'You have not specified one or more required parameters.');
+            echo '</div>';
+        } else {
+
+        	$highestAction2 = getHighestGroupedAction($guid, '/modules/Markbook/markbook_edit.php', $connection2);
+
+            try {
+                if ($highestAction == 'Edit Markbook_everything') {
+                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
+                    $sql = 'SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID, gibbonCourse.gibbonDepartmentID, gibbonYearGroupIDList FROM gibbonCourse, gibbonCourseClass WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID ORDER BY course, class';
+                } else {
+                    $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $gibbonCourseClassID);
+                    $sql = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID, gibbonCourse.gibbonDepartmentID, gibbonYearGroupIDList FROM gibbonCourse, gibbonCourseClass, gibbonCourseClassPerson WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND role='Teacher' AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID ORDER BY course, class";
+                }
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+            } catch (PDOException $e) {
+                echo "<div class='error'>".$e->getMessage().'</div>';
+            }
+
+            if ($result->rowCount() != 1) {
+                echo '<h1>';
+                echo __($guid, 'Copy Columns');
+                echo '</h1>';
+                echo "<div class='error'>";
+                echo __($guid, 'The selected record does not exist, or you do not have access to it.');
+                echo '</div>';
+            } else {
+                $row = $result->fetch();
+
+	        	//Get teacher list
+	            $teacherList = getTeacherList( $pdo, $gibbonCourseClassID );
+	            $teaching = (isset($teacherList[ $_SESSION[$guid]['gibbonPersonID'] ]) );
+	            $isCoordinator = isDepartmentCoordinator( $pdo, $_SESSION[$guid]['gibbonPersonID'] );
+
+	            $canEditThisClass = ($teaching == true || $isCoordinator == true or $highestAction2 == 'Edit Markbook_multipleClassesAcrossSchool' or $highestAction2 == 'Edit Markbook_everything');
+
+	            if ($canEditThisClass == false) {
+	            	//Acess denied
+				    echo "<div class='error'>";
+				    echo __($guid, 'You do not have access to this action.');
+				    echo '</div>';
+	            } else {
+
+	            	echo "<div class='trail'>";
+	            	echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/markbook_edit.php&gibbonCourseClassID='.$_GET['gibbonCourseClassID']."'>".__($guid, 'Edit').' '.$row['course'].'.'.$row['class'].' '.__($guid, 'Markbook')."</a> > </div><div class='trailEnd'>".__($guid, 'Copy Columns').'</div>';
+                    echo '</div>';
+	            
+	            	//Print mark
+		            // echo '<h3>';
+		            // echo __($guid, 'Copy Columns');
+		            // echo '</h3>';
+
+                    
+
+
+		            try {
+			            $data = array('gibbonCourseClassID' => $gibbonMarkbookCopyClassID);
+			            $sql = 'SELECT * FROM gibbonMarkbookColumn WHERE gibbonCourseClassID=:gibbonCourseClassID';
+			            $result = $connection2->prepare($sql);
+			            $result->execute($data);
+			        } catch (PDOException $e) {
+			            echo "<div class='error'>".$e->getMessage().'</div>';
+			        }
+
+
+
+			        if ($result->rowCount() < 1) {
+	                    echo "<div class='error'>";
+	                    echo __($guid, 'There are no records to display.');
+	                    echo '</div>';
+	                } else {
+
+	                	try {
+		                    $data2 = array('gibbonCourseClassID' => $gibbonMarkbookCopyClassID);
+		                    $sql2 = 'SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourseClassID=:gibbonCourseClassID';
+		                    $result2 = $connection2->prepare($sql2);
+		                    $result2->execute($data2);
+		                } catch (PDOException $e) {
+		                    echo "<div class='error'>".$e->getMessage().'</div>';
+		                }
+
+		                $row2 = $result2->fetch();
+
+	                	echo '<p>';
+	                	printf( __($guid, 'This action will copy the following columns from %s.%s to the current class %s.%s '), $row2['course'], $row2['class'], $row['course'], $row['class'] );
+	                	echo '</p>';
+
+	                	echo "<form method='post' action='".$_SESSION[$guid]['absoluteURL']."/modules/Markbook/markbook_edit_copyProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonMarkbookCopyClassID=$gibbonMarkbookCopyClassID'>";
+
+	                    echo "<table cellspacing='0' style='width: 100%' class='fullwidth colorOddEven'>";
+	                    echo "<tr class='head'>";
+	                    echo '<th style="width:40px">';
+	  
+	                    echo '</th>';
+	                    echo '<th>';
+	                    echo __($guid, 'Name');
+	                    echo '</th>';
+	                    echo '<th>';
+	                    echo __($guid, 'Type');
+	                    echo '</th>';
+	                    echo '<th>';
+	                    echo __($guid, 'Description');
+	                    echo '</th>';
+	                    echo '<th>';
+	                    echo __($guid, 'Date<br/>Added');
+	                    echo '</th>';
+	                    echo '</tr>';
+
+	                    $count = 0;
+	                    while ($row = $result->fetch()) {
+	                      
+	                        //COLOR ROW BY STATUS!
+	                        echo "<tr>";
+	                        echo '<td>';
+	                        echo '<input type="checkbox" value="1" name="copyColumnID['.$row['gibbonMarkbookColumnID'].']" checked>';
+	                        echo '</td>';
+	                        echo '<td>';
+	                        echo '<b>'.$row['name'].'</b>';
+	                        echo '</td>';
+	                        echo '<td>';
+	                        echo $row['type'];
+	                        echo '</td>';
+	                        echo '<td>';
+	                        echo $row['description'];
+	                        echo '</td>';
+	                        echo '<td>';
+	                        if (!empty($row['date']) && $row['date'] != '0000-00-00') {
+	                            echo dateConvertBack($guid, $row['date']);
+	                        }
+	                        echo '</td>';
+	                        
+	                        echo '</tr>';
+
+	                        
+
+							$count++;
+	                    }
+	                    echo '<tr>';
+							echo '<td colspan="7" class="right">';
+							echo '<input type="submit" value="'.__($guid, 'Submit').'">';
+							echo '</td>';
+						echo '</tr>';
+
+	                    echo '</table>';
+	                    echo '</form>';
+	                }
+
+	            }
+
+
+		    }
+                
+
+            
+        }
+    }
+}
+?>

--- a/modules/Markbook/markbook_edit_copyProcess.php
+++ b/modules/Markbook/markbook_edit_copyProcess.php
@@ -1,0 +1,101 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+include '../../functions.php';
+include '../../config.php';
+
+//New PDO DB connection
+$pdo = new Gibbon\sqlConnection();
+$connection2 = $pdo->getConnection();
+
+@session_start();
+
+
+//Set timezone from session variable
+date_default_timezone_set($_SESSION[$guid]['timezone']);
+
+$gibbonCourseClassID = $_GET['gibbonCourseClassID'];
+$URL = $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Markbook/markbook_edit.php&gibbonCourseClassID=$gibbonCourseClassID";
+
+if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_copy.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    $gibbonMarkbookCopyClassID = (isset($_GET['gibbonMarkbookCopyClassID']))? $_GET['gibbonMarkbookCopyClassID'] : null;
+    $copyColumnID = (isset($_POST['copyColumnID']))? $_POST['copyColumnID'] : null;
+
+    if (empty($_POST)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+    } else if (empty($gibbonCourseClassID) || empty($gibbonMarkbookCopyClassID) || empty($copyColumnID)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+    } else {
+
+        try {
+            $data2 = array('gibbonCourseClassID' => $gibbonMarkbookCopyClassID);
+            $sql2 = 'SELECT * FROM gibbonMarkbookColumn WHERE gibbonCourseClassID=:gibbonCourseClassID';
+            $result2 = $connection2->prepare($sql2);
+            $result2->execute($data2);
+        } catch (PDOException $e) {
+            $URL .= '&return=error2';
+            header("Location: {$URL}");
+            exit();
+        }
+
+        if ($result2->rowCount() <= 0) {
+            $URL .= '&return=warning1';
+            header("Location: {$URL}");
+            exit();
+        } else {
+
+            $partialFail = false;
+            while ($column = $result2->fetch() ) {
+
+                // Only include the selected columns
+                if ( isset($copyColumnID[ $column['gibbonMarkbookColumnID'] ]) && $column['gibbonMarkbookColumnID'] == true ) {
+
+                    //Write to database
+                    try {
+                        $date = (!empty($_POST['date']))? dateConvert($guid, $_POST['date']) : date('Y-m-d');
+                        $data = array('gibbonUnitID' => $column['gibbonUnitID'], 'gibbonHookID' => $column['gibbonHookID'], 'gibbonPlannerEntryID' => $column['gibbonPlannerEntryID'], 'gibbonCourseClassID' => $gibbonCourseClassID, 'name' => $column['name'], 'description' => $column['description'], 'type' => $column['type'], 'date' => $date, 'sequenceNumber' => $column['sequenceNumber'], 'attainment' => $column['attainment'], 'gibbonScaleIDAttainment' => $column['gibbonScaleIDAttainment'], 'attainmentWeighting' => $column['attainmentWeighting'], 'attainmentRaw' => $column['attainmentRaw'], 'attainmentRawMax' => $column['attainmentRawMax'], 'effort' => $column['effort'], 'gibbonScaleIDEffort' => $column['gibbonScaleIDEffort'], 'gibbonRubricIDAttainment' => $column['gibbonRubricIDAttainment'], 'gibbonRubricIDEffort' => $column['gibbonRubricIDEffort'], 'comment' => $column['comment'], 'uploadedResponse' => $column['uploadedResponse'], 'viewableStudents' => $column['viewableStudents'], 'viewableParents' => $column['viewableParents'], 'attachment' => $column['attachment'], 'gibbonPersonIDCreator' => $column['gibbonPersonIDCreator'], 'gibbonPersonIDLastEdit' => $column['gibbonPersonIDLastEdit'], 'gibbonSchoolYearTermID' => $column['gibbonSchoolYearTermID']);
+                    $sql = 'INSERT INTO gibbonMarkbookColumn SET gibbonUnitID=:gibbonUnitID, gibbonHookID=:gibbonHookID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonCourseClassID=:gibbonCourseClassID, name=:name, description=:description, type=:type, date=:date, sequenceNumber=:sequenceNumber, attainment=:attainment, gibbonScaleIDAttainment=:gibbonScaleIDAttainment, attainmentWeighting=:attainmentWeighting, attainmentRaw=:attainmentRaw, attainmentRawMax=:attainmentRawMax, effort=:effort, gibbonScaleIDEffort=:gibbonScaleIDEffort, gibbonRubricIDAttainment=:gibbonRubricIDAttainment, gibbonRubricIDEffort=:gibbonRubricIDEffort, comment=:comment, uploadedResponse=:uploadedResponse, viewableStudents=:viewableStudents, viewableParents=:viewableParents, attachment=:attachment, gibbonPersonIDCreator=:gibbonPersonIDCreator, gibbonPersonIDLastEdit=:gibbonPersonIDLastEdit, gibbonSchoolYearTermID=:gibbonSchoolYearTermID';
+                        $result = $connection2->prepare($sql);
+                        $result->execute($data);
+                    } catch (PDOException $e) {
+                        $partialFail = true;
+                    }
+
+                }
+
+                if ($partialFail) {
+                    $URL .= '&return=warning1';
+                    header("Location: {$URL}");
+                    exit();
+                } else {
+                    $URL .= "&return=success0";
+                    header("Location: {$URL}");
+                }
+            }
+            
+        }
+    }
+}
+
+?>

--- a/modules/Markbook/weighting_manage.php
+++ b/modules/Markbook/weighting_manage.php
@@ -45,6 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.
             echo "<div class='error'>";
             echo __($guid, 'Your request failed because you do not have access to this action.');
             echo '</div>';
+            return;
         }
 
         //Get class variable
@@ -120,7 +121,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.
                     echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
-                if ($teaching) {
+                if ($teaching || $highestAction == 'Manage Weightings_everything') {
                     echo "<div class='linkTop'>";
                     echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/weighting_manage_add.php&gibbonCourseClassID=$gibbonCourseClassID'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
                     echo '</div>';
@@ -268,12 +269,62 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.
                     }
 
 
-                    echo '<br/>&nbsp;<br/>';
                 }
-                
-                
-                
+
+                echo '<br/>&nbsp;<br/>';
+
+                echo '<h3>';
+                echo __($guid, 'Copy Weightings');
+                echo '</h1>';
+
+                echo "<table cellspacing='0' class='noIntBorder' style='width: 100%; margin: 10px 0 10px 0'>";
+                echo '<tr>';
+                echo "<td style='vertical-align: top'>";
+
+                echo '</td>';
+                echo "<td style='vertical-align: top; text-align: right'>";
+                echo "<form method='post' action='".$_SESSION[$guid]['absoluteURL']."/modules/Markbook/weighting_manage_copyProcess.php?gibbonCourseClassID=$gibbonCourseClassID'>";
+
+                echo "&nbsp;&nbsp;&nbsp;<span>".__($guid, 'Copy from')." ".__($guid, 'Class').": </span>";
+                echo "<select name='gibbonWeightingCopyClassID' id='gibbonWeightingCopyClassID' style='width:193px; float: none;'>";
+                echo "<option value=''></option>";
+                try {
+                    $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+                    $sqlSelect = 'SELECT DISTINCT gibbonCourseClass.gibbonCourseClassID, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonMarkbookWeight ON (gibbonMarkbookWeight.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID ORDER BY course, class';
+                    $resultSelect = $pdo->executeQuery($dataSelect, $sqlSelect);
+                } catch (PDOException $e) {
+                }
+                $selectCount = 0;
+
+                echo "<optgroup label='--".__($guid, 'My Classes')."--'>";
+                while ($rowSelect = $resultSelect->fetch()) {
+                    if ($rowSelect['gibbonCourseClassID'] == $gibbonCourseClassID) continue; // Skip the current class
+                    echo "<option value='".$rowSelect['gibbonCourseClassID']."'>".htmlPrep($rowSelect['course']).'.'.htmlPrep($rowSelect['class']).'</option>';
+                }
+                echo '</optgroup>';
+                try {
+                    $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+                    $sqlSelect = 'SELECT DISTINCT gibbonCourseClass.gibbonCourseClassID, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonMarkbookWeight ON (gibbonMarkbookWeight.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY course, class';
+                    $resultSelect = $pdo->executeQuery($dataSelect, $sqlSelect);
+                } catch (PDOException $e) {
+                }
+                echo "<optgroup label='--".__($guid, 'All Classes')."--'>";
+                while ($rowSelect = $resultSelect->fetch()) {
+                    if ($rowSelect['gibbonCourseClassID'] == $gibbonCourseClassID) continue; // Skip the current class
+                    echo "<option value='".$rowSelect['gibbonCourseClassID']."'>".htmlPrep($rowSelect['course']).'.'.htmlPrep($rowSelect['class']).'</option>';
+                }
+                echo '</optgroup>';
+                echo '</select>';
+                echo "<input type='submit' value='".__($guid, 'Go')."'>";
+                echo '</form>';
+                echo '</td>';
+                echo '</tr>';
+                echo '</table>';
+                  
             }
         }
+
+        
+
     }
 }

--- a/modules/Markbook/weighting_manage_copyProcess.php
+++ b/modules/Markbook/weighting_manage_copyProcess.php
@@ -1,0 +1,93 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+include '../../functions.php';
+include '../../config.php';
+
+//New PDO DB connection
+$pdo = new Gibbon\sqlConnection();
+$connection2 = $pdo->getConnection();
+
+@session_start();
+
+
+//Set timezone from session variable
+date_default_timezone_set($_SESSION[$guid]['timezone']);
+
+$gibbonCourseClassID = $_GET['gibbonCourseClassID'];
+$URL = $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Markbook/weighting_manage.php&gibbonCourseClassID=$gibbonCourseClassID";
+
+if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_edit.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    $gibbonWeightingCopyClassID = (isset($_POST['gibbonWeightingCopyClassID']))? $_POST['gibbonWeightingCopyClassID'] : null;
+
+    if (empty($_POST)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+    } else if (empty($gibbonCourseClassID) || empty($gibbonWeightingCopyClassID)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+    } else {
+
+        try {
+            $data2 = array('gibbonCourseClassID' => $gibbonWeightingCopyClassID);
+            $sql2 = 'SELECT * FROM gibbonMarkbookWeight WHERE gibbonCourseClassID=:gibbonCourseClassID';
+            $result2 = $connection2->prepare($sql2);
+            $result2->execute($data2);
+        } catch (PDOException $e) {
+            echo "<div class='error'>".$e->getMessage().'</div>';
+        }
+
+        if ($result2->rowCount() <= 0) {
+            $URL .= '&return=warning1';
+            header("Location: {$URL}");
+            exit();
+        } else {
+
+            $partialFail = false;
+            while ($weighting = $result2->fetch() ) {
+
+                //Write to database
+                try {
+                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'description' => $weighting['description'], 'type' => $weighting['type'], 'weighting' => $weighting['weighting'], 'reportable' => $weighting['reportable'], 'calculate' => $weighting['calculate'] );
+
+                    $sql = 'INSERT INTO gibbonMarkbookWeight SET gibbonCourseClassID=:gibbonCourseClassID, description=:description, type=:type, weighting=:weighting, reportable=:reportable, calculate=:calculate';
+                    $result = $connection2->prepare($sql);
+                    $result->execute($data);
+                } catch (PDOException $e) {
+                    $partialFail = true;
+                }
+
+                if ($partialFail) {
+                    $URL .= '&return=warning1';
+                    header("Location: {$URL}");
+                    exit();
+                } else {
+                    $URL .= "&return=success0";
+                    header("Location: {$URL}");
+                }
+            }
+            
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
Added two new tools to the markbook:

- Copy columns from one class to another. This helps with teachers who teach the same lessons across multiple classes or multiple semesters.
- Copy markbook weighting categories from one class to another. Same purpose.

Also fixed a bug with Manage Weightings_everything not having access when checking grouped actions (updated action precedence to fix the issue).

Tested locally and on our school's production system.

Thanks!