### PR TITLE
Form Class: usability improvements for the File Upload field

### DIFF
--- a/modules/School Admin/house_manage_edit.php
+++ b/modules/School Admin/house_manage_edit.php
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
                 $file = $row->addFileUpload('file1')
                     ->addClass('right')
                     ->accepts($fileUploader->getFileExtensions('Graphics/Design'))
-                    ->setAttachment($_SESSION[$guid]['absoluteURL'], $values['logo'])
+                    ->setAttachment('logo', $_SESSION[$guid]['absoluteURL'], $values['logo'])
                     ->setDeleteAction('/modules/School Admin/house_manage_edit_photoDeleteProcess.php?gibbonHouseID='.$gibbonHouseID);
 
             $row = $form->addRow();

--- a/modules/School Admin/house_manage_edit.php
+++ b/modules/School Admin/house_manage_edit.php
@@ -81,11 +81,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
                 $file = $row->addFileUpload('file1')
                     ->addClass('right')
                     ->accepts($fileUploader->getFileExtensions('Graphics/Design'))
-                    ->setAttachment($_SESSION[$guid]['absoluteURL'], $values['logo']);
-
-                if (!empty($values['logo'])) {
-                    $file->prepend("<a href='".$_SESSION[$guid]['absoluteURL']."/modules/School Admin/house_manage_edit_photoDeleteProcess.php?gibbonHouseID=$gibbonHouseID' onclick='return confirm(\"Are you sure you want to delete this record? Unsaved changes will be lost.\")'><img style='margin-bottom: -8px;float: right;' title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a><br/>");
-                }
+                    ->setAttachment($_SESSION[$guid]['absoluteURL'], $values['logo'])
+                    ->setDeleteAction('/modules/School Admin/house_manage_edit_photoDeleteProcess.php?gibbonHouseID='.$gibbonHouseID);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/School Admin/house_manage_editProcess.php
+++ b/modules/School Admin/house_manage_editProcess.php
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
 
                     //Sort out logo
                     $imageFail = false;
-                    $logo = $row['logo'];
+                    $logo = $_POST['logo'];
                     if (!empty($_FILES['file1']['tmp_name'])) {
                         $fileUploader = new Gibbon\FileUploader($pdo, $gibbon->session);
                         

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -884,10 +884,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow();
             $row->addLabel('file'.$i, $requiredDocumentsList[$i])->description($description);
-            $row->addFileUpload('file'.$i)
-                ->accepts($fileUploader->getFileExtensions())
-                ->setRequired($requiredDocumentsCompulsory == 'Y')
-                ->setAttachment($_SESSION[$guid]['absoluteURL'], $attachment);
+                $row->addFileUpload('file'.$i)
+                    ->accepts($fileUploader->getFileExtensions())
+                    ->setRequired($requiredDocumentsCompulsory == 'Y')
+                    ->setAttachment('attachment'.$i, $_SESSION[$guid]['absoluteURL'], $attachment)
+                    ->canDelete(false);
         }
 
         $row = $form->addRow()->addContent(getMaxUpload($guid));

--- a/modules/System Admin/alarm.php
+++ b/modules/System Admin/alarm.php
@@ -57,7 +57,6 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/alarm.php') =
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
     $setting = getSettingByScope($connection2, 'System Admin', 'customAlarmSound', true);
-    $form->addHiddenValue('attachmentCurrent', $setting['value']);
 
     $row = $form->addRow();
         $label = $row->addLabel('file', __($setting['nameDisplay']))->description(__($setting['description']));
@@ -65,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/alarm.php') =
 
         $file = $row->addFileUpload('file')
                     ->accepts($fileUploader->getFileExtensionsCSV())
-                    ->setAttachment($_SESSION[$guid]['absoluteURL'], $setting['value']);
+                    ->setAttachment('attachmentCurrent', $_SESSION[$guid]['absoluteURL'], $setting['value']);
 
     $setting = getSettingByScope($connection2, 'System', 'alarm', true);
     $form->addHiddenValue('alarmCurrent', $setting['value']);

