### PR TITLE
User Admin: Adjusted handling of Family Adult contact priorities

### DIFF
--- a/modules/User Admin/family_manage_edit_addAdultProcess.php
+++ b/modules/User Admin/family_manage_edit_addAdultProcess.php
@@ -93,10 +93,10 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
 
                     //Enforce one and only one contactPriority=1 parent
                     if ($contactPriority == 1) {
-                        //Set all other parents in family who are set to 1, to 2
+                        //Set all other parents in family who are set to 1 to 2, 2 to 3
                         try {
                             $dataCP = array('gibbonPersonID' => $gibbonPersonID, 'gibbonFamilyID' => $gibbonFamilyID);
-                            $sqlCP = 'UPDATE gibbonFamilyAdult SET contactPriority=2 WHERE gibbonFamilyID=:gibbonFamilyID AND NOT gibbonPersonID=:gibbonPersonID';
+                            $sqlCP = 'UPDATE gibbonFamilyAdult SET contactPriority=contactPriority+1 WHERE contactPriority < 3 AND gibbonFamilyID=:gibbonFamilyID AND NOT gibbonPersonID=:gibbonPersonID';
                             $resultCP = $connection2->prepare($sqlCP);
                             $resultCP->execute($dataCP);
                         } catch (PDOException $e) {
@@ -116,6 +116,17 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
                             $contactSMS = 'Y';
                             $contactEmail = 'Y';
                             $contactMail = 'Y';
+                        }
+
+                        // Set any other contact priority 2 to 3
+                        if ($contactPriority == 2) {
+                            try {
+                            $dataCP = array('gibbonPersonID' => $gibbonPersonID, 'gibbonFamilyID' => $gibbonFamilyID);
+                                $sqlCP = 'UPDATE gibbonFamilyAdult SET contactPriority=3 WHERE contactPriority=2 AND gibbonFamilyID=:gibbonFamilyID AND NOT gibbonPersonID=:gibbonPersonID';
+                                $resultCP = $connection2->prepare($sqlCP);
+                                $resultCP->execute($dataCP);
+                            } catch (PDOException $e) {
+                            }
                         }
                     }
 

--- a/modules/User Admin/family_manage_edit_deleteAdultProcess.php
+++ b/modules/User Admin/family_manage_edit_deleteAdultProcess.php
@@ -47,7 +47,7 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
         } else {
             try {
                 $data = array('gibbonFamilyID' => $gibbonFamilyID, 'gibbonPersonID' => $gibbonPersonID);
-                $sql = 'SELECT * FROM gibbonPerson, gibbonFamily, gibbonFamilyAdult WHERE gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID AND gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonFamily.gibbonFamilyID=:gibbonFamilyID AND gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID';
+                $sql = 'SELECT gibbonPerson.gibbonPersonID, gibbonFamilyAdult.contactPriority FROM gibbonPerson, gibbonFamily, gibbonFamilyAdult WHERE gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID AND gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonFamily.gibbonFamilyID=:gibbonFamilyID AND gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -60,6 +60,19 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
                 $URL .= '&return=error2';
                 header("Location: {$URL}");
             } else {
+                $row = $result->fetch();
+
+                // If we're deleting the first contact priority, move the second one to first
+                if ($row['contactPriority'] == 1) {
+                    try {
+                        $dataCP = array('gibbonPersonID' => $gibbonPersonID, 'gibbonFamilyID' => $gibbonFamilyID);
+                        $sqlCP = 'UPDATE gibbonFamilyAdult SET contactPriority=1 WHERE contactPriority=2 AND gibbonFamilyID=:gibbonFamilyID AND NOT gibbonPersonID=:gibbonPersonID LIMIT 1';
+                        $resultCP = $connection2->prepare($sqlCP);
+                        $resultCP->execute($dataCP);
+                    } catch (PDOException $e) {
+                    }
+                }
+
                 //Write to database
                 try {
                     $data = array('gibbonFamilyID' => $gibbonFamilyID, 'gibbonPersonID' => $gibbonPersonID);

--- a/modules/User Admin/family_manage_edit_editAdultProcess.php
+++ b/modules/User Admin/family_manage_edit_editAdultProcess.php
@@ -80,7 +80,7 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
                     //Set all other parents in family who are set to 1, to 2
                     try {
                         $dataCP = array('gibbonPersonID' => $gibbonPersonID, 'gibbonFamilyID' => $gibbonFamilyID);
-                        $sqlCP = 'UPDATE gibbonFamilyAdult SET contactPriority=2 WHERE gibbonFamilyID=:gibbonFamilyID AND NOT gibbonPersonID=:gibbonPersonID';
+                        $sqlCP = 'UPDATE gibbonFamilyAdult SET contactPriority=contactPriority+1 WHERE contactPriority < 3 AND gibbonFamilyID=:gibbonFamilyID AND NOT gibbonPersonID=:gibbonPersonID';
                         $resultCP = $connection2->prepare($sqlCP);
                         $resultCP->execute($dataCP);
                     } catch (PDOException $e) {
@@ -100,6 +100,17 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
                         $contactSMS = 'Y';
                         $contactEmail = 'Y';
                         $contactMail = 'Y';
+                    }
+
+                    // Set any other contact priority 2 to 3
+                    if ($contactPriority == 2) {
+                        try {
+                        $dataCP = array('gibbonPersonID' => $gibbonPersonID, 'gibbonFamilyID' => $gibbonFamilyID);
+                            $sqlCP = 'UPDATE gibbonFamilyAdult SET contactPriority=3 WHERE contactPriority=2 AND gibbonFamilyID=:gibbonFamilyID AND NOT gibbonPersonID=:gibbonPersonID';
+                            $resultCP = $connection2->prepare($sqlCP);
+                            $resultCP->execute($dataCP);
+                        } catch (PDOException $e) {
+                        }
                     }
                 }
 


### PR DESCRIPTION
PR to help address the contact priority issue from the forums: https://ask.gibbonedu.org/discussion/comment/2348#Comment_2348

Helps preserve one each for CP 1 and 2:
- When adding a CP 1, it bumps other CP 1 to 2, and 2 to 3s
- When adding a CP 2, it bumps the 2 to 3
- When deleting a CP 1, it bumps the 2 up to a 1 (but won't ever bump a 3 up)

I think this should help with the issue. The other thing the Query likely needs is a Group By on gibbonPersonID to handle any duplication from multiple CP 3s.