### PR TITLE
Students: fixed display of Other Fields headings for parents in Application Form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,7 @@ v15.0.00
 		Students: fixed School History section in Student Profile to exclude upcoming years
 		Students: fixed Application Form for logged in users not selecting a family by default (if one exists)
 		Students: fixed interface string issue in student details screen
+		Students: fixed display of Other Fields heading for parents in Application Form
 		Timetable: added ability to set and display text and background colour for timetable day headers
 		Timetable: adjusted font size for shorter lessons to allow display or facility name
 		Timetable Admin: added link from course view in Manage Courses & Classes to edit class enrolment

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -376,7 +376,7 @@ if ($proceed == false) {
     // CUSTOM FIELDS FOR STUDENT
     $resultFields = getCustomFields($connection2, $guid, true, false, false, false, true, null);
     if ($resultFields->rowCount() > 0) {
-        $heading = $form->addRow()->addSubheading('Other Information');
+        $heading = $form->addRow()->addSubheading(__('Other Information'));
 
         while ($rowFields = $resultFields->fetch()) {
             $name = 'custom'.$rowFields['gibbonPersonFieldID'];
@@ -456,8 +456,11 @@ if ($proceed == false) {
             $existingFields = (isset($application["parent1fields"]))? unserialize($application["parent1fields"]) : null;
             $resultFields = getCustomFields($connection2, $guid, false, false, true, false, true, null);
             if ($resultFields->rowCount() > 0) {
+                $row = $form->addRow();
+                $row->addSubheading(__('Parent/Guardian').' 1 '.__('Other Fields'));
+
                 while ($rowFields = $resultFields->fetch()) {
-                    $name = "parent{$i}custom".$rowFields['gibbonPersonFieldID'];
+                    $name = "parent1custom".$rowFields['gibbonPersonFieldID'];
                     $value = (isset($existingFields[$rowFields['gibbonPersonFieldID']]))? $existingFields[$rowFields['gibbonPersonFieldID']] : '';
 
                     $row = $form->addRow();
@@ -586,12 +589,12 @@ if ($proceed == false) {
                 $row->addTextField("parent{$i}employer")->maxLength(30)->loadFrom($application);
 
             // CUSTOM FIELDS FOR PARENTS
-            $row = $form->addRow()->setClass("parentSection{$i}");
-                $row->addSubheading(__('Parent/Guardian')." $i ".__('Other Fields'));
-
             $existingFields = (isset($application["parent{$i}fields"]))? unserialize($application["parent{$i}fields"]) : null;
             $resultFields = getCustomFields($connection2, $guid, false, false, true, false, true, null);
             if ($resultFields->rowCount() > 0) {
+                $row = $form->addRow()->setClass("parentSection{$i}");
+                $row->addSubheading(__('Parent/Guardian')." $i ".__('Other Fields'));
+
                 while ($rowFields = $resultFields->fetch()) {
                     $name = "parent{$i}custom".$rowFields['gibbonPersonFieldID'];
                     $value = (isset($existingFields[$rowFields['gibbonPersonFieldID']]))? $existingFields[$rowFields['gibbonPersonFieldID']] : '';

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -452,7 +452,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     $existingFields = (isset($application["fields"]))? unserialize($application["fields"]) : null;
     $resultFields = getCustomFields($connection2, $guid, true, false, false, false, true, null);
     if ($resultFields->rowCount() > 0) {
-        $heading = $form->addRow()->addSubheading('Other Information');
+        $heading = $form->addRow()->addSubheading(__('Other Information'));
 
         while ($rowFields = $resultFields->fetch()) {
             $name = 'custom'.$rowFields['gibbonPersonFieldID'];
@@ -513,8 +513,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
             $existingFields = (isset($application["parent1fields"]))? unserialize($application["parent1fields"]) : null;
             $resultFields = getCustomFields($connection2, $guid, false, false, true, false, true, null);
             if ($resultFields->rowCount() > 0) {
+                $row = $form->addRow();
+                $row->addSubheading(__('Parent/Guardian').' 1 '.__('Other Fields'));
+
                 while ($rowFields = $resultFields->fetch()) {
-                    $name = "parent{$i}custom".$rowFields['gibbonPersonFieldID'];
+                    $name = "parent1custom".$rowFields['gibbonPersonFieldID'];
                     $value = (isset($existingFields[$rowFields['gibbonPersonFieldID']]))? $existingFields[$rowFields['gibbonPersonFieldID']] : '';
 
                     $row = $form->addRow();
@@ -644,12 +647,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                 $row->addTextField("parent{$i}employer")->maxLength(30);
 
             // CUSTOM FIELDS FOR PARENTS
-            $row = $form->addRow()->setClass("parentSection{$i}");
-                $row->addSubheading(__('Parent/Guardian')." $i ".__('Other Fields'));
-
             $existingFields = (isset($application["parent{$i}fields"]))? unserialize($application["parent{$i}fields"]) : null;
             $resultFields = getCustomFields($connection2, $guid, false, false, true, false, true, null);
             if ($resultFields->rowCount() > 0) {
+                $row = $form->addRow()->setClass("parentSection{$i}");
+                $row->addSubheading(__('Parent/Guardian')." $i ".__('Other Fields'));
+
                 while ($rowFields = $resultFields->fetch()) {
                     $name = "parent{$i}custom".$rowFields['gibbonPersonFieldID'];
                     $value = (isset($existingFields[$rowFields['gibbonPersonFieldID']]))? $existingFields[$rowFields['gibbonPersonFieldID']] : '';


### PR DESCRIPTION
- adds missing Other Fields heading for logged-in parent
- hides Other Fields heading for parents when no custom fields are set
- also adds missing translation wrapper on student Other Information heading