### PR TITLE
Form Class: added a getLabel method to Input class

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -194,3 +194,8 @@ interface OutputableInterface
 {
     public function getOutput();
 }
+
+interface RowDependancyInterface
+{
+    public function setRow($row);
+}

--- a/src/Forms/Input/Input.php
+++ b/src/Forms/Input/Input.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 namespace Gibbon\Forms\Input;
 
 use Gibbon\Forms\Layout\Element;
+use Gibbon\Forms\RowDependancyInterface;
 use Gibbon\Forms\ValidatableInterface;
 use Gibbon\Forms\Traits\InputAttributesTrait;
 
@@ -29,9 +30,11 @@ use Gibbon\Forms\Traits\InputAttributesTrait;
  * @version v14
  * @since   v14
  */
-abstract class Input extends Element implements ValidatableInterface
+abstract class Input extends Element implements ValidatableInterface, RowDependancyInterface
 {
     use InputAttributesTrait;
+
+    protected $row;
 
     protected $validationOptions = array();
     protected $validation = array();
@@ -41,6 +44,16 @@ abstract class Input extends Element implements ValidatableInterface
         $this->setID($name);
         $this->setName($name);
         $this->setClass('standardWidth');
+    }
+
+    public function setRow($row)
+    {
+        $this->row = $row;
+    }
+
+    public function getLabel()
+    {
+        return $this->row->getElement('label-'.$this->getID());
     }
 
     public function addValidationOption($option = '')

--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -56,6 +56,10 @@ class Select extends Input
     {
         $this->setAttribute('multiple', $value);
 
+        if ($value == true && !empty($this->getLabel())) {
+            $this->getLabel()->description(__('Use Control, Command and/or Shift to select multiple.'));
+        }
+
         return $this;
     }
 
@@ -95,7 +99,9 @@ class Select extends Input
                 $this->setAttribute('size', $this->getOptionCount());
             }
 
-            $this->setName($this->getName().'[]');
+            if (stripos($this->getName(), '[]') === false) {
+                $this->setName($this->getName().'[]');
+            }
         }
 
         $output .= '<select '.$this->getAttributeString().'>';

--- a/src/Forms/Layout/Heading.php
+++ b/src/Forms/Layout/Heading.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 namespace Gibbon\Forms\Layout;
 
 use Gibbon\Forms\OutputableInterface;
+use Gibbon\Forms\RowDependancyInterface;
 
 /**
  * Content
@@ -36,7 +37,7 @@ class Heading extends Element implements OutputableInterface, RowDependancyInter
         $this->content = $content;
     }
 
-    public function setRow(Row $row)
+    public function setRow($row)
     {
         $this->row = $row;
 

--- a/src/Forms/Layout/Label.php
+++ b/src/Forms/Layout/Label.php
@@ -53,7 +53,7 @@ class Label extends Element implements RowDependancyInterface
 
     public function description($value = '')
     {
-        $this->description = (!empty($this->description))? $this->description.' '.$value : $value;
+        $this->description = (!empty($this->description))? $this->description.'<br><br>'.$value : $value;
         return $this;
     }
 

--- a/src/Forms/Layout/Label.php
+++ b/src/Forms/Layout/Label.php
@@ -19,6 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Forms\Layout;
 
+use Gibbon\Forms\RowDependancyInterface;
+
 /**
  * Label
  *
@@ -39,14 +41,19 @@ class Label extends Element implements RowDependancyInterface
         $this->for = $for;
     }
 
-    public function setRow(Row $row)
+    public function setRow($row)
     {
         $this->row = $row;
     }
 
+    public function getName()
+    {
+        return 'label-'.$this->for;
+    }
+
     public function description($value = '')
     {
-        $this->description = $value;
+        $this->description = (!empty($this->description))? $this->description.' '.$value : $value;
         return $this;
     }
 

--- a/src/Forms/Layout/Row.php
+++ b/src/Forms/Layout/Row.php
@@ -21,6 +21,7 @@ namespace Gibbon\Forms\Layout;
 
 use Gibbon\Forms\OutputableInterface;
 use Gibbon\Forms\FormFactoryInterface;
+use Gibbon\Forms\RowDependancyInterface;
 use Gibbon\Forms\Traits\BasicAttributesTrait;
 
 /**
@@ -113,9 +114,4 @@ class Row
 
         return $this;
     }
-}
-
-interface RowDependancyInterface
-{
-    public function setRow(Row $row);
 }


### PR DESCRIPTION
Implemented getLabel in Select class to add a helper description "Use Control, Command and/or Shift to select multiple." for multi-select inputs.