### PR TITLE
System: cleanup and move password code into Password class

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -23,4 +23,25 @@ jQuery(function($){
     $('.checkall').click(function () {
         $(this).parents('fieldset:eq(0)').find(':checkbox').attr('checked', this.checked);
     });
+
+    /**
+     * Password Generator. Requires data-source, data-confirm and data-alert attributes.
+     */
+    $(".generatePassword").click(function(){
+        if ($(this).data("source") == "" || $(this).data("confirm") == "") return;
+
+        var chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789![]{}()%&*$#^~@|";
+        var text = '';
+        for(var i=0; i < 12; i++) {
+            if (i==0) { text += chars.charAt(Math.floor(Math.random() * 26)); }
+            else if (i==1) { text += chars.charAt(Math.floor(Math.random() * 26)+26); }
+            else if (i==2) { text += chars.charAt(Math.floor(Math.random() * 10)+52); }
+            else if (i==3) { text += chars.charAt(Math.floor(Math.random() * 19)+62); }
+            else { text += chars.charAt(Math.floor(Math.random() * chars.length)); }
+        }
+        $('input[name="' + $(this).data("source") + '"]').val(text).blur();
+        $('input[name="' + $(this).data("confirm") + '"]').val(text).blur();
+        prompt($(this).data("alert"), text);
+    });
+
 });

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -97,94 +97,76 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
             ->description(__('Displayed at 240px by 320px.'))
             ->description(__('Accepts images up to 360px by 480px.'))
             ->description(__('Accepts aspect ratio between 1:1.2 and 1:1.4.'));
-		$row->addFileUpload('file1')
-			->accepts('.jpg,.jpeg,.gif,.png')
-			->setMaxUpload(false);
+        $row->addFileUpload('file1')
+            ->accepts('.jpg,.jpeg,.gif,.png')
+            ->setMaxUpload(false);
 
     // SYSTEM ACCESS
     $form->addRow()->addHeading(__('System Access'));
 
-	// Put together an array of this user's current roles
-	$currentUserRoles = (is_array($_SESSION[$guid]['gibbonRoleIDAll'])) ? array_column($_SESSION[$guid]['gibbonRoleIDAll'], 0) : array();
-	$currentUserRoles[] = $_SESSION[$guid]['gibbonRoleIDPrimary'];
+    // Put together an array of this user's current roles
+    $currentUserRoles = (is_array($_SESSION[$guid]['gibbonRoleIDAll'])) ? array_column($_SESSION[$guid]['gibbonRoleIDAll'], 0) : array();
+    $currentUserRoles[] = $_SESSION[$guid]['gibbonRoleIDPrimary'];
 
-	$data = array();
-	$sql = "SELECT * FROM gibbonRole ORDER BY name";
-	$result = $pdo->executeQuery($data, $sql);
+    $data = array();
+    $sql = "SELECT * FROM gibbonRole ORDER BY name";
+    $result = $pdo->executeQuery($data, $sql);
 
-	// Get all roles and filter roles based on role restrictions
-	$availableRoles = ($result && $result->rowCount() > 0)? $result->fetchAll() : array();
-	$availableRoles = array_reduce($availableRoles, function ($carry, $item) use (&$currentUserRoles) {
-		if ($item['restriction'] == 'Admin Only') {
-			if (!in_array('001', $currentUserRoles)) return $carry;
-		} else if ($item['restriction'] == 'Same Role') {
-			if (!in_array($item['gibbonRoleID'], $currentUserRoles) && !in_array('001', $currentUserRoles)) return $carry;
-		}
-		$carry[$item['gibbonRoleID']] = $item['name'];
-		return $carry;
-	}, array());
+    // Get all roles and filter roles based on role restrictions
+    $availableRoles = ($result && $result->rowCount() > 0)? $result->fetchAll() : array();
+    $availableRoles = array_reduce($availableRoles, function ($carry, $item) use (&$currentUserRoles) {
+        if ($item['restriction'] == 'Admin Only') {
+            if (!in_array('001', $currentUserRoles)) return $carry;
+        } else if ($item['restriction'] == 'Same Role') {
+            if (!in_array($item['gibbonRoleID'], $currentUserRoles) && !in_array('001', $currentUserRoles)) return $carry;
+        }
+        $carry[$item['gibbonRoleID']] = $item['name'];
+        return $carry;
+    }, array());
 
     $row = $form->addRow();
         $row->addLabel('gibbonRoleIDPrimary', __('Primary Role'))->description(__('Controls what a user can do and see.'));
-		$row->addSelect('gibbonRoleIDPrimary')->fromArray($availableRoles)->isRequired()->placeholder();
+        $row->addSelect('gibbonRoleIDPrimary')->fromArray($availableRoles)->isRequired()->placeholder();
 
-	$row = $form->addRow();
+    $generateUsername = $form->getFactory()->createButton(__('Generate'))->addClass('generateUsername alignRight');
+    $row = $form->addRow();
         $row->addLabel('username', __('Username'))->description(__('Must be unique. System login name. Cannot be changed.'));
-		$column = $row->addColumn('username')->addClass('inline right');
-		$column->addButton(__('Generate Username'))->addClass('generateUsername');
-		$column->addTextField('username')
-			->isRequired()
-			->maxLength(20)
-			->append('<span></span><div class="LV_validation_message LV_invalid" id="username_availability_result"></div><br/>');
+        $row->addTextField('username')
+            ->isRequired()
+            ->maxLength(20)
+            ->append('<span></span><div class="LV_validation_message LV_invalid" id="username_availability_result"></div>')
+            ->append($generateUsername->getOutput());
 
-	$policy = getPasswordPolicy($guid, $connection2);
-	if ($policy != false) {
-		$form->addRow()->addAlert($policy, 'warning');
-	}
-	$row = $form->addRow();
-		$row->addLabel('passwordNew', __('Password'));
-		$column = $row->addColumn('passwordNew')->addClass('inline right');
-		$column->addButton(__('Generate Password'))->addClass('generatePassword');
-		$password = $column->addPassword('passwordNew')
-			->isRequired()
-			->maxLength(30);
+    $policy = getPasswordPolicy($guid, $connection2);
+    if ($policy != false) {
+        $form->addRow()->addAlert($policy, 'warning');
+    }
+    $row = $form->addRow();
+        $row->addLabel('passwordNew', __('Password'));
+        $row->addPassword('passwordNew')
+            ->addPasswordPolicy($pdo)
+            ->addGeneratePasswordButton($form)
+            ->isRequired()
+            ->maxLength(30);
 
-	$alpha = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha');
-	$numeric = getSettingByScope($connection2, 'System', 'passwordPolicyNumeric');
-	$punctuation = getSettingByScope($connection2, 'System', 'passwordPolicyNonAlphaNumeric');
-	$minLength = getSettingByScope($connection2, 'System', 'passwordPolicyMinLength');
+    $row = $form->addRow();
+        $row->addLabel('passwordConfirm', __('Confirm Password'));
+        $row->addPassword('passwordConfirm')
+            ->addConfirmation('passwordNew')
+            ->isRequired()
+            ->maxLength(30);
 
