### PR TITLE
Form Class: updated renderer to not aggregate LiveValidation javascript

### DIFF
--- a/src/Forms/FormRenderer.php
+++ b/src/Forms/FormRenderer.php
@@ -78,6 +78,7 @@ class FormRenderer implements FormRendererInterface
 
         // Output form rows
         foreach ($form->getRows() as $row) {
+            $validation = '';
             $output .= sprintf('<%1$s id="%2$s" class="%3$s">', $this->wrappers['row'], $row->getID(), $row->getClass());
 
             // Output each element inside the row
@@ -85,30 +86,29 @@ class FormRenderer implements FormRendererInterface
                 $colspan = ($row->isLastElement($element) && $row->getElementCount() < $totalColumns)? 'colspan="'.($totalColumns + 1 - $row->getElementCount()).'"' : '';
 
                 $output .= sprintf('<%1$s class="%2$s" %3$s>', $this->wrappers['cell'], $element->getClass(), $colspan);
-                    $output .= $element->getOutput();
+                $output .= $element->getOutput();
                 $output .= sprintf('</%1$s>', $this->wrappers['cell']);
+
+                if ($element instanceof ValidatableInterface) {
+                    $validation .= $element->getValidationOutput();
+                }
             }
+
+            // Output the validation code for this row
+            if (!empty($validation)) {
+                $output .= '<script type="text/javascript">'.$validation.'</script>';
+            } 
+            
             $output .= sprintf('</%1$s>', $this->wrappers['row']);
         }
 
         $output .= sprintf('</%1$s>', $this->wrappers['form']);
 
-        // Output the validation code, aggregated
-        $output .= '<script type="text/javascript">'."\n";
-
-        foreach ($form->getRows() as $row) {
-            foreach ($row->getElements() as $element) {
-                if ($element instanceof ValidatableInterface) {
-                    $output .= $element->getValidationOutput();
-                }
-            }
-        }
-
         // Output the trigger code
+        $output .= '<script type="text/javascript">'."\n";
         foreach (array_reverse($form->getTriggers()) as $trigger) {
             $output .= $trigger->getOutput();
         }
-
         $output .= '</script>';
 
         $output .= '</form>';


### PR DESCRIPTION
**Bug Fix**

The form renderer was aggregating the LiveValidation js for the entire form and outputting it at the bottom. The idea was to cut down on all the separate inline script blocks. The downside of this is a js error in one section could cause the whole script block to fail.

This fix changes the renderer to output the LV js for each row at a time. If one LV field fails it will not affect the rest of the form validation.

Tested locally (by hand & automated tests) and in production.