### PR TITLE
System: fix passwordForceReset not resetting after a password change

### DIFF
--- a/preferencesPasswordProcess.php
+++ b/preferencesPasswordProcess.php
@@ -36,10 +36,8 @@ if (isset($_SESSION[$guid]['gibbonAcademicYearID']) == false or isset($_SESSION[
 $password = $_POST['password'];
 $passwordNew = $_POST['passwordNew'];
 $passwordConfirm = $_POST['passwordConfirm'];
-$forceReset = null;
-if (isset($_POST['forceReset'])) {
-    $forceReset = $_POST['forceReset'];
-}
+$forceReset = $_SESSION[$guid]['passwordForceReset'];
+
 if ($forceReset != 'Y') {
     $forceReset = 'N';
 }


### PR DESCRIPTION
**Bug Fix**

The passwordForceReset flag wasn't turning off again after changing a users password through Preferences. Looks like the culprit may have been a missing $_POST value in the password form. Rather than passing it by post (which could be tampered with), updated it to grab from the existing session value.