### PR TITLE
Markbook: Add a class average row to the bottom of markbook views

### DIFF
--- a/modules/Markbook/css/module.css
+++ b/modules/Markbook/css/module.css
@@ -80,6 +80,11 @@ th.dataColumn {
 	border-left: 1px solid #666;
 }
 
+.dataColumn.dataDividerTop {
+	border-top: 2px solid #bbbbbb;
+	background: #FBFBFB;
+}
+
 .marksColumn {
 	padding: 0px !important;
 	text-align: center;


### PR DESCRIPTION
This PR adds a row to the bottom of the Markbook View, which gives a class-wide average for an individual assignment or cumulative grade. In the Markbook, this is perpendicular to the previous student averages added in v12.

Only visible if Markbook setting enableColumnWeighting is on.