### PR TITLE
Tests: Added additional check to prevent running on production

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,3 +18,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 require_once '../gibbon.php';
+
+$installType = getSettingByScope($connection2, 'System', 'installType');
+if ($installType == 'Production') {
+    die('ERROR: Test suite cannot run on a production system.'."\n");
+}


### PR DESCRIPTION
Added a check to the Codeception tests to help ensure it can't run on production systems. Someone would also have to install PHPUnit and Codeception on their server, and edit the config file to add the test environment variable ... but one more preventative measure couldn't hurt.