### PR TITLE
Fast Finder: Updated student token to always include roll group

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2156,8 +2156,8 @@ function getFastFinder($connection2, $guid)
     }
 
     $output .= '<style>';
-    $output .= 'ul.token-input-list-facebook { width: 275px; float: left; height: 25px!important; }';
-    $output .= 'div.token-input-dropdown-facebook { width: 275px; z-index: 99999999 }';
+    $output .= 'ul.token-input-list-facebook { width: 300px; float: left; height: 25px!important; }';
+    $output .= 'div.token-input-dropdown-facebook { width: 300px; z-index: 99999999 }';
     $output .= '</style>';
     $output .= "<div style='padding-bottom: 7px; height: 40px; margin-top: 0px'>";
     $output .= "<form method='get' action='".$_SESSION[$guid]['absoluteURL']."/indexFindRedirect.php'>";

--- a/index_fastFinder_ajax.php
+++ b/index_fastFinder_ajax.php
@@ -150,9 +150,9 @@ if (isset($_SESSION[$guid]) == false or isset($_SESSION[$guid]['gibbonPersonID']
         try {
             $data = array('search' => '%'.$searchTerm.'%', 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'today' => date('Y-m-d') );
             $sql = "SELECT gibbonPerson.gibbonPersonID AS id,
-                    (CASE WHEN gibbonPerson.username LIKE :search THEN concat(surname, ', ', preferredName, ' (', gibbonPerson.username, ')')
-                        WHEN gibbonPerson.studentID LIKE :search THEN concat(surname, ', ', preferredName, ' (ID: ', gibbonPerson.studentID, ')')
-                        WHEN gibbonPerson.firstName LIKE :search AND firstName<>preferredName THEN concat(surname, ', ', preferredName, ' (', gibbonPerson.firstName, ', ', gibbonRollGroup.name, ')')
+                    (CASE WHEN gibbonPerson.username LIKE :search THEN concat(surname, ', ', preferredName, ' (', gibbonRollGroup.name, ', ', gibbonPerson.username, ')')
+                        WHEN gibbonPerson.studentID LIKE :search THEN concat(surname, ', ', preferredName, ' (', gibbonRollGroup.name, ', ', gibbonPerson.studentID, ')')
+                        WHEN gibbonPerson.firstName LIKE :search AND firstName<>preferredName THEN concat(surname, ', ', firstName, ' \"', preferredName, '\" (', gibbonRollGroup.name, ')' )
                         ELSE concat(surname, ', ', preferredName, ' (', gibbonRollGroup.name, ')') END) AS name,
                     NULL as type
                     FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup
@@ -183,7 +183,7 @@ if (isset($_SESSION[$guid]) == false or isset($_SESSION[$guid]['gibbonPersonID']
                 $list .= '{"id": "'.substr($type, 0, 3).'-'.$token['id'].'", "name": "'.htmlPrep(__($guid, $type)).' - '.htmlPrep(__($guid, $token['name'])).'"},';
             }
             else if ($token['type'] == 'Additional') {
-                $list .= '{"id": "'.substr($type, 0, 3).'-'.$token['id'].'", "name": "'.htmlPrep(__($guid, $type)).' - '.htmlPrep(__($guid, $token['name']), $token['module']).'"},';
+                $list .= '{"id": "'.substr($type, 0, 3).'-'.$token['id'].'", "name": "'.htmlPrep(__($guid, $type)).' - '.htmlPrep(__($guid, $token['name'], $token['module'])).'"},';
             }
             else {
                 $list .= '{"id": "'.substr($type, 0, 3).'-'.$token['id'].'", "name": "'.htmlPrep(__($guid, $type)).' - '.htmlPrep($token['name']).'"},';

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -98,7 +98,7 @@ body {
 	top:24px;
 	right:24px;
 	left:auto;
-	width:360px;
+	width:400px;
 }
 #header-finder h2 {
 	text-align: right ;


### PR DESCRIPTION
Note: A firstname that matches the search and is not the same as the preferred name will return the legal name with preferred name in "" (eg: Doe, John "Johnny"). This seemed to be a slightly more readable option than putting the firstname after the roll group.

Also increased the FF field size a bit.