### PR TITLE
Attendance: require_once path fix

### DIFF
--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -22,7 +22,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
 
-require_once './modules/Attendance/src/attendanceView.php';
+require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_future_byPerson.php') == false) {
     //Acess denied

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -22,7 +22,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //Module includes
 include "./modules/" . $_SESSION[$guid]["module"] . "/moduleFunctions.php" ;
 
-require_once './modules/Attendance/src/attendanceView.php';
+require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 
 if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take_byCourseClass.php")==FALSE) {
 	//Acess denied

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -22,7 +22,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
 
-require_once './modules/Attendance/src/attendanceView.php';
+require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson.php') == false) {
     //Acess denied

--- a/modules/Attendance/attendance_take_byPerson_edit.php
+++ b/modules/Attendance/attendance_take_byPerson_edit.php
@@ -22,7 +22,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
 
-require_once './modules/Attendance/src/attendanceView.php';
+require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_edit.php') == false) {

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -22,7 +22,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
 
-require_once './modules/Attendance/src/attendanceView.php';
+require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byRollGroup.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_graph_by
     $sort = !empty($_POST['sort'])? $_POST['sort'] : 'surname, preferredName';
 
     
-    require_once './modules/Attendance/src/attendanceView.php';
+    require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
     $attendance = new Module\Attendance\attendanceView($gibbon, $pdo);
 
     if (isset($_POST['types']) && isset($_POST['dateStart'])) {

--- a/modules/Attendance/report_studentsNotOnsite_byDate.php
+++ b/modules/Attendance/report_studentsNotOnsite_byDate.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
     $allStudents = !empty($_GET["allStudents"])? 1 : 0;
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname';
 
-    require_once './modules/Attendance/src/attendanceView.php';
+    require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
     $attendance = new Module\Attendance\attendanceView($gibbon, $pdo);
 
     ?>

--- a/modules/Attendance/report_studentsNotOnsite_byDate_print.php
+++ b/modules/Attendance/report_studentsNotOnsite_byDate_print.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
 
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname, preferredName';
 
-    require_once './modules/Attendance/src/attendanceView.php';
+    require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
     $attendance = new Module\Attendance\attendanceView($gibbon, $pdo);
 
     //Proceed!

--- a/modules/Attendance/report_studentsNotPresent_byDate.php
+++ b/modules/Attendance/report_studentsNotPresent_byDate.php
@@ -47,7 +47,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
 
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname, preferredName';
 
-    require_once './modules/Attendance/src/attendanceView.php';
+    require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
     $attendance = new Module\Attendance\attendanceView($gibbon, $pdo);
     ?>
 

--- a/modules/Attendance/report_studentsNotPresent_byDate_print.php
+++ b/modules/Attendance/report_studentsNotPresent_byDate_print.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
 
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname, preferredName';
 
-    require_once './modules/Attendance/src/attendanceView.php';
+    require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
     $attendance = new Module\Attendance\attendanceView($gibbon, $pdo);
 
     //Proceed!

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -1633,7 +1633,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                         // Only show certain options if Class Attendance is Enabled school-wide, and for this particular class
                         $attendanceEnabled = isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take_byCourseClass.php") && $row['attendance'] == 'Y';
 
-                        require_once './modules/Attendance/src/attendanceView.php';
+                        require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 
                         $attendance = new Module\Attendance\attendanceView($gibbon, $pdo);
 


### PR DESCRIPTION
Standardized the require_once to all use absolute paths so there's no conflicts. For whatever reason PHP sees absolute and relative includes as separate files.

One day I'll go through and figure out the Autoloader for module use, which is meant to handle including classes.