### PR TITLE
System: fixed timezone not being set in CLI scripts

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ v15.0.00
 		System: fixed missing form validation for dropdowns created with User Custom Fields
 		System: updated Google OAuth library to latest version (v2.2.0)
 		System: fixed Sign In With Google to fix missing token refresh issue
+        System: fixed fixed timezone not being set in CLI scripts
 		Attendance: fixed GROUP BY issue in moduleFunctions.php when MySQL is using only_full_group_by
 		Attendance: adjusted attendance checking CLI script to only include lessons whose start time has already passed
 		Attendance: show staff dashboard link to attendance only if user has access to Form Group attendance

--- a/src/Gibbon/core.php
+++ b/src/Gibbon/core.php
@@ -108,14 +108,28 @@ class Core {
 
 		if ($this->initialized == true) return;
 
+		// Provide the session class with a db connection
+		$this->session->setDatabaseConnection($pdo);
+
+		if (empty($this->session->get('systemSettingsSet'))) {
+			// Load all system settings into session data
+			$this->session->loadSystemSettings($pdo);
+
+			// Load all i18n values into session data
+			$this->session->loadLanguageSettings($pdo);
+		}
+
+		// Setup the Internationalization code from session
+		$this->locale->setLocale($this->session->get(array('i18n', 'code')));
+
+		// Set timezone from session variable
+		$this->locale->setTimezone($this->session->get('timezone', 'UTC'));
+
 		// Setup the textdomain based on the current locale  (if any)
 		$this->locale->setTextDomain($pdo);
 
 		// Load the string replacements from db
 		$this->locale->setStringReplacementList($pdo);
-
-		// Provide the session class with a db connection
-		$this->session->setDatabaseConnection($pdo);
 
 		$this->initialized = true;
 	}

--- a/src/Gibbon/locale.php
+++ b/src/Gibbon/locale.php
@@ -36,8 +36,6 @@ namespace Gibbon;
  */
 class Locale
 {
-	protected $i18n;
-
 	protected $i18ncode;
 
 	protected $session;
@@ -50,13 +48,6 @@ class Locale
 	public function __construct( core $gibbon )
 	{
 		$this->session = $gibbon->session;
-
-		// Setup the Internationalization code from session
-		$this->i18n = $this->session->get('i18n');
-		$this->setLocale($this->i18n['code']);
-
-		// Set timezone from session variable
-		date_default_timezone_set($this->session->get('timezone', 'UTC'));
 	}
 
 	/**
@@ -82,6 +73,16 @@ class Locale
 	 */
 	public function getLocale() {
 		return $this->i18ncode;
+	}
+
+	public function setTimezone($timezone)
+	{
+		date_default_timezone_set($timezone);
+	}
+
+	public function getTimezone()
+	{
+		return date_default_timezone_get();
 	}
 
 	/**

--- a/src/Gibbon/session.php
+++ b/src/Gibbon/session.php
@@ -90,7 +90,20 @@ class Session
 	 */
 	public function get($name, $default = null)
 	{
-		return (isset($_SESSION[$this->guid][$name]))? $_SESSION[$this->guid][$name] : $default;
+        if (is_array($name)) {
+            // Fetch a value from multi-dimensional array with an array of keys
+            $retrieve = function($array, $keys, $default) {
+                foreach($keys as $key) {
+                    if (!isset($array[$key])) return $default;
+                    $array = $array[$key];
+                }
+                return $array;
+            };
+
+            return $retrieve($_SESSION[$this->guid], $name, $default);
+        }
+
+        return (isset($_SESSION[$this->guid][$name]))? $_SESSION[$this->guid][$name] : $default;
 	}
 
 	/**

--- a/src/Gibbon/session.php
+++ b/src/Gibbon/session.php
@@ -137,6 +137,28 @@ class Session
 		return $this;
 	}
 
+	public function loadSystemSettings($pdo)
+	{
+		// System settings from gibbonSetting
+		$sql = "SELECT name, value FROM gibbonSetting WHERE scope='System'";
+	    $result = $pdo->executeQuery(array(), $sql);
+
+        while ($row = $result->fetch()) {
+            $this->set($row['name'], $row['value']);
+        }
+	}
+
+    public function loadLanguageSettings($pdo)
+    {
+        // Language settings from gibboni18n
+        $sql = "SELECT * FROM gibboni18n WHERE systemDefault='Y'";
+        $result = $pdo->executeQuery(array(), $sql);
+
+        while ($row = $result->fetch()) {
+            $this->set('i18n', $row);
+        }
+    }
+
 	public function createUserSession($username, $userData) {
 
 		$this->set('username', $username);


### PR DESCRIPTION
Timezones are set in the Locale class from a session variable. In CLI scripts, the system settings were being populated into the session after the locale was already set, resulting in the CLI running with UTC as the default timezone.

A lot of the page setup is still split between global function calls and newer class methods, this fix moves some more of the session populating logic into the Session class, but the overall architecture changes are still a work in progress. Hope to get more of these classes sorted out soon.