### PR TITLE
User Admin: added a setting to require email addresses to be unique

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -853,5 +853,6 @@ ALTER TABLE `gibbonActivityStaff` MODIFY `gibbonPersonID` INT(10) UNSIGNED ZEROF
 UPDATE gibbonSetting SET description='The number of Markbook concerns needed in the past 60 days to raise a low level academic alert on a student.' WHERE scope='Students' AND name='academicAlertLowThreshold';end
 UPDATE gibbonSetting SET description='The number of Markbook concerns needed in the past 60 days to raise a medium level academic alert on a student.' WHERE scope='Students' AND name='academicAlertMediumThreshold';end
 UPDATE gibbonSetting SET description='The number of Markbook concerns needed in the past 60 days to raise a high level academic alert on a student.' WHERE scope='Students' AND name='academicAlertHighThreshold';end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('User Admin', 'uniqueEmailAddress', 'Unique Email Address', 'Are primary email addresses required to be unique?', 'N');end
 
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -95,6 +95,7 @@ v15.0.00
         User Admin: added ability to set username formats by role in User Settings
         User Admin: added a button to generate usernames in Add User
         User Admin: added an Available Years of Entry setting to select which years are available in the student application
+		User Admin: added a setting to require a user's primary email address to be unique
 
 v14.0.01
 --------

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -333,7 +333,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 						$row->addTextField('emergency1Number2')->maxLength(30);
 
 						$row = $form->addRow();
-						$row->addLabel('emergency2Name', __('Contact 1 Name'));
+						$row->addLabel('emergency2Name', __('Contact 2 Name'));
 						$row->addTextField('emergency2Name')->maxLength(30);
 
 						$row = $form->addRow();

--- a/modules/User Admin/userSettings.php
+++ b/modules/User Admin/userSettings.php
@@ -147,6 +147,13 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
+    $row = $form->addRow()->addHeading(__('User Data Options'));
+
+    $setting = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress', true);
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addYesNo($setting['name'])->selected($setting['value']);
+
     $row = $form->addRow()->addHeading(__('User Interface Options'));
 
     $setting = getSettingByScope($connection2, 'User Admin', 'personalBackground', true);

--- a/modules/User Admin/userSettingsProcess.php
+++ b/modules/User Admin/userSettingsProcess.php
@@ -41,6 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
     $privacy = $_POST['privacy'];
     $privacyBlurb = (isset($_POST['privacyBlurb'])) ? $_POST['privacyBlurb'] : null;
     $privacyOptions = (isset($_POST['privacyOptions'])) ? $_POST['privacyOptions'] : null;
+    $uniqueEmailAddress = (isset($_POST['uniqueEmailAddress'])) ? $_POST['uniqueEmailAddress'] : 'N';
     $personalBackground = $_POST['personalBackground'];
     $dayTypeOptions = $_POST['dayTypeOptions'];
     $dayTypeText = $_POST['dayTypeText'];
@@ -114,6 +115,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
     try {
         $data = array('value' => $privacyOptions);
         $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='User Admin' AND name='privacyOptions'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
+    try {
+        $data = array('value' => $uniqueEmailAddress);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='User Admin' AND name='uniqueEmailAddress'";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -419,7 +419,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 		$row->addTextField('emergency1Number2')->maxLength(30);
 
 	$row = $form->addRow();
-		$row->addLabel('emergency2Name', __('Contact 1 Name'));
+		$row->addLabel('emergency2Name', __('Contact 2 Name'));
 		$row->addTextField('emergency2Name')->maxLength(30);
 
 	$row = $form->addRow();

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -132,7 +132,10 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addLabel('username', __('Username'))->description(__('Must be unique. System login name. Cannot be changed.'));
 		$column = $row->addColumn('username')->addClass('inline right');
 		$column->addButton(__('Generate Username'))->addClass('generateUsername');
-		$column->addTextField('username')->isRequired()->maxLength(20);
+		$column->addTextField('username')
+			->isRequired()
+			->maxLength(20)
+			->append('<span></span><div class="LV_validation_message LV_invalid" id="username_availability_result"></div><br/>');
 
 	$policy = getPasswordPolicy($guid, $connection2);
 	if ($policy != false) {
@@ -187,8 +190,14 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
     $form->addRow()->addHeading(__('Contact Information'));
 
     $row = $form->addRow();
-        $row->addLabel('email', __('Email'));
-        $row->addEmail('email')->maxLength(50);
+        $emailLabel = $row->addLabel('email', __('Email'));
+        $email = $row->addEmail('email')->maxLength(50);
+		
+	$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
+	if ($uniqueEmailAddress == 'Y') {
+        $emailLabel->description(__('Must be unique.'));
+        $email->append('<span></span><div class="LV_validation_message LV_invalid" id="email_availability_result"></div>');
+	}
 
     $row = $form->addRow();
         $row->addLabel('emailAlternate', __('Alternate Email'));
@@ -556,6 +565,35 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 				}
 			});
 		});
