### PR TITLE
System: Google login fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ v14.0.00
 		System: fixed broken Credits link in footer
 		System: removed Media plugin from tinyMCE
 		System: added timestamp update when incrementing notification count
+		System: fixed error messages and failed login redirect on Google login page
 		Activities: added optional permission for activity organisers to manage their activities enrolment
 		Activities: fixed PHP Notice error (repeated many times) in activity add and edit interfaces
 		Activities: added optional permission for activity organisers to take attendance only within their activities

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -159,26 +159,10 @@ if (isset($authUrl)){
 			header("Location: {$URL}");
 			exit;
 		}
+
 		if ($row["passwordForceReset"] == "Y") {
-			$salt = getSalt();
-			$password = randomPassword(8);
-			$passwordStrong = hash("sha256", $salt.$password);
-
-			try {
-				$data = array("passwordStrong"=>$passwordStrong, "passwordStrongSalt"=>$salt, "username"=>$username);
-				$sql = "UPDATE gibbonPerson SET password='', passwordStrong=:passwordStrong, passwordStrongSalt=:passwordStrongSalt, failCount=0, passwordForceReset='N' WHERE username=:username";
-				$result = $connection2->prepare($sql);
-				$result->execute($data);
-			}
-			catch(PDOException $e) { }
-
-			$row["passwordForceReset"] = "N";
-
-			$to = $row["email"];
-			$subject = $_SESSION[$guid]["organisationNameShort"] . " Gibbon Password Reset";
-			$body = "Your new password for account $username is as follows:\n\n$password\n\nPlease log in an change your password as soon as possible.\n\n" . $_SESSION[$guid]["systemName"] . " Administrator";
-			$headers = "From: " . $_SESSION[$guid]["organisationAdministratorEmail"];
-			mail($to, $subject, $body, $headers);
+            // Sends the user to the password reset page after login
+            $_SESSION[$guid]['passwordForceReset'] = 'Y';
 		}
 
 

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -146,7 +146,10 @@ if (isset($authUrl)){
 			}
 
             setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, $row['gibbonPersonID'], 'Google Login - Failed', array('username' => $username, 'reason' => 'Too many failed logins'), $_SERVER['REMOTE_ADDR']);
-            $URL .= "?loginReturn=fail6";
+            unset($_SESSION[$guid]['googleAPIAccessToken'] );
+            unset($_SESSION[$guid]['gplusuer']);
+            @session_destroy();
+            $URL = "../../index.php?loginReturn=fail6";
 			header("Location: {$URL}");
 			exit;
 		}
@@ -176,7 +179,10 @@ if (isset($authUrl)){
 		if ($row["gibbonRoleIDPrimary"] == "" OR count(getRoleList($row["gibbonRoleIDAll"], $connection2)) == 0) {
 			//FAILED TO SET ROLES
             setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, $row['gibbonPersonID'], 'Google Login - Failed', array('username' => $username, 'reason' => 'Failed to set role(s)'), $_SERVER['REMOTE_ADDR']);
-            $URL .= "?loginReturn=fail2";
+            unset($_SESSION[$guid]['googleAPIAccessToken'] );
+            unset($_SESSION[$guid]['gplusuer']);
+            @session_destroy();
+            $URL = "../../index.php?loginReturn=fail2";
 			header("Location: {$URL}");
 			exit;
 		}

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -102,7 +102,7 @@ if (isset($authUrl)){
 
 	//Test to see if email exists in logintable
 	if ($result->rowCount() != 1) {
-        setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, null, 'Google Login - Failed', array('username' => $username, 'reason' => 'No matching email found', 'email' => $email), $_SERVER['REMOTE_ADDR']);
+        setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], null, null, 'Google Login - Failed', array('username' => $email, 'reason' => 'No matching email found', 'email' => $email), $_SERVER['REMOTE_ADDR']);
         unset($_SESSION[$guid]['googleAPIAccessToken'] );
 		unset($_SESSION[$guid]['gplusuer']);
  		session_destroy();
@@ -126,6 +126,9 @@ if (isset($authUrl)){
 		unset($_SESSION[$guid]['gplusuer']);
 		@session_destroy();
 		$_SESSION[$guid] = NULL;
+        $URL = "../../index.php?loginReturn=fail8";
+        header("Location: {$URL}");
+        exit;
 	}
 	else {
 		$row = $result->fetch();

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -114,7 +114,7 @@ if (isset($authUrl)){
 	//Start to collect User Info and test
 	try {
 		$data = array("email"=>$email);
-		$sql = "SELECT * FROM gibbonPerson WHERE email=:email AND status='Full' AND canLogin='Y'";
+		$sql = "SELECT * FROM gibbonPerson WHERE email=:email AND status='Full'";
 		$result = $connection2->prepare($sql);
 		$result->execute($data);
 	}
@@ -129,6 +129,16 @@ if (isset($authUrl)){
 	}
 	else {
 		$row = $result->fetch();
+
+        // Insufficient privileges to login
+        if ($row['canLogin'] != 'Y') {
+            unset($_SESSION[$guid]['googleAPIAccessToken'] );
+            unset($_SESSION[$guid]['gplusuer']);
+            @session_destroy();
+            $URL = "../../index.php?loginReturn=fail2";
+            header("Location: {$URL}");
+            exit;
+        }
 
 		$username = $row['username'];
 		if ($row["failCount"] >= 3) {


### PR DESCRIPTION
Found a redirect-loop in the google login script and patched up a few other issues along the way:

- An account with too many failed logins was creating a redirect loop rather than giving an error message
- An account with canLogin set to N was causing a blank page rather than an error message
- An account with a non-unique email could cause a PHP error and fail to redirect back to index
- The old style password reset wasn't working; fixed to send user to the password reset page after login
- Failed login notifications were using the old mail() function (and not sending for our system); replaced with Notification Event