### PR TITLE
Students: fixed default selected gibbonFamilyID in Application Form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ v15.0.00
 		Finance: set name of outgoing email to school name, not user's name
 		Library: added Optical Media as item type
 		Students: fixed School History section in Student Profile to exclude upcoming years
+		Students: fixed Application Form for logged in users not selecting a family by default (if one exists)
 		Timetable: added ability to set and display text and background colour for timetable day headers
 		Timetable: adjusted font size for shorter lessons to allow display or facility name
 		Timetable Admin: added link from course view in Manage Courses & Classes to edit class enrolment

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -616,9 +616,14 @@ if ($proceed == false) {
         $header->addContent(__('Selected'));
         $header->addContent(__('Relationships'));
 
-        $rowCount = 0;
+        $checked = null;
         while ($rowSelect = $resultSelect->fetch()) {
-            $checked = (isset($application['gibbonFamilyID']))? ($application['gibbonFamilyID'] == $rowSelect['gibbonFamilyID']) : ($rowCount == 0);
+            // Re-select the family for sibling applications, otherwise select the first family
+            if (isset($application['gibbonFamilyID'])) {
+                $checked = $application['gibbonFamilyID'];
+            } else if (is_null($checked)) {
+                $checked = $rowSelect['gibbonFamilyID'];
+            }
 
             // Get the family relationships
             try {
@@ -648,8 +653,6 @@ if ($proceed == false) {
             if ($resultSelect->rowCount() == 1) {
                 $gibbonFamilyID = $rowSelect['gibbonFamilyID'];
             }
-
-            $rowCount++;
         }
     }
 


### PR DESCRIPTION
For issue #291. This fix updates the Student Application Form to always select the first gibbonFamilyID when one or more families are available to select (ensuring the value is never null).

This one must have snuck past us in pre-release testing (although I do recall testing the logged-in application form a few times). Currently there isn't an automated test for the logged-in family-exists variant of the form so I've made a note to write one.

We had previously discovered that LiveValidation doesn't work for Radio elements (because LV uses IDs and they have to be unique). This means currently there's no handling for required radio elements. Do you think it would make sense to update the Radio class to always select a default value if its a required field? It makes it possible for a user to accidentally leave the default selected, but that's likely better than submitting a form with nothing selected, as currently there isn't a way to flag it during LiveValidation 🤔 