### PR TITLE
System: Updated password reset process to use PHPMailer

### DIFF
--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -94,13 +94,29 @@ else {
             }
             $gibbonPersonResetID = str_pad($connection2->lastInsertID(), 12, '0', STR_PAD_LEFT);
 
+            require $_SESSION[$guid]["absolutePath"] . '/lib/PHPMailer/PHPMailerAutoload.php';
+
             //Send email
-            $to = $email;
             $subject = $_SESSION[$guid]['organisationNameShort'].' '.__($guid, 'Gibbon Password Reset');
             $body = sprintf(__($guid, 'A password reset request has been initiated for account %1$s, which is registered to this email address.%2$sIf you did not initiate this request, please ignore this email.%2$sIf you do wish to reset your password, please use the link below to access the reset form:%2$s%3$s%2$s%4$s'), $username, "\n\n", $_SESSION[$guid]['absoluteURL']."/index.php?q=/passwordReset.php&input=$input&step=2&gibbonPersonResetID=$gibbonPersonResetID&key=$key", $_SESSION[$guid]['systemName']." Administrator");
-            $headers = 'From: '.$_SESSION[$guid]['organisationAdministratorEmail'];
 
-            if (mail($to, $subject, $body, $headers)) {
+            $mail = getGibbonMailer($guid);
+            $mail->AddAddress($email);
+
+            if (isset($_SESSION[$guid]['organisationEmail']) && $_SESSION[$guid]['organisationEmail'] != '') {
+                $mail->SetFrom($_SESSION[$guid]['organisationEmail'], $_SESSION[$guid]['organisationName']);
+            } else {
+                $mail->SetFrom($_SESSION[$guid]['organisationAdministratorEmail'], $_SESSION[$guid]['organisationName']);
+            }
+            
+            $mail->CharSet="UTF-8";
+            $mail->Encoding="base64" ;
+            $mail->IsHTML(true);
+            $mail->Subject=$subject ;
+            $mail->Body = $body ;
+            $mail->AltBody = emailBodyConvert($body) ;
+
+            if ($mail->Send()) {
                 $URL = $URL.'&return=success0';
                 header("Location: {$URL}");
             } else {


### PR DESCRIPTION
Discovered passwordResetProcess was still using the old mail() class (& failing to send on our system). Updated it to use PHPMailer so it's SMTP compatible. Also did a search over the project, looks like this was the last page still using the mail() class.

Thanks!