### PR TITLE
Attendance: add a warning to Attendance by Class when not timetabled

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@ v15.0.00
 		Attendance: added count column to Students Not Present and Students Not Onsite reports
 		Attendance: granted like to those students who successfully self register
 		Attendance: added selective auto-redirect to move students to self-registration page under certain conditions
+		Attendance: added a warning to Attendance by Class when not currently timetabled for the selected date
 		Behaviour: fixed typo in three settings
 		Departments: fixed bug preventing students from seeing other students in a class
 		Finance: set name of outgoing email to school name, not user's name


### PR DESCRIPTION
**New Feature**

## Description
- Adds a warning to the top of Attendance by Class if that class is not timetabled for the selected date (and only displays if it's a regularly timetabled class)

## Motivation and Context
Provides and extra visual cue to help prevent staff from taking attendance for a class on the wrong date.

## Screenshots:
![screen shot 2017-10-24 at 10 25 23 am](https://user-images.githubusercontent.com/897700/31922129-e3c219c6-b8a5-11e7-86bc-d05948907252.png)