### PR TITLE
Tests: fixed the loginForm to reference by ID instead of name

### DIFF
--- a/tests/config/support/AcceptanceTester.php
+++ b/tests/config/support/AcceptanceTester.php
@@ -31,7 +31,7 @@ class AcceptanceTester extends \Codeception\Actor
         $I = $this;
 
         $I->amOnPage('/');
-        $I->submitForm('form[name=loginForm]', [
+        $I->submitForm('form[id=loginForm]', [
             'username' => $name,
             'password' => $password
         ]);


### PR DESCRIPTION
**Bug Fix**

The login form OOification changed the form name to an ID, which broke the loginForm selector for acceptance tests, and I forgot to run the tests before that PR. Oops!