### PR TITLE
Form Class: add a prefab Delete Form, implement in Manage Roles

### DIFF
--- a/modules/User Admin/role_manage.php
+++ b/modules/User Admin/role_manage.php
@@ -118,9 +118,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage.php
             echo '<td>';
             echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/role_manage_edit.php&gibbonRoleID='.$row['gibbonRoleID']."'><img title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
             if ($row['type'] == 'Additional') {
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/role_manage_delete.php&gibbonRoleID='.$row['gibbonRoleID']."'><img title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a>";
+                echo "<a class='thickbox' href='".$_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/role_manage_delete.php&gibbonRoleID='.$row['gibbonRoleID']."&width=650&height=135'><img title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a>";
             }
-            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/role_manage_duplicate.php&gibbonRoleID='.$row['gibbonRoleID']."'><img title='".__($guid, 'Duplicate')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/copy.png'/></a> ";
+            echo "<a class='thickbox' href='".$_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/role_manage_duplicate.php&gibbonRoleID='.$row['gibbonRoleID']."&width=650&height=200'><img title='".__($guid, 'Duplicate')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/copy.png'/></a> ";
             echo '</td>';
             echo '</tr>';
         }

--- a/modules/User Admin/role_manage_delete.php
+++ b/modules/User Admin/role_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-@session_start();
+use Gibbon\Forms\PrefabFormFactory;
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_delete.php') == false) {
     //Acess denied
@@ -56,31 +56,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_del
             echo '</div>';
         } else {
             //Let's go!
-            $row = $result->fetch(); ?>
-			<form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/role_manage_deleteProcess.php?gibbonRoleID=$gibbonRoleID" ?>">
-				<table class='smallIntBorder fullWidth' cellspacing='0'>	
-					<tr>
-						<td> 
-							<b><?php echo __($guid, 'Are you sure you want to delete this record?'); ?></b><br/>
-							<span style="font-size: 90%; color: #cc0000"><i><?php echo __($guid, 'This operation cannot be undone, and may lead to loss of vital data in your system. PROCEED WITH CAUTION!'); ?></span>
-						</td>
-						<td class="right">
-							
-						</td>
-					</tr>
-					<tr>
-						<td> 
-							<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
-							<input type="submit" value="<?php echo __($guid, 'Yes'); ?>">
-						</td>
-						<td class="right">
-							
-						</td>
-					</tr>
-				</table>
-			</form>
-			<?php
 
+            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/role_manage_deleteProcess.php?gibbonRoleID=$gibbonRoleID", true);
+            echo $form->getOutput();
         }
     }
 }

--- a/src/Forms/PrefabFormFactory.php
+++ b/src/Forms/PrefabFormFactory.php
@@ -1,0 +1,61 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Forms;
+
+/**
+ * PrefabFormFactory
+ *
+ * For building pre-made forms all at once.
+ *
+ * @version v14
+ * @since   v14
+ */
+class PrefabFormFactory
+{
+    public static function createDeleteForm($action, $confirmation = false)
+    {
+        $form = Form::create('deleteRecord', $action);
+        $form->addHiddenValue('address', $_GET['q']);
+
+        foreach ($_GET as $key => $value) {
+            $form->addHiddenValue($key, $value);
+        }
+
+        $row = $form->addRow();
+            $column = $row->addColumn();
+            $column->addContent(__('Are you sure you want to delete this record?'))->wrap('<strong>', '</strong>');
+            $column->addContent(__('This operation cannot be undone, and may lead to loss of vital data in your system. PROCEED WITH CAUTION!'))->wrap('<span style="color: #cc0000"><i>', '</i></span>');
+
+        if ($confirmation) {
+            $row = $form->addRow();
+            $row->addLabel('confirm', sprintf(__('Type %1$s to confirm'), __('DELETE')));
+            $row->addTextField('confirm')
+                ->isRequired()
+                ->addValidation(
+                    'Validate.Inclusion',
+                    'within: [\''.__('DELETE').'\'], failureMessage: "'.__('Please enter the text exactly as it is displayed to confirm this action.').'", caseSensitive: false')
+                ->addValidationOption('onlyOnSubmit: true');
+        }
+
+        $form->addRow()->addSubmit(__('Yes'));
+        return $form;
+    }
+
+}

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1443,3 +1443,8 @@ tr.head td {
 .right {
 	text-align: right!important;
 }
+
+/* Hide breadcrumbs in fullscreen */
+#TB_window .trail {
+	display: none;
+}


### PR DESCRIPTION
This adds a new PrefabFormFactory class for creating predefined forms in one method call. Helps reduce duplicate code for forms that are nearly identical throughout the system. The createDeleteForm method has option for confirmation text-entry, off by default.

I've implemented it in Manage Roles as an example. Both the delete and duplicate actions function as modal windows with a small tweak to the code (also as an example, easy to revert out if needed).