-	if ($alpha == 'Y') {
-		$password->addValidation('Validate.Format', 'pattern: /.*(?=.*[a-z])(?=.*[A-Z]).*/, failureMessage: "'.__('Does not meet password policy.').'"');
-	}
-	if ($numeric == 'Y') {
-		$password->addValidation('Validate.Format', 'pattern: /.*[0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-	}
-	if ($punctuation == 'Y') {
-		$password->addValidation('Validate.Format', 'pattern: /[^a-zA-Z0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-	}
-	if (!empty($minLength) && is_numeric($minLength)) {
-		$password->addValidation('Validate.Length', 'minimum: '.$minLength.', failureMessage: "'.__('Does not meet password policy.').'"');
-	}
+    $row = $form->addRow();
+        $row->addLabel('status', __('Status'))->description(__('This determines visibility within the system.'));
+        $row->addSelectStatus('status')->isRequired();
 
-	$row = $form->addRow();
-		$row->addLabel('passwordConfirm', __('Confirm Password'));
-		$row->addPassword('passwordConfirm')
-			->isRequired()
-			->maxLength(30)
-			->addValidation('Validate.Confirmation', "match: 'passwordNew'");
+    $row = $form->addRow();
+        $row->addLabel('canLogin', __('Can Login?'));
+        $row->addYesNo('canLogin')->isRequired();
 
-	$row = $form->addRow();
-		$row->addLabel('status', __('Status'))->description(__('This determines visibility within the system.'));
-		$row->addSelectStatus('status')->isRequired();
-
-	$row = $form->addRow();
-		$row->addLabel('canLogin', __('Can Login?'));
-		$row->addYesNo('canLogin')->isRequired();
-
-	$row = $form->addRow();
-		$row->addLabel('passwordForceReset', __('Force Reset Password?'))->description(__('User will be prompted on next login.'));
-		$row->addYesNo('passwordForceReset')->isRequired();
+    $row = $form->addRow();
+        $row->addLabel('passwordForceReset', __('Force Reset Password?'))->description(__('User will be prompted on next login.'));
+        $row->addYesNo('passwordForceReset')->isRequired();
 
     // CONTACT INFORMATION
     $form->addRow()->addHeading(__('Contact Information'));
@@ -192,286 +174,286 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
     $row = $form->addRow();
         $emailLabel = $row->addLabel('email', __('Email'));
         $email = $row->addEmail('email')->maxLength(50);
-		
-	$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
-	if ($uniqueEmailAddress == 'Y') {
+        
+    $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
+    if ($uniqueEmailAddress == 'Y') {
         $emailLabel->description(__('Must be unique.'));
         $email->append('<span></span><div class="LV_validation_message LV_invalid" id="email_availability_result"></div>');
-	}
+    }
 
     $row = $form->addRow();
         $row->addLabel('emailAlternate', __('Alternate Email'));
-		$row->addEmail('emailAlternate')->maxLength(50);
+        $row->addEmail('emailAlternate')->maxLength(50);
 
-	$row = $form->addRow();
-	$row->addAlert(__('Address information for an individual only needs to be set under the following conditions:'), 'warning')
-		->append('<ol>')
-		->append('<li>'.__('If the user is not in a family.').'</li>')
-		->append('<li>'.__('If the user\'s family does not have a home address set.').'</li>')
-		->append('<li>'.__('If the user needs an address in addition to their family\'s home address.').'</li>')
-		->append('</ol>');
+    $row = $form->addRow();
+    $row->addAlert(__('Address information for an individual only needs to be set under the following conditions:'), 'warning')
+        ->append('<ol>')
+        ->append('<li>'.__('If the user is not in a family.').'</li>')
+        ->append('<li>'.__('If the user\'s family does not have a home address set.').'</li>')
+        ->append('<li>'.__('If the user needs an address in addition to their family\'s home address.').'</li>')
+        ->append('</ol>');
 
-	$row = $form->addRow();
-		$row->addLabel('showAddresses', __('Enter Personal Address?'));
-		$row->addCheckbox('showAddresses')->setValue('Yes');
+    $row = $form->addRow();
+        $row->addLabel('showAddresses', __('Enter Personal Address?'));
+        $row->addCheckbox('showAddresses')->setValue('Yes');
 
-	$form->toggleVisibilityByClass('address')->onCheckbox('showAddresses')->when('Yes');
+    $form->toggleVisibilityByClass('address')->onCheckbox('showAddresses')->when('Yes');
 
-	$row = $form->addRow()->addClass('address');
-		$row->addLabel('address1', __('Address 1'))->description(__('Unit, Building, Street'));
-		$row->addTextField('address1')->maxLength(255);
+    $row = $form->addRow()->addClass('address');
+        $row->addLabel('address1', __('Address 1'))->description(__('Unit, Building, Street'));
+        $row->addTextField('address1')->maxLength(255);
 
-	$row = $form->addRow()->addClass('address');
-		$row->addLabel('address1District', __('Address 1 District'))->description(__('County, State, District'));
-		$row->addTextFieldDistrict('address1District');
+    $row = $form->addRow()->addClass('address');
+        $row->addLabel('address1District', __('Address 1 District'))->description(__('County, State, District'));
+        $row->addTextFieldDistrict('address1District');
 
-	$row = $form->addRow()->addClass('address');
-		$row->addLabel('address1Country', __('Address 1 Country'));
-		$row->addSelectCountry('address1Country');
+    $row = $form->addRow()->addClass('address');
+        $row->addLabel('address1Country', __('Address 1 Country'));
+        $row->addSelectCountry('address1Country');
 
-	$row = $form->addRow()->addClass('address');
-		$row->addLabel('address2', __('Address 2'))->description(__('Unit, Building, Street'));
-		$row->addTextField('address2')->maxLength(255);
+    $row = $form->addRow()->addClass('address');
+        $row->addLabel('address2', __('Address 2'))->description(__('Unit, Building, Street'));
+        $row->addTextField('address2')->maxLength(255);
 
-	$row = $form->addRow()->addClass('address');
-		$row->addLabel('address2District', __('Address 2 District'))->description(__('County, State, District'));
-		$row->addTextFieldDistrict('address2District');
+    $row = $form->addRow()->addClass('address');
+        $row->addLabel('address2District', __('Address 2 District'))->description(__('County, State, District'));
+        $row->addTextFieldDistrict('address2District');
 
-	$row = $form->addRow()->addClass('address');
-		$row->addLabel('address2Country', __('Address 2 Country'));
-		$row->addSelectCountry('address2Country');
+    $row = $form->addRow()->addClass('address');
+        $row->addLabel('address2Country', __('Address 2 Country'));
+        $row->addSelectCountry('address2Country');
 
     for ($i = 1; $i < 5; ++$i) {
-		$row = $form->addRow();
-		$row->addLabel('phone'.$i, __('Phone').' '.$i)->description(__('Type, country code, number.'));
+        $row = $form->addRow();
+        $row->addLabel('phone'.$i, __('Phone').' '.$i)->description(__('Type, country code, number.'));
         $row->addPhoneNumber('phone'.$i);
-	}
+    }
 
-	$row = $form->addRow();
-		$row->addLabel('website', __('Website'))->description(__('Include http://'));
-		$row->addURL('website');
+    $row = $form->addRow();
+        $row->addLabel('website', __('Website'))->description(__('Include http://'));
+        $row->addURL('website');
 
     // SCHOOL INFORMATION
-	$form->addRow()->addHeading(__('School Information'));
+    $form->addRow()->addHeading(__('School Information'));
 
-	$dayTypeOptions = getSettingByScope($connection2, 'User Admin', 'dayTypeOptions');
-	if (!empty($dayTypeOptions)) {
-		$dayTypeText = getSettingByScope($connection2, 'User Admin', 'dayTypeText');
-		$row = $form->addRow();
-			$row->addLabel('dayType', __('Day Type'))->description($dayTypeText);
-			$row->addSelect('dayType')->fromString($dayTypeOptions)->placeholder();
-	}
+    $dayTypeOptions = getSettingByScope($connection2, 'User Admin', 'dayTypeOptions');
+    if (!empty($dayTypeOptions)) {
+        $dayTypeText = getSettingByScope($connection2, 'User Admin', 'dayTypeText');
+        $row = $form->addRow();
+            $row->addLabel('dayType', __('Day Type'))->description($dayTypeText);
+            $row->addSelect('dayType')->fromString($dayTypeOptions)->placeholder();
+    }
 
-	$sql = "SELECT DISTINCT lastSchool FROM gibbonPerson ORDER BY lastSchool";
-	$result = $pdo->executeQuery(array(), $sql);
-	$schools = ($result && $result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_COLUMN) : array();
+    $sql = "SELECT DISTINCT lastSchool FROM gibbonPerson ORDER BY lastSchool";
+    $result = $pdo->executeQuery(array(), $sql);
+    $schools = ($result && $result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_COLUMN) : array();
 
-	$row = $form->addRow();
-		$row->addLabel('lastSchool', __('Last School'));
-		$row->addTextField('lastSchool')->autocomplete($schools);
+    $row = $form->addRow();
+        $row->addLabel('lastSchool', __('Last School'));
+        $row->addTextField('lastSchool')->autocomplete($schools);
 
-	$row = $form->addRow();
-		$row->addLabel('dateStart', __('Start Date'))->description(__("Users's first day at school."));
-		$row->addDate('dateStart');
+    $row = $form->addRow();
+        $row->addLabel('dateStart', __('Start Date'))->description(__("Users's first day at school."));
+        $row->addDate('dateStart');
 
-	$row = $form->addRow();
-		$row->addLabel('gibbonSchoolYearIDClassOf', __('Class Of'))->description(__('When is the student expected to graduate?'));
-		$row->addSelectSchoolYear('gibbonSchoolYearIDClassOf');
+    $row = $form->addRow();
+        $row->addLabel('gibbonSchoolYearIDClassOf', __('Class Of'))->description(__('When is the student expected to graduate?'));
+        $row->addSelectSchoolYear('gibbonSchoolYearIDClassOf');
 
     // BACKGROUND INFORMATION
-	$form->addRow()->addHeading(__('Background Information'));
+    $form->addRow()->addHeading(__('Background Information'));
 
-	$row = $form->addRow();
-		$row->addLabel('languageFirst', __('First Language'));
-		$row->addSelectLanguage('languageFirst');
+    $row = $form->addRow();
+        $row->addLabel('languageFirst', __('First Language'));
+        $row->addSelectLanguage('languageFirst');
 
-	$row = $form->addRow();
-		$row->addLabel('languageSecond', __('Second Language'));
-		$row->addSelectLanguage('languageSecond');
+    $row = $form->addRow();
+        $row->addLabel('languageSecond', __('Second Language'));
+        $row->addSelectLanguage('languageSecond');
 
-	$row = $form->addRow();
-		$row->addLabel('languageThird', __('Third Language'));
-		$row->addSelectLanguage('languageThird');
+    $row = $form->addRow();
+        $row->addLabel('languageThird', __('Third Language'));
+        $row->addSelectLanguage('languageThird');
 
-	$row = $form->addRow();
-		$row->addLabel('countryOfBirth', __('Country of Birth'));
-		$row->addSelectCountry('countryOfBirth');
+    $row = $form->addRow();
+        $row->addLabel('countryOfBirth', __('Country of Birth'));
+        $row->addSelectCountry('countryOfBirth');
 
-	$row = $form->addRow();
-		$row->addLabel('birthCertificateScan', __('Birth Certificate Scan'))->description(__('Less than 1440px by 900px').'. '.__('Accepts PDF files.'));
-		$row->addFileUpload('birthCertificateScan')->accepts('.jpg,.jpeg,.gif,.png,.pdf')->setMaxUpload(false);
+    $row = $form->addRow();
+        $row->addLabel('birthCertificateScan', __('Birth Certificate Scan'))->description(__('Less than 1440px by 900px').'. '.__('Accepts PDF files.'));
+        $row->addFileUpload('birthCertificateScan')->accepts('.jpg,.jpeg,.gif,.png,.pdf')->setMaxUpload(false);
 
-	$ethnicities = getSettingByScope($connection2, 'User Admin', 'ethnicity');
-	$row = $form->addRow();
-		$row->addLabel('ethnicity', __('Ethnicity'));
-		if (!empty($ethnicities)) {
-			$row->addSelect('ethnicity')->fromString($ethnicities)->placeholder();
-		} else {
-			$row->addTextField('ethnicity')->maxLength(255);
-		}
+    $ethnicities = getSettingByScope($connection2, 'User Admin', 'ethnicity');
+    $row = $form->addRow();
+        $row->addLabel('ethnicity', __('Ethnicity'));
+        if (!empty($ethnicities)) {
+            $row->addSelect('ethnicity')->fromString($ethnicities)->placeholder();
+        } else {
+            $row->addTextField('ethnicity')->maxLength(255);
+        }
 
-	$religions = getSettingByScope($connection2, 'User Admin', 'religions');
-	$row = $form->addRow();
-		$row->addLabel('religion', __('Religion'));
-		if (!empty($religions)) {
-			$row->addSelect('religion')->fromString($religions)->placeholder();
-		} else {
-			$row->addTextField('religion')->maxLength(30);
-		}
+    $religions = getSettingByScope($connection2, 'User Admin', 'religions');
+    $row = $form->addRow();
+        $row->addLabel('religion', __('Religion'));
+        if (!empty($religions)) {
+            $row->addSelect('religion')->fromString($religions)->placeholder();
+        } else {
+            $row->addTextField('religion')->maxLength(30);
+        }
 
-	$nationalityList = getSettingByScope($connection2, 'User Admin', 'nationality');
-	$row = $form->addRow();
-		$row->addLabel('citizenship1', __('Citizenship 1'));
-		if (!empty($nationalityList)) {
-			$row->addSelect('citizenship1')->fromString($nationalityList)->placeholder();
-		} else {
-			$row->addSelectCountry('citizenship1');
-		}
+    $nationalityList = getSettingByScope($connection2, 'User Admin', 'nationality');
+    $row = $form->addRow();
+        $row->addLabel('citizenship1', __('Citizenship 1'));
+        if (!empty($nationalityList)) {
+            $row->addSelect('citizenship1')->fromString($nationalityList)->placeholder();
+        } else {
+            $row->addSelectCountry('citizenship1');
+        }
 
-	$row = $form->addRow();
-		$row->addLabel('citizenship1Passport', __('Citizenship 1 Passport Number'));
-		$row->addTextField('citizenship1Passport')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('citizenship1Passport', __('Citizenship 1 Passport Number'));
+        $row->addTextField('citizenship1Passport')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('citizenship1PassportScan', __('Citizenship 1 Passport Scan'))->description(__('Less than 1440px by 900px').'. '.__('Accepts PDF files.'));
-		$row->addFileUpload('citizenship1PassportScan')->accepts('.jpg,.jpeg,.gif,.png,.pdf')->setMaxUpload(false);
+    $row = $form->addRow();
+        $row->addLabel('citizenship1PassportScan', __('Citizenship 1 Passport Scan'))->description(__('Less than 1440px by 900px').'. '.__('Accepts PDF files.'));
+        $row->addFileUpload('citizenship1PassportScan')->accepts('.jpg,.jpeg,.gif,.png,.pdf')->setMaxUpload(false);
 
-	$row = $form->addRow();
-		$row->addLabel('citizenship2', __('Citizenship 2'));
-		if (!empty($nationalityList)) {
-			$row->addSelect('citizenship2')->fromString($nationalityList)->placeholder();
-		} else {
-			$row->addSelectCountry('citizenship2');
-		}
+    $row = $form->addRow();
+        $row->addLabel('citizenship2', __('Citizenship 2'));
+        if (!empty($nationalityList)) {
+            $row->addSelect('citizenship2')->fromString($nationalityList)->placeholder();
+        } else {
+            $row->addSelectCountry('citizenship2');
+        }
 
-	$row = $form->addRow();
-		$row->addLabel('citizenship2Passport', __('Citizenship 2 Passport Number'));
-		$row->addTextField('citizenship2Passport')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('citizenship2Passport', __('Citizenship 2 Passport Number'));
+        $row->addTextField('citizenship2Passport')->maxLength(30);
 
-	if (!empty($_SESSION[$guid]['country'])) {
-		$nationalIDCardNumberLabel = $_SESSION[$guid]['country'].' '.__('ID Card Number');
-		$nationalIDCardScanLabel = $_SESSION[$guid]['country'].' '.__('ID Card Scan');
-		$residencyStatusLabel = $_SESSION[$guid]['country'].' '.__('Residency/Visa Type');
-		$visaExpiryDateLabel = $_SESSION[$guid]['country'].' '.__('Visa Expiry Date');
-	} else {
-		$nationalIDCardNumberLabel = __('National ID Card Number');
-		$nationalIDCardScanLabel = __('National ID Card Scan');
-		$residencyStatusLabel = __('Residency/Visa Type');
-		$visaExpiryDateLabel = __('Visa Expiry Date');
-	}
+    if (!empty($_SESSION[$guid]['country'])) {
+        $nationalIDCardNumberLabel = $_SESSION[$guid]['country'].' '.__('ID Card Number');
+        $nationalIDCardScanLabel = $_SESSION[$guid]['country'].' '.__('ID Card Scan');
+        $residencyStatusLabel = $_SESSION[$guid]['country'].' '.__('Residency/Visa Type');
+        $visaExpiryDateLabel = $_SESSION[$guid]['country'].' '.__('Visa Expiry Date');
+    } else {
+        $nationalIDCardNumberLabel = __('National ID Card Number');
+        $nationalIDCardScanLabel = __('National ID Card Scan');
+        $residencyStatusLabel = __('Residency/Visa Type');
+        $visaExpiryDateLabel = __('Visa Expiry Date');
+    }
 
-	$row = $form->addRow();
-		$row->addLabel('nationalIDCardNumber', $nationalIDCardNumberLabel);
-		$row->addTextField('nationalIDCardNumber')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('nationalIDCardNumber', $nationalIDCardNumberLabel);
+        $row->addTextField('nationalIDCardNumber')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('nationalIDCardScan', $nationalIDCardScanLabel)->description(__('Less than 1440px by 900px').'. '.__('Accepts PDF files.'));
-		$row->addFileUpload('nationalIDCardScan')->accepts('.jpg,.jpeg,.gif,.png,.pdf')->setMaxUpload(false);
+    $row = $form->addRow();
+        $row->addLabel('nationalIDCardScan', $nationalIDCardScanLabel)->description(__('Less than 1440px by 900px').'. '.__('Accepts PDF files.'));
+        $row->addFileUpload('nationalIDCardScan')->accepts('.jpg,.jpeg,.gif,.png,.pdf')->setMaxUpload(false);
 
-	$residencyStatusList = getSettingByScope($connection2, 'User Admin', 'residencyStatus');
+    $residencyStatusList = getSettingByScope($connection2, 'User Admin', 'residencyStatus');
 
-	$row = $form->addRow();
-		$row->addLabel('residencyStatus', $residencyStatusLabel);
-		if (!empty($residencyStatusList)) {
-			$row->addSelect('residencyStatus')->fromString($residencyStatusList)->placeholder();
-		} else {
+    $row = $form->addRow();
+        $row->addLabel('residencyStatus', $residencyStatusLabel);
+        if (!empty($residencyStatusList)) {
+            $row->addSelect('residencyStatus')->fromString($residencyStatusList)->placeholder();
+        } else {
             $row->addTextField('residencyStatus')->maxLength(30);
-		}
+        }
 
-	$row = $form->addRow();
-		$row->addLabel('visaExpiryDate', $visaExpiryDateLabel)->description(__('If relevant.'));
-		$row->addDate('visaExpiryDate');
+    $row = $form->addRow();
+        $row->addLabel('visaExpiryDate', $visaExpiryDateLabel)->description(__('If relevant.'));
+        $row->addDate('visaExpiryDate');
 
     // EMPLOYMENT
-	$form->addRow()->addHeading(__('Employment'));
+    $form->addRow()->addHeading(__('Employment'));
 
-	$row = $form->addRow();
-		$row->addLabel('profession', __('Profession'));
-		$row->addTextField('profession')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('profession', __('Profession'));
+        $row->addTextField('profession')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('employer', __('Employer'));
-		$row->addTextField('employer')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('employer', __('Employer'));
+        $row->addTextField('employer')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('jobTitle', __('Job Title'));
-		$row->addTextField('jobTitle')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('jobTitle', __('Job Title'));
+        $row->addTextField('jobTitle')->maxLength(30);
 
     // EMERGENCY CONTACTS
-	$form->addRow()->addHeading(__('Emergency Contacts'));
+    $form->addRow()->addHeading(__('Emergency Contacts'));
 
-	$form->addRow()->addContent(__('These details are used when immediate family members (e.g. parent, spouse) cannot be reached first. Please try to avoid listing immediate family members.'));
+    $form->addRow()->addContent(__('These details are used when immediate family members (e.g. parent, spouse) cannot be reached first. Please try to avoid listing immediate family members.'));
 
-	$row = $form->addRow();
-		$row->addLabel('emergency1Name', __('Contact 1 Name'));
-		$row->addTextField('emergency1Name')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('emergency1Name', __('Contact 1 Name'));
+        $row->addTextField('emergency1Name')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('emergency1Relationship', __('Contact 1 Relationship'));
-		$row->addSelectEmergencyRelationship('emergency1Relationship');
+    $row = $form->addRow();
+        $row->addLabel('emergency1Relationship', __('Contact 1 Relationship'));
+        $row->addSelectEmergencyRelationship('emergency1Relationship');
 
-	$row = $form->addRow();
-		$row->addLabel('emergency1Number1', __('Contact 1 Number 1'));
-		$row->addTextField('emergency1Number1')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('emergency1Number1', __('Contact 1 Number 1'));
+        $row->addTextField('emergency1Number1')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('emergency1Number2', __('Contact 1 Number 2'));
-		$row->addTextField('emergency1Number2')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('emergency1Number2', __('Contact 1 Number 2'));
+        $row->addTextField('emergency1Number2')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('emergency2Name', __('Contact 2 Name'));
-		$row->addTextField('emergency2Name')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('emergency2Name', __('Contact 2 Name'));
+        $row->addTextField('emergency2Name')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('emergency2Relationship', __('Contact 2 Relationship'));
-		$row->addSelectEmergencyRelationship('emergency2Relationship');
+    $row = $form->addRow();
+        $row->addLabel('emergency2Relationship', __('Contact 2 Relationship'));
+        $row->addSelectEmergencyRelationship('emergency2Relationship');
 
-	$row = $form->addRow();
-		$row->addLabel('emergency2Number1', __('Contact 2 Number 1'));
-		$row->addTextField('emergency2Number1')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('emergency2Number1', __('Contact 2 Number 1'));
+        $row->addTextField('emergency2Number1')->maxLength(30);
 
-	$row = $form->addRow();
-		$row->addLabel('emergency2Number2', __('Contact 2 Number 2'));
-		$row->addTextField('emergency2Number2')->maxLength(30);
+    $row = $form->addRow();
+        $row->addLabel('emergency2Number2', __('Contact 2 Number 2'));
+        $row->addTextField('emergency2Number2')->maxLength(30);
 
     // MISCELLANEOUS
-	$form->addRow()->addHeading(__('Miscellaneous'));
+    $form->addRow()->addHeading(__('Miscellaneous'));
 
-	$sql = "SELECT gibbonHouseID as value, name FROM gibbonHouse ORDER BY name";
-	$row = $form->addRow();
-		$row->addLabel('gibbonHouseID', __('House'));
-		$row->addSelect('gibbonHouseID')->fromQuery($pdo, $sql)->placeholder();
+    $sql = "SELECT gibbonHouseID as value, name FROM gibbonHouse ORDER BY name";
+    $row = $form->addRow();
+        $row->addLabel('gibbonHouseID', __('House'));
+        $row->addSelect('gibbonHouseID')->fromQuery($pdo, $sql)->placeholder();
 
-	$row = $form->addRow();
-		$row->addLabel('studentID', __('Student ID'))->description(__('Must be unique if set.'));
-		$row->addTextField('studentID')->maxLength(10);
+    $row = $form->addRow();
+        $row->addLabel('studentID', __('Student ID'))->description(__('Must be unique if set.'));
+        $row->addTextField('studentID')->maxLength(10);
 
-	$sql = "SELECT DISTINCT transport FROM gibbonPerson
-			JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID)
-			WHERE gibbonStudentEnrolment.gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current')
-			ORDER BY transport";
-	$result = $pdo->executeQuery(array(), $sql);
-	$transport = ($result && $result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_COLUMN) : array();
+    $sql = "SELECT DISTINCT transport FROM gibbonPerson
+            JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            WHERE gibbonStudentEnrolment.gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current')
+            ORDER BY transport";
+    $result = $pdo->executeQuery(array(), $sql);
+    $transport = ($result && $result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_COLUMN) : array();
 
-	$row = $form->addRow();
-		$row->addLabel('transport', __('Transport'));
-		$row->addTextField('transport')->maxLength(255)->autocomplete($transport);
+    $row = $form->addRow();
+        $row->addLabel('transport', __('Transport'));
+        $row->addTextField('transport')->maxLength(255)->autocomplete($transport);
 
-	$row = $form->addRow();
-		$row->addLabel('transportNotes', __('Transport Notes'));
-		$row->addTextArea('transportNotes')->setRows(4);
+    $row = $form->addRow();
+        $row->addLabel('transportNotes', __('Transport Notes'));
+        $row->addTextArea('transportNotes')->setRows(4);
 
-	$row = $form->addRow();
-		$row->addLabel('lockerNumber', __('Locker Number'));
-		$row->addTextField('lockerNumber')->maxLength(20);
+    $row = $form->addRow();
+        $row->addLabel('lockerNumber', __('Locker Number'));
+        $row->addTextField('lockerNumber')->maxLength(20);
 
-	$row = $form->addRow();
-		$row->addLabel('vehicleRegistration', __('Vehicle Registration'));
-		$row->addTextField('vehicleRegistration')->maxLength(20);
+    $row = $form->addRow();
+        $row->addLabel('vehicleRegistration', __('Vehicle Registration'));
+        $row->addTextField('vehicleRegistration')->maxLength(20);
 
-	$privacySetting = getSettingByScope($connection2, 'User Admin', 'privacy');
-    	$privacyBlurb = getSettingByScope($connection2, 'User Admin', 'privacyBlurb');
-    	$privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
+    $privacySetting = getSettingByScope($connection2, 'User Admin', 'privacy');
+        $privacyBlurb = getSettingByScope($connection2, 'User Admin', 'privacyBlurb');
+        $privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
 
     if ($privacySetting == 'Y' && !empty($privacyBlurb) && !empty($privacyOptions)) {
         $options = array_map(function($item) { return trim($item); }, explode(',', $privacyOptions));
@@ -479,15 +461,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row = $form->addRow();
             $row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
             $row->addCheckbox('privacyOptions[]')->fromArray($options);
-	}
+    }
 
-	$studentAgreementOptions = getSettingByScope($connection2, 'School Admin', 'studentAgreementOptions');
+    $studentAgreementOptions = getSettingByScope($connection2, 'School Admin', 'studentAgreementOptions');
     if (!empty($studentAgreementOptions)) {
-		$options = array_map(function($item) { return trim($item); }, explode(',', $studentAgreementOptions));
+        $options = array_map(function($item) { return trim($item); }, explode(',', $studentAgreementOptions));
 
         $row = $form->addRow();
-		$row->addLabel('studentAgreements[]', __('Student Agreements'))->description(__('Check to indicate that student has signed the relevant agreement.'));
-		$row->addCheckbox('studentAgreements[]')->fromArray($options);
+        $row->addLabel('studentAgreements[]', __('Student Agreements'))->description(__('Check to indicate that student has signed the relevant agreement.'));
+        $row->addCheckbox('studentAgreements[]')->fromArray($options);
     }
 
     $row = $form->addRow();
@@ -495,105 +477,89 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addSubmit();
 
     echo $form->getOutput();
-	?>
+    ?>
 
-	<script type="text/javascript">
-		// Password Generation
-		$(".generatePassword").click(function(){
-			var chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789![]{}()%&*$#^~@|';
-			var text = '';
-			for(var i=0; i < <?php echo $minLength + 4 ?>; i++) {
-				if (i==0) { text += chars.charAt(Math.floor(Math.random() * 26)); }
-				else if (i==1) { text += chars.charAt(Math.floor(Math.random() * 26)+26); }
-				else if (i==2) { text += chars.charAt(Math.floor(Math.random() * 10)+52); }
-				else if (i==3) { text += chars.charAt(Math.floor(Math.random() * 19)+62); }
-				else { text += chars.charAt(Math.floor(Math.random() * chars.length)); }
-			}
-			$('input[name="passwordNew"]').val(text);
-			$('input[name="passwordConfirm"]').val(text);
-			alert('<?php echo __('Copy this password if required:') ?>' + '\r\n\r\n' + text) ;
-		});
+    <script type="text/javascript">
+        // Username Generation
+        $(".generateUsername").click(function(){
+            $.ajax({
+                type : 'POST',
+                data : {
+                    gibbonRoleID: $('#gibbonRoleIDPrimary').val(),
+                    preferredName: $('#preferredName').val(),
+                    firstName: $('#firstName').val(),
+                    surname: $('#surname').val(),
+                },
+                url: "./modules/User Admin/user_manage_usernameAjax.php",
+                success: function(responseText){
+                    if (responseText == 0) {
+                        $('#gibbonRoleIDPrimary').change();
+                        $('#preferredName').blur();
+                        $('#firstName').blur();
+                        $('#surname').blur();
+                        alert("<?php
+                            echo __('The following fields are required to generate a username:').'\n\n';
+                            echo __('Primary Role').', '.__('Preferred Name').', '.__('First Name').', '.__('Surname').'\n';
+                        ?>");
+                    } else {
+                        $('#username').val(responseText);
+                        $('#username').trigger('input');
+                        $('#username').blur();
+                    }
+                }
+            });
+        });
 
-		// Username Generation
-		$(".generateUsername").click(function(){
-			$.ajax({
-				type : 'POST',
-				data : {
-					gibbonRoleID: $('#gibbonRoleIDPrimary').val(),
-					preferredName: $('#preferredName').val(),
-					firstName: $('#firstName').val(),
-					surname: $('#surname').val(),
-				},
-				url: "./modules/User Admin/user_manage_usernameAjax.php",
-				success: function(responseText){
-					if (responseText == 0) {
-						$('#gibbonRoleIDPrimary').change();
-						$('#preferredName').blur();
-						$('#firstName').blur();
-						$('#surname').blur();
-						alert("<?php
-							echo __('The following fields are required to generate a username:').'\n\n';
-							echo __('Primary Role').', '.__('Preferred Name').', '.__('First Name').', '.__('Surname').'\n';
-						?>");
-					} else {
-						$('#username').val(responseText);
-						$('#username').trigger('input');
-						$('#username').blur();
-					}
-				}
-			});
-		});
+        // Username Uniqueness
+        $('#username').on('input', function(){
+            if ($('#username').val() == '') {
+                $('#username_availability_result').html('');
+                return;
+            }
+            $.ajax({
+                type : 'POST',
+                data : { username: $('#username').val() },
+                url: "./publicRegistrationCheck.php",
+                success: function(responseText){
+                    if(responseText == 0){
+                        $('#username_availability_result').html('<?php echo __('Username available'); ?>');
+                        $('#username_availability_result').switchClass('LV_invalid', 'LV_valid');
+                    }else if(responseText > 0){
+                        $('#username_availability_result').html('<?php echo __('Username already taken'); ?>');
+                        $('#username_availability_result').switchClass('LV_valid', 'LV_invalid');
+                    }
+                }
+            });
+        });
 
-		// Username Uniqueness
-		$('#username').on('input', function(){
-			if ($('#username').val() == '') {
-				$('#username_availability_result').html('');
-				return;
-			}
-			$.ajax({
-				type : 'POST',
-				data : { username: $('#username').val() },
-				url: "./publicRegistrationCheck.php",
-				success: function(responseText){
-					if(responseText == 0){
-						$('#username_availability_result').html('<?php echo __('Username available'); ?>');
-						$('#username_availability_result').switchClass('LV_invalid', 'LV_valid');
-					}else if(responseText > 0){
-						$('#username_availability_result').html('<?php echo __('Username already taken'); ?>');
-						$('#username_availability_result').switchClass('LV_valid', 'LV_invalid');
-					}
-				}
-			});
-		});
+        <?php if ($uniqueEmailAddress == 'Y') : ?>
+        // Email Uniqueness
+        $('#email').on('input', function(){
+            if (emailValidate.doValidations() == false || $('#email').val() == '') {
+                $('#email_availability_result').html('');
+                return;
+            }
 
-		<?php if ($uniqueEmailAddress == 'Y') : ?>
-		// Email Uniqueness
-		$('#email').on('input', function(){
-			if (emailValidate.doValidations() == false || $('#email').val() == '') {
-				$('#email_availability_result').html('');
-				return;
-			}
-
-			$.ajax({
-				type : 'POST',
-				data : { email: $('#email').val(), gibbonPersonID: 0 },
-				url: "./modules/User Admin/user_manage_emailAjax.php",
-				success: function(responseText){
-					if(responseText == 0){
-						$('#email + .LV_validation_message').hide();
-						$('#email_availability_result').html('<?php echo sprintf(__('%1$s available'), __('Email')); ?>');
-						$('#email_availability_result').switchClass('LV_invalid', 'LV_valid');
-					} else if(responseText > 0){
-						$('#email_availability_result').html('');
-						$('#email_availability_result').switchClass('LV_valid', 'LV_invalid');
-						// Prevent submitting form with a non-unique email
-						$('#email').switchClass('LV_valid_field', 'LV_invalid_field');
-						emailValidate.add(Validate.Exclusion, { within: [$('#email').val()], failureMessage: "<?php echo sprintf(__('%1$s already in use'), __('Email')); ?>" });
-					}
-				}
-			});
-		});
+            $.ajax({
+                type : 'POST',
+                data : { email: $('#email').val(), gibbonPersonID: 0 },
+                url: "./modules/User Admin/user_manage_emailAjax.php",
+                success: function(responseText){
+                    if(responseText == 0){
+                        $('#email + .LV_validation_message').hide();
+                        $('#email_availability_result').html('<?php echo sprintf(__('%1$s available'), __('Email')); ?>');
+                        $('#email_availability_result').switchClass('LV_invalid', 'LV_valid');
+                    } else if(responseText > 0){
+                        $('#email_availability_result').html('');
+                        $('#email_availability_result').switchClass('LV_valid', 'LV_invalid');
+                        // Prevent submitting form with a non-unique email
+                        $('#email').switchClass('LV_valid_field', 'LV_invalid_field');
+                        emailValidate.add(Validate.Exclusion, { within: [$('#email').val()], failureMessage: "<?php echo sprintf(__('%1$s already in use'), __('Email')); ?>" });
+                    }
+                }
+            });
+        });
         <?php endif; ?>
-	</script>
-	<?php
+    </script>
+    <?php
 }

--- a/modules/User Admin/user_manage_password.php
+++ b/modules/User Admin/user_manage_password.php
@@ -85,13 +85,18 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
 
             $row = $form->addRow();
                 $row->addLabel('passwordNew', __('Password'));
-                $column = $row->addColumn('passwordNew')->addClass('inline right');
-                $column->addButton(__('Generate Password'))->addClass('generatePassword');
-                $column->addPassword('passwordNew')->isRequired()->maxLength(30)->addValidationOption('onlyOnSubmit: true');
+                $row->addPassword('passwordNew')
+                    ->addPasswordPolicy($pdo)
+                    ->addGeneratePasswordButton($form)
+                    ->isRequired()
+                    ->maxLength(30);
 
             $row = $form->addRow();
                 $row->addLabel('passwordConfirm', __('Confirm Password'));
-                $row->addPassword('passwordConfirm')->isRequired()->maxLength(30)->addValidationOption('onlyOnSubmit: true')->addValidation('Validate.Confirmation', "match: 'passwordNew'");
+                $row->addPassword('passwordConfirm')
+                    ->addConfirmation('passwordNew')
+                    ->isRequired()
+                    ->maxLength(30);
 
             $row = $form->addRow();
                 $row->addLabel('passwordForceReset', __('Force Reset Password?'))->description(__('User will be prompted on next login.'));
@@ -102,49 +107,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
                 $row->addSubmit();
 
             echo $form->getOutput();
-            ?>
-
-            <script type="text/javascript">
-                var passwordNew=new LiveValidation('passwordNew');
-                passwordNew.add(Validate.Presence);
-                <?php
-                $alpha = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha');
-                $numeric = getSettingByScope($connection2, 'System', 'passwordPolicyNumeric');
-                $punctuation = getSettingByScope($connection2, 'System', 'passwordPolicyNonAlphaNumeric');
-                $minLength = getSettingByScope($connection2, 'System', 'passwordPolicyMinLength');
-                if ($alpha == 'Y') {
-                    echo 'passwordNew.add( Validate.Format, { pattern: /.*(?=.*[a-z])(?=.*[A-Z]).*/, failureMessage: "'.__($guid, 'Does not meet password policy.').'" } );';
-                }
-                if ($numeric == 'Y') {
-                    echo 'passwordNew.add( Validate.Format, { pattern: /.*[0-9]/, failureMessage: "'.__($guid, 'Does not meet password policy.').'" } );';
-                }
-                if ($punctuation == 'Y') {
-                    echo 'passwordNew.add( Validate.Format, { pattern: /[^a-zA-Z0-9]/, failureMessage: "'.__($guid, 'Does not meet password policy.').'" } );';
-                }
-                if (is_numeric($minLength)) {
-                    echo 'passwordNew.add( Validate.Length, { minimum: '.$minLength.'} );';
-                }
-                ?>
-
-                $(".generatePassword").click(function(){
-                    var chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789![]{}()%&*$#^~@|';
-                    var text = '';
-                    for(var i=0; i < <?php echo $minLength + 4 ?>; i++) {
-                        if (i==0) { text += chars.charAt(Math.floor(Math.random() * 26)); }
-                        else if (i==1) { text += chars.charAt(Math.floor(Math.random() * 26)+26); }
-                        else if (i==2) { text += chars.charAt(Math.floor(Math.random() * 10)+52); }
-                        else if (i==3) { text += chars.charAt(Math.floor(Math.random() * 19)+62); }
-                        else { text += chars.charAt(Math.floor(Math.random() * chars.length)); }
-                    }
-                    $('input[name="passwordNew"]').val(text);
-                    $('input[name="passwordConfirm"]').val(text);
-                    alert('<?php echo __($guid, 'Copy this password if required:') ?>' + '\r\n\r\n' + text) ;
-                });
-            </script>
-
-			<?php
-
         }
     }
 }
