### PR TITLE
Students: added ability to delete files and upload multiple files in Edit Application Form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -68,6 +68,7 @@ v15.0.00
 		Students: fixed display of Other Fields heading for parents in Application Form
         Students: added a notification event for Application Form Accepted
         Students: added an option for logged-in users to link new Application Forms to an existing user or family
+		Students: added ability to delete files and upload multiple files in Edit Application Form
 		System Admin: increased length of Absolute URL and Absolute Path to 100 characters
         System Admin: updated version check to handle semantic version numbers
 		Timetable: added ability to set and display text and background colour for timetable day headers

--- a/modules/Students/applicationForm_manage_editProcess.php
+++ b/modules/Students/applicationForm_manage_editProcess.php
@@ -643,48 +643,51 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                         for ($i = 0; $i < $fileCount; ++$i) {
                             if (empty($_FILES["file$i"]['tmp_name'])) continue;
 
-                            $file = (isset($_FILES["file$i"]))? $_FILES["file$i"] : null;
                             $fileName = (isset($_POST["fileName$i"]))? $_POST["fileName$i"] : null;
 
-                            // Upload the file, return the /uploads relative path
-                            $attachment = $fileUploader->uploadFromPost($file, 'ApplicationDocument');
-
-                            // Write files to database, if there is one
-                            if (!empty($attachment)) {
-                                // Check for uniqueness
-                                try {
-                                    $dataFile = array('gibbonApplicationFormID' => $gibbonApplicationFormID, 'name' => $fileName);
-                                    $sqlFile = 'SELECT gibbonApplicationFormFileID FROM gibbonApplicationFormFile WHERE gibbonApplicationFormID=:gibbonApplicationFormID, name=:name ORDER BY gibbonApplicationFormFileID DESC';
-                                    $resultFile = $connection2->prepare($sqlFile);
-                                    $resultFile->execute($dataFile);
-                                } catch (PDOException $e) {
-                                    $partialFail = true;
+                            // Handle multiple file uploads (and transpose array)
+                            $uploads = array();
+                            foreach ($_FILES["file$i"] as $key => $subarr) {
+                                foreach ($subarr as $subkey => $subvalue) {
+                                    $uploads[$subkey][$key] = $subvalue;
                                 }
+                            }
 
-                                if ($resultFile->rowCount() > 0) {
-                                    // If the file exists, replace the most recent one
-                                    $gibbonApplicationFormFileID = $resultFile->fetchColumn(0);
+                            foreach ($uploads as $file) {
+                                if ($file['error'] == UPLOAD_ERR_NO_FILE) continue;
+
+                                // Upload the file, return the /uploads relative path
+                                $attachment = $fileUploader->uploadFromPost($file, 'ApplicationDocument');
+    
+                                // Write files to database, if there is one
+                                if (!empty($attachment)) {
                                     try {
-                                        $dataFile = array('gibbonApplicationFormFileID' => $gibbonApplicationFormFileID, 'path' => $attachment);
-                                        $sqlFile = 'UPDATE gibbonApplicationFormFile SET path=:path WHERE gibbonApplicationFormFileID=:gibbonApplicationFormFileID';
+                                        $dataFile = array('gibbonApplicationFormID' => $gibbonApplicationFormID, 'name' => $fileName, 'path' => $attachment);
+                                        $sqlFile = "INSERT INTO gibbonApplicationFormFile SET gibbonApplicationFormID=:gibbonApplicationFormID, name=:name, path=:path";
                                         $resultFile = $connection2->prepare($sqlFile);
                                         $resultFile->execute($dataFile);
                                     } catch (PDOException $e) {
                                         $partialFail = true;
                                     }
                                 } else {
-                                    // Otherwise add the new file to the database
-                                    try {
-                                        $dataFile = array('gibbonApplicationFormID' => $gibbonApplicationFormID, 'name' => $fileName, 'path' => $attachment);
-                                        $sqlFile = 'INSERT INTO gibbonApplicationFormFile SET gibbonApplicationFormID=:gibbonApplicationFormID, name=:name, path=:path';
-                                        $resultFile = $connection2->prepare($sqlFile);
-                                        $resultFile->execute($dataFile);
-                                    } catch (PDOException $e) {
-                                        $partialFail = true;
-                                    }
+                                    $partialFail = true;
                                 }
-                            } else {
-                                $partialFail = true;
+                            }
+                        }
+
+                        $attachments = (isset($_POST['attachment']))? $_POST['attachment'] : array();
+
+                        // File is flagged for deletion if the attachment path has been removed
+                        foreach ($attachments as $gibbonApplicationFormFileID => $attachment) {
+                            if (!empty($gibbonApplicationFormFileID) && empty($attachment)) {
+                                try {
+                                    $dataFile = array('gibbonApplicationFormFileID' => $gibbonApplicationFormFileID);
+                                    $sqlFile = "DELETE FROM gibbonApplicationFormFile WHERE gibbonApplicationFormFileID=:gibbonApplicationFormFileID";
+                                    $resultFile = $connection2->prepare($sqlFile);
+                                    $resultFile->execute($dataFile);
+                                } catch (PDOException $e) {
+                                    $partialFail = true;
+                                }
                             }
                         }
                     }

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1399,15 +1399,22 @@ input[name*="phone"] ~ .LV_invalid {
 	cursor: pointer;
 }
 
+.input-box ~ .input-box {
+	border-top-width: 0px;
+}
+
+.input-box-meta {
+	float: right;
+	line-height: 22px;
+}
+
 .floatNone {
 	float:none;
 }
 
 .max-upload {
-    float: right;
     font-style: italic;
-    color: #c00;
-    line-height: 22px;
+	color: #c00;
     font-size: 11px;
 }
 


### PR DESCRIPTION
**New Feature**

## Description
- Updates the FileUpload class to handle displaying multiple attachments for one file input
- Adds the ability to delete application form attachments
- Adds the ability to upload multiple files to the application form (at the same time, or one at a time)

## Motivation and Context
Admissions staff often need more tools to manage the files attached to an application form.

## How Has This Been Tested?
Tested locally.