### PR TITLE
System: Fixed Google Login error when accounts have the same email

### DIFF
--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -112,6 +112,7 @@ if (isset($authUrl)){
 		$_SESSION[$guid]=NULL ;
 		$URL="../../index.php?loginReturn=fail8" ;
 		header("Location: {$URL}");
+		exit;
 	}
 	//Start to collect User Info and test
 	try {
@@ -152,6 +153,7 @@ if (isset($authUrl)){
 
 			$URL.="?loginReturn=fail6" ;
 			header("Location: {$URL}");
+			exit;
 		}
 		if ($row["passwordForceReset"]=="Y") {
 			$salt=getSalt() ;
@@ -180,6 +182,7 @@ if (isset($authUrl)){
 			//FAILED TO SET ROLES
 			$URL.="?loginReturn=fail2" ;
 			header("Location: {$URL}");
+			exit;
 		}
 		
 		//USER EXISTS, SET SESSION VARIABLES
@@ -230,6 +233,7 @@ if (isset($authUrl)){
 			$URL="../../index.php?loginReturn=fail8" ;
 		}
 		header("Location: {$URL}");
+		exit;
 
 
 		}
@@ -247,6 +251,7 @@ if (isset($_GET['logout'])) {
 
   session_destroy();
   header('Location: http://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF']); // it will simply destroy the current seesion which you started before
+  exit;
   //NOTE: for logout and clear all the session direct google just uncomment the above line and comment the first header function
 }
 }

--- a/login.php
+++ b/login.php
@@ -47,6 +47,7 @@ $password = $_POST['password'];
 if (($username == '') or ($password == '')) {
     $URL .= '?loginReturn=fail0b';
     header("Location: {$URL}");
+    exit;
 }
 //VALIDATE LOGIN INFORMATION
 else {
@@ -63,6 +64,7 @@ else {
         setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, null, 'Login - Failed', array('username' => $username, 'reason' => 'Username does not exist'), $_SERVER['REMOTE_ADDR']);
         $URL .= '?loginReturn=fail1';
         header("Location: {$URL}");
+        exit;
     } else {
         $row = $result->fetch();
 
@@ -84,6 +86,7 @@ else {
             setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, $row['gibbonPersonID'], 'Login - Failed', array('username' => $username, 'reason' => 'Too many failed logins'), $_SERVER['REMOTE_ADDR']);
             $URL .= '?loginReturn=fail6';
             header("Location: {$URL}");
+            exit;
         } else {
             $passwordTest = false;
             //If strong password exists
@@ -129,12 +132,14 @@ else {
                 setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, $row['gibbonPersonID'], 'Login - Failed', array('username' => $username, 'reason' => 'Incorrect password'), $_SERVER['REMOTE_ADDR']);
                 $URL .= '?loginReturn=fail1';
                 header("Location: {$URL}");
+                exit;
             } else {
                 if ($row['gibbonRoleIDPrimary'] == '' or count(getRoleList($row['gibbonRoleIDAll'], $connection2)) == 0) {
                     //FAILED TO SET ROLES
                     setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, $row['gibbonPersonID'], 'Login - Failed', array('username' => $username, 'reason' => 'Failed to set role(s)'), $_SERVER['REMOTE_ADDR']);
                     $URL .= '?loginReturn=fail2';
                     header("Location: {$URL}");
+                    exit;
                 } else {
                     //Allow for non-current school years to be specified
                     if ($_POST['gibbonSchoolYearID'] != $_SESSION[$guid]['gibbonSchoolYearID']) {
@@ -238,6 +243,7 @@ else {
                     }
                     setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, $row['gibbonPersonID'], 'Login - Success', array('username' => $username), $_SERVER['REMOTE_ADDR']);
                     header("Location: {$URL}");
+                    exit;
                 }
             }
         }


### PR DESCRIPTION
Discovered a bug in the Google login. The code intends to create an error and cancel login if two accounts have the same email address, but it actually continued and completed login but failed to set a lot of vital session vars. The result was a user who could login but nothing seemed to work right for them.

Adding a hard `exit;` after the header fixed this. It seems setting the header() doesn't terminate the script, so any time header is used as a redirect it should be followed by exit to ensure no code continues to run. I've added these in the google login and regular login script, and can do a more thorough header find/update for v14. 