### PR TITLE
Students: updated Edit Application Form to handle spaces in privacy options csv

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -120,6 +120,7 @@ v14.0.00
         Students: fixed auto-assign houses potentially failing on Application Form acceptance if houses are empty
         Students: fixed PHP notice for gibbonPersonID in Add Medical Form
         Students: fixed link to Add Medical Form in Student Profile
+        Students: updated Edit Application Form to handle spaces in privacy options csv
 		Timetable: fixed TT not being navigable if user is not involved in any timetable
 		Timetable Admin: fix bulk checking bug in Tie Days to Dates
 		Timetable Admin: widened listing of staff in Course Enrolment by Person to include all staff (not just Teaching staff)

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -919,10 +919,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     if ($privacySetting == 'Y' && !empty($privacyBlurb) && !empty($privacyOptions)) {
         $options = array_map(function($item) { return trim($item); }, explode(',', $privacyOptions));
+        $checked = array_map(function($item) { return trim($item); }, explode(',', $application['privacy']));
 
         $row = $form->addRow();
-            $row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
-            $row->addCheckbox('privacyOptions[]')->fromArray($options);
+            $row->addLabel('privacyOptions', __('Privacy'))->description($privacyBlurb);
+            $row->addCheckbox('privacyOptions')->fromArray($options)->checked($checked);
     }
 
     // ⋆⋆⋆ Magic ⋆⋆⋆

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -922,8 +922,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $checked = array_map(function($item) { return trim($item); }, explode(',', $application['privacy']));
 
         $row = $form->addRow();
-            $row->addLabel('privacyOptions', __('Privacy'))->description($privacyBlurb);
-            $row->addCheckbox('privacyOptions')->fromArray($options)->checked($checked);
+            $row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
+            $row->addCheckbox('privacyOptions[]')->fromArray($options)->checked($checked);
     }
 
     // ⋆⋆⋆ Magic ⋆⋆⋆

--- a/modules/Students/applicationForm_manage_editProcess.php
+++ b/modules/Students/applicationForm_manage_editProcess.php
@@ -504,7 +504,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                 $privacyOptions = $_POST['privacyOptions'];
                 foreach ($privacyOptions as $privacyOption) {
                     if ($privacyOption != '') {
-                        $privacy .= $privacyOption.', ';
+                        $privacy .= $privacyOption.',';
                     }
                 }
                 if ($privacy != '') {

--- a/modules/Students/applicationForm_manage_editProcess.php
+++ b/modules/Students/applicationForm_manage_editProcess.php
@@ -508,7 +508,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                     }
                 }
                 if ($privacy != '') {
-                    $privacy = substr($privacy, 0, -2);
+                    $privacy = substr($privacy, 0, -1);
                 } else {
                     $privacy = null;
                 }


### PR DESCRIPTION
An odd one: looks like the process page for Edit Application Form was adding spaces to the privacy options csv. I checked the User Edit process page and it isn't doing the same, so I took out the extra spaces and updated the Edit Application page to handle records with existing spaces.