### PR TITLE
System: added ability to search Fast Finder actions using current Gibbon language

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -58,6 +58,7 @@ v13.0.00
 		System: removed robots meta tag
 		System: added ability to custom order module categories in main menu
 		System: AJAXified Fast Finder
+		System: added ability to search Fast Finder actions using current Gibbon language
 		System: set tinyMCE default target for new links to New Window
 		System: made organisationEmail compulsory: on install, and if blank on update, it defaults to email of gibbonPersonID=1
 		System: notification emails now come from organisation email address, not administrator address

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -181,40 +181,9 @@ if (isset($authUrl)){
 			$URL.="?loginReturn=fail2" ;
 			header("Location: {$URL}");
 		}
-		$_SESSION[$guid]["username"]=$username ;
-		$_SESSION[$guid]["email"]=$email ;
-		$_SESSION[$guid]["passwordStrong"]=$row["passwordStrong"] ;
-		$_SESSION[$guid]["passwordStrongSalt"]=$row["passwordStrongSalt"] ;
-		$_SESSION[$guid]["passwordForceReset"]=$row["passwordForceReset"] ;
-		$_SESSION[$guid]["gibbonPersonID"]=$row["gibbonPersonID"] ;
-		$_SESSION[$guid]["surname"]=$row["surname"] ;
-		$_SESSION[$guid]["firstName"]=$row["firstName"] ;
-		$_SESSION[$guid]["preferredName"]=$row["preferredName"] ;
-		$_SESSION[$guid]["officialName"]=$row["officialName"] ;
-		$_SESSION[$guid]["email"]=$row["email"] ;
-		$_SESSION[$guid]["emailAlternate"]=$row["emailAlternate"] ;
-		$_SESSION[$guid]["website"]=$row["website"] ;
-		$_SESSION[$guid]["gender"]=$row["gender"] ;
-		$_SESSION[$guid]["status"]=$row["status"] ;
-		$_SESSION[$guid]["gibbonRoleIDPrimary"]=$row["gibbonRoleIDPrimary"] ;
-		$_SESSION[$guid]["gibbonRoleIDCurrent"]=$row["gibbonRoleIDPrimary"] ;
-		$_SESSION[$guid]["gibbonRoleIDCurrentCategory"]=getRoleCategory($row["gibbonRoleIDPrimary"], $connection2)  ;
-		$_SESSION[$guid]["gibbonRoleIDAll"]=getRoleList($row["gibbonRoleIDAll"], $connection2) ;
-		$_SESSION[$guid]["image_240"]=$row["image_240"] ;
-		$_SESSION[$guid]["lastTimestamp"]=$row["lastTimestamp"] ;
-		$_SESSION[$guid]["calendarFeedPersonal"]=$row["calendarFeedPersonal"] ;
-		$_SESSION[$guid]["viewCalendarSchool"]=$row["viewCalendarSchool"] ;
-		$_SESSION[$guid]["viewCalendarPersonal"]=$row["viewCalendarPersonal"] ;
-		$_SESSION[$guid]["viewCalendarSpaceBooking"]=$row["viewCalendarSpaceBooking"] ;
-		$_SESSION[$guid]["dateStart"]=$row["dateStart"] ;
-		$_SESSION[$guid]["personalBackground"]=$row["personalBackground"] ;
-		$_SESSION[$guid]["messengerLastBubble"]=$row["messengerLastBubble"] ;
-		$_SESSION[$guid]["gibbonThemeIDPersonal"]=$row["gibbonThemeIDPersonal"] ;
-		$_SESSION[$guid]["gibboni18nIDPersonal"]=$row["gibboni18nIDPersonal"] ;
-		$_SESSION[$guid]["googleAPIRefreshToken"]=$row["googleAPIRefreshToken"] ;
-		$_SESSION[$guid]['receiveNotificationEmails']=$row["receiveNotificationEmails"] ;
-		$_SESSION[$guid]['gibbonHouseID']=$row["gibbonHouseID"] ;
-
+		
+		//USER EXISTS, SET SESSION VARIABLES
+		$gibbon->session->createUserSession($username, $row);
 
 		//If user has personal language set, load it to session variable.
 		if (!is_null($_SESSION[$guid]["gibboni18nIDPersonal"])) {

--- a/login.php
+++ b/login.php
@@ -181,39 +181,11 @@ else {
                     }
 
                     //USER EXISTS, SET SESSION VARIABLES
-                    $_SESSION[$guid]['username'] = $username;
-                    $_SESSION[$guid]['passwordStrong'] = $passwordStrong;
-                    $_SESSION[$guid]['passwordStrongSalt'] = $salt;
-                    $_SESSION[$guid]['passwordForceReset'] = $row['passwordForceReset'];
-                    $_SESSION[$guid]['gibbonPersonID'] = $row['gibbonPersonID'];
-                    $_SESSION[$guid]['surname'] = $row['surname'];
-                    $_SESSION[$guid]['firstName'] = $row['firstName'];
-                    $_SESSION[$guid]['preferredName'] = $row['preferredName'];
-                    $_SESSION[$guid]['officialName'] = $row['officialName'];
-                    $_SESSION[$guid]['email'] = $row['email'];
-                    $_SESSION[$guid]['emailAlternate'] = $row['emailAlternate'];
-                    $_SESSION[$guid]['website'] = $row['website'];
-                    $_SESSION[$guid]['gender'] = $row['gender'];
-                    $_SESSION[$guid]['status'] = $row['status'];
-                    $_SESSION[$guid]['gibbonRoleIDPrimary'] = $row['gibbonRoleIDPrimary'];
-                    $_SESSION[$guid]['gibbonRoleIDCurrent'] = $row['gibbonRoleIDPrimary'];
-                    $_SESSION[$guid]['gibbonRoleIDCurrentCategory'] = getRoleCategory($row['gibbonRoleIDPrimary'], $connection2);
-                    $_SESSION[$guid]['gibbonRoleIDAll'] = getRoleList($row['gibbonRoleIDAll'], $connection2);
-                    $_SESSION[$guid]['image_240'] = $row['image_240'];
-                    $_SESSION[$guid]['lastTimestamp'] = $row['lastTimestamp'];
-                    $_SESSION[$guid]['calendarFeedPersonal'] = $row['calendarFeedPersonal'];
-                    $_SESSION[$guid]['viewCalendarSchool'] = $row['viewCalendarSchool'];
-                    $_SESSION[$guid]['viewCalendarPersonal'] = $row['viewCalendarPersonal'];
-                    $_SESSION[$guid]['viewCalendarSpaceBooking'] = $row['viewCalendarSpaceBooking'];
-                    $_SESSION[$guid]['dateStart'] = $row['dateStart'];
-                    $_SESSION[$guid]['personalBackground'] = $row['personalBackground'];
-                    $_SESSION[$guid]['messengerLastBubble'] = $row['messengerLastBubble'];
-                    $_SESSION[$guid]['gibbonThemeIDPersonal'] = $row['gibbonThemeIDPersonal'];
-                    $_SESSION[$guid]['gibboni18nIDPersonal'] = $row['gibboni18nIDPersonal'];
-                    $_SESSION[$guid]['googleAPIRefreshToken'] = $row['googleAPIRefreshToken'];
-                    $_SESSION[$guid]['googleAPIAccessToken'] = null; //Set only when user logs in with Google
-                    $_SESSION[$guid]['receiveNotificationEmails'] = $row['receiveNotificationEmails'];
-                    $_SESSION[$guid]['gibbonHouseID'] = $row['gibbonHouseID'];
+                    $gibbon->session->createUserSession($username, $row);
+
+                    // Set these from local values
+                    $gibbon->session->set('passwordStrong', $passwordStrong);
+                    $gibbon->session->set('passwordStrongSalt', $salt);
 
                     //Allow for non-system default language to be specified from login form
                     if (@$_POST['gibboni18nID'] != $_SESSION[$guid]['i18n']['gibboni18nID']) {

--- a/roleSwitcherProcess.php
+++ b/roleSwitcherProcess.php
@@ -54,9 +54,15 @@ else {
         header("Location: {$URL}");
     } else {
         //Make the switch
-        $_SESSION[$guid]['gibbonRoleIDCurrent'] = $role;
+        $gibbon->session->set('gibbonRoleIDCurrent', $role);
+
+        // Reload cached FF actions
+        $gibbon->session->cacheFastFinderActions($role);
+
+        // Reload the cached menu
         $mainMenu = new Gibbon\menuMain($gibbon, $pdo);
         $mainMenu->setMenu();
+
         $URL .= '?return=success0';
         header("Location: {$URL}");
     }

--- a/src/Gibbon/core.php
+++ b/src/Gibbon/core.php
@@ -113,6 +113,9 @@ class Core {
 		// Load the string replacements from db
 		$this->locale->setStringReplacementList($pdo);
 
+		// Provide the session class with a db connection
+		$this->session->setDatabaseConnection($pdo);
+
 		$this->initialized = true;
 	}
 


### PR DESCRIPTION
The FF actions are translated & cached on login and role switch. This approach also includes string replacements which is a nice bonus (eg: our school uses Homeroom instead of Form Group, so it also handles this)