### PR TITLE
Attendance: Fixed daily attendance counts, partial future attendance

### DIFF
--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -198,10 +198,11 @@ else {
 								$dataLog=array("gibbonRollGroupID"=>$row["gibbonRollGroupID"], "date"=>$currentDate . "%");
 
 								$sqlLog="SELECT DISTINCT gibbonAttendanceLogRollGroupID, gibbonAttendanceLogRollGroup.timestampTaken as timestamp,
-								COUNT(DISTINCT gibbonPersonID) AS total,
-								COUNT(DISTINCT CASE WHEN gibbonAttendanceLogPerson.direction = 'Out' THEN gibbonPersonID END) AS absent
+								COUNT(DISTINCT gibbonAttendanceLogPerson.gibbonPersonID) AS total,
+								COUNT(DISTINCT CASE WHEN gibbonAttendanceLogPerson.direction = 'Out' THEN gibbonAttendanceLogPerson.gibbonPersonID END) AS absent
 								FROM gibbonAttendanceLogPerson
-								JOIN gibbonAttendanceLogRollGroup ON gibbonAttendanceLogRollGroup.date = gibbonAttendanceLogPerson.date
+								JOIN gibbonAttendanceLogRollGroup ON (gibbonAttendanceLogRollGroup.date = gibbonAttendanceLogPerson.date)
+								JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonAttendanceLogPerson.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonAttendanceLogRollGroup.gibbonRollGroupID)
 								WHERE gibbonAttendanceLogRollGroup.gibbonRollGroupID=:gibbonRollGroupID
 								AND gibbonAttendanceLogPerson.date LIKE :date
 								AND gibbonAttendanceLogPerson.context = 'Roll Group'

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -217,7 +217,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
 
 
                 if ($rowLog['context'] != '') {
-                    if ($rowLog['context'] == 'Class' && $rowLog['gibbonCourseClassID'] > 0)
+                    if (($rowLog['context'] == 'Future' || $rowLog['context'] == 'Class') && $rowLog['gibbonCourseClassID'] > 0)
                         echo '<td>'.__($guid, $rowLog['context']).' ('.$rowLog['courseName'].'.'.$rowLog['className'].')</td>';
                     else
                         echo '<td>'.__($guid, $rowLog['context']).'</td>';

--- a/modules/Attendance/attendance_future_byPersonProcess.php
+++ b/modules/Attendance/attendance_future_byPersonProcess.php
@@ -141,7 +141,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
 
                                             try {
                                                 $dataUpdate = array('gibbonPersonID' => $gibbonPersonID, 'direction' => $direction, 'type' => $type, 'reason' => $reason, 'comment' => $comment, 'gibbonPersonIDTaker' => $_SESSION[$guid]['gibbonPersonID'], 'date' => $date, 'gibbonCourseClassID' => $course, 'timestampTaken' => date('Y-m-d H:i:s'));
-                                                $sqlUpdate = 'INSERT INTO gibbonAttendanceLogPerson SET gibbonAttendanceCodeID=(SELECT gibbonAttendanceCodeID FROM gibbonAttendanceCode WHERE name=:type), gibbonPersonID=:gibbonPersonID, direction=:direction, type=:type, context=\'Future\', reason=:reason, comment=:comment, gibbonPersonIDTaker=:gibbonPersonIDTaker, date=:date, gibbonCourseClassID=:gibbonCourseClassID, timestampTaken=:timestampTaken';
+                                                $sqlUpdate = 'INSERT INTO gibbonAttendanceLogPerson SET gibbonAttendanceCodeID=(SELECT gibbonAttendanceCodeID FROM gibbonAttendanceCode WHERE name=:type), gibbonPersonID=:gibbonPersonID, direction=:direction, type=:type, context=\'Class\', reason=:reason, comment=:comment, gibbonPersonIDTaker=:gibbonPersonIDTaker, date=:date, gibbonCourseClassID=:gibbonCourseClassID, timestampTaken=:timestampTaken';
                                                 $resultUpdate = $connection2->prepare($sqlUpdate);
                                                 $resultUpdate->execute($dataUpdate);
                                             } catch (PDOException $e) {


### PR DESCRIPTION
- PR #263 fixed the checkmark on View Daily Attendance for roll groups but the query needed updated to ensure correct in/out counts
- Partial attendance wasn't working properly with the Future context (no differentiation in Future - Roll Group vs Future - Class). Changed it back to Class for partial future attendance. Wondering about the utility value of the Future context 🤔
- Something odd was up with the printable Activity attendance sheet (it was fetching the same result set twice, and so the student list didn't show up).

I think these are all v14-only fixes so I'm not sure if they're changelog worthy.

_(Again, ?w=1 as very few lines have actually changed. Wish I could default this.)_