### PR TITLE
School Admin: fixed image attachment in Edit Department

### DIFF
--- a/modules/School Admin/department_manage_add.php
+++ b/modules/School Admin/department_manage_add.php
@@ -93,7 +93,6 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
         $row->addLabel('file', __('Logo'))->description('125x125px jpg/png/gif');
         $row->addFileUpload('file')
             ->accepts('.jpg,.jpeg,.gif,.png')
-            ->append('<br/><br/>'.getMaxUpload($guid))
             ->addClass('right');
 
     $row = $form->addRow();

--- a/modules/School Admin/department_manage_edit.php
+++ b/modules/School Admin/department_manage_edit.php
@@ -115,6 +115,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
                 $row->addFileUpload('file')
                     ->accepts('.jpg,.jpeg,.gif,.png')
                     ->append('<br/><br/>'.getMaxUpload($guid))
+                    ->setAttachment('logo', $_SESSION[$guid]['absoluteURL'], $values['logo'])
                     ->addClass('right');
 
             $form->addRow()->addHeading(__('Current Staff'));

--- a/modules/School Admin/department_manage_edit.php
+++ b/modules/School Admin/department_manage_edit.php
@@ -114,7 +114,6 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
                 $row->addLabel('file', 'Logo')->description('125x125px jpg/png/gif');
                 $row->addFileUpload('file')
                     ->accepts('.jpg,.jpeg,.gif,.png')
-                    ->append('<br/><br/>'.getMaxUpload($guid))
                     ->setAttachment('logo', $_SESSION[$guid]['absoluteURL'], $values['logo'])
                     ->addClass('right');
 

--- a/modules/School Admin/department_manage_editProcess.php
+++ b/modules/School Admin/department_manage_editProcess.php
@@ -84,7 +84,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
                         $partialFail = true;
                     }
                 } else {
-                    $attachment = $row['logo'];
+                    $attachment = $_POST['logo'];
                 }
 
                 //Scan through staff

--- a/src/Forms/Input/FileUpload.php
+++ b/src/Forms/Input/FileUpload.php
@@ -137,7 +137,7 @@ class FileUpload extends Input
         $label = ($post < $file)? $post : $file;
 
         if ($this->maxUpload !== true && $this->maxUpload >= 1) {
-            $label = $this->maxUpload;
+            $label = ($this->maxUpload < $label)? $this->maxUpload : $label;
             $output .= '<input type="hidden" name="MAX_FILE_SIZE" value="'.(1024 * (1024 * $this->maxUpload)).'">';
         }
 

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1372,6 +1372,7 @@ input[name*="phone"] ~ .LV_invalid {
 	display: table;
 	border: 1px solid #BFBFBF;
 	background-color: #ffffff;
+    box-sizing: border-box;
 }
 
 .input-box .inline-label {
@@ -1380,6 +1381,18 @@ input[name*="phone"] ~ .LV_invalid {
 	text-align:left;
 	vertical-align:middle;
 	word-break: break-all;
+}
+
+.input-box.max-upload {
+    border-top: 0px;
+}
+
+.input-box.max-upload .inline-label {
+    background: #fafafa;
+    background: -moz-linear-gradient(top, #fbfbfb, #fafafa);
+    font-style: italic;
+    color: #c00;
+    line-height: 11px;
 }
 
 .input-box .inline-button {


### PR DESCRIPTION
**Bug Fix**

Also fixes the appended max upload text by adding the text to the FileUpload class by default. Adds two new methods to FileUpload: 
- setMaxUpload($value) : Displays the max filesize text. On by default and set to the system level. Can be used to set a smaller max upload value.
- uploadMultiple() : turns on the `multiple` flag for the input type="file"