### PR TITLE
School Admin: updated Manage School Years to prevent removing or unsetting the current School Year

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ v15.0.00
 		Individual Needs: added ability to record educational assistants for a student
 		Library: added Optical Media as item type
 		Planner: updated attendance to only hide the reason and comment fields if Present is the default attendance
+		School Admin: updated Manage School Years to prevent removing or unsetting the current School Year
 		Students: fixed School History section in Student Profile to exclude upcoming years
 		Students: fixed Application Form for logged in users not selecting a family by default (if one exists)
 		Students: fixed interface string issue in student details screen

--- a/functions.php
+++ b/functions.php
@@ -4307,7 +4307,7 @@ function setCurrentSchoolYear($guid,  $connection2)
     //Check number of rows returned.
     //If it is not 1, show error
     if (!($result->rowCount() == 1)) {
-        die(__($guid, 'Your request failed due to a database error.'));
+        die(__($guid, 'Configuration Error: there is a problem accessing the current Academic Year from the database.'));
     }
     //Else get schoolYearID
     else {

--- a/login.php
+++ b/login.php
@@ -180,7 +180,7 @@ else {
                             //Check number of rows returned.
                             //If it is not 1, show error
                             if (!($resultYear->rowCount() == 1)) {
-                                die('Configuration Error: there is a problem accessing the current Academic Year from the database.');
+                                die(__($guid, 'Configuration Error: there is a problem accessing the current Academic Year from the database.'));
                             }
                             //Else get year details
                             else {

--- a/modules/School Admin/schoolYear_manage.php
+++ b/modules/School Admin/schoolYear_manage.php
@@ -98,7 +98,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
             echo '</td>';
             echo '<td>';
             echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/schoolYear_manage_edit.php&gibbonSchoolYearID='.$row['gibbonSchoolYearID']."'><img title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
-            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/schoolYear_manage_delete.php&gibbonSchoolYearID='.$row['gibbonSchoolYearID']."'><img title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a> ";
+
+            // Only non-current School Years are delete-able
+            if ($row['status'] != 'Current') {
+                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/schoolYear_manage_delete.php&gibbonSchoolYearID='.$row['gibbonSchoolYearID']."'><img title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a> ";
+            }
             echo '</td>';
             echo '</tr>';
 

--- a/modules/School Admin/schoolYear_manage_add.php
+++ b/modules/School Admin/schoolYear_manage_add.php
@@ -60,6 +60,13 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
         $row->addLabel('status', __('Status'));
         $row->addSelect('status')->fromArray($statuses)->isRequired()->selected('Upcoming');
 
+    $form->toggleVisibilityByClass('statusChange')->onSelect('status')->when('Current');
+    $direction = __('Past');
+
+    // Display an alert to warn users that changing this will have an impact on their system.
+    $row = $form->addRow()->setClass('statusChange');
+    $row->addAlert(sprintf(__('Setting the status of this school year to Current will change the current school year %1$s to %2$s. Adjustments to the Academic Year can affect the visibility of vital data in your system. It\'s recommended to use the Rollover tool in User Admin to advance school years rather than changing them here. PROCEED WITH CAUTION!'), $_SESSION[$guid]['gibbonSchoolYearNameCurrent'], $direction) );
+
     $row = $form->addRow();
         $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
         $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYear')->isRequired()->maxLength(3);

--- a/modules/School Admin/schoolYear_manage_addProcess.php
+++ b/modules/School Admin/schoolYear_manage_addProcess.php
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
             if ($status == 'Current') {
                 try {
                     $data = array();
-                    $sql = "SELECT * FROM gibbonSchoolYear WHERE status='Current'";
+                    $sql = "SELECT gibbonSchoolYearID, sequenceNumber FROM gibbonSchoolYear WHERE status='Current'";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
@@ -74,17 +74,34 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
                     exit();
                 }
                 if ($result->rowCount() > 0) {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
-                    exit();
+                    // Enforces a single current school year by updating the status of the previous current year
+                    while ($currentSchoolYear = $result->fetch()) {
+                        $direction = ($sequenceNumber < $currentSchoolYear['sequenceNumber'])? 'Upcoming' : 'Past';
+                        try {
+                            $data = array('gibbonSchoolYearID' => $currentSchoolYear['gibbonSchoolYearID'], 'status' => $direction, 'sequenceNumber' => $sequenceNumber);
+                            $sql = "UPDATE gibbonSchoolYear SET status = (CASE
+                                WHEN gibbonSchoolYearID=:gibbonSchoolYearID THEN :status
+                                WHEN sequenceNumber < :sequenceNumber THEN 'Past'
+                                ELSE 'Upcoming'
+                            END)";
+                            $resultUpdate = $connection2->prepare($sql);
+                            $resultUpdate->execute($data);
+                        } catch (PDOException $e) {
+                            $currentFail = true;
+                        }
+                    }
                 }
             }
 
-            if ($currentFail == false) {
+            if ($currentFail) {
+                $URL .= '&return=error2';
+                header("Location: {$URL}");
+                exit();
+            } else {
                 //Write to database
                 try {
                     $data = array('name' => $name, 'status' => $status, 'sequenceNumber' => $sequenceNumber, 'firstDay' => $firstDay, 'lastDay' => $lastDay);
-                    $sql = 'INSERT INTO gibbonSchoolYear SET name=:name, status=:status, sequenceNumber=:sequenceNumber, firstDay=:firstDay, lastDay=:lastDay';
+                    $sql = "INSERT INTO gibbonSchoolYear SET name=:name, status=:status, sequenceNumber=:sequenceNumber, firstDay=:firstDay, lastDay=:lastDay";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
@@ -94,6 +111,13 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
 
                 //Last insert ID
                 $AI = str_pad($connection2->lastInsertID(), 3, '0', STR_PAD_LEFT);
+
+                // Update session vars so the user is warned if they're logged into a different year
+                if ($status == 'Current') {
+                    $_SESSION[$guid]['gibbonSchoolYearIDCurrent'] = $AI;
+                    $_SESSION[$guid]['gibbonSchoolYearNameCurrent'] = $name;
+                    $_SESSION[$guid]['gibbonSchoolYearSequenceNumberCurrent'] = $sequenceNumber;
+                }
 
                 $URL .= "&return=success0&editID=$AI";
                 header("Location: {$URL}");

--- a/modules/School Admin/schoolYear_manage_edit.php
+++ b/modules/School Admin/schoolYear_manage_edit.php
@@ -86,12 +86,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
                     $row->addLabel('status', __('Status'));
                     $row->addSelect('status')->fromArray($statuses)->isRequired()->selected($values['status']);
 
-                    $form->toggleVisibilityByClass('statusChangePast')->onSelect('status')->when('Current');
+                    $form->toggleVisibilityByClass('statusChange')->onSelect('status')->when('Current');
                     $direction = ($values['sequenceNumber'] < $_SESSION[$guid]['gibbonSchoolYearSequenceNumberCurrent'])? __('Upcoming') : __('Past');
 
                     // Display an alert to warn users that changing this will have an impact on their system.
-                    $row = $form->addRow()->setClass('statusChangePast');
-                    $row->addAlert(sprintf(__('Changing the status of this school year to Current will set the current school year %1$s to %2$s. Adjustments to the Academic Year can affect the visibility of vital data in your system. It\'s recommended to use the Rollover tool in User Admin to advance school years rather than changing them here. PROCEED WITH CAUTION!'), $_SESSION[$guid]['gibbonSchoolYearNameCurrent'], $direction) );
+                    $row = $form->addRow()->setClass('statusChange');
+                    $row->addAlert(sprintf(__('Setting the status of this school year to Current will change the current school year %1$s to %2$s. Adjustments to the Academic Year can affect the visibility of vital data in your system. It\'s recommended to use the Rollover tool in User Admin to advance school years rather than changing them here. PROCEED WITH CAUTION!'), $_SESSION[$guid]['gibbonSchoolYearNameCurrent'], $direction) );
             }
 
             $row = $form->addRow();

--- a/modules/School Admin/schoolYear_manage_edit.php
+++ b/modules/School Admin/schoolYear_manage_edit.php
@@ -76,9 +76,23 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
                 $row->addLabel('name', __('Name'));
                 $row->addTextField('name')->isRequired()->maxLength(9)->setValue($values['name']);
 
-            $row = $form->addRow();
-                $row->addLabel('status', __('Status'));
-                $row->addSelect('status')->fromArray($statuses)->isRequired()->selected($values['status']);
+            if ($values['status'] == 'Current') {
+                $form->addHiddenValue('status', $values['status']);
+                $row = $form->addRow();
+                    $row->addLabel('status', __('Status'));
+                    $row->addTextField('status')->readOnly()->setValue($values['status']);
+            } else {
+                $row = $form->addRow();
+                    $row->addLabel('status', __('Status'));
+                    $row->addSelect('status')->fromArray($statuses)->isRequired()->selected($values['status']);
+
+                    $form->toggleVisibilityByClass('statusChangePast')->onSelect('status')->when('Current');
+                    $direction = ($values['sequenceNumber'] < $_SESSION[$guid]['gibbonSchoolYearSequenceNumberCurrent'])? __('Upcoming') : __('Past');
+
+                    // Display an alert to warn users that changing this will have an impact on their system.
+                    $row = $form->addRow()->setClass('statusChangePast');
+                    $row->addAlert(sprintf(__('Changing the status of this school year to Current will set the current school year %1$s to %2$s. Adjustments to the Academic Year can affect the visibility of vital data in your system. It\'s recommended to use the Rollover tool in User Admin to advance school years rather than changing them here. PROCEED WITH CAUTION!'), $_SESSION[$guid]['gibbonSchoolYearNameCurrent'], $direction) );
+            }
 
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));

--- a/modules/School Admin/schoolYear_manage_editProcess.php
+++ b/modules/School Admin/schoolYear_manage_editProcess.php
@@ -99,8 +99,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
                             while ($currentSchoolYear = $result->fetch()) {
                                 $direction = ($sequenceNumber < $currentSchoolYear['sequenceNumber'])? 'Upcoming' : 'Past';
                                 try {
-                                    $data = array('gibbonSchoolYearID' => $currentSchoolYear['gibbonSchoolYearID'], 'status' => $direction);
-                                    $sql = 'UPDATE gibbonSchoolYear SET status=:status WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
+                                    $data = array('gibbonSchoolYearID' => $currentSchoolYear['gibbonSchoolYearID'], 'status' => $direction, 'sequenceNumber' => $sequenceNumber);
+                                    $sql = "UPDATE gibbonSchoolYear SET status = (CASE
+                                        WHEN gibbonSchoolYearID=:gibbonSchoolYearID THEN :status
+                                        WHEN sequenceNumber < :sequenceNumber THEN 'Past'
+                                        ELSE 'Upcoming'
+                                    END)";
                                     $resultUpdate = $connection2->prepare($sql);
                                     $resultUpdate->execute($data);
                                 } catch (PDOException $e) {
@@ -118,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
                         //Write to database
                         try {
                             $data = array('name' => $name, 'status' => $status, 'sequenceNumber' => $sequenceNumber, 'firstDay' => $firstDay, 'lastDay' => $lastDay, 'gibbonSchoolYearID' => $gibbonSchoolYearID);
-                            $sql = 'UPDATE gibbonSchoolYear SET name=:name, status=:status, sequenceNumber=:sequenceNumber, firstDay=:firstDay, lastDay=:lastDay WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
+                            $sql = "UPDATE gibbonSchoolYear SET name=:name, status=:status, sequenceNumber=:sequenceNumber, firstDay=:firstDay, lastDay=:lastDay WHERE gibbonSchoolYearID=:gibbonSchoolYearID";
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
@@ -127,8 +131,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
                             exit();
                         }
 
+                        // Update session vars so the user is warned if they're logged into a different year
                         if ($status == 'Current') {
-                            // Update session vars so the user is warned if they're logged into a different year
                             $_SESSION[$guid]['gibbonSchoolYearIDCurrent'] = $gibbonSchoolYearID;
                             $_SESSION[$guid]['gibbonSchoolYearNameCurrent'] = $name;
                             $_SESSION[$guid]['gibbonSchoolYearSequenceNumberCurrent'] = $sequenceNumber;

--- a/modules/School Admin/schoolYear_manage_editProcess.php
+++ b/modules/School Admin/schoolYear_manage_editProcess.php
@@ -84,33 +84,16 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
                     //Check for other currents
                     $currentFail = false;
                     if ($status == 'Current') {
+                        // Enforces a single current school year by updating the status of other years
                         try {
-                            $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-                            $sql = "SELECT gibbonSchoolYearID, sequenceNumber FROM gibbonSchoolYear WHERE status='Current' AND NOT gibbonSchoolYearID=:gibbonSchoolYearID";
-                            $result = $connection2->prepare($sql);
-                            $result->execute($data);
+                            $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'sequenceNumber' => $sequenceNumber);
+                            $sql = "UPDATE gibbonSchoolYear SET status = (CASE
+                                WHEN sequenceNumber < :sequenceNumber THEN 'Past' ELSE 'Upcoming'
+                            END) WHERE gibbonSchoolYearID <> :gibbonSchoolYearID";
+                            $resultUpdate = $connection2->prepare($sql);
+                            $resultUpdate->execute($data);
                         } catch (PDOException $e) {
-                            $URL .= '&return=error2';
-                            header("Location: {$URL}");
-                            exit();
-                        }
-                        if ($result->rowCount() > 0) {
-                            // Enforces a single current school year by updating the status of the previous current year
-                            while ($currentSchoolYear = $result->fetch()) {
-                                $direction = ($sequenceNumber < $currentSchoolYear['sequenceNumber'])? 'Upcoming' : 'Past';
-                                try {
-                                    $data = array('gibbonSchoolYearID' => $currentSchoolYear['gibbonSchoolYearID'], 'status' => $direction, 'sequenceNumber' => $sequenceNumber);
-                                    $sql = "UPDATE gibbonSchoolYear SET status = (CASE
-                                        WHEN gibbonSchoolYearID=:gibbonSchoolYearID THEN :status
-                                        WHEN sequenceNumber < :sequenceNumber THEN 'Past'
-                                        ELSE 'Upcoming'
-                                    END)";
-                                    $resultUpdate = $connection2->prepare($sql);
-                                    $resultUpdate->execute($data);
-                                } catch (PDOException $e) {
-                                    $currentFail = true;
-                                }
-                            }
+                            $currentFail = true;
                         }
                     }
 


### PR DESCRIPTION
It's possible to accidentally set the current year to Past without setting a new Current year, which causes all further login attempts to fail. This PR aims to enforce the presence of a single Current year with the following changes:

- Current school year cannot be deleted or it's status changed
- Changing another year's status to Current will replace the current school year, and warn the user making the change:
![screen shot 2017-08-16 at 3 22 22 pm](https://user-images.githubusercontent.com/897700/29351781-c139c150-8296-11e7-94c4-33e64bf0e863.png)
- Changes to the current year updates session variables, which enables the top-of-page warning if they're now logged into a non-current year
- Clarified the error message when there's no current year, on the off chance it's changed through the database or some other means