### PR TITLE
Theme: update clearfix used in Form class columns

### DIFF
--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1299,7 +1299,7 @@ select[multiple] {
 	width: 70px;
 }
 
-.column div:after {
+.column > div:after {
   content: "";
   display: table;
   clear: both;


### PR DESCRIPTION
**Bug Fix**

By default the theme css applies a float to all form inputs. For form columns to align properly a clearfix was introduced. This PR updates the clearfix to only apply to the first div inside the column, so elements like Editor with many nested divs don't have unwanted clearfixes applied.