### PR TITLE
Attendance: Updated pre-fill logic for Attendance by Roll Group/Class

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -69,6 +69,8 @@ v14.0.00
 		Attendance: added dynamic legend for Student History report
 		Attendance: added extra role to allow form group attendance to be restricted to own form group
 		Attendance: updated Take Attendance by Class to exclude students with timetable exceptions
+		Attendance: fixed pre-filled attendance to always display the most recent attendance log
+		Attendance: updated pre-filled class attendance to not pre-fill for another class
 		Data Updater: made various fields optional when user has _any privileges
 		Finance: added ability to bulk issue invoices without sending email
 		Finance: tweaked interface for display of payment log to make it more usable

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -321,10 +321,17 @@ else {
 
 								$rowLog = array('type' => $defaultAttendanceType, 'reason' => '', 'comment' => '', 'context' => '');
 
-								//Get any student log data by context
 								try {
-									$dataLog=array("gibbonPersonID"=>$rowCourseClass["gibbonPersonID"], "date"=>$currentDate . "%", 'gibbonCourseClassID' => $gibbonCourseClassID);
-									$sqlLog="SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE context='Class' AND gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID AND date LIKE :date ORDER BY timestampTaken DESC" ;
+									$dataLog=array('gibbonPersonID'=>$rowCourseClass['gibbonPersonID'], 'date' => $currentDate.'%', 'gibbonCourseClassID' => $gibbonCourseClassID);
+
+									if ($prefillAttendanceType == 'Y') {
+										// Get any student log data
+										$sqlLog="SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE (context<>'Class' OR (context='Class' AND gibbonCourseClassID=:gibbonCourseClassID)) AND gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY timestampTaken DESC" ;
+									} else {
+										// Get student log data by Class context only
+										$sqlLog="SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE context='Class' AND gibbonCourseClassID=:gibbonCourseClassID AND gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY timestampTaken DESC" ;
+									}
+
 									$resultLog=$connection2->prepare($sqlLog);
 									$resultLog->execute($dataLog);
 								}
@@ -335,22 +342,6 @@ else {
 								if ($resultLog && $resultLog->rowCount() > 0 ) {
                                     $rowLog = $resultLog->fetch();
                                 }
-                                elseif ($prefillAttendanceType == 'Y') {
-									//Get any student log data
-									try {
-										$dataLog=array("gibbonPersonID"=>$rowCourseClass["gibbonPersonID"], "date"=>$currentDate . "%");
-										$sqlLog="SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY timestampTaken DESC" ;
-										$resultLog=$connection2->prepare($sqlLog);
-										$resultLog->execute($dataLog);
-									}
-									catch(PDOException $e) {
-										print "<div class='error'>" . $e->getMessage() . "</div>" ;
-									}
-
-									if ($resultLog && $resultLog->rowCount() > 0 ) {
-                                        $rowLog = $resultLog->fetch();
-                                    }
-								}
 
 
 								if ( $attendance->isTypeAbsent($rowLog["type"]) ) {

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -275,9 +275,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                                     $rowLog = array('type' => $defaultAttendanceType, 'reason' => '', 'comment' => '', 'context' => '');
 
                                     try {
-                                        //Get student log data by context
                                         $dataLog = array('gibbonPersonID' => $rowRollGroup['gibbonPersonID'], 'date' => $currentDate.'%');
-                                        $sqlLog = "SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE context='Roll Group' AND gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY timestampTaken DESC LIMIT 1";
+
+                                        if ($prefillAttendanceType == 'Y') {
+                                            //Get any student log data
+                                            $sqlLog = "SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE context <> 'Class' AND gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY timestampTaken DESC LIMIT 1";
+                                        } else {
+                                            //Get student log data by Roll Group context only
+                                            $sqlLog = "SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE context='Roll Group' AND gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY timestampTaken DESC LIMIT 1";
+                                        }
+
                                         $resultLog = $connection2->prepare($sqlLog);
                                         $resultLog->execute($dataLog);
                                     } catch (PDOException $e) {
@@ -286,20 +293,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
                                     if ($resultLog && $resultLog->rowCount() > 0 ) {
                                         $rowLog = $resultLog->fetch();
-                                    } elseif ($prefillAttendanceType == 'Y') {
-                                        //Get any student log data
-                                        try {
-                                            $dataLog = array('gibbonPersonID' => $rowRollGroup['gibbonPersonID'], 'date' => $currentDate.'%');
-                                            $sqlLog = 'SELECT * FROM gibbonAttendanceLogPerson, gibbonPerson WHERE gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY timestampTaken DESC LIMIT 1';
-                                            $resultLog = $connection2->prepare($sqlLog);
-                                            $resultLog->execute($dataLog);
-                                        } catch (PDOException $e) {
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
-                                        }
-
-                                        if ($resultLog && $resultLog->rowCount() > 0 ) {
-                                            $rowLog = $resultLog->fetch();
-                                        }
                                     }
 
                                     if ( $attendance->isTypeAbsent($rowLog["type"]) ) {


### PR DESCRIPTION
PR to fix attendance issue from release prep line 16:

- Pre-filled attendance will always show the most recent attendance status (except class attendance)
- Class attendance will pre-fill attendance logs from other contexts, but will no longer pre-fill from another class
- When pre-fill settings are disabled the Take Attendance pages will only show the most recent attendance status for the same context 