### PR TITLE
System: add Enable Smart Workflow Help option to Preferences 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,7 @@ v15.0.00
 		System: fixed text alginment in module menu
 		System: fixed long-string and large image issue causing content to bleed under sidebar
 		System: fixed bug causing two entries in a module menu to be highlighted as active in some cases
+		System: added Enable Smart Workflow Help option to Preferences
 		Activities: added new payment fields to activities (cost type and cost status)
 		Activities: fixed database field length issue in gibbonActivityStaff
 		Attendance: fixed GROUP BY issue in moduleFunctions.php when MySQL is using only_full_group_by

--- a/preferences.php
+++ b/preferences.php
@@ -187,11 +187,13 @@ if (!isset($_SESSION[$guid]["username"])) {
         $sql = "SELECT smartWorkflowHelp FROM gibbonStaff WHERE gibbonPersonID=:gibbonPersonID";
         $result = $pdo->executeQuery($data, $sql);
 
-        $smartWorkflowHelp = ($result && $result->rowCount() > 0)? $result->fetchColumn(0) : 'Y';
+        if ($result && $result->rowCount() > 0) {
+            $smartWorkflowHelp = $result->fetchColumn(0);
 
-        $row = $form->addRow();
-            $row->addLabel('smartWorkflowHelp', __('Enable Smart Workflow Help?'));
-            $row->addYesNo('smartWorkflowHelp')->selected($smartWorkflowHelp);
+            $row = $form->addRow();
+                $row->addLabel('smartWorkflowHelp', __('Enable Smart Workflow Help?'));
+                $row->addYesNo('smartWorkflowHelp')->selected($smartWorkflowHelp);
+        }
     }
 
     $row = $form->addRow();

--- a/preferences.php
+++ b/preferences.php
@@ -144,6 +144,12 @@ if (!isset($_SESSION[$guid]["username"])) {
     </script>
     <?php
 
+    $staff = false;
+    foreach ($_SESSION[$guid]['gibbonRoleIDAll'] as $role) {
+        $roleCategory = getRoleCategory($role[0], $connection2);
+        $staff = $staff || ($roleCategory == 'Staff');
+    }
+    
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/preferencesProcess.php');
 
     $form->addRow()->addHeading(__('Settings'));
@@ -175,6 +181,18 @@ if (!isset($_SESSION[$guid]["username"])) {
     $row = $form->addRow();
         $row->addLabel('receiveNotificationEmails', __('Receive Email Notifications?'))->description(__('Notifications can always be viewed on screen.'));
         $row->addYesNo('receiveNotificationEmails');
+        
+    if ($staff) {
+        $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+        $sql = "SELECT smartWorkflowHelp FROM gibbonStaff WHERE gibbonPersonID=:gibbonPersonID";
+        $result = $pdo->executeQuery($data, $sql);
+
+        $smartWorkflowHelp = ($result && $result->rowCount() > 0)? $result->fetchColumn(0) : 'Y';
+
+        $row = $form->addRow();
+            $row->addLabel('smartWorkflowHelp', __('Enable Smart Workflow Help?'));
+            $row->addYesNo('smartWorkflowHelp')->selected($smartWorkflowHelp);
+    }
 
     $row = $form->addRow();
         $row->addFooter();

--- a/preferencesProcess.php
+++ b/preferencesProcess.php
@@ -63,6 +63,20 @@ try {
     exit();
 }
 
+$smartWorkflowHelp = isset($_POST['smartWorkflowHelp'])? $_POST['smartWorkflowHelp'] : null;
+if (!empty($smartWorkflowHelp)) {
+    try {
+        $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'smartWorkflowHelp' => $smartWorkflowHelp);
+        $sql = "UPDATE gibbonStaff SET smartWorkflowHelp=:smartWorkflowHelp WHERE gibbonPersonID=:gibbonPersonID";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit();
+    }
+}
+
 //Update personal preferences in session
 $_SESSION[$guid]['calendarFeedPersonal'] = $calendarFeedPersonal;
 $_SESSION[$guid]['personalBackground'] = $personalBackground;


### PR DESCRIPTION
**New Feature**

Adds an Enable Smart Workflow Help option to the preferences page for users in the Staff category.

## Motivation and Context
It's often easy to dismiss and teachers currently have no way to turn it back on.