### PR TITLE
Attendance: Updated date used to check enrolment for Take Attendance

### DIFF
--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -276,14 +276,14 @@ else {
 
 					//Show roll group grid
 					try {
-						$dataCourseClass=array("gibbonCourseClassID"=>$gibbonCourseClassID, 'date' => $currentDate, 'today' => date('Y-m-d') );
+						$dataCourseClass=array("gibbonCourseClassID"=>$gibbonCourseClassID, 'date' => $currentDate);
 						$sqlCourseClass="SELECT gibbonPerson.surname, gibbonPerson.preferredName, gibbonPerson.gibbonPersonID, gibbonPerson.image_240 FROM gibbonCourseClassPerson
 							INNER JOIN gibbonPerson ON gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID
 							LEFT JOIN (SELECT gibbonTTDayRowClass.gibbonCourseClassID, gibbonTTDayRowClass.gibbonTTDayRowClassID FROM gibbonTTDayDate JOIN gibbonTTDayRowClass ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID) WHERE gibbonTTDayDate.date=:date) AS gibbonTTDayRowClassSubset ON (gibbonTTDayRowClassSubset.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID)
 							LEFT JOIN gibbonTTDayRowClassException ON (gibbonTTDayRowClassException.gibbonTTDayRowClassID=gibbonTTDayRowClassSubset.gibbonTTDayRowClassID AND gibbonTTDayRowClassException.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID)
 							WHERE gibbonCourseClassPerson.gibbonCourseClassID=:gibbonCourseClassID
 							AND status='Full' AND role='Student'
-							AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL OR dateEnd>=:today)
+							AND (dateStart IS NULL OR dateStart<=:date) AND (dateEnd IS NULL OR dateEnd>=:date)
 							GROUP BY gibbonCourseClassPerson.gibbonPersonID
 							HAVING COUNT(gibbonTTDayRowClassExceptionID) = 0
 							ORDER BY surname, preferredName" ;

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -75,8 +75,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 						<?php
                         echo "<option value=''></option>";
 						try {
-							$dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-							$sqlSelect = "SELECT * FROM gibbonPerson JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) WHERE gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID AND status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') ORDER BY surname, preferredName";
+							$dataSelect = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'date' => $currentDate);
+							$sqlSelect = "SELECT * FROM gibbonPerson JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) WHERE gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID AND status='Full' AND (dateStart IS NULL OR dateStart<=:date) AND (dateEnd IS NULL  OR dateEnd>=:date) ORDER BY surname, preferredName";
 							$resultSelect = $connection2->prepare($sqlSelect);
 							$resultSelect->execute($dataSelect);
 						} catch (PDOException $e) {

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -230,8 +230,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
                         //Show roll group grid
                         try {
-                            $dataRollGroup = array('gibbonRollGroupID' => $gibbonRollGroupID);
-                            $sqlRollGroup = "SELECT * FROM gibbonStudentEnrolment INNER JOIN gibbonPerson ON gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID WHERE gibbonRollGroupID=:gibbonRollGroupID AND status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') ORDER BY rollOrder, surname, preferredName";
+                            $dataRollGroup = array('gibbonRollGroupID' => $gibbonRollGroupID, 'date' => $currentDate);
+                            $sqlRollGroup = "SELECT * FROM gibbonStudentEnrolment INNER JOIN gibbonPerson ON gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID WHERE gibbonRollGroupID=:gibbonRollGroupID AND status='Full' AND (dateStart IS NULL OR dateStart<=:date) AND (dateEnd IS NULL  OR dateEnd>=:date) ORDER BY rollOrder, surname, preferredName";
                             $resultRollGroup = $connection2->prepare($sqlRollGroup);
                             $resultRollGroup->execute($dataRollGroup);
                         } catch (PDOException $e) {


### PR DESCRIPTION
The take attendance pages currently check the enrolment for a student based on their start and end dates using the current date. This can cause the class lists to appear incorrect when taking attendance for a date in the past when a student has joined the class after that day. This PR updates the roll group/class queries to use the date entered rather than current date, which reflects the enrolment at that point in time.