### PR TITLE
Timetable Admin: Fixed school year uniqueness check for add/edit TT

### DIFF
--- a/modules/Timetable Admin/tt_addProcess.php
+++ b/modules/Timetable Admin/tt_addProcess.php
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php
     } else {
         //Check unique inputs for uniquness
         try {
-            $data = array('name' => $name, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
+            $data = array('name' => $name, 'gibbonSchoolYearID' => $gibbonSchoolYearID);
             $sql = 'SELECT * FROM gibbonTT WHERE (name=:name AND gibbonSchoolYearID=:gibbonSchoolYearID)';
             $result = $connection2->prepare($sql);
             $result->execute($data);

--- a/modules/Timetable Admin/tt_editProcess.php
+++ b/modules/Timetable Admin/tt_editProcess.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
             } else {
                 //Check unique inputs for uniquness
                 try {
-                    $data = array('name' => $name, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonTTID' => $gibbonTTID);
+                    $data = array('name' => $name, 'gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonTTID' => $gibbonTTID);
                     $sql = 'SELECT * FROM gibbonTT WHERE (name=:name AND gibbonSchoolYearID=:gibbonSchoolYearID) AND NOT gibbonTTID=:gibbonTTID';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);


### PR DESCRIPTION
The add/edit timetable was checking uniqueness against the session school year vs. the target school year, which prevented adding timetables to upcoming years with the same name as the current year.