### PR TITLE
School Admin: Fix orphaned Special Days casing Input Invalid error

### DIFF
--- a/modules/School Admin/schoolYearSpecialDay_manage.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage.php
@@ -118,8 +118,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 
                 //Get the special days
                 try {
-                    $dataSpecial = array('gibbonSchoolYearTermID' => $row['gibbonSchoolYearTermID']);
-                    $sqlSpecial = 'SELECT * FROM gibbonSchoolYearSpecialDay WHERE gibbonSchoolYearTermID=:gibbonSchoolYearTermID ORDER BY date';
+                    $dataSpecial = array('firstDay' => $row['firstDay'], 'lastDay' => $row['lastDay']);
+                    $sqlSpecial = 'SELECT * FROM gibbonSchoolYearSpecialDay WHERE date BETWEEN :firstDay AND :lastDay ORDER BY date';
                     $resultSpecial = $connection2->prepare($sqlSpecial);
                     $resultSpecial->execute($dataSpecial);
                 } catch (PDOException $e) {
@@ -216,7 +216,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
                         if ($i == $specialDayStamp) {
                             echo "<span style='color: #ff0000'>".dateConvertBack($guid, date('Y-m-d', $i)).'<br/>'.$rowSpecial['name'].'</span>';
                             echo '<br/>';
-                            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/schoolYearSpecialDay_manage_edit.php&gibbonSchoolYearSpecialDayID='.$rowSpecial['gibbonSchoolYearSpecialDayID']."&gibbonSchoolYearID=$gibbonSchoolYearID'><img style='margin-top: 3px' title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
+                            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/schoolYearSpecialDay_manage_edit.php&gibbonSchoolYearSpecialDayID='.$rowSpecial['gibbonSchoolYearSpecialDayID']."&gibbonSchoolYearTermID=".$row['gibbonSchoolYearTermID']."&gibbonSchoolYearID=$gibbonSchoolYearID'><img style='margin-top: 3px' title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
                             echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/schoolYearSpecialDay_manage_delete.php&gibbonSchoolYearSpecialDayID='.$rowSpecial['gibbonSchoolYearSpecialDayID']."&gibbonSchoolYearID=$gibbonSchoolYearID'><img style='margin-top: 3px' title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a> ";
                             $rowSpecial = $resultSpecial->fetch();
                         } else {

--- a/modules/School Admin/schoolYearSpecialDay_manage_addProcess.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_addProcess.php
@@ -78,8 +78,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 
         //Check unique inputs for uniquness
         try {
-            $data = array('date' => dateConvert($guid, $date));
-            $sql = 'SELECT * FROM gibbonSchoolYearSpecialDay WHERE date=:date';
+            $data = array('date' => dateConvert($guid, $date), 'gibbonSchoolYearTermID' => $gibbonSchoolYearTermID);
+            $sql = 'SELECT * FROM gibbonSchoolYearSpecialDay WHERE date=:date AND gibbonSchoolYearTermID=:gibbonSchoolYearTermID';
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {

--- a/modules/School Admin/schoolYearSpecialDay_manage_addProcess.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_addProcess.php
@@ -78,8 +78,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 
         //Check unique inputs for uniquness
         try {
-            $data = array('date' => dateConvert($guid, $date), 'gibbonSchoolYearTermID' => $gibbonSchoolYearTermID);
-            $sql = 'SELECT * FROM gibbonSchoolYearSpecialDay WHERE date=:date AND gibbonSchoolYearTermID=:gibbonSchoolYearTermID';
+            $data = array('date' => dateConvert($guid, $date));
+            $sql = 'SELECT * FROM gibbonSchoolYearSpecialDay WHERE date=:date';
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {

--- a/modules/School Admin/schoolYearSpecialDay_manage_edit.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_edit.php
@@ -290,6 +290,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 						<span class="emphasis small">* <?php echo __($guid, 'denotes a required field'); ?></span>
 					</td>
 					<td class="right">
+						<input name="gibbonSchoolYearTermID" id="gibbonSchoolYearTermID" value="<?php echo $_GET['gibbonSchoolYearTermID'] ?>" type="hidden">
 						<input name="gibbonSchoolYearID" id="gibbonSchoolYearID" value="<?php echo $_GET['gibbonSchoolYearID'] ?>" type="hidden">
 						<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
 						<input type="submit" value="<?php echo __($guid, 'Submit'); ?>">

--- a/modules/School Admin/schoolYearSpecialDay_manage_editProcess.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_editProcess.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
     } else {
         try {
             $data = array('gibbonSchoolYearSpecialDayID' => $gibbonSchoolYearSpecialDayID);
-            $sql = 'SELECT * FROM gibbonSchoolYearSpecialDay WHERE gibbonSchoolYearSpecialDayID=:gibbonSchoolYearSpecialDayID';
+            $sql = 'SELECT gibbonSchoolYearTermID FROM gibbonSchoolYearSpecialDay WHERE gibbonSchoolYearSpecialDayID=:gibbonSchoolYearSpecialDayID';
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
@@ -79,14 +79,17 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
                 $schoolClose = $_POST['schoolCloseH'].':'.$_POST['schoolCloseM'].':00';
             }
 
+            // Update the term ID, or fallback to the previous one
+            $gibbonSchoolYearTermID = (isset($_POST['gibbonSchoolYearTermID']))? $_POST['gibbonSchoolYearTermID'] : $result->fetchColumn(0);
+
             if ($type == '' or $name == '' or $gibbonSchoolYearID == '') {
                 $URL .= '&return=error3';
                 header("Location: {$URL}");
             } else {
                 //Write to database
                 try {
-                    $data = array('type' => $type, 'name' => $name, 'description' => $description, 'schoolOpen' => $schoolOpen, 'schoolStart' => $schoolStart, 'schoolEnd' => $schoolEnd, 'schoolClose' => $schoolClose, 'gibbonSchoolYearSpecialDayID' => $gibbonSchoolYearSpecialDayID);
-                    $sql = 'UPDATE gibbonSchoolYearSpecialDay SET type=:type, name=:name, description=:description,schoolOpen=:schoolOpen, schoolStart=:schoolStart, schoolEnd=:schoolEnd, schoolClose=:schoolClose WHERE gibbonSchoolYearSpecialDayID=:gibbonSchoolYearSpecialDayID';
+                    $data = array('type' => $type, 'name' => $name, 'description' => $description, 'schoolOpen' => $schoolOpen, 'schoolStart' => $schoolStart, 'schoolEnd' => $schoolEnd, 'schoolClose' => $schoolClose, 'gibbonSchoolYearTermID' => $gibbonSchoolYearTermID, 'gibbonSchoolYearSpecialDayID' => $gibbonSchoolYearSpecialDayID);
+                    $sql = 'UPDATE gibbonSchoolYearSpecialDay SET type=:type, name=:name, description=:description,schoolOpen=:schoolOpen, schoolStart=:schoolStart, schoolEnd=:schoolEnd, schoolClose=:schoolClose, gibbonSchoolYearTermID=:gibbonSchoolYearTermID WHERE gibbonSchoolYearSpecialDayID=:gibbonSchoolYearSpecialDayID';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {


### PR DESCRIPTION
Fixes:
- Updated the term query to grab special dates by date range rather than term ID: If a special day is tied to a term that is changed or deleted, it still shows up if it falls in any valid term (prevents the Input Invalid error)
- Editing a special day will update it to the appropriate term ID (adopting the orphans)
- Allows for overlapping terms without breaking things: the dates are still unique, but can show up within different date-ranges for various terms