-?>

--- a/passwordReset.php
+++ b/passwordReset.php
@@ -25,56 +25,56 @@ echo '</div>';
 
 $step = 1;
 if (isset($_GET['step'])) {
-	if ($_GET['step'] == 2) {
-		$step = 2;
-	}
+    if ($_GET['step'] == 2) {
+        $step = 2;
+    }
 }
 
 if ($step == 1) {
-	?>
-	<p>
-		<?php echo sprintf(__($guid, 'Enter your %1$s username, or the email address you have listed in the system, and press submit: a unique password reset link will be emailed to you.'), $_SESSION[$guid]['systemName']); ?>
-	</p>
-	<?php
-	$returns = array();
-	$returns['error0'] = __($guid, 'Email address not set.');
-	$returns['error4'] = __($guid, 'Your request failed due to incorrect or non-existent or non-unique email address.');
-	$returns['error3'] = __($guid, 'Failed to send update email.');
-	$returns['error4'] = __($guid, 'Your request failed due to non-matching passwords.');
+    ?>
+    <p>
+        <?php echo sprintf(__($guid, 'Enter your %1$s username, or the email address you have listed in the system, and press submit: a unique password reset link will be emailed to you.'), $_SESSION[$guid]['systemName']); ?>
+    </p>
+    <?php
+    $returns = array();
+    $returns['error0'] = __($guid, 'Email address not set.');
+    $returns['error4'] = __($guid, 'Your request failed due to incorrect or non-existent or non-unique email address.');
+    $returns['error3'] = __($guid, 'Failed to send update email.');
+    $returns['error4'] = __($guid, 'Your request failed due to non-matching passwords.');
     $returns['error6'] = __($guid, 'Your request failed because your password to not meet the minimum requirements for strength.');
     $returns['error7'] = __($guid, 'Your request failed because your new password is the same as your current password.');
     $returns['success0'] = __($guid, 'Password reset request successfully initiated, please check your email.');
-	if (isset($_GET['return'])) {
-	    returnProcess($guid, $_GET['return'], null, $returns);
-	}
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, $returns);
+    }
 
