### PR TITLE
System: Fix PDOException in sqlConnection class

### DIFF
--- a/src/Gibbon/sqlConnection.php
+++ b/src/Gibbon/sqlConnection.php
@@ -171,13 +171,12 @@ class sqlConnection
 			$this->result = $this->getConnection()->prepare($query);
 			$this->result->execute($data);
 		}
-		catch(PDOException $e)
+		catch(\PDOException $e)
 		{
 			$this->error = $e->getMessage();
 			$this->querySuccess = false;
 			if ($error !== NULL)
 				echo str_replace('{message}', $this->error, $error);
-			$this->result = NULL;
 		}
 
 		return $this->result ;


### PR DESCRIPTION
**Bug Fix**

Namespacing in the sqlConnection class was causing some exceptions to not be caught in the executeQuery method.

We may also want to consider logging the errors rather than echoing them, so we can opt to only output errors in non-production environments.