### PR TITLE
System: Allow users to login with username or email address

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ v14.0.00
 		System: added Moroccan dirham as a currency option
 		System: upgraded jQuery to v2.2.4 and jQuery Migrate to v1.4.1
 		System: fixed bug preventing jQuery Chained from working properly
+		System: allow user login with either username or email, if email is unique
 		Attendance: added ability (off by default) for students to register themselves as Present, when within a set of IP addresses
 		Attendance: added explicitly stored context recording where attendance was taken
 		Attendance: added settings to determine pre-filling of attendance in different contexts

--- a/functions.php
+++ b/functions.php
@@ -2832,11 +2832,9 @@ function sidebar($gibbon, $pdo)
 		<form name="loginForm" method="post" action="./login.php?<?php if (isset($_GET['q'])) { echo 'q='.$_GET['q']; } ?>">
 			<table class='noIntBorder' cellspacing='0' style="width: 100%; margin: 0px 0px">
 				<tr>
-					<td>
-						<b><?php echo __($guid, 'Username'); ?></b>
-					</td>
-					<td class="right">
-						<input name="username" id="username" maxlength=20 type="text" style="width:120px">
+					<td colspan="2">
+                        <img src="<?php echo $_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/attendance.png"; ?>" style="width:20px;height:20px;margin:4px 0 0 2px;" title="<?php echo __($guid, 'Username or email'); ?>">
+						<input name="username" id="username" maxlength=50 type="text" style="width:200px;margin-left:0;padding-left: 5px;" placeholder="<?php echo __($guid, 'Username or email'); ?>">
 						<script type="text/javascript">
 							var username=new LiveValidation('username', {onlyOnSubmit: true });
 							username.add(Validate.Presence);
@@ -2844,11 +2842,9 @@ function sidebar($gibbon, $pdo)
 					</td>
 				</tr>
 				<tr>
-					<td>
-						<b><?php echo __($guid, 'Password'); ?></b>
-					</td>
-					<td class="right">
-						<input name="password" id="password" maxlength=30 type="password" style="width:120px">
+					<td colspan="2">
+                        <img src="<?php echo $_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/key.png"; ?>" style="width:20px;height:20px;margin:4px 0 0 2px;" title="<?php echo __($guid, 'Password'); ?>">
+						<input name="password" id="password" maxlength=30 type="password" style="width:200px;margin-left:0;padding-left: 5px;" placeholder="<?php echo __($guid, 'Password'); ?>">
 						<script type="text/javascript">
 							var password=new LiveValidation('password', {onlyOnSubmit: true });
 							password.add(Validate.Presence);

--- a/login.php
+++ b/login.php
@@ -53,7 +53,7 @@ if (($username == '') or ($password == '')) {
 else {
     try {
         $data = array('username' => $username);
-        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username) AND (status='Full') AND (canLogin='Y'))";
+        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full') AND (canLogin='Y'))";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
@@ -67,6 +67,9 @@ else {
         exit;
     } else {
         $row = $result->fetch();
+
+        // Set the username explicity, to handle logging in with email
+        $username = $row['username'];
 
         //Check fail count, reject & alert if 3rd time
         if ($row['failCount'] >= 3) {

--- a/login.php
+++ b/login.php
@@ -53,7 +53,7 @@ if (($username == '') or ($password == '')) {
 else {
     try {
         $data = array('username' => $username);
-        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full') AND (canLogin='Y'))";
+        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, canLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full'))";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
@@ -67,6 +67,13 @@ else {
         exit;
     } else {
         $row = $result->fetch();
+
+        // Insufficient privledges to login
+        if ($row['canLogin'] != 'Y') {
+            $URL .= '?loginReturn=fail2';
+            header("Location: {$URL}");
+            exit;
+        }
 
         // Set the username explicity, to handle logging in with email
         $username = $row['username'];


### PR DESCRIPTION
Updated the Login functionality to allow a user to login with either a username or valid email address (as long as the email address is unique). 

Changes the Login field to use icons for Username and Password (because the field needed a bit more room to accommodate email addresses).

Also provides a more specific error message if a user's canLogin='N' ("You do not have sufficient privileges to login.") rather than the initial error ("Incorrect username and password.")