### PR TITLE
System: added Myanmar, Burmese, Filipino to list of languages

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -724,4 +724,10 @@ INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, 
 INSERT INTO `gibbonPermission` (`permissionID` ,`gibbonRoleID` ,`gibbonActionID`) VALUES (NULL , '1', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Activities' AND gibbonAction.name='Enter Activity Attendance_leader')), (NULL , '2', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Activities' AND gibbonAction.name='Enter Activity Attendance_leader'));end
 UPDATE `gibbonAction` SET precedence = 1 WHERE name = 'Enter Activity Attendance' AND gibbonModuleID = (SELECT gibbonModuleID FROM gibbonModule WHERE name='Activities');end
 UPDATE gibbonAction SET description='Record student attendance for activities you organise, coach or assist in.' WHERE gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Activities') AND (name='Enter Activity Attendance_leader');end
+ALTER TABLE `gibbonLanguage` ADD UNIQUE (`name`);end
+INSERT IGNORE INTO `gibbonLanguage` (`name`) VALUES ('Myanmar'), ('Burmese'), ('Filipino');end
+UPDATE `gibbonLanguage` SET `name`='Croatian' WHERE `gibbonLanguageID`='0012';end
+UPDATE `gibbonLanguage` SET `name`='Ukrainian' WHERE `gibbonLanguageID`='0068';end
+UPDATE `gibbonLanguage` SET `name` = 'Swedish' WHERE `gibbonLanguageID` = 0060;end
+UPDATE `gibbonCountry` SET iddCountryCode='95' WHERE `printable_name`='Myanmar';end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ v14.0.00
 		System: upgraded jQuery to v2.2.4 and jQuery Migrate to v1.4.1
 		System: fixed bug preventing jQuery Chained from working properly
 		System: allow user login with either username or email, if email is unique
+		System: added Myanmar, Burmese, Filipino to list of languages, fixed Croatian, Ukrainian, Swedish spelling
 		Activities: added optional permission for activity organisers to manage their activities enrolment
 		Activities: fixed PHP Notice error (repeated many times) in activity add and edit interfaces
 		Activities: added optional permission for activity organisers to take attendance only within their activities


### PR DESCRIPTION
Merged in Victor's language changes and added a couple requested ones from this end:

- Adds a unique key to gibbonLanguage (`INSERT IGNORE` and `DUPLICATE KEY` don't work otherwise)
- Adds Myanmar, Burmese, Filipino to gibbonLanguage
- Updates Croatian, Ukrainian, Swedish spelling in gibbonLanguage
- Updates iddCountryCode for Myanmar