--- a/src/Forms/Input/FileUpload.php
+++ b/src/Forms/Input/FileUpload.php
@@ -82,20 +82,20 @@ class FileUpload extends Input
         $output = '';
 
         if (!empty($this->absoluteURL) && !empty($this->attachmentPath)) {
-            $output .= '<div class="standardWidth" style="float: right;border: 1px solid #BFBFBF;background-color: #ffffff;margin-bottom:4px;height:48px;overflow:hidden;display: table;">';
+            $output .= '<div class="attachment standardWidth" style="">';
 
-            $output .= '<div style="display:table-cell;vertical-align:middle;text-align:left;padding: 5px;">';
+            $output .= '<div class="filename">';
             $output .= __('Current attachment:').'<br/>';
-            $output .= '<a target="_blank" style="display:block; word-break: break-all;" href="'.$this->absoluteURL.'/'.$this->attachmentPath.'">'.basename($this->attachmentPath).'</a>';
+            $output .= '<a target="_blank" href="'.$this->absoluteURL.'/'.$this->attachmentPath.'">'.basename($this->attachmentPath).'</a>';
             $output .= '</div>';
 
-            $output .=  "<a download style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa); width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->attachmentPath."'><img title='".__('Download')."' src='./themes/Default/img/download.png'/></a>";
+            $output .=  "<a download class='inline-button' href='".$this->absoluteURL.'/'.$this->attachmentPath."'><img title='".__('Download')."' src='./themes/Default/img/download.png'/></a>";
 
             if ($this->canDelete) {
                 if (!empty($this->deleteAction)) {
-                    $output .=  "<a style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa); width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->deleteAction."' onclick='return confirm(\"".__('Are you sure you want to delete this record? Unsaved changes will be lost.')."\")'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></a>";
+                    $output .=  "<a class='inline-button' href='".$this->absoluteURL.'/'.$this->deleteAction."' onclick='return confirm(\"".__('Are you sure you want to delete this record? Unsaved changes will be lost.')."\")'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></a>";
                 } else {
-                    $output .= "<div style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa); width:48px;vertical-align:middle;text-align:center;cursor:pointer;' onclick='if(confirm(\"".__('Are you sure you want to delete this record? Changes will be saved when you submit this form.')."\")) { $(\"input[name=".$this->attachmentName."]\").val(\"\"); $(\"#".$this->getID()."\").show(); $(this).parent().detach().remove(); };'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></div>";
+                    $output .= "<div class='inline-button' onclick='if(confirm(\"".__('Are you sure you want to delete this record? Changes will be saved when you submit this form.')."\")) { $(\"input[name=".$this->attachmentName."]\").val(\"\"); $(\"#".$this->getID()."\").show(); $(this).parent().detach().remove(); };'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></div>";
                 }
             }
             $output .= '</div>';

--- a/src/Forms/Input/FileUpload.php
+++ b/src/Forms/Input/FileUpload.php
@@ -28,7 +28,8 @@ namespace Gibbon\Forms\Input;
 class FileUpload extends Input
 {
     protected $accepts = array();
-    protected $absolutePath = '';
+    protected $absoluteURL = '';
+    protected $deleteAction = '';
 
     public function accepts($accepts)
     {
@@ -48,10 +49,17 @@ class FileUpload extends Input
         return $this;
     }
 
-    public function setAttachment($absolutePath, $filePath)
+    public function setAttachment($absoluteURL, $filePath)
     {
-        $this->absolutePath = $absolutePath;
+        $this->absoluteURL = $absoluteURL;
         $this->setValue($filePath);
+
+        return $this;
+    }
+
+    public function setDeleteAction($actionURL)
+    {
+        $this->deleteAction = ltrim($actionURL, '/');
 
         return $this;
     }
@@ -60,10 +68,19 @@ class FileUpload extends Input
     {
         $output = '';
 
-        if (!empty($this->absolutePath) && !empty($this->getValue())) {
-            $output .= '<div class="right">';
-            $output .= __('Current attachment:').' ';
-            $output .= '<a href="'.$this->absolutePath.'/'.$this->getValue().'" target="_blank">'.basename($this->getValue()).'</a><br/><br/>';
+        if (!empty($this->absoluteURL) && !empty($this->getValue())) {
+            $output .= '<div class="standardWidth" style="float: right;border: 1px solid #BFBFBF;background-color: #ffffff;margin-bottom:4px;height:48px;overflow:hidden;display: table;">';
+
+            $output .= '<div style="display:table-cell;white-space:no-wrap;text-align:left;padding: 5px;">';
+            $output .= __('Current attachment:').'<br/>';
+            $output .= '<a target="_blank" style="display:block; word-break: break-all;" href="'.$this->absoluteURL.'/'.$this->getValue().'">'.$this->getValue().'</a>';
+            $output .= '</div>';
+
+            $output .=  "<a download style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa);height: 48px; width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->getValue()."'><img title='".__('Download')."' src='./themes/Default/img/download.png'/></a>";
+
+            if (!empty($this->deleteAction)) {
+                $output .=  "<a style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa);height: 48px; width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->deleteAction."' onclick='return confirm(\"Are you sure you want to delete this record? Unsaved changes will be lost.\")'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></a>";
+            }
             $output .= '</div>';
         }
 

--- a/src/Forms/Input/FileUpload.php
+++ b/src/Forms/Input/FileUpload.php
@@ -27,7 +27,6 @@ namespace Gibbon\Forms\Input;
  */
 class FileUpload extends Input
 {
-    protected $accepts = array();
     protected $absoluteURL = '';
     protected $deleteAction = '';
 
@@ -42,12 +41,16 @@ class FileUpload extends Input
         }
 
         if (!empty($accepts) && is_array($accepts)) {
+            $accepts = array_map(function ($str) {
+                return trim(strtolower($str), " .'");
+            }, $accepts);
 
             $within = implode(',', array_map(function ($str) {
-                return sprintf("'.%s'", trim($str, " .'")); },
-            $accepts));
+                return sprintf("'.%s'", $str);
+            }, $accepts));
 
-            $this->setAttribute('accept', str_replace("'",'', $within));
+            $this->setAttribute('title', (count($accepts) < 20? implode(', ', $accepts) : ''));
+            $this->setAttribute('accept', str_replace("'", '', $within));
             $this->addValidation('Validate.Inclusion', 'within: ['.$within.'], failureMessage: "Illegal file type!", partialMatch: true, caseSensitive: false');
         }
         return $this;
@@ -64,10 +67,9 @@ class FileUpload extends Input
 
     public function setDeleteAction($actionURL)
     {
-        $this->canDelete = true;
         $this->deleteAction = ltrim($actionURL, '/');
 
-        return $this;
+        return $this->canDelete(true);
     }
 
     public function canDelete($value)
@@ -82,9 +84,9 @@ class FileUpload extends Input
         $output = '';
 
         if (!empty($this->absoluteURL) && !empty($this->attachmentPath)) {
-            $output .= '<div class="attachment standardWidth" style="">';
+            $output .= '<div class="input-box standardWidth">';
 
-            $output .= '<div class="filename">';
+            $output .= '<div class="inline-label">';
             $output .= __('Current attachment:').'<br/>';
             $output .= '<a target="_blank" href="'.$this->absoluteURL.'/'.$this->attachmentPath.'">'.basename($this->attachmentPath).'</a>';
             $output .= '</div>';
@@ -93,9 +95,9 @@ class FileUpload extends Input
 
             if ($this->canDelete) {
                 if (!empty($this->deleteAction)) {
-                    $output .=  "<a class='inline-button' href='".$this->absoluteURL.'/'.$this->deleteAction."' onclick='return confirm(\"".__('Are you sure you want to delete this record? Unsaved changes will be lost.')."\")'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></a>";
+                    $output .=  "<a class='inline-button' href='".$this->absoluteURL.'/'.$this->deleteAction."' onclick='return confirm(\"".__('Are you sure you want to delete this record?').' '.__('Unsaved changes will be lost.')."\")'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></a>";
                 } else {
-                    $output .= "<div class='inline-button' onclick='if(confirm(\"".__('Are you sure you want to delete this record? Changes will be saved when you submit this form.')."\")) { $(\"input[name=".$this->attachmentName."]\").val(\"\"); $(\"#".$this->getID()."\").show(); $(this).parent().detach().remove(); };'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></div>";
+                    $output .= "<div class='inline-button' onclick='if(confirm(\"".__('Are you sure you want to delete this record?').' '.__('Changes will be saved when you submit this form.')."\")) { $(\"input[name=".$this->attachmentName."]\").val(\"\"); $(\"#".$this->getID()."\").show(); $(this).parent().detach().remove(); };'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></div>";
                 }
             }
             $output .= '</div>';

--- a/src/Forms/Input/FileUpload.php
+++ b/src/Forms/Input/FileUpload.php
@@ -31,6 +31,10 @@ class FileUpload extends Input
     protected $absoluteURL = '';
     protected $deleteAction = '';
 
+    protected $attachmentName;
+    protected $attachmentPath;
+    protected $canDelete = true;
+
     public function accepts($accepts)
     {
         if (is_string($accepts)) {
@@ -49,17 +53,26 @@ class FileUpload extends Input
         return $this;
     }
 
-    public function setAttachment($absoluteURL, $filePath)
+    public function setAttachment($name, $absoluteURL, $filePath = '')
     {
         $this->absoluteURL = $absoluteURL;
-        $this->setValue($filePath);
+        $this->attachmentName = $name;
+        $this->attachmentPath = $filePath;
 
         return $this;
     }
 
     public function setDeleteAction($actionURL)
     {
+        $this->canDelete = true;
         $this->deleteAction = ltrim($actionURL, '/');
+
+        return $this;
+    }
+
+    public function canDelete($value)
+    {
+        $this->canDelete = $value;
 
         return $this;
     }
@@ -68,22 +81,29 @@ class FileUpload extends Input
     {
         $output = '';
 
-        if (!empty($this->absoluteURL) && !empty($this->getValue())) {
+        if (!empty($this->absoluteURL) && !empty($this->attachmentPath)) {
             $output .= '<div class="standardWidth" style="float: right;border: 1px solid #BFBFBF;background-color: #ffffff;margin-bottom:4px;height:48px;overflow:hidden;display: table;">';
 
-            $output .= '<div style="display:table-cell;white-space:no-wrap;text-align:left;padding: 5px;">';
+            $output .= '<div style="display:table-cell;vertical-align:middle;text-align:left;padding: 5px;">';
             $output .= __('Current attachment:').'<br/>';
-            $output .= '<a target="_blank" style="display:block; word-break: break-all;" href="'.$this->absoluteURL.'/'.$this->getValue().'">'.$this->getValue().'</a>';
+            $output .= '<a target="_blank" style="display:block; word-break: break-all;" href="'.$this->absoluteURL.'/'.$this->attachmentPath.'">'.basename($this->attachmentPath).'</a>';
             $output .= '</div>';
 
-            $output .=  "<a download style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa);height: 48px; width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->getValue()."'><img title='".__('Download')."' src='./themes/Default/img/download.png'/></a>";
+            $output .=  "<a download style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa); width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->attachmentPath."'><img title='".__('Download')."' src='./themes/Default/img/download.png'/></a>";
 
-            if (!empty($this->deleteAction)) {
-                $output .=  "<a style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa);height: 48px; width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->deleteAction."' onclick='return confirm(\"Are you sure you want to delete this record? Unsaved changes will be lost.\")'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></a>";
+            if ($this->canDelete) {
+                if (!empty($this->deleteAction)) {
+                    $output .=  "<a style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa); width:48px;vertical-align:middle;text-align:center;' href='".$this->absoluteURL.'/'.$this->deleteAction."' onclick='return confirm(\"".__('Are you sure you want to delete this record? Unsaved changes will be lost.')."\")'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></a>";
+                } else {
+                    $output .= "<div style='display:table-cell;border-left: 1px solid #BFBFBF;background: -moz-linear-gradient(top, #fbfbfb, #fafafa); width:48px;vertical-align:middle;text-align:center;cursor:pointer;' onclick='if(confirm(\"".__('Are you sure you want to delete this record? Changes will be saved when you submit this form.')."\")) { $(\"input[name=".$this->attachmentName."]\").val(\"\"); $(\"#".$this->getID()."\").show(); $(this).parent().detach().remove(); };'><img title='".__('Delete')."' src='./themes/Default/img/garbage.png'/></div>";
+                }
             }
             $output .= '</div>';
+
+            $this->setAttribute('style', 'display:none;');
         }
 
+        $output .= '<input type="hidden" name="'.$this->attachmentName.'" value="'.$this->attachmentPath.'">';
         $output .= '<input type="file" '.$this->getAttributeString().'>';
 
         return $output;

--- a/src/Gibbon/FileUploader.php
+++ b/src/Gibbon/FileUploader.php
@@ -237,7 +237,7 @@ class FileUploader
     }
 
     /**
-     * Lazy load an array of the File Extensions from DB. Optionally loads a specific Type of extension.
+     * Lazy load an array of the File Extensions from DB. Optionally loads specific types of extensions (accepts array or CSV list).
      *
      * @version  v14
      * @since    v14
@@ -249,8 +249,10 @@ class FileUploader
             $this->fileExtensions = array();
 
             if (!empty($type)) {
-                $data = array('type' => strtolower($type));
-                $sql = "SELECT LOWER(extension) FROM gibbonFileExtension WHERE LOWER(type)=:type ORDER BY type, name";
+                $type = (is_array($type))? implode(',', $type) : $type;
+
+                $data = array('types' => strtolower($type));
+                $sql = "SELECT LOWER(extension) FROM gibbonFileExtension WHERE FIND_IN_SET(LOWER(type), :types) ORDER BY type, name";
             } else {
                 $data = array();
                 $sql = "SELECT LOWER(extension) FROM gibbonFileExtension ORDER BY type, name";

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1337,6 +1337,7 @@ table tr.heading:first-child td:last-child {
 	padding-left: 5px !important;
 }
 
+
 /* Usability tweak to make large data tables like User Permissions easier to read */
 table.rowHighlight tr:not(.break):hover td {
 	background: #EDF7FF !important;
@@ -1356,4 +1357,30 @@ input[name*="phone"] ~ .LV_invalid {
 /* Remove the tiny gap that appears near valid elements */
 .LV_valid {
     margin: 0;
+
+.attachment {
+	float: right;
+	display: table;
+	border: 1px solid #BFBFBF;
+	background-color: #ffffff;
+	height:48px;
+}
+
+.attachment .filename {
+	display:table-cell;
+	padding: 5px;
+	text-align:left;
+	vertical-align:middle;
+	word-break: break-all;
+}
+
+.attachment .inline-button {
+	display:table-cell;
+	border-left: 1px solid #BFBFBF;
+	background: #fafafa;
+	background: -moz-linear-gradient(top, #fbfbfb, #fafafa);
+	width:48px;
+	vertical-align:middle;
+	text-align:center;
+	cursor: pointer;
 }

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1337,7 +1337,6 @@ table tr.heading:first-child td:last-child {
 	padding-left: 5px !important;
 }
 
-
 /* Usability tweak to make large data tables like User Permissions easier to read */
 table.rowHighlight tr:not(.break):hover td {
 	background: #EDF7FF !important;
@@ -1358,15 +1357,14 @@ input[name*="phone"] ~ .LV_invalid {
 .LV_valid {
     margin: 0;
 
-.attachment {
+.input-box {
 	float: right;
 	display: table;
 	border: 1px solid #BFBFBF;
 	background-color: #ffffff;
-	height:48px;
 }
 
-.attachment .filename {
+.input-box .inline-label {
 	display:table-cell;
 	padding: 5px;
 	text-align:left;
@@ -1374,12 +1372,13 @@ input[name*="phone"] ~ .LV_invalid {
 	word-break: break-all;
 }
 
-.attachment .inline-button {
+.input-box .inline-button {
 	display:table-cell;
 	border-left: 1px solid #BFBFBF;
 	background: #fafafa;
 	background: -moz-linear-gradient(top, #fbfbfb, #fafafa);
 	width:48px;
+	height:48px;
 	vertical-align:middle;
 	text-align:center;
 	cursor: pointer;

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1356,6 +1356,7 @@ input[name*="phone"] ~ .LV_invalid {
 /* Remove the tiny gap that appears near valid elements */
 .LV_valid {
     margin: 0;
+}
 
 .input-box {
 	float: right;


### PR DESCRIPTION
Improves the layout of the File Upload field when there's an existing attachment. Currently only affects forms that are OOified (alarm, house edit, application form)

Eg:
![screenshot](https://user-images.githubusercontent.com/897700/29403031-9ddaa3d6-8369-11e7-9a6c-5c551d6e40cd.png)

- Moves the attachment name and options inside a box, same width as other form inputs
- Adds a delete button, and FileUpload methods to implement it. Allows attachment deletion/replacement to be part of the form submission rather than a separate action.
- Adds a download button, for ease of access
- File upload input displays allowed file-types on hover