-	$form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/passwordResetProcess.php?step=1');
+    $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/passwordResetProcess.php?step=1');
 
-	$form->setClass('smallIntBorder fullWidth');
-	$form->addHiddenValue('address', $_SESSION[$guid]['address']);
+    $form->setClass('smallIntBorder fullWidth');
+    $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
-	$row = $form->addRow();
-	    $row->addLabel('email', __('Username/Email'));
-	    $row->addTextField('email')->maxLength(255)->isRequired();
+    $row = $form->addRow();
+        $row->addLabel('email', __('Username/Email'));
+        $row->addTextField('email')->maxLength(255)->isRequired();
 
-	$row = $form->addRow();
-	    $row->addFooter();
-	    $row->addSubmit();
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
 
-	echo $form->getOutput();
+    echo $form->getOutput();
 }
 else {
-	// Sanitize the whole $_GET array
+    // Sanitize the whole $_GET array
     $validator = new \Gibbon\Data\Validator();
     $_GET = $validator->sanitize($_GET);
 
-	//Get URL parameters
-	$input = $_GET['input'];
-	$key = $_GET['key'];
-	$gibbonPersonResetID = $_GET['gibbonPersonResetID'];
+    //Get URL parameters
+    $input = $_GET['input'];
+    $key = $_GET['key'];
+    $gibbonPersonResetID = $_GET['gibbonPersonResetID'];
 
-	//Verify authenticity of this request and check it is fresh (within 48 hours)
-	try {
+    //Verify authenticity of this request and check it is fresh (within 48 hours)
+    try {
         $data = array('key' => $key, 'gibbonPersonResetID' => $gibbonPersonResetID);
         $sql = "SELECT * FROM gibbonPersonReset WHERE `key`=:key AND gibbonPersonResetID=:gibbonPersonResetID AND (timestamp > DATE_SUB(now(), INTERVAL 2 DAY))";
         $result = $connection2->prepare($sql);
@@ -83,83 +83,47 @@ else {
         echo "<div class='error'>".$e->getMessage().'</div>';
     }
 
-	if ($result->rowCount() != 1) {
-		echo "<div class='error'>";
-		echo __($guid, 'Your reset request is invalid: you may not proceed.');
-		echo '</div>';
-	} else {
-		echo "<div class='success'>";
-		echo __($guid, 'Your reset request is valid: you may proceed.');
-		echo '</div>';
+    if ($result->rowCount() != 1) {
+        echo "<div class='error'>";
+        echo __($guid, 'Your reset request is invalid: you may not proceed.');
+        echo '</div>';
+    } else {
+        echo "<div class='success'>";
+        echo __($guid, 'Your reset request is valid: you may proceed.');
+        echo '</div>';
 
-		$form = Form::create('action', $_SESSION[$guid]['absoluteURL']."/passwordResetProcess.php?input=$input&step=2&gibbonPersonResetID=$gibbonPersonResetID&key=$key");
+        $form = Form::create('action', $_SESSION[$guid]['absoluteURL']."/passwordResetProcess.php?input=$input&step=2&gibbonPersonResetID=$gibbonPersonResetID&key=$key");
 
-		$form->setClass('smallIntBorder fullWidth');
-		$form->addHiddenValue('address', $_SESSION[$guid]['address']);
+        $form->setClass('smallIntBorder fullWidth');
+        $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
-		$form->addRow()->addHeading(__('Reset Password'));
+        $form->addRow()->addHeading(__('Reset Password'));
 
-		$policy = getPasswordPolicy($guid, $connection2);
-		if ($policy != false) {
-			$form->addRow()->addAlert($policy, 'warning');
-		}
+        $policy = getPasswordPolicy($guid, $connection2);
+        if ($policy != false) {
+            $form->addRow()->addAlert($policy, 'warning');
+        }
 
-		$row = $form->addRow();
-			$row->addLabel('passwordNew', __('New Password'));
-			$column = $row->addColumn('passwordNew')->addClass('inline right');
-			$column->addButton(__('Generate Password'))->addClass('generatePassword');
-			$password = $column->addPassword('passwordNew')->isRequired()->maxLength(30);
+        $row = $form->addRow();
+            $row->addLabel('passwordNew', __('New Password'));
+            $row->addPassword('passwordNew')
+                ->addPasswordPolicy($pdo)
+                ->addGeneratePasswordButton($form)
+                ->isRequired()
+                ->maxLength(30);
 
-	    $alpha = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha');
-		$numeric = getSettingByScope($connection2, 'System', 'passwordPolicyNumeric');
-		$punctuation = getSettingByScope($connection2, 'System', 'passwordPolicyNonAlphaNumeric');
-		$minLength = getSettingByScope($connection2, 'System', 'passwordPolicyMinLength');
+        $row = $form->addRow();
+            $row->addLabel('passwordConfirm', __('Confirm New Password'));
+            $row->addPassword('passwordConfirm')
+                ->addConfirmation('passwordNew')
+                ->isRequired()
+                ->maxLength(30);
 
-		if ($alpha == 'Y') {
-			$password->addValidation('Validate.Format', 'pattern: /.*(?=.*[a-z])(?=.*[A-Z]).*/, failureMessage: "'.__('Does not meet password policy.').'"');
-		}
-		if ($numeric == 'Y') {
-			$password->addValidation('Validate.Format', 'pattern: /.*[0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-		}
-		if ($punctuation == 'Y') {
-			$password->addValidation('Validate.Format', 'pattern: /[^a-zA-Z0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-		}
-		if (!empty($minLength) && is_numeric($minLength)) {
-			$password->addValidation('Validate.Length', 'minimum: '.$minLength.', failureMessage: "'.__('Does not meet password policy.').'"');
-		}
+        $row = $form->addRow();
+            $row->addFooter();
+            $row->addSubmit();
 
-		$row = $form->addRow();
-			$row->addLabel('passwordConfirm', __('Confirm New Password'));
-			$row->addPassword('passwordConfirm')
-				->isRequired()
-				->maxLength(30)
-				->addValidation('Validate.Confirmation', "match: 'passwordNew'");
-
-		$row = $form->addRow();
-			$row->addFooter();
-			$row->addSubmit();
-
-		echo $form->getOutput();
-
-		?>
-		<script type="text/javascript">
-	        // Password Generation
-	        $(".generatePassword").click(function(){
-	            var chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789![]{}()%&*$#^~@|';
-	            var text = '';
-	            for(var i=0; i < <?php echo $minLength + 4 ?>; i++) {
-	                if (i==0) { text += chars.charAt(Math.floor(Math.random() * 26)); }
-	                else if (i==1) { text += chars.charAt(Math.floor(Math.random() * 26)+26); }
-	                else if (i==2) { text += chars.charAt(Math.floor(Math.random() * 10)+52); }
-	                else if (i==3) { text += chars.charAt(Math.floor(Math.random() * 19)+62); }
-	                else { text += chars.charAt(Math.floor(Math.random() * chars.length)); }
-	            }
-	            $('input[name="passwordNew"]').val(text);
-	            $('input[name="passwordConfirm"]').val(text);
-	            alert('<?php echo __('Copy this password if required:') ?>' + '\r\n\r\n' + text) ;
-	        });
-	    </script>
-		<?php
-	}
+        echo $form->getOutput();
+    }
 }
-?>
+

--- a/preferences.php
+++ b/preferences.php
@@ -87,35 +87,19 @@ if (!isset($_SESSION[$guid]["username"])) {
 
     $row = $form->addRow();
 
-		$row->addLabel('passwordNew', __('New Password'));
-		$column = $row->addColumn('passwordNew')->addClass('inline right');
-		$column->addButton(__('Generate Password'))->addClass('generatePassword');
-		$password = $column->addPassword('passwordNew')->isRequired()->maxLength(30);
+        $row->addLabel('passwordNew', __('New Password'));
+        $row->addPassword('passwordNew')
+            ->addPasswordPolicy($pdo)
+            ->addGeneratePasswordButton($form)
+            ->isRequired()
+            ->maxLength(30);
 
-    $alpha = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha');
-	$numeric = getSettingByScope($connection2, 'System', 'passwordPolicyNumeric');
-	$punctuation = getSettingByScope($connection2, 'System', 'passwordPolicyNonAlphaNumeric');
-	$minLength = getSettingByScope($connection2, 'System', 'passwordPolicyMinLength');
-
-	if ($alpha == 'Y') {
-		$password->addValidation('Validate.Format', 'pattern: /.*(?=.*[a-z])(?=.*[A-Z]).*/, failureMessage: "'.__('Does not meet password policy.').'"');
-	}
-	if ($numeric == 'Y') {
-		$password->addValidation('Validate.Format', 'pattern: /.*[0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-	}
-	if ($punctuation == 'Y') {
-		$password->addValidation('Validate.Format', 'pattern: /[^a-zA-Z0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-	}
-	if (!empty($minLength) && is_numeric($minLength)) {
-		$password->addValidation('Validate.Length', 'minimum: '.$minLength.', failureMessage: "'.__('Does not meet password policy.').'"');
-	}
-
-	$row = $form->addRow();
-		$row->addLabel('passwordConfirm', __('Confirm New Password'));
-		$row->addPassword('passwordConfirm')
-			->isRequired()
-			->maxLength(30)
-			->addValidation('Validate.Confirmation', "match: 'passwordNew'");
+    $row = $form->addRow();
+        $row->addLabel('passwordConfirm', __('Confirm New Password'));
+        $row->addPassword('passwordConfirm')
+            ->addConfirmation('passwordNew')
+            ->isRequired()
+            ->maxLength(30);
 
     $row = $form->addRow();
         $row->addFooter();
@@ -123,25 +107,6 @@ if (!isset($_SESSION[$guid]["username"])) {
 
     echo $form->getOutput();
 
-    ?>
-    <script type="text/javascript">
-        // Password Generation
-        $(".generatePassword").click(function(){
-            var chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789![]{}()%&*$#^~@|';
-            var text = '';
-            for(var i=0; i < <?php echo $minLength + 4 ?>; i++) {
-                if (i==0) { text += chars.charAt(Math.floor(Math.random() * 26)); }
-                else if (i==1) { text += chars.charAt(Math.floor(Math.random() * 26)+26); }
-                else if (i==2) { text += chars.charAt(Math.floor(Math.random() * 10)+52); }
-                else if (i==3) { text += chars.charAt(Math.floor(Math.random() * 19)+62); }
-                else { text += chars.charAt(Math.floor(Math.random() * chars.length)); }
-            }
-            $('input[name="passwordNew"]').val(text);
-            $('input[name="passwordConfirm"]').val(text);
-            alert('<?php echo __('Copy this password if required:') ?>' + '\r\n\r\n' + text) ;
-        });
-    </script>
-    <?php
     if ($forceReset != 'Y') {
         $staff = false;
         foreach ($_SESSION[$guid]['gibbonRoleIDAll'] as $role) {

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -104,27 +104,11 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('passwordNew', __('Password'));
-        $column = $row->addColumn('passwordNew')->addClass('inline right');
-        $column->addButton(__('Generate Password'))->addClass('generatePassword');
-        $password = $column->addPassword('passwordNew')->isRequired()->maxLength(30);
-
-    $alpha = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha');
-    $numeric = getSettingByScope($connection2, 'System', 'passwordPolicyNumeric');
-    $punctuation = getSettingByScope($connection2, 'System', 'passwordPolicyNonAlphaNumeric');
-    $minLength = getSettingByScope($connection2, 'System', 'passwordPolicyMinLength');
-
-    if ($alpha == 'Y') {
-        $password->addValidation('Validate.Format', 'pattern: /.*(?=.*[a-z])(?=.*[A-Z]).*/, failureMessage: "'.__('Does not meet password policy.').'"');
-    }
-    if ($numeric == 'Y') {
-        $password->addValidation('Validate.Format', 'pattern: /.*[0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-    }
-    if ($punctuation == 'Y') {
-        $password->addValidation('Validate.Format', 'pattern: /[^a-zA-Z0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
-    }
-    if (!empty($minLength) && is_numeric($minLength)) {
-        $password->addValidation('Validate.Length', 'minimum: '.$minLength.', failureMessage: "'.__('Does not meet password policy.').'"');
-    }
+        $row->addPassword('passwordNew')
+            ->addPasswordPolicy($pdo)
+            ->addGeneratePasswordButton($form)
+            ->isRequired()
+            ->maxLength(30);
 
     $privacyStatement = getSettingByScope($connection2, 'User Admin', 'publicRegistrationPrivacyStatement');
     if ($privacyStatement != '') {
@@ -174,25 +158,7 @@ if ($proceed == false) {
             });
         });
     </script>
-    <script type="text/javascript">
-        // Password Generation
-        $(".generatePassword").click(function(){
-            var chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789![]{}()%&*$#^~@|';
-            var text = '';
-            for(var i=0; i < <?php echo $minLength + 4 ?>; i++) {
-                if (i==0) { text += chars.charAt(Math.floor(Math.random() * 26)); }
-                else if (i==1) { text += chars.charAt(Math.floor(Math.random() * 26)+26); }
-                else if (i==2) { text += chars.charAt(Math.floor(Math.random() * 10)+52); }
-                else if (i==3) { text += chars.charAt(Math.floor(Math.random() * 19)+62); }
-                else { text += chars.charAt(Math.floor(Math.random() * chars.length)); }
-            }
-            $('input[name="passwordNew"]').val(text);
-            $('input[name="passwordConfirm"]').val(text);
-            alert('<?php echo __('Copy this password if required:') ?>' + '\r\n\r\n' + text) ;
-        });
-    </script>
-
-	<?php
+    <?php
     //Get postscrript
     $postscript = getSettingByScope($connection2, 'User Admin', 'publicRegistrationPostscript');
     if ($postscript != '') {

--- a/src/Forms/Input/Password.php
+++ b/src/Forms/Input/Password.php
@@ -28,17 +28,6 @@ namespace Gibbon\Forms\Input;
 class Password extends TextField
 {
     /**
-     * Adds the validation to indicate this password field is a confirmation for another field.
-     * @return self
-     */
-    public function addConfirmation($fieldName)
-    {
-        $this->addValidation('Validate.Confirmation', "match: '$fieldName'");
-
-        return $this;
-    }
-
-    /**
      * Attach the validation requirements for the system-wide password policy.
      * @param sqlConnection $pdo
      * @return self
@@ -64,6 +53,35 @@ class Password extends TextField
         if (!empty($minLength) && is_numeric($minLength)) {
             $this->addValidation('Validate.Length', 'minimum: '.$minLength.', failureMessage: "'.__('Does not meet password policy.').'"');
         }
+
+        return $this;
+    }
+
+    /**
+     * Adds a button to the field that uses JS to generate and insert a password into the form.
+     * @param Form $form
+     * @return self
+     */
+    public function addGeneratePasswordButton($form, $sourceField = 'passwordNew', $confirmField = 'passwordConfirm')
+    {
+        $button = $form->getFactory()->createButton(__('Generate'));
+        $button->addClass('generatePassword alignRight')
+            ->addData('source', $sourceField)
+            ->addData('confirm', $confirmField)
+            ->addData('alert', __('Copy this password if required:'));
+
+        $this->append($button->getOutput());
+
+        return $this;
+    }
+
+    /**
+     * Adds the validation to indicate this password field is a confirmation for another field.
+     * @return self
+     */
+    public function addConfirmation($fieldName)
+    {
+        $this->addValidation('Validate.Confirmation', "match: '$fieldName'");
 
         return $this;
     }

--- a/src/Forms/Input/Password.php
+++ b/src/Forms/Input/Password.php
@@ -28,6 +28,47 @@ namespace Gibbon\Forms\Input;
 class Password extends TextField
 {
     /**
+     * Adds the validation to indicate this password field is a confirmation for another field.
+     * @return self
+     */
+    public function addConfirmation($fieldName)
+    {
+        $this->addValidation('Validate.Confirmation', "match: '$fieldName'");
+
+        return $this;
+    }
+
+    /**
+     * Attach the validation requirements for the system-wide password policy.
+     * @param sqlConnection $pdo
+     * @return self
+     */
+    public function addPasswordPolicy($pdo)
+    {
+        $connection2 = $pdo->getConnection();
+
+        $alpha = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha');
+        $numeric = getSettingByScope($connection2, 'System', 'passwordPolicyNumeric');
+        $punctuation = getSettingByScope($connection2, 'System', 'passwordPolicyNonAlphaNumeric');
+        $minLength = getSettingByScope($connection2, 'System', 'passwordPolicyMinLength');
+
+        if ($alpha == 'Y') {
+            $this->addValidation('Validate.Format', 'pattern: /.*(?=.*[a-z])(?=.*[A-Z]).*/, failureMessage: "'.__('Does not meet password policy.').'"');
+        }
+        if ($numeric == 'Y') {
+            $this->addValidation('Validate.Format', 'pattern: /.*[0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
+        }
+        if ($punctuation == 'Y') {
+            $this->addValidation('Validate.Format', 'pattern: /[^a-zA-Z0-9]/, failureMessage: "'.__('Does not meet password policy.').'"');
+        }
+        if (!empty($minLength) && is_numeric($minLength)) {
+            $this->addValidation('Validate.Length', 'minimum: '.$minLength.', failureMessage: "'.__('Does not meet password policy.').'"');
+        }
+
+        return $this;
+    }
+
+    /**
      * Gets the HTML output for this form element.
      * @return  string
      */

--- a/src/Forms/Traits/BasicAttributesTrait.php
+++ b/src/Forms/Traits/BasicAttributesTrait.php
@@ -112,6 +112,31 @@ trait BasicAttributesTrait
     }
 
     /**
+     * Set a data-* attribute for passing values to scripts.
+     * @param  string $name
+     * @param  mixed  $data
+     * @return self
+     */
+    public function addData($name, $data = '', $encode = false)
+    {
+        if ($encode || is_array($data)) $data = json_encode($data);
+        $this->setAttribute('data-'.$name, $data);
+
+        return $this;
+    }
+
+    /**
+     * Gets a data-* attribute value by name.
+     * @return  string $name
+     */
+    public function getData($name, $decode = false)
+    {
+        $data = $this->getAttribute('data-'.$name);
+
+        return ($decode)? json_decode($data) : $data;
+    }
+
+    /**
      * Add a $key => $value pair to the attributes collection.
      * @param  string  $key
      * @param  mixed   $value

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1472,3 +1472,19 @@ tr.head td {
 	vertical-align: top;
 	font-size: 10px;
 }
+
+td.standardWidth {
+	position: relative;
+}
+
+input[type="button"],
+input[type="submit"],
+input[type="reset"] {
+	padding: 0px 6px;
+}
+
+input[type="button"].alignRight {
+	position: absolute;
+	right: 5px;
+	margin: 0;
+}


### PR DESCRIPTION
This changeset helps cleanup the password code and move it into one location. 

- Moves the generatePassword JS function into assets
- Adds new methods to the form Password class:
  - addConfirmation: links a password field as confirmation for another field
  - addPasswordPolicy: attaches the validation for system-defined password requirements
  - addGeneratePasswordButton: adds the button, hooked up to the JS function
- Fixes the alignment issue with buttons and LV messages by pulling the buttons over to the right-hand side of the input.
- Changes the password pop-up from an alert to a prompt to make copy-pasting easier ([from forum issue](https://ask.gibbonedu.org/discussion/2050/generate-password-when-creating-new-user-unable-to-copy-the-text))
- Adds addData and getData methods to the BasicAttributes, allowing the HTML data-* attributes to be written to through the Form API


## Screenshots (if appropriate):
![screen shot 2017-11-16 at 10 05 45 am](https://user-images.githubusercontent.com/897700/32870274-108aadde-cab6-11e7-9f1f-152518ed3bb2.png)

![screen shot 2017-11-16 at 10 04 26 am](https://user-images.githubusercontent.com/897700/32870277-14dff862-cab6-11e7-8de3-022f1fd11631.png)

_Fixes some mismatched indentation style, best viewed with `?w=1 `_