### PR TITLE
Fix column objects to support multiple buttons

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -849,5 +849,5 @@ ALTER TABLE `gibbonRubricEntry` ADD INDEX(`contextDBTable`);end
 ALTER TABLE `gibbonRubricEntry` ADD INDEX(`contextDBTableID`);end
 ALTER TABLE `gibbonRubricRow` ADD INDEX(`gibbonRubricID`);end
 INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Weekly Attendance Summary ', 'Attendance', 'Attendance Summary by Date', 'CLI', 'All,gibbonYearGroupID', 'Y');end
-
+ALTER TABLE `gibbonActivityStaff` MODIFY `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL DEFAULT '0000000000';end
 ";

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -164,9 +164,9 @@ class FormFactory implements FormFactoryInterface
         return new Input\MultiSelect($this, $name);
     }
 
-    public function createButton($label = 'Button', $onClick = '')
+    public function createButton($name, $label = 'Button', $onClick = '')
     {
-        return new Input\Button($label, $onClick);
+        return new Input\Button($name, $label, $onClick);
     }
 
     public function createCustomBlocks($name, OutputableInterface $block, \Gibbon\Session $session)

--- a/src/Forms/Input/Button.php
+++ b/src/Forms/Input/Button.php
@@ -28,22 +28,36 @@ namespace Gibbon\Forms\Input;
 class Button extends Input
 {
 
-    public function __construct($name, $onClick)
-    {
-        $this->setAttribute('value', $name);
-        $this->onClick($onClick);
-    }
+	protected $name;
 
-    public function onClick($value)
-    {
-        $this->setAttribute('onClick', $value);
-        return $this;
-    }
+	public function __construct($name, $text, $onClick)
+	{
+		$this->setAttribute('value', $text);
+		$this->onClick($onClick);
+		$this->setName($name);
+	}
 
-    protected function getElement()
-    {
-        $output = '<input type="button" '.$this->getAttributeString().'>';
+	public function onClick($value)
+	{
+		$this->setAttribute('onClick', $value);
+		return $this;
+	}
 
-        return $output;
-    }
+	protected function getElement()
+	{
+		$output = '<input type="button" '.$this->getAttributeString().'>';
+
+		return $output;
+	}
+
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	public function setName($name = '')
+	{
+		$this->name = $name;
+		return $this->name;
+	}
 }


### PR DESCRIPTION
Buttons did not identify properly before with IDs, this is now fixed but beware that addButton now requires another value at construction to supply the ID. 

When the column was running getOutput(), the ID was picked but the ID was a string value "NULL" and therefore the ID matches on all buttons inside that column object. This fix uses the ID assigned to the button instead.