### PR TITLE
Planner: updated sidebar attendance show/hide behaviour

### DIFF
--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -1663,7 +1663,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                                     $_SESSION[$guid]['sidebarExtra'] .= $attendance->renderAttendanceTypeSelect( $rowLog['type'], "$countStudents-type", '86px;margin-left:1px;');
 
                                     // Only hide the reason and comment fields if Present is the default attendance type
-                                    if ($defaultAttendanceType == 'Present') {
+                                    if ($defaultAttendanceType == 'Present' || $attendance->isTypePresent($rowLog['type'])) {
                                         $_SESSION[$guid]['sidebarExtra'] .= "<div id='$countStudents-hideReasons' style='display:none;'>";
                                     } else {
                                         $_SESSION[$guid]['sidebarExtra'] .= "<div>";


### PR DESCRIPTION
Quick visual tweak to hide extra fields if the default attendance type is present _or_ the currently set attendance is Present.