### PR TITLE
System: Fixes for PHP notices

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -64,6 +64,7 @@ v14.0.00
 		Activities: added upper limit to number of columns in Printable Attendance Sheet
         Activities: fixed total attendance counts to exclude left students
         Activities: fixed PHP notice in Manage Enrolment
+        Activities: fixed PHP notice on status field in Activity Spread by Roll Group
 		Attendance: added ability (off by default) for students to register themselves as Present, when within a set of IP addresses
 		Attendance: added explicitly stored context recording where attendance was taken
 		Attendance: added settings to determine pre-filling of attendance in different contexts
@@ -76,6 +77,7 @@ v14.0.00
 		Crowd Assessment: fixed parent role determination error
 		Data Updater: made various fields optional when user has _any privileges
         Data Updater: fixed PHP notice for empty array in Student Data Updater History
+        Data Updater: fixed PHP notice for address country fields in Personal Data Updater
 		Finance: added ability to bulk issue invoices without sending email
 		Finance: tweaked interface for display of payment log to make it more usable
 		Finance: added ability to view and print receipts for refunded invoices
@@ -83,6 +85,7 @@ v14.0.00
 		Finance: fixed bug leading to invoice values changing (in print view only) after issue
 		Finance: added reminder number to Email Reminder section header in overdue invoice edit view
 		Finance: removed incorrectly applied currency label from expense export
+		Finance: fixed PHP notices for unset IDs in Manage Expenses and My Expense Requests
 		Formal Assessment: improved layout of Internal Assessment view
 		Formal Assessment: fixed incorrect string wrapping for translation in Internal Assessment import
 		Library: added new type to store Audio/Visual equipment
@@ -101,6 +104,7 @@ v14.0.00
 		Planner: fixed bug causing incorrect Satisfactory count in Work Summary by Form Group report
 		Planner: fixed PHP notice issue when listing lessons with unit that no longer exists
         Planner: added resources from unit outline to the resources tab in Unit Dump
+        Planner: fixed PHP notice on completion checkbox in Planner Deadlines
 		School Admin: fixed timezone issue in display of dates in Special Days view
 		School Admin: fixed bug in Manage School Days involving active days not having timings set
 		Staff: fixed PHP notice in Application Form edit Status field

--- a/modules/Activities/report_activitySpread_rollGroup.php
+++ b/modules/Activities/report_activitySpread_rollGroup.php
@@ -42,11 +42,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
         $gibbonRollGroupID = $_GET['gibbonRollGroupID'];
     }
     ?>
-	
+
 	<form method="get" action="<?php echo $_SESSION[$guid]['absoluteURL']?>/index.php">
-		<table class='smallIntBorder fullWidth' cellspacing='0'>	
+		<table class='smallIntBorder fullWidth' cellspacing='0'>
 			<tr>
-				<td style='width: 275px'> 
+				<td style='width: 275px'>
 					<b><?php echo __($guid, 'Roll Group') ?> *</b><br/>
 				</td>
 				<td class="right">
@@ -67,12 +67,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
 								echo "<option value='".$rowSelect['gibbonRollGroupID']."'>".htmlPrep($rowSelect['name']).'</option>';
 							}
 						}
-						?>				
+						?>
 					</select>
 				</td>
 			</tr>
 			<tr>
-				<td> 
+				<td>
 					<b><?php echo __($guid, 'Status') ?> *</b><br/>
 				</td>
 				<td class="right">
@@ -80,10 +80,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
 						<?php
                         echo "<option value='Accepted'>".__($guid, 'Accepted').'</option>';
 						$selected = '';
-						if ($_GET['status'] == 'Registered') {
+						if (!empty($_GET['status']) && $_GET['status'] == 'Registered') {
 							$selected = 'selected';
 						}
-						echo "<option $selected value='Registered'>".__($guid, 'Registered').'</option>';?>				
+						echo "<option $selected value='Registered'>".__($guid, 'Registered').'</option>';?>
 					</select>
 				</td>
 			</tr>

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -933,7 +933,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                                             $resultSelect->execute($dataSelect);
                                         } catch (PDOException $e) {
                                         }
