### PR TITLE
System: Added ability to set mysql port through config.php

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,7 @@ v14.0.00
 		System: removed Media plugin from tinyMCE
 		System: added timestamp update when incrementing notification count
 		System: fixed error messages and failed login redirect on Google login page
+		System: added ability to set mysql port through config.php
 		Activities: added optional permission for activity organisers to manage their activities enrolment
 		Activities: fixed PHP Notice error (repeated many times) in activity add and edit interfaces
 		Activities: added optional permission for activity organisers to take attendance only within their activities

--- a/src/Gibbon/sqlConnection.php
+++ b/src/Gibbon/sqlConnection.php
@@ -78,7 +78,9 @@ class sqlConnection
 			return NULL;
 		}
 
-		return $this->generateConnection($databaseServer, $databaseName, $databaseUsername, $databasePassword, $message);
+		$databasePort = (isset($databasePort))? $databasePort : null;
+
+		return $this->generateConnection($databaseServer, $databaseName, $databaseUsername, $databasePassword, $databasePort, $message);
 	}
 
 	/**
@@ -92,13 +94,18 @@ class sqlConnection
 	 *
 	 * @return	Object	PDO Connection
 	 */
-	 private function generateConnection($databaseServer, $databaseName, $databaseUsername, $databasePassword, $message = NULL)
+	 private function generateConnection($databaseServer, $databaseName, $databaseUsername, $databasePassword, $databasePort = NULL, $message = NULL)
 	 {
 		$this->pdo = NULL;
 		$this->success = true;
 		try
 		{
-			$this->pdo = new \PDO("mysql:host=".$databaseServer.";dbname=".$databaseName.";charset=utf8", $databaseUsername, $databasePassword );
+			$dns = "mysql:host=$databaseServer;";
+			$dns .= (!empty($databasePort))? "port=$databasePort;" : '';
+			$dns .= "dbname=$databaseName;";
+			$dns .= "charset=utf8";
+
+			$this->pdo = new \PDO($dns, $databaseUsername, $databasePassword );
 			$this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 			$this->pdo->setAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC);
 			$this->setSQLMode();


### PR DESCRIPTION
Allows users to add $databasePort to their config file to specify a MySQL port number. Due to a PDO limitation, the port is only recognized when using `127.0.0.1` instead of localhost, or when using a specific hostname.