### PR TITLE
Markbook: Class Chooser in Sidebar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -70,6 +70,7 @@ v13.0.00
 		Markbook: fixed return and presetting of fields when landing on add page from Planner
 		Markbook: made target scale selectable (so not constained to Default Assessment Scale)
 		Markbook: fixed issue preventing some staff from seeing Markbook columns from other classes (depending on Edit rights)
+		Markbook: added a class chooser to the sidebar for view, edit and weightings sub-pages
 		Messenger: fixed formatting of Sent From Gibbon tag
 		Messenger: fixed display of email/SMS report for recipients with , in their name
 		Messenger: disabled Canned Response for any non-staff users

--- a/modules/Markbook/markbook_edit.php
+++ b/modules/Markbook/markbook_edit.php
@@ -307,4 +307,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'markbook_edit.php');
 }

--- a/modules/Markbook/markbook_edit_add.php
+++ b/modules/Markbook/markbook_edit_add.php
@@ -860,5 +860,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'markbook_edit_add.php');
 }
 ?>

--- a/modules/Markbook/markbook_edit_copy.php
+++ b/modules/Markbook/markbook_edit_copy.php
@@ -200,5 +200,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_cop
             
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'markbook_edit.php');
 }
 ?>

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -687,5 +687,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'markbook_view.php');
 }
 ?>

--- a/modules/Markbook/markbook_edit_delete.php
+++ b/modules/Markbook/markbook_edit_delete.php
@@ -123,5 +123,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_del
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'markbook_view.php');
 }
 ?>

--- a/modules/Markbook/markbook_edit_edit.php
+++ b/modules/Markbook/markbook_edit_edit.php
@@ -905,5 +905,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'markbook_view.php');
 }
 ?>

--- a/modules/Markbook/markbook_edit_targets.php
+++ b/modules/Markbook/markbook_edit_targets.php
@@ -207,5 +207,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_tar
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'markbook_edit_targets.php');
 }
 ?>

--- a/modules/Markbook/moduleFunctions.php
+++ b/modules/Markbook/moduleFunctions.php
@@ -17,6 +17,72 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+function sidebarExtra($guid, $pdo, $gibbonPersonID, $gibbonCourseClassID = '', $basePage = '')
+{
+    $output = '';
+
+    if (empty($basePage)) $basePage = 'markbook_view.php';
+
+    //Show class picker in sidebar
+    $output .= '<h2>';
+    $output .= __($guid, 'Choose A Class');
+    $output .= '</h2>';
+
+    $output .= "<form method='get' action='".$_SESSION[$guid]['absoluteURL']."/index.php'>";
+    $output .= "<input name='q' id='q' type='hidden' value='/modules/Markbook/".$basePage."'>";
+
+    $output .= "<table class='smallIntBorder' cellspacing='0' style='width: 100%; margin: 0px 0px'>";
+    $output .= '<tr>';
+    $output .= "<td style='width: 190px'>";
+
+    $output .= "<select name='gibbonCourseClassID' id='gibbonCourseClassID' style='width:161px; float: none;'>";
+    $output .= "<option value=''></option>";
+    try {
+        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $gibbonPersonID );
+        $sqlSelect = 'SELECT gibbonCourseClass.gibbonCourseClassID, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID ORDER BY course, class';
+        $resultSelect = $pdo->executeQuery($dataSelect, $sqlSelect);
+    } catch (PDOException $e) {
+    }
+    $isSelected = false;
+
+    $output .= "<optgroup label='--".__($guid, 'My Classes')."--'>";
+    while ($rowSelect = $resultSelect->fetch()) {
+        $selected = '';
+        if ($rowSelect['gibbonCourseClassID'] == $gibbonCourseClassID && !$isSelected) {
+            $selected = 'selected';
+            $isSelected = true;
+        }
+        $output .= "<option $selected value='".$rowSelect['gibbonCourseClassID']."'>".htmlPrep($rowSelect['course']).'.'.htmlPrep($rowSelect['class']).'</option>';
+    }
+    $output .= '</optgroup>';
+    try {
+        $dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+        $sqlSelect = 'SELECT gibbonCourseClass.gibbonCourseClassID, gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY course, class';
+        $resultSelect = $pdo->executeQuery($dataSelect, $sqlSelect);
+    } catch (PDOException $e) {
+    }
+    $output .= "<optgroup label='--".__($guid, 'All Classes')."--'>";
+    while ($rowSelect = $resultSelect->fetch()) {
+        $selected = '';
+        if ($rowSelect['gibbonCourseClassID'] == $gibbonCourseClassID && !$isSelected) {
+            $selected = 'selected';
+            $isSelected = true;
+        }
+        $output .= "<option $selected value='".$rowSelect['gibbonCourseClassID']."'>".htmlPrep($rowSelect['course']).'.'.htmlPrep($rowSelect['class']).'</option>';
+    }
+    $output .= '</optgroup>';
+    $output .= '</select>';
+    $output .= '</td>';
+    $output .= "<td class='right'>";
+    $output .= "<input type='submit' value='".__($guid, 'Go')."'>";
+    $output .= '</td>';
+    $output .= '</tr>';
+    $output .= '</table>';
+    $output .= '</form>';
+
+    return $output;
+}
+
 function classChooser($guid, $pdo, $gibbonCourseClassID)
 {
     //Set timezone from session variable

--- a/modules/Markbook/weighting_manage.php
+++ b/modules/Markbook/weighting_manage.php
@@ -327,4 +327,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.
         
 
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'weighting_manage.php');
 }

--- a/modules/Markbook/weighting_manage_add.php
+++ b/modules/Markbook/weighting_manage_add.php
@@ -217,4 +217,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'weighting_manage.php');
 }

--- a/modules/Markbook/weighting_manage_delete.php
+++ b/modules/Markbook/weighting_manage_delete.php
@@ -148,4 +148,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'weighting_manage.php');
 }

--- a/modules/Markbook/weighting_manage_edit.php
+++ b/modules/Markbook/weighting_manage_edit.php
@@ -244,4 +244,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
             }
         }
     }
+
+    // Print the sidebar
+    $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $pdo, $_SESSION[$guid]['gibbonPersonID'], $gibbonCourseClassID, 'weighting_manage.php');
 }


### PR DESCRIPTION
Added the class chooser to the markbook sidebar. It uses a basePage variable to determine where to send people to on submit, so if you're in the Edit area it stays in edit, if you're in Weightings it stays in that section, and certain pages like Add Column and Targets stay on the same page, making it easier to perform those tasks while switching between several courses.