### PR TITLE
Form Class:fixed size attribute for Select class with multiple options

### DIFF
--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -86,7 +86,10 @@ class Select extends Input
         $output = '';
 
         if (!empty($this->getAttribute('multiple'))) {
-            $this->setAttribute('size', $this->getOptionCount());
+            if (empty($this->getAttribute('size'))) {
+                $this->setAttribute('size', $this->getOptionCount());
+            }
+
             $this->setName($this->getName().'[]');
         }
 


### PR DESCRIPTION
Minor fix to the Select class, the size attribute was being overwritten if it had been manually set. Part of the changes Ray and I worked on for the Multi-Selector.