### PR TITLE
Planner: updated show/hide behaviour for attendance reason & comment

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ v15.0.00
 		Finance: set name of outgoing email to school name, not user's name
 		Individual Needs: added ability to record educational assistants for a student
 		Library: added Optical Media as item type
+		Planner: updated attendance to only hide the reason and comment fields if Present is the default attendance
 		Students: fixed School History section in Student Profile to exclude upcoming years
 		Students: fixed Application Form for logged in users not selecting a family by default (if one exists)
 		Students: fixed interface string issue in student details screen

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -1658,14 +1658,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                             if ($attendanceEnabled && $row['role'] == 'Teacher' and $teacher == true) {
                                 if ($rowClassGroup['role'] == 'Student') {
 
-
                                     $_SESSION[$guid]['sidebarExtra'] .= "<input type='hidden' name='$countStudents-gibbonPersonID' value='".$rowClassGroup['gibbonPersonID']."' data-id='$countStudents'>";
 
                                     $_SESSION[$guid]['sidebarExtra'] .= $attendance->renderAttendanceTypeSelect( $rowLog['type'], "$countStudents-type", '86px;margin-left:1px;');
 
-                                    $_SESSION[$guid]['sidebarExtra'] .= "<div id='$countStudents-hideReasons' style='display:none;'>";
-                                        $_SESSION[$guid]['sidebarExtra'] .= $attendance->renderAttendanceReasonSelect( $rowLog['reason'], "$countStudents-reason", '84px');
-                                        $_SESSION[$guid]['sidebarExtra'] .= "<input type='text' maxlength=255 name='$countStudents-comment' id='$countStudents-comment' style='float: none; width:82px; margin-bottom: 3px' value='".htmlPrep($rowLog['comment'])."'>";
+                                    // Only hide the reason and comment fields if Present is the default attendance type
+                                    if ($defaultAttendanceType == 'Present') {
+                                        $_SESSION[$guid]['sidebarExtra'] .= "<div id='$countStudents-hideReasons' style='display:none;'>";
+                                    } else {
+                                        $_SESSION[$guid]['sidebarExtra'] .= "<div>";
+                                    }
+
+                                    $_SESSION[$guid]['sidebarExtra'] .= $attendance->renderAttendanceReasonSelect( $rowLog['reason'], "$countStudents-reason", '84px');
+                                    $_SESSION[$guid]['sidebarExtra'] .= "<input type='text' maxlength=255 name='$countStudents-comment' id='$countStudents-comment' style='float: none; width:82px; margin-bottom: 3px' value='".htmlPrep($rowLog['comment'])."'>";
                                     $_SESSION[$guid]['sidebarExtra'] .= "</div>";
 
                                 }


### PR DESCRIPTION
The reason and comment fields in planner attendance are hidden by default and only appear on change, to keep the sidebar less cluttered. Updated this behaviour to only apply when Present is the default attendance type.