### PR TITLE
Students: Fixed application form failing for logged in parents

### DIFF
--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -632,7 +632,7 @@ if ($proceed == false) {
 
             $row = $table->addRow()->setClass('break');
             $row->addContent($rowSelect['name'])->wrap('<strong>','</strong>')->addClass('shortWidth');
-            $row->addRadio('gibbonFamilyID')->fromArray(array($rowSelect['gibbonFamilyID'] => ''))->checked($checked)->isRequired();
+            $row->addRadio('gibbonFamilyID')->fromArray(array($rowSelect['gibbonFamilyID'] => ''))->checked($checked);
             $subTable = $row->addTable()->setClass('blank');
 
             while ($rowRelationships = $resultRelationships->fetch()) {

--- a/src/Forms/Input/Input.php
+++ b/src/Forms/Input/Input.php
@@ -64,14 +64,19 @@ abstract class Input extends Element implements ValidatableInterface
     {
         $output = '';
 
+        // Prevent LiveValidation breaking for elements with no ID
+        if (empty($this->getID())) {
+            return $output;
+        }
+
         if ($this->getRequired() == true || !empty($this->validation)) {
             $output .= 'var '.$this->getID().'Validate=new LiveValidation(\''.$this->getID().'\', {'.implode(',', $this->validationOptions).' }); '."\r";
 
             if ($this->getRequired() == true) {
                 if ($this instanceof Checkbox && $this->getOptionCount() == 1) {
-                    $output .= $this->getID().'Validate.add(Validate.Acceptance); '."\r";
+                    $this->addValidation('Validate.Acceptance');
                 } else {
-                    $output .= $this->getID().'Validate.add(Validate.Presence); '."\r";
+                    $this->addValidation('Validate.Presence');
                 }
             }
 

--- a/src/Forms/Input/Radio.php
+++ b/src/Forms/Input/Radio.php
@@ -35,7 +35,7 @@ class Radio extends Input
 
     public function __construct($name)
     {
-        $this->setID('');
+        $this->setID(''); // Cannot share an ID across multiple Radio inputs
         $this->setName($name);
     }
 
@@ -48,6 +48,12 @@ class Radio extends Input
     public function inline($value = true)
     {
         $this->inline = $value;
+        return $this;
+    }
+
+    public function addValidation($type, $params = '')
+    {
+        // Override and prevent; LiveValidation does not support Radio elements
         return $this;
     }
 

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1261,7 +1261,8 @@ div.notificationTray a.inactive {
 
 /* v14 */
 
-table.standardForm td:last-child:nth-child(2) {
+/* Ensure forms leave enough room in the second column for LiveValidation to fit. Updated to fix nested tables in forms. */
+table.standardForm td.standardWidth:last-child:nth-child(2) {
 	min-width: 450px;
 }
 


### PR DESCRIPTION
PR for release prep issue, line 204:
- It would seem LiveValidation doesn't support radio elements, so the isRequired on the gibbonFamilyID radio caused the whole LV for the form to break
- Removed isRequired from the application radio element, updated the Form Class handling of validation for the radio element
- Added an extra check to ensure blank element IDs can't make it into the LiveValidation for a form