### PR TITLE
Students: Fixed School History in profile to exclude upcoming years

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ v15.0.00
 
 	Tweaks & Bug Fixes
 		i18n: fixed erroneous Georgian language code
+		Students: fixed School History section in Student Profile to exclude upcoming years
 
 v14.0.00
 --------

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -503,7 +503,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         }
                         try {
                             $dataSelect = array('gibbonPersonID' => $row['gibbonPersonID']);
-                            $sqlSelect = 'SELECT gibbonRollGroup.name AS rollGroup, gibbonSchoolYear.name AS schoolYear FROM gibbonStudentEnrolment JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE gibbonPersonID=:gibbonPersonID ORDER BY gibbonStudentEnrolment.gibbonSchoolYearID';
+                            $sqlSelect = "SELECT gibbonRollGroup.name AS rollGroup, gibbonSchoolYear.name AS schoolYear
+                                FROM gibbonStudentEnrolment
+                                JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                                JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
+                                WHERE gibbonPersonID=:gibbonPersonID
+                                AND (gibbonSchoolYear.status = 'Current' OR gibbonSchoolYear.status='Past')
+                                ORDER BY gibbonStudentEnrolment.gibbonSchoolYearID";
                             $resultSelect = $connection2->prepare($sqlSelect);
                             $resultSelect->execute($dataSelect);
                         } catch (PDOException $e) {


### PR DESCRIPTION
This one caused an unexpected surprise when the enrolment for upcoming years was visible even though the user role did not have access to future years 😧 