### PR TITLE
Students: Fixed file uploads failing in applicationFormProcess

### DIFF
--- a/modules/Students/applicationFormProcess.php
+++ b/modules/Students/applicationFormProcess.php
@@ -683,7 +683,7 @@ if ($proceed == false) {
                             //Check for folder in uploads based on today's date
                             $path = $_SESSION[$guid]['absolutePath'];
                             if (is_dir($path.'/uploads/'.date('Y', $time).'/'.date('m', $time)) == false) {
-                                mkdir($path.'/uploads/'.date('Y', $time).'/'.date('m', $time), 0777, true);
+                                mkdir($path.'/uploads/'.date('Y', $time).'/'.date('m', $time), 0775, true);
                             }
                             $unique = false;
                             $count = 0;

--- a/modules/Students/applicationFormProcess.php
+++ b/modules/Students/applicationFormProcess.php
@@ -27,6 +27,11 @@ $connection2 = $pdo->getConnection();
 
 @session_start();
 
+//Check to see if system settings are set from databases
+if ($_SESSION[$guid]['systemSettingsSet'] == false) {
+    getSystemSettings($guid, $connection2);
+}
+
 //Module includes from User Admin (for custom fields)
 include '../User Admin/moduleFunctions.php';
 

--- a/modules/Students/applicationFormProcess.php
+++ b/modules/Students/applicationFormProcess.php
@@ -28,7 +28,7 @@ $connection2 = $pdo->getConnection();
 @session_start();
 
 //Check to see if system settings are set from databases
-if ($_SESSION[$guid]['systemSettingsSet'] == false) {
+if (empty($_SESSION[$guid]['systemSettingsSet'])) {
     getSystemSettings($guid, $connection2);
 }
 

--- a/modules/Students/applicationFormProcess.php
+++ b/modules/Students/applicationFormProcess.php
@@ -682,20 +682,27 @@ if ($proceed == false) {
                         if ($_FILES["file$i"]['tmp_name'] != '') {
                             //Check for folder in uploads based on today's date
                             $path = $_SESSION[$guid]['absolutePath'];
-                            if (is_dir($path.'/uploads/'.date('Y', $time).'/'.date('m', $time)) == false) {
-                                mkdir($path.'/uploads/'.date('Y', $time).'/'.date('m', $time), 0775, true);
+                            $directory = 'uploads/'.date('Y', $time).'/'.date('m', $time);
+                            if (is_dir($path.'/'.$directory) == false) {
+                                mkdir($path.'/'.$directory, 0775, true);
                             }
                             $unique = false;
                             $count = 0;
                             while ($unique == false and $count < 100) {
                                 $suffix = randomPassword(16);
-                                $attachment = 'uploads/'.date('Y', $time).'/'.date('m', $time)."/Application Document_$suffix".strrchr($_FILES["file$i"]['name'], '.');
+                                $attachment = $directory."/Application Document_$suffix".strrchr($_FILES["file$i"]['name'], '.');
                                 if (!(file_exists($path.'/'.$attachment))) {
                                     $unique = true;
                                 }
                                 ++$count;
                             }
                             if (!(move_uploaded_file($_FILES["file$i"]['tmp_name'], $path.'/'.$attachment))) {
+                                // Make one more attempt at moving the file, using gibbon root path
+                                $basePath = str_replace('\\', '/', dirname(__FILE__));
+                                $basePath = str_replace('modules/Students', '', $basePath);
+                                $basePath = rtrim($basePath, '/');
+
+                                move_uploaded_file($_FILES["file$i"]['tmp_name'], $basePath.'/'.$attachment);
                             }
 
                             //Write files to database


### PR DESCRIPTION
If cookies are disabled in a user's browser the session variables like $_SESSION[$guid]['absolutePath'] are missing so the file uploads were silently failing.

This fix does two things: loads the system settings into $_SESSION if they don't exist, and does one more attempt at uploading using the base Gibbon path if the first attempt fails.