### PR TITLE
School Admin: Fixed Days of Week to prevent unset times for active days

### DIFF
--- a/modules/School Admin/daysOfWeek_manage.php
+++ b/modules/School Admin/daysOfWeek_manage.php
@@ -76,22 +76,24 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
             $row = $form->addRow()->addClass($day['name']);
                 $row->addLabel($day['name'].'schoolOpen', __('School Opens'));
                 $col = $row->addColumn()->addClass('right inline');
-                    $col->addSelect($day['name'].'schoolOpenH')
-                        ->fromString($hours)
-                        ->setClass('shortWidth')
-                        ->placeholder(__('Hours'))
-                        ->selected(substr($day['schoolOpen'], 0, 2));
-                    $col->addSelect($day['name'].'schoolOpenM')
-                        ->fromString($minutes)
-                        ->setClass('shortWidth')
-                        ->placeholder(__('Minutes'))
-                        ->selected(substr($day['schoolOpen'], 3, 2));
+                $col->addSelect($day['name'].'schoolOpenH')
+                    ->fromString($hours)
+                    ->isRequired()
+                    ->setClass('shortWidth')
+                    ->placeholder(__('Hours'))
+                    ->selected(substr($day['schoolOpen'], 0, 2));
+                $col->addSelect($day['name'].'schoolOpenM')
+                    ->fromString($minutes)
+                    ->setClass('shortWidth')
+                    ->placeholder(__('Minutes'))
+                    ->selected(substr($day['schoolOpen'], 3, 2));
 
             $row = $form->addRow()->addClass($day['name']);
                 $row->addLabel($day['name'].'schoolStart', __('School Starts'));
                 $col = $row->addColumn()->addClass('right inline');
                 $col->addSelect($day['name'].'schoolStartH')
                     ->fromString($hours)
+                    ->isRequired()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
                     ->selected(substr($day['schoolStart'], 0, 2));
@@ -106,6 +108,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                 $col = $row->addColumn()->addClass('right inline');
                 $col->addSelect($day['name'].'schoolEndH')
                     ->fromString($hours)
+                    ->isRequired()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
                     ->selected(substr($day['schoolEnd'], 0, 2));
@@ -120,6 +123,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                 $col = $row->addColumn()->addClass('right inline');
                 $col->addSelect($day['name'].'schoolCloseH')
                     ->fromString($hours)
+                    ->isRequired()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
                     ->selected(substr($day['schoolClose'], 0, 2));


### PR DESCRIPTION
- Updates Manage Days of Week to set the time fields to be required when a day is active. 
- Adds some logic to the process page to ensure times aren't null for an active day. 
- Changed error3 to warning1 because the loop saves data as it goes, so it's only a partial failure.
- Relaxed the field for Minutes a little so it defaults to 00 if unselected vs. generating an error.

This fixes the source of the problem for line 97. Let me know if you think the timetable function should also check & ensure it's not receiving null values.