### PR TITLE
Fast Finder: Moved data to AJAX request

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2135,48 +2135,6 @@ function getFastFinder($connection2, $guid)
     if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') and $highestActionClass != 'Lesson Planner_viewMyChildrensClasses') {
         $classIsAccessible = true;
     }
-        //Get list
-        try {
-            $dataList = array('gibbonRoleID' => $_SESSION[$guid]['gibbonRoleIDCurrent']);
-            $sqlList = "(SELECT DISTINCT concat(gibbonModule.name, '/', gibbonAction.entryURL) AS id, SUBSTRING_INDEX(gibbonAction.name, '_', 1) AS name, 'Action' AS type FROM gibbonModule JOIN gibbonAction ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) JOIN gibbonPermission ON (gibbonPermission.gibbonActionID=gibbonAction.gibbonActionID) WHERE active='Y' AND menuShow='Y' AND gibbonPermission.gibbonRoleID=:gibbonRoleID)";
-            if ($staffIsAccessible == true) {
-                $sqlList .= " UNION (SELECT gibbonPerson.gibbonPersonID AS id, concat(surname, ', ', preferredName) AS name, 'Staff' AS type FROM gibbonPerson JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."'))";
-            }
-            if ($studentIsAccessible == true) {
-                $dataList['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
-                $sqlList .= " UNION (SELECT gibbonPerson.gibbonPersonID AS id, concat(surname, ', ', preferredName, ' (', gibbonRollGroup.name, ')') AS name, 'Student' AS type FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND status='FULL' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID)";
-            }
-            if ($classIsAccessible) {
-                if ($highestActionClass == 'Lesson Planner_viewEditAllClasses' or $highestActionClass == 'Lesson Planner_viewAllEditMyClasses') {
-                    $dataList['gibbonSchoolYearID2'] = $_SESSION[$guid]['gibbonSchoolYearID'];
-                    $sqlList .= " UNION (SELECT gibbonCourseClass.gibbonCourseClassID AS id, concat(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name, 'Class' AS type FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID2)";
-                } else {
-                    $dataList['gibbonSchoolYearID3'] = $_SESSION[$guid]['gibbonSchoolYearID'];
-                    $dataList['gibbonPersonID'] = $_SESSION[$guid]['gibbonPersonID'];
-                    $sqlList .= " UNION (SELECT gibbonCourseClass.gibbonCourseClassID AS id, concat(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name, 'Class' AS type FROM gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID3 AND gibbonPersonID=:gibbonPersonID)";
-                }
-            }
-            $sqlList .= ' ORDER BY type, name';
-
-            $resultList = $connection2->prepare($sqlList);
-            $resultList->execute($dataList);
-        } catch (PDOException $e) {
-            $output .= $e->getMessage();
-        }
-
-    $studentCount = 0;
-    $list = '';
-    while ($rowList = $resultList->fetch()) {
-        $list .= '{id: "'.substr($rowList['type'], 0, 3).'-'.$rowList['id'].'", name: "'.htmlPrep($rowList['type']).' - '.htmlPrep($rowList['name']).'"},';
-        if ($rowList['name'] == 'Sound Alarm') { //Special lockdown entry
-                if (isActionAccessible($guid, $connection2, '/modules/System Admin/alarm.php')) {
-                    $list .= '{id: "'.substr($rowList['type'], 0, 3).'-'.$rowList['id'].'", name: "'.htmlPrep($rowList['type']).' - Lockdown"},';
-                }
-        }
-        if ($rowList['type'] == 'Student') {
-            ++$studentCount;
-        }
-    }
 
     $output .= '<style>';
     $output .= 'ul.token-input-list-facebook { width: 275px; float: left; height: 25px!important; }';
@@ -2205,17 +2163,15 @@ function getFastFinder($connection2, $guid)
     $output .= '<tr>';
     $output .= "<td style='vertical-align: top; border: none'>";
     $output .= "<input class='topFinder' style='width: 275px' type='text' id='id' name='id' />";
-    $output .= "<script type='text/javascript'>";
-    $output .= '$(document).ready(function() {';
-    $output .= '$("#id").tokenInput([';
-    $output .= substr($list, 0, -1);
-    $output .= '],';
-    $output .= '{theme: "facebook",';
-    $output .= 'hintText: "Start typing a name...",';
-    $output .= 'allowCreation: false,';
-    $output .= 'preventDuplicates: true,';
-    $output .= 'tokenLimit: 1});';
-    $output .= '});';
+    $output .= '<script type="text/javascript">';
+        $output .= '$(document).ready(function() {';
+        $output .= '$("#id").tokenInput("'.$_SESSION[$guid]['absoluteURL'].'/index_fastFinder_ajax.php",';
+        $output .= '{theme: "facebook",';
+        $output .= 'hintText: "Start typing a name...",';
+        $output .= 'allowCreation: false,';
+        $output .= 'preventDuplicates: true,';
+        $output .= 'tokenLimit: 1});';
+        $output .= '});';
     $output .= '</script>';
     $output .= "<script type='text/javascript'>";
     $output .= "var id=new LiveValidation('id');";
@@ -2227,11 +2183,23 @@ function getFastFinder($connection2, $guid)
     $output .= '</td>';
     $output .= '</tr>';
     if (getRoleCategory($_SESSION[$guid]['gibbonRoleIDCurrent'], $connection2) == 'Staff') {
-        $output .= '<tr>';
-        $output .= "<td style='vertical-align: top' colspan=2>";
-        $output .= "<div style='padding-bottom: 0px; font-size: 80%; font-weight: normal; font-style: italic; line-height: 80%; padding: 1em,1em,1em,1em; width: 99%; text-align: left; color: #888;' >".__($guid, 'Total Student Enrolment:').' '.$studentCount.'</div>';
-        $output .= '</td>';
-        $output .= '</tr>';
+
+        try {
+            $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d') );
+            $sql = "SELECT COUNT(gibbonPerson.gibbonPersonID) FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND status='FULL' AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL  OR dateEnd>=:today) AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID";
+            $resultStudentCount = $connection2->prepare($sql);
+            $resultStudentCount->execute($data);
+        } catch (PDOException $e) {}
+
+        if ($resultStudentCount->rowCount() > 0) {
+            $studentCount = $resultStudentCount->fetchColumn(0);
+
+            $output .= '<tr>';
+            $output .= "<td style='vertical-align: top' colspan=2>";
+            $output .= "<div style='padding-bottom: 0px; font-size: 80%; font-weight: normal; font-style: italic; line-height: 80%; padding: 1em,1em,1em,1em; width: 99%; text-align: left; color: #888;' >".__($guid, 'Total Student Enrolment:').' '.$studentCount.'</div>';
+            $output .= '</td>';
+            $output .= '</tr>';
+        }
     }
     $output .= '</table>';
     $output .= '</form>';

--- a/index_fastFinder_ajax.php
+++ b/index_fastFinder_ajax.php
@@ -1,0 +1,181 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+@session_start();
+
+//Gibbon system-wide includes
+include './functions.php';
+include './config.php';
+
+// AJAX check - die if the origin looks suspicious
+if(empty($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) != 'xmlhttprequest') {
+    die( __($guid, 'Your request failed because you do not have access to this action.') );
+}
+
+//New PDO DB connection
+$pdo = new Gibbon\sqlConnection();
+$connection2 = $pdo->getConnection();
+
+$themeName = 'Default';
+if (isset($_SESSION[$guid]['gibbonThemeName'])) {
+    $themeName = $_SESSION[$guid]['gibbonThemeName'];
+}
+
+if (isset($_SESSION[$guid]) == false or isset($_SESSION[$guid]['gibbonPersonID']) == false) {
+    die( __($guid, 'Your request failed because you do not have access to this action.') );
+} else {
+
+    $searchTerm = (isset($_REQUEST['q']))? $_REQUEST['q'] : '';
+
+    // Allow for * as wildcard (as well as %)
+    $searchTerm = str_replace('*', '%', $searchTerm);
+
+    // Cancel out early for empty searches
+    if (empty($searchTerm)) die('[]');
+
+    // Check access levels
+    $studentIsAccessible = isActionAccessible($guid, $connection2, '/modules/students/student_view.php');
+    $staffIsAccessible = isActionAccessible($guid, $connection2, '/modules/Staff/staff_view.php');
+    $classIsAccessible = false;
+    $alarmIsAccessible = isActionAccessible($guid, $connection2, '/modules/System Admin/alarm.php');
+    $highestActionClass = getHighestGroupedAction($guid, '/modules/Planner/planner.php', $connection2);
+    if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') and $highestActionClass != 'Lesson Planner_viewMyChildrensClasses') {
+        $classIsAccessible = true;
+    }
+
+    $resultSet = array();
+    $resultError = '[{"id":"","name":"Database Error"}]';
+
+    // ACTIONS
+    try {
+        $data = array( 'search' => '%'.$searchTerm.'%', 'gibbonRoleID' => $_SESSION[$guid]['gibbonRoleIDCurrent'] );
+        $sql = "SELECT DISTINCT concat(gibbonModule.name, '/', gibbonAction.entryURL) AS id, SUBSTRING_INDEX(gibbonAction.name, '_', 1) AS name, 'Action' AS type  
+                FROM gibbonModule 
+                JOIN gibbonAction ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) 
+                JOIN gibbonPermission ON (gibbonPermission.gibbonActionID=gibbonAction.gibbonActionID) 
+                WHERE active='Y' 
+                AND menuShow='Y' 
+                AND gibbonPermission.gibbonRoleID=:gibbonRoleID
+                AND gibbonAction.name LIKE :search 
+                ORDER BY name";
+        $resultList = $connection2->prepare($sql);
+        $resultList->execute($data);
+    } catch (PDOException $e) { die($resultError); }
+
+    if ($resultList->rowCount() > 0) $resultSet += $resultList->fetchAll();
+       
+    // CLASSES
+    if ($classIsAccessible) {
+        try { 
+            if ($highestActionClass == 'Lesson Planner_viewEditAllClasses' or $highestActionClass == 'Lesson Planner_viewAllEditMyClasses') {
+                $data = array( 'search' => '%'.$searchTerm.'%', 'gibbonSchoolYearID2' => $_SESSION[$guid]['gibbonSchoolYearID'] );
+                $sql = "SELECT 'Class' AS type, gibbonCourseClass.gibbonCourseClassID AS id, concat(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name  
+                        FROM gibbonCourseClass 
+                        JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) 
+                        WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID2 
+                        AND (gibbonCourse.name LIKE :search 
+                            OR gibbonCourse.nameShort LIKE :search 
+                            OR gibbonCourseClass.nameShort LIKE :search) 
+                        ORDER BY name";
+            } else {
+                $data = array('search' => '%'.$searchTerm.'%', 'gibbonSchoolYearID3' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'] );
+                $sql = "SELECT 'Class' AS type, gibbonCourseClass.gibbonCourseClassID AS id, concat(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name  
+                        FROM gibbonCourseClassPerson 
+                        JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) 
+                        JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) 
+                        WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID3 
+                        AND gibbonPersonID=:gibbonPersonID 
+                        AND (gibbonCourse.name LIKE :search 
+                            OR gibbonCourse.nameShort LIKE :search 
+                            OR gibbonCourseClass.nameShort LIKE :search) 
+                        ORDER BY name";
+            }
+            $resultList = $connection2->prepare($sql);
+            $resultList->execute($data);
+        } catch (PDOException $e) { die($resultError); }
+
+        if ($resultList->rowCount() > 0) $resultSet += $resultList->fetchAll();
+    }
+    
+    // STAFF
+    if ($staffIsAccessible == true) {
+        try {
+            $data = array('search' => '%'.$searchTerm.'%', 'today' => date('Y-m-d') );
+            $sql = "SELECT 'Staff' AS type, gibbonPerson.gibbonPersonID AS id, 
+                    (CASE WHEN gibbonPerson.username LIKE :search 
+                        THEN concat(surname, ', ', preferredName, ' (', gibbonPerson.username, ')') 
+                        ELSE concat(surname, ', ', preferredName) END) AS name 
+                    FROM gibbonPerson 
+                    JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) 
+                    WHERE status='Full' 
+                    AND (dateStart IS NULL OR dateStart<=:today) 
+                    AND (dateEnd IS NULL  OR dateEnd>=:today) 
+                    AND (gibbonPerson.surname LIKE :search 
+                        OR gibbonPerson.preferredName LIKE :search 
+                        OR gibbonPerson.username LIKE :search) 
+                    ORDER BY name";
+            $resultList = $connection2->prepare($sql);
+            $resultList->execute($data);
+        } catch (PDOException $e) { die($resultError); }
+
+        if ($resultList->rowCount() > 0) $resultSet += $resultList->fetchAll();
+    }
+
+    // STUDENTS
+    if ($studentIsAccessible == true) {
+        try {
+            $data = array('search' => '%'.$searchTerm.'%', 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d') );
+            $sql = "SELECT 'Student' AS type, gibbonPerson.gibbonPersonID AS id, 
+                    (CASE WHEN gibbonPerson.username LIKE :search THEN concat(surname, ', ', preferredName, ' (', gibbonPerson.username, ')') 
+                        WHEN gibbonPerson.studentID LIKE :search THEN concat(surname, ', ', preferredName, ' (ID: ', gibbonPerson.studentID, ')') 
+                        WHEN gibbonPerson.firstName LIKE :search AND firstName<>preferredName THEN concat(surname, ', ', preferredName, ' (', gibbonPerson.firstName, ', ', gibbonRollGroup.name, ')') 
+                        ELSE concat(surname, ', ', preferredName, ' (', gibbonRollGroup.name, ')') END) AS name 
+                    FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup 
+                    WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID 
+                    AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID 
+                    AND status='FULL' 
+                    AND (dateStart IS NULL OR dateStart<=:today) 
+                    AND (dateEnd IS NULL  OR dateEnd>=:today) 
+                    AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID 
+                    AND (gibbonPerson.surname LIKE :search 
+                        OR gibbonPerson.firstName LIKE :search 
+                        OR gibbonPerson.preferredName LIKE :search 
+                        OR gibbonPerson.username LIKE :search 
+                        OR gibbonPerson.studentID LIKE :search 
+                        OR gibbonRollGroup.name LIKE :search) 
+                    ORDER BY name";
+            $resultList = $connection2->prepare($sql);
+            $resultList->execute($data);
+        } catch (PDOException $e) { die($resultError); }
+
+        if ($resultList->rowCount() > 0) $resultSet += $resultList->fetchAll();
+    }
+    
+    $list = '';
+    foreach ($resultSet as $rowList) {
+        $list .= '{"id": "'.substr($rowList['type'], 0, 3).'-'.$rowList['id'].'", "name": "'.htmlPrep($rowList['type']).' - '.htmlPrep($rowList['name']).'"},';
+
+        if ($alarmIsAccessible && $rowList['name'] == 'Sound Alarm') { // Special lockdown entry
+            $list .= '{"id": "'.substr($rowList['type'], 0, 3).'-'.$rowList['id'].'", "name": "'.htmlPrep($rowList['type']).' - Lockdown"},';
+        }
+    }
+
+    // Output the json
+    echo '['.substr($list, 0, -1).']';
+}

--- a/lib/jquery-tokeninput/styles/token-input-facebook.css
+++ b/lib/jquery-tokeninput/styles/token-input-facebook.css
@@ -107,6 +107,7 @@ div.token-input-dropdown-facebook ul li {
     padding: 3px;
     margin: 0;
     list-style-type: none;
+    text-align: left !important;
 }
 
 div.token-input-dropdown-facebook ul li.token-input-dropdown-item-facebook {


### PR DESCRIPTION
Fast Finder search now includes:

Action - Name
Student - Surname, Preferred Name, First Name, Student ID, Username, Roll Group
Staff - Surname, Preferred Name, Username
Course - Name, Name Short, Class Name Short

The results returned in brackets depend on the context, if a secondary search term was matched. Also removed the use of UNION queries in sql (which create temp tables).