### PR TITLE
System: Minor fixes for usability 

### DIFF
--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -798,7 +798,7 @@ else {
 									}
 									else {
 										$dataSelect=array("gibbonSchoolYearID"=>$_SESSION[$guid]["gibbonSchoolYearID"], "gibbonPersonID"=>$_SESSION[$guid]["gibbonPersonID"] );
-										$sqlSelect="SELECT gibbonCourse.* FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND NOT role LIKE '%- Left' ORDER BY name" ;
+										$sqlSelect="SELECT gibbonCourse.* FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND NOT role LIKE '%- Left' GROUP BY gibbonCourse.gibbonCourseID ORDER BY name" ;
 									}
 									$resultSelect=$connection2->prepare($sqlSelect);
 									$resultSelect->execute($dataSelect);

--- a/modules/Planner/units_dump.php
+++ b/modules/Planner/units_dump.php
@@ -187,7 +187,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_dump.php') =
                                 echo "<div class='error'>".$e->getMessage().'</div>';
                             }
 
-                            $resourceContents = '';
+                            $resourceContents = $row['details'];
 
                             while ($rowBlocks = $resultBlocks->fetch()) {
                                 if ($rowBlocks['title'] != '' or $rowBlocks['type'] != '' or $rowBlocks['length'] != '') {

--- a/modules/User Admin/permission_manage.php
+++ b/modules/User Admin/permission_manage.php
@@ -91,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/permission_mana
         $totalCount = 0;
         echo "<form method='post' action='".$_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/permission_manageProcess.php'>";
         echo "<input type='hidden' name='address' value='".$_SESSION[$guid]['address']."'>";
-        echo "<table class='mini' cellspacing='0' style='width: 100%'>";
+        echo "<table class='mini rowHighlight' cellspacing='0' style='width: 100%'>";
         while ($rowModules = $resultModules->fetch()) {
             echo "<tr class='break'>";
             echo '<td colspan='.($resultRoles->rowCount() + 1).'>';

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1336,6 +1336,11 @@ table tr.heading:first-child td:last-child {
 	padding-left: 5px !important;
 }
 
+/* Usability tweak to make large data tables like User Permissions easier to read */
+table.rowHighlight tr:hover td {
+	background: #EDF7FF !important;
+}
+
 /* Unfloat validation preceded by a phone input, adjust line height for vertical alignment */
 input[name*="phone"] ~ .LV_invalid {
     float: none;

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1337,7 +1337,7 @@ table tr.heading:first-child td:last-child {
 }
 
 /* Usability tweak to make large data tables like User Permissions easier to read */
-table.rowHighlight tr:hover td {
+table.rowHighlight tr:not(.break):hover td {
 	background: #EDF7FF !important;
 }
 


### PR DESCRIPTION
Some random things noticed during release prep:
- Accidentally turned on/off the wrong permission a few times (it can be hard to visually scan across the table when there's a fair number of roles.) Added a row highlight on hover to help indicate which permission is being changed.
- Unit Dump appeared to be ignoring resources added that were added to a unit: updated it to also include the Unit Outline when collecting/displaying resources.
- Messenger target for Courses was showing duplicate course names (I think FF automatically removes non-unique option values in a select list, but Chrome doesn't appear to)