### PR TITLE
Button Fix

### DIFF
--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -164,9 +164,18 @@ class FormFactory implements FormFactoryInterface
         return new Input\MultiSelect($this, $name);
     }
 
-    public function createButton($label = 'Button', $onClick = '')
+    public function createButton($label = 'Button', $onClick = '', $id = null)
     {
-        return new Input\Button($label, $onClick);
+        if($id == null)
+        {
+            return new Input\Button($label, $onClick);
+        }
+        else
+        {
+            $button = new Input\Button($label, $onClick);
+            $button->setName($id);
+            return $button;
+        }
     }
 
     public function createCustomBlocks($name, OutputableInterface $block, \Gibbon\Session $session)

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -173,6 +173,7 @@ class FormFactory implements FormFactoryInterface
         else
         {
             $button = new Input\Button($label, $onClick);
+            $button->setID($id);
             $button->setName($id);
             return $button;
         }

--- a/src/Forms/Input/Button.php
+++ b/src/Forms/Input/Button.php
@@ -27,47 +27,25 @@ namespace Gibbon\Forms\Input;
  */
 class Button extends Input
 {
-    private $name;
-    private $id;
     private $onclick;
 
     public function __construct($name, $onClick)
     {
         $this->setName($name);
         $this->onClick($onClick);
-        $this->setElementAttributes();
+        $this->setValue($name);
+        $this->setID($name);
     }
 
     public function onClick($value)
     {
-        $this->onclick = $value;
-        $this->setElementAttributes();
+        $this->setAttribute('onClick',$value);
         return $this;
-    }
-
-    public function setName($name = '')
-    {
-        $this->id = $name;
-        $this->name = $name;
-        $this->setElementAttributes();
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    protected function setElementAttributes()
-    {
-        $this->setAttribute('value', $this->getName());
-        $this->setAttribute('id', $this->getName());
-        $this->setAttribute('onClick', $this->onclick);
     }
 
     protected function getElement()
     {
         $output = '<input type="button" '.$this->getAttributeString().'>';
-
         return $output;
     }
 }

--- a/src/Forms/Input/Button.php
+++ b/src/Forms/Input/Button.php
@@ -27,17 +27,41 @@ namespace Gibbon\Forms\Input;
  */
 class Button extends Input
 {
+    private $name;
+    private $id;
+    private $onclick;
 
     public function __construct($name, $onClick)
     {
-        $this->setAttribute('value', $name);
+        $this->setName($name);
         $this->onClick($onClick);
+        $this->setElementAttributes();
     }
 
     public function onClick($value)
     {
-        $this->setAttribute('onClick', $value);
+        $this->onclick = $value;
+        $this->setElementAttributes();
         return $this;
+    }
+
+    public function setName($name = '')
+    {
+        $this->id = $name;
+        $this->name = $name;
+        $this->setElementAttributes();
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    protected function setElementAttributes()
+    {
+        $this->setAttribute('value', $this->getName());
+        $this->setAttribute('id', $this->getName());
+        $this->setAttribute('onClick', $this->onclick);
     }
 
     protected function getElement()


### PR DESCRIPTION
Following on from previous PR where I clearly displayed my superior git knowledge and totally borked the branch... Here is a branch with just one fix instead of like 3 fixes bundled in!

Post copied from last PR:

==============

Ok I've set vim to use 4 spaces instead of tab chars now.

I've made a solution to the button class which leaves the constructors for the class alone. When created through FormFactory, the ID is assigned through a 3rd, optional, variable. If no ID is provided, the label is used, as before. If you want to use multiple buttons of the same name, you'll need to use the third variable to set it.

Here's what you can do with the changes:

```
    $frm = Form::create('test',null,'get');

    $frm->addRow()->addButton('hello'); //Create a button with a label and no onclick
    $frm->addRow()->addButton('hello again',null); //Create a button with an imaginary onclick in place of null
    $frm->addRow()->addButton('hello again again',null,'fancyid'); //Create a button with an ID

    //This snippet will make one button since the button objects will use the name 'hello' in the array
    $frmRow = $frm->addRow();
    $frmRow->addButton('hello');
    $frmRow->addButton('hello');

    //This snippet, with buttons embedded in a column will output 3 buttons in said column. You could embed the buttons in a row too since they work in a similar fashion.
    $frmRow2 = $frm->addRow();
    $rowCol = $frmRow2->addColumn();
    $rowCol->addButton('hello',null,'hello1'); //Button with ID 'hello1'
    $rowCol->addButton('hello',null,'hello2'); //Button with ID 'hello2'
    $rowCol->addButton('hello',null,'hello3'); //You get the idea...
    echo $frm->getOutput();
```