### PR TITLE
System: fixed form validation for dropdowns created with User Custom Fields

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ v15.0.00
 		System: fixed erroneous Georgian language code
 		System: added Greek as development language
 		System: added South African Rand as currency
+		System: fixed missing form validation for dropdowns created with User Custom Fields
 		Attendance: fixed GROUP BY issue in moduleFunctions.php when MySQL is using only_full_group_by
 		Behaviour: fixed typo in three settings
 		Departments: fixed bug preventing students from seeing other students in a class

--- a/src/Forms/Input/CustomField.php
+++ b/src/Forms/Input/CustomField.php
@@ -114,4 +114,9 @@ class CustomField extends Input
     {
         return $this->customField->getElement();
     }
+
+    public function getValidationOutput()
+    {
+        return $this->customField->getValidationOutput();
+    }
 }


### PR DESCRIPTION
Fix for #289. The CustomField class internally creates an object based on the variable types of custom fields. This fix updates the CustomField class to override the getValidationOutput() method from the Input base class to pass the getValidationOutput() from the internal object instead. Tested & working for each type of custom field.