+
+		<?php if ($uniqueEmailAddress == 'Y') : ?>
+		// Email Uniqueness
+		$('#email').on('input', function(){
+			if (emailValidate.doValidations() == false || $('#email').val() == '') {
+				$('#email_availability_result').html('');
+				return;
+			}
+
+			$.ajax({
+				type : 'POST',
+				data : { email: $('#email').val(), gibbonPersonID: 0 },
+				url: "./modules/User Admin/user_manage_emailAjax.php",
+				success: function(responseText){
+					if(responseText == 0){
+						$('#email + .LV_validation_message').hide();
+						$('#email_availability_result').html('<?php echo sprintf(__('%1$s available'), __('Email')); ?>');
+						$('#email_availability_result').switchClass('LV_invalid', 'LV_valid');
+					} else if(responseText > 0){
+						$('#email_availability_result').html('');
+						$('#email_availability_result').switchClass('LV_valid', 'LV_invalid');
+						// Prevent submitting form with a non-unique email
+						$('#email').switchClass('LV_valid_field', 'LV_invalid_field');
+						emailValidate.add(Validate.Exclusion, { within: [$('#email').val()], failureMessage: "<?php echo sprintf(__('%1$s already in use'), __('Email')); ?>" });
+					}
+				}
+			});
+		});
+        <?php endif; ?>
 	</script>
 	<?php
 }

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -533,7 +533,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 					$row->addTextField('emergency1Number2')->maxLength(30);
 
 				$row = $form->addRow();
-					$row->addLabel('emergency2Name', __('Contact 1 Name'));
+					$row->addLabel('emergency2Name', __('Contact 2 Name'));
 					$row->addTextField('emergency2Name')->maxLength(30);
 
 				$row = $form->addRow();

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -229,8 +229,14 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 			$form->addRow()->addHeading(__('Contact Information'));
 
 			$row = $form->addRow();
-				$row->addLabel('email', __('Email'));
-				$row->addEmail('email')->maxLength(50);
+                $emailLabel = $row->addLabel('email', __('Email'));
+                $email = $row->addEmail('email')->maxLength(50);
+				
+			$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
+			if ($uniqueEmailAddress == 'Y') {
+                $emailLabel->description(__('Must be unique.'));
+                $email->append('<span></span><div class="LV_validation_message LV_invalid" id="email_availability_result"></div>');
+			}
 
 			$row = $form->addRow();
 				$row->addLabel('emailAlternate', __('Alternate Email'));
@@ -647,6 +653,35 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 						}
 						});
 				});
+
+				<?php if ($uniqueEmailAddress == 'Y') : ?>
+				// Email Uniqueness
+				$('#email').on('input', function(){
+					if (emailValidate.doValidations() == false || $('#email').val() == '') {
+						$('#email_availability_result').html('');
+						return;
+					}
+
+					$.ajax({
+						type : 'POST',
+						data : { email: $('#email').val(), gibbonPersonID: '<?php echo $gibbonPersonID; ?>' },
+						url: "./modules/User Admin/user_manage_emailAjax.php",
+						success: function(responseText){
+							if(responseText == 0){
+								$('#email + .LV_validation_message').hide();
+								$('#email_availability_result').html('<?php echo sprintf(__('%1$s available'), __('Email')); ?>');
+								$('#email_availability_result').switchClass('LV_invalid', 'LV_valid');
+							} else if(responseText > 0){
+								$('#email_availability_result').html('');
+								$('#email_availability_result').switchClass('LV_valid', 'LV_invalid');
+								// Prevent submitting form with a non-unique email
+								$('#email').switchClass('LV_valid_field', 'LV_invalid_field');
+								emailValidate.add(Validate.Exclusion, { within: [$('#email').val()], failureMessage: "<?php echo sprintf(__('%1$s already in use'), __('Email')); ?>" });
+							}
+						}
+					});
+				});
+				<?php endif; ?>
 			</script>
 
 			<?php

--- a/modules/User Admin/user_manage_emailAjax.php
+++ b/modules/User Admin/user_manage_emailAjax.php
@@ -1,0 +1,34 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//Gibbon system-wide include
+include '../../gibbon.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php') == false) {
+    die(__('Your request failed because you do not have access to this action.'));
+} else {
+    $gibbonPersonID = isset($_POST['gibbonPersonID'])? $_POST['gibbonPersonID'] : '';
+    $email = isset($_POST['email'])? $_POST['email'] : '';
+
+    $data = array('gibbonPersonID' => $gibbonPersonID, 'email' => $email);
+    $sql = "SELECT COUNT(*) FROM gibbonPerson WHERE email=:email AND gibbonPersonID<>:gibbonPersonID";
+    $result = $pdo->executeQuery($data, $sql);
+
+    echo ($result && $result->rowCount() == 1)? $result->fetchColumn(0) : -1;
+}


### PR DESCRIPTION
**New Feature**

Adds an option to Manage User Settings which allows requiring a user's primary email address to be unique. This option is off by default. The check is performed via AJAX when adding and editing users.

I also have a Query Builder query for finding non-unique emails which may be handy to add to the collection.

## Motivation and Context
Systems using Google to login need to enforce unique emails otherwise conflicts arise and users cannot login. A unique email is also required to use the password reset form and login via email address.

## How Has This Been Tested?
Tested locally and in production at TIS.

_Edit: snuck in a tiny fix for the Emergency Contact 2 Name_