-										if ($required['address1Country'] == 'Y') {
+										if (!empty($required['address1Country']) && $required['address1Country'] == 'Y') {
 											echo "<option value='Please select...'>".__($guid, 'Please select...').'</option>';
 										} else {
 											echo "<option value=''></option>";
@@ -1043,7 +1043,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                                             $resultSelect->execute($dataSelect);
                                         } catch (PDOException $e) {
                                         }
-										if ($required['address2Country'] == 'Y') {
+										if (!empty($required['address2Country']) && $required['address2Country'] == 'Y') {
 											echo "<option value='Please select...'>".__($guid, 'Please select...').'</option>';
 										} else {
 											echo "<option value=''></option>";

--- a/modules/Finance/expenseRequest_manage_add.php
+++ b/modules/Finance/expenseRequest_manage_add.php
@@ -131,13 +131,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 									<?php
                                     echo "<select name='gibbonFinanceBudgetID' id='gibbonFinanceBudgetID' style='width:302px'>";
 									$selected = '';
-									if ($gibbonFinanceBudgetID == '') {
+									if (empty($gibbonFinanceBudgetID)) {
 										$selected = 'selected';
 									}
 									echo "<option $selected value='Please select...'>".__($guid, 'Please select...').'</option>';
 									foreach ($budgets as $budget) {
 										$selected = '';
-										if ($gibbonFinanceBudgetID == $budget[0]) {
+										if (!empty($gibbonFinanceBudgetID) && $gibbonFinanceBudgetID == $budget[0]) {
 											$selected = 'selected';
 										}
 										echo "<option $selected value='".$budget[0]."'>".$budget[1].'</option>';
@@ -249,7 +249,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 									<span class="emphasis small">* <?php echo __($guid, 'denotes a required field'); ?></span>
 								</td>
 								<td class="right">
-									<input name="gibbonFinanceInvoiceID" id="gibbonFinanceInvoiceID" value="<?php echo $gibbonFinanceInvoiceID ?>" type="hidden">
 									<input name="status2" id="status2" value="<?php echo $status2 ?>" type="hidden">
 									<input name="gibbonFinanceBudgetID2" id="gibbonFinanceBudgetID2" value="<?php echo $gibbonFinanceBudgetID2 ?>" type="hidden">
 									<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">

--- a/modules/Finance/expenseRequest_manage_view.php
+++ b/modules/Finance/expenseRequest_manage_view.php
@@ -36,6 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
     //Check if params are specified
     $gibbonFinanceExpenseID = $_GET['gibbonFinanceExpenseID'];
     $gibbonFinanceBudgetCycleID = $_GET['gibbonFinanceBudgetCycleID'];
+    $status = '';
     $status2 = $_GET['status2'];
     $gibbonFinanceBudgetID2 = $_GET['gibbonFinanceBudgetID2'];
     if ($gibbonFinanceExpenseID == '' or $gibbonFinanceBudgetCycleID == '') {

--- a/modules/Finance/expenses_manage_approve.php
+++ b/modules/Finance/expenses_manage_approve.php
@@ -46,6 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
         //Check if params are specified
         $gibbonFinanceExpenseID = $_GET['gibbonFinanceExpenseID'];
         $gibbonFinanceBudgetCycleID = $_GET['gibbonFinanceBudgetCycleID'];
+        $status = '';
         $status2 = $_GET['status2'];
         $gibbonFinanceBudgetID2 = $_GET['gibbonFinanceBudgetID2'];
         if ($gibbonFinanceExpenseID == '' or $gibbonFinanceBudgetCycleID == '') {
@@ -191,7 +192,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
 
                                                 echo "<select name='gibbonFinanceBudgetID' id='gibbonFinanceBudgetID' style='width:302px'>";
                                                 $selected = '';
-                                                if ($gibbonFinanceBudgetID == '') {
+                                                if (empty($gibbonFinanceBudgetID)) {
                                                     $selected = 'selected';
                                                 }
                                                 echo "<option $selected value='Please select...'>".__($guid, 'Please select...').'</option>';

--- a/modules/Finance/expenses_manage_edit.php
+++ b/modules/Finance/expenses_manage_edit.php
@@ -48,6 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
         $gibbonFinanceBudgetCycleID = $_GET['gibbonFinanceBudgetCycleID'];
         $status2 = $_GET['status2'];
         $gibbonFinanceBudgetID2 = $_GET['gibbonFinanceBudgetID2'];
+        $gibbonFinanceBudgetID = '';
         if ($gibbonFinanceExpenseID == '' or $gibbonFinanceBudgetCycleID == '') {
             echo "<div class='error'>";
             echo __($guid, 'You have not specified one or more required parameters.');

--- a/modules/Planner/planner_deadlines.php
+++ b/modules/Planner/planner_deadlines.php
@@ -144,17 +144,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_deadlines.
 
                 ?>
 				<form method="get" action="<?php echo $_SESSION[$guid]['absoluteURL']?>/index.php">
-					<table class='noIntBorder' cellspacing='0' style="width: 100%">	
+					<table class='noIntBorder' cellspacing='0' style="width: 100%">
 						<tr><td style="width: 30%"></td><td></td></tr>
 						<tr>
-							<td> 
+							<td>
 								<b><?php echo __($guid, 'Search For') ?></b><br/>
 								<span class="emphasis small"><?php echo __($guid, 'Preferred, surname, username.') ?></span>
 							</td>
 							<td class="right">
 								<select name="search" id="search" class="standardWidth">
 									<option value=""></value>
-									<?php echo $options; ?> 
+									<?php echo $options; ?>
 								</select>
 							</td>
 						</tr>
@@ -785,7 +785,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_deadlines.
 										$completion = "<input disabled type='checkbox'>";
 									} else {
 										$status .= __($guid, 'Pending');
-										$completion = '<input '.$completionArray[$row['gibbonPlannerEntryID']]." name='complete-$count' type='checkbox'>";
+                                        $submissionCompletion = (isset($completionArray[$row['gibbonPlannerEntryID']]))? $completionArray[$row['gibbonPlannerEntryID']] : '';
+										$completion = "<input $submissionCompletion name='complete-$count' type='checkbox'>";
 									}
 								}
 								//After
@@ -795,7 +796,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_deadlines.
 										$completion = "<input disabled type='checkbox'>";
 									} else {
 										$status .= __($guid, 'Not submitted online');
-										@$completion = '<input '.$completionArray[$row['gibbonPlannerEntryID']]." name='complete-$count' type='checkbox'>";
+                                        $submissionCompletion = (isset($completionArray[$row['gibbonPlannerEntryID']]))? $completionArray[$row['gibbonPlannerEntryID']] : '';
+										$completion = "<input $submissionCompletion name='complete-$count' type='checkbox'>";
 									}
 								}
 							} else {


### PR DESCRIPTION
Testing continues, clearing out some more notices.

In expenseRequest_manage_add.php, the hidden gibbonFinanceInvoiceID appears to be vestigial (no variables to set it, and not used by the process page), took it out to fix a PHP notice.

(Some whitespace changes snuck in, ?w=1 to ignore them)