### PR TITLE
User Admin: added setting to limit Student Application Form years of entry

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -829,5 +829,6 @@ INSERT INTO `gibbonPermission` (`permissionID` ,`gibbonRoleID` ,`gibbonActionID`
 CREATE TABLE `gibbonCourseClassMap` (`gibbonCourseClassMapID` int(8) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT, `gibbonCourseClassID` int(8) UNSIGNED ZEROFILL NULL,`gibbonRollGroupID` int(5) UNSIGNED ZEROFILL NULL, `gibbonYearGroupID` int(3) UNSIGNED ZEROFILL NULL, UNIQUE KEY `gibbonCourseClassID` (gibbonCourseClassID), PRIMARY KEY (`gibbonCourseClassMapID`)) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;end
 INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Timetable Admin', 'autoEnrolCourses', 'Auto-Enrol Courses Default', 'Should auto-enrolment of new students into courses be turned on or off by default?', 'N');end
 UPDATE `gibbonNotificationEvent` SET actionName='View Student Profile_full' WHERE (event='Application Form Accepted' OR event='New Application Form') AND moduleName='Students';end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Application Form', 'availableYearsOfEntry', 'Available Years of Entry', 'Which school years should be available to apply to?', '');end
 
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -74,6 +74,7 @@ v15.0.00
         User Admin: updated Add User and Edit User to allow PDF files for ID documents
         User Admin: added ability to set username formats by role in User Settings
         User Admin: added a button to generate usernames in Add User
+        User Admin: added an Available Years of Entry setting to select which years are available in the student application
 
 v14.0.00
 --------

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -337,8 +337,16 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('gibbonSchoolYearIDEntry', __('Anticipated Year of Entry'))->description(__('What school year will the student join in?'));
-        $sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear WHERE (status='Current' OR status='Upcoming') ORDER BY sequenceNumber";
-        $row->addSelect('gibbonSchoolYearIDEntry')->fromQuery($pdo, $sql)->isRequired()->placeholder(__('Please select...'));
+
+        $availableYearsOfEntry = getSettingByScope($connection2, 'Application Form', 'availableYearsOfEntry');
+        if (!empty($availableYearsOfEntry)) {
+            $data = array('gibbonSchoolYearIDList' => $availableYearsOfEntry);
+            $sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear WHERE FIND_IN_SET(gibbonSchoolYearID, :gibbonSchoolYearIDList) ORDER BY sequenceNumber";
+        } else {
+            $data = array();
+            $sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear WHERE (status='Current' OR status='Upcoming') ORDER BY sequenceNumber";
+        }
+        $row->addSelect('gibbonSchoolYearIDEntry')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder(__('Please select...'));
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Intended Start Date'))->description(__('Student\'s intended first day at school.'))->append('<br/>'.__('Format:'))->append(' '.$_SESSION[$guid]['i18n']['dateFormat']);

--- a/modules/User Admin/applicationFormSettings.php
+++ b/modules/User Admin/applicationFormSettings.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 @session_start();
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationFormSettings.php') == false) {
     //Acess denied
@@ -37,6 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     }
 
     $form = Form::create('applicationFormSettings', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/applicationFormSettingsProcess.php');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
@@ -86,6 +88,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
+
+    $setting = getSettingByScope($connection2, 'Application Form', 'availableYearsOfEntry', true);
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $years = $row->addSelectSchoolYear($setting['name'], 'Active')
+            ->setSize(3)
+            ->selectMultiple()
+            ->selected(explode(',', $setting['value']))
+            ->isRequired();
+
+        if (empty($setting['value'])) {
+            $years->selectAll();
+        }
 
     $row = $form->addRow()->addHeading(__('Required Documents Options'));
 

--- a/modules/User Admin/applicationFormSettingsProcess.php
+++ b/modules/User Admin/applicationFormSettingsProcess.php
@@ -64,6 +64,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $scholarshipOptionsActive = (isset($_POST['scholarshipOptionsActive']))? $_POST['scholarshipOptionsActive'] : '';
     $paymentOptionsActive = (isset($_POST['paymentOptionsActive']))? $_POST['paymentOptionsActive'] : '';
 
+    $availableYearsOfEntry = (isset($_POST['availableYearsOfEntry']))? $_POST['availableYearsOfEntry'] : '';
+    $availableYearsOfEntry = (is_array($availableYearsOfEntry))? implode(',', $availableYearsOfEntry) : $availableYearsOfEntry;
+
     //Write to database
     $fail = false;
 
@@ -317,6 +320,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     try {
         $data = array('value' => $paymentOptionsActive);
         $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Application Form' AND name='paymentOptionsActive'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
+    try {
+        $data = array('value' => $availableYearsOfEntry);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Application Form' AND name='availableYearsOfEntry'";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {


### PR DESCRIPTION
**New Feature**

## Description
- Adds an Available Years of Entry setting to Application Form Settings to select which years are selectable in the student application form.
- Defaults to the current behaviour of all current and upcoming years

## Motivation and Context
Even though a school year exists in the database it's not always open for new student applications. Our office staff needed a way to limit which years could be applied to, and change it easily when application windows open/close.

## How Has This Been Tested?
Tested locally and in production at TIS.

## Screenshots (if appropriate):
![screen shot 2017-09-15 at 9 35 10 am](https://user-images.githubusercontent.com/897700/30462589-3282d13e-99f9-11e7-99b1-abad786b814c.png)
