### PR TITLE
Form Class: move DeleteForm into its own class, remove PrefabFormFactory 

### DIFF
--- a/modules/Activities/activities_manage_delete.php
+++ b/modules/Activities/activities_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
                 echo __($guid, 'The selected record does not exist, or you do not have access to it.');
                 echo '</div>';
             } else {
-                $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/activities_manage_deleteProcess.php?gibbonActivityID=$gibbonActivityID&search=".$_GET['search']."&gibbonSchoolYearTermID=".$_GET['gibbonSchoolYearTermID']);
+                $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/activities_manage_deleteProcess.php?gibbonActivityID=$gibbonActivityID&search=".$_GET['search']."&gibbonSchoolYearTermID=".$_GET['gibbonSchoolYearTermID']);
                 echo $form->getOutput();
             }
         }

--- a/modules/Activities/activities_manage_enrolment_delete.php
+++ b/modules/Activities/activities_manage_enrolment_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
                 echo '</div>';
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/activities_manage_enrolment_deleteProcess.php?gibbonActivityID=$gibbonActivityID&gibbonPersonID=$gibbonPersonID&search=".$_GET['search']."&gibbonSchoolYearTermID=".$_GET['gibbonSchoolYearTermID']);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/activities_manage_enrolment_deleteProcess.php?gibbonActivityID=$gibbonActivityID&gibbonPersonID=$gibbonPersonID&search=".$_GET['search']."&gibbonSchoolYearTermID=".$_GET['gibbonSchoolYearTermID']);
             echo $form->getOutput();
         }
     }

--- a/modules/Behaviour/behaviour_manage_delete.php
+++ b/modules/Behaviour/behaviour_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 echo __($guid, 'The selected record does not exist, or you do not have access to it.');
                 echo '</div>';
             } else {
-                $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/behaviour_manage_deleteProcess.php?gibbonBehaviourID=$gibbonBehaviourID&gibbonPersonID=".$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
+                $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/behaviour_manage_deleteProcess.php?gibbonBehaviourID=$gibbonBehaviourID&gibbonPersonID=".$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
 	            echo $form->getOutput();
             }
         }

--- a/modules/Data Updater/data_family_manage_delete.php
+++ b/modules/Data Updater/data_family_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_m
         } else {
             //Let's go!
             
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_family_manage_deleteProcess.php?gibbonFamilyUpdateID=".$gibbonFamilyUpdateID);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_family_manage_deleteProcess.php?gibbonFamilyUpdateID=".$gibbonFamilyUpdateID);
             echo $form->getOutput();
         }
     }

--- a/modules/Data Updater/data_finance_manage_delete.php
+++ b/modules/Data Updater/data_finance_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
         } else {
             //Let's go!
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_finance_manage_deleteProcess.php?gibbonFinanceInvoiceeUpdateID=".$gibbonFinanceInvoiceeUpdateID);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_finance_manage_deleteProcess.php?gibbonFinanceInvoiceeUpdateID=".$gibbonFinanceInvoiceeUpdateID);
             echo $form->getOutput();
         }
     }

--- a/modules/Data Updater/data_medical_manage_delete.php
+++ b/modules/Data Updater/data_medical_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_medical_manage_deleteProcess.php?gibbonPersonMedicalUpdateID=$gibbonPersonMedicalUpdateID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_medical_manage_deleteProcess.php?gibbonPersonMedicalUpdateID=$gibbonPersonMedicalUpdateID");
 	        echo $form->getOutput();
         }
     }

--- a/modules/Data Updater/data_personal_manage_delete.php
+++ b/modules/Data Updater/data_personal_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
         } else {
             //Let's go!
             
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_personal_manage_deleteProcess.php?gibbonPersonUpdateID=".$gibbonPersonUpdateID);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/data_personal_manage_deleteProcess.php?gibbonPersonUpdateID=".$gibbonPersonUpdateID);
             echo $form->getOutput();
         }
     }

--- a/modules/Finance/budgetCycles_manage_delete.php
+++ b/modules/Finance/budgetCycles_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
         } else {
             //Let's go!
             $row = $result->fetch();
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/budgetCycles_manage_deleteProcess.php?gibbonFinanceBudgetCycleID=$gibbonFinanceBudgetCycleID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/budgetCycles_manage_deleteProcess.php?gibbonFinanceBudgetCycleID=$gibbonFinanceBudgetCycleID");
             echo $form->getOutput();
         }
     }

--- a/modules/Finance/budgets_manage_delete.php
+++ b/modules/Finance/budgets_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_del
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/budgets_manage_deleteProcess.php?gibbonFinanceBudgetID=$gibbonFinanceBudgetID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/budgets_manage_deleteProcess.php?gibbonFinanceBudgetID=$gibbonFinanceBudgetID");
             echo $form->getOutput();
         }
     }

--- a/modules/Finance/expenseApprovers_manage_delete.php
+++ b/modules/Finance/expenseApprovers_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/expenseApprovers_manage_deleteProcess.php?gibbonFinanceExpenseApproverID=$gibbonFinanceExpenseApproverID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/expenseApprovers_manage_deleteProcess.php?gibbonFinanceExpenseApproverID=$gibbonFinanceExpenseApproverID");
             echo $form->getOutput();
         }
     }

--- a/modules/Finance/feeCategories_manage_delete.php
+++ b/modules/Finance/feeCategories_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/feeCategories_manage_deleteProcess.php?gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/feeCategories_manage_deleteProcess.php?gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID");
             echo $form->getOutput();
         }
     }

--- a/modules/Finance/invoices_manage_delete.php
+++ b/modules/Finance/invoices_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_de
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/invoices_manage_deleteProcess.php?gibbonFinanceInvoiceID=$gibbonFinanceInvoiceID&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/invoices_manage_deleteProcess.php?gibbonFinanceInvoiceID=$gibbonFinanceInvoiceID&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID");
             echo $form->getOutput();
         }
     }

--- a/modules/Formal Assessment/externalAssessment_manage_details_delete.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -71,7 +71,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
                 echo '</div>';
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/externalAssessment_manage_details_deleteProcess.php?gibbonExternalAssessmentStudentID=$gibbonExternalAssessmentStudentID&gibbonPersonID=$gibbonPersonID&search=$search&allStudents=$allStudents");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/externalAssessment_manage_details_deleteProcess.php?gibbonExternalAssessmentStudentID=$gibbonExternalAssessmentStudentID&gibbonPersonID=$gibbonPersonID&search=$search&allStudents=$allStudents");
             echo $form->getOutput();
         }
     }

--- a/modules/Formal Assessment/internalAssessment_manage_delete.php
+++ b/modules/Formal Assessment/internalAssessment_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     returnProcess($guid, $_GET['return'], null, null);
                 }
 
-                $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/internalAssessment_manage_deleteProcess.php?gibbonInternalAssessmentColumnID=$gibbonInternalAssessmentColumnID");
+                $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/internalAssessment_manage_deleteProcess.php?gibbonInternalAssessmentColumnID=$gibbonInternalAssessmentColumnID");
                 echo $form->getOutput();
             }
         }

--- a/modules/Library/library_manage_catalog_delete.php
+++ b/modules/Library/library_manage_catalog_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/library_manage_catalog_deleteProcess.php?gibbonLibraryItemID=$gibbonLibraryItemID&name=".$_GET['name'].'&gibbonLibraryTypeID='.$_GET['gibbonLibraryTypeID'].'&gibbonSpaceID='.$_GET['gibbonSpaceID'].'&status='.$_GET['status'].'&gibbonPersonIDOwnership='.$_GET['gibbonPersonIDOwnership'].'&typeSpecificFields='.$_GET['typeSpecificFields']);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/library_manage_catalog_deleteProcess.php?gibbonLibraryItemID=$gibbonLibraryItemID&name=".$_GET['name'].'&gibbonLibraryTypeID='.$_GET['gibbonLibraryTypeID'].'&gibbonSpaceID='.$_GET['gibbonSpaceID'].'&status='.$_GET['status'].'&gibbonPersonIDOwnership='.$_GET['gibbonPersonIDOwnership'].'&typeSpecificFields='.$_GET['typeSpecificFields']);
 	        echo $form->getOutput();
         }
     }

--- a/modules/Markbook/markbook_edit_delete.php
+++ b/modules/Markbook/markbook_edit_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -94,7 +94,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_del
                             returnProcess($guid, $_GET['return'], null, null);
                         }
 
-                        $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/markbook_edit_deleteProcess.php?gibbonMarkbookColumnID=$gibbonMarkbookColumnID");
+                        $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/markbook_edit_deleteProcess.php?gibbonMarkbookColumnID=$gibbonMarkbookColumnID");
                         echo $form->getOutput();
                     }
                 }

--- a/modules/Markbook/weighting_manage_delete.php
+++ b/modules/Markbook/weighting_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -120,7 +120,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
                     echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > </div><div class='trailEnd'>".__($guid, 'Delete').' '.$row['course'].'.'.$row['class'].' '.__($guid, ' Weighting').'</div>';
                     echo '</div>';
 
-                    $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/weighting_manage_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID");
+                    $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/weighting_manage_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID");
                     echo $form->getOutput();
                 }
             }

--- a/modules/Messenger/cannedResponse_manage_delete.php
+++ b/modules/Messenger/cannedResponse_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_m
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/cannedResponse_manage_deleteProcess.php?gibbonMessengerCannedResponseID=$gibbonMessengerCannedResponseID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/cannedResponse_manage_deleteProcess.php?gibbonMessengerCannedResponseID=$gibbonMessengerCannedResponseID");
             echo $form->getOutput();
         }
     }

--- a/modules/Messenger/messenger_manage_delete.php
+++ b/modules/Messenger/messenger_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_manage
                 echo __($guid, 'The specified record cannot be found.');
                 echo '</div>';
             } else {
-                $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/messenger_manage_deleteProcess.php?gibbonMessengerID=$gibbonMessengerID&search=$search");
+                $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/messenger_manage_deleteProcess.php?gibbonMessengerID=$gibbonMessengerID&search=$search");
 	            echo $form->getOutput();
             }
         }

--- a/modules/Planner/outcomes_delete.php
+++ b/modules/Planner/outcomes_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_delete.ph
                     echo __($guid, 'The selected record does not exist, or you do not have access to it.');
                     echo '</div>';
                 } else {
-                    $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/outcomes_deleteProcess.php?gibbonOutcomeID=$gibbonOutcomeID&filter2=".$filter2);
+                    $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/outcomes_deleteProcess.php?gibbonOutcomeID=$gibbonOutcomeID&filter2=".$filter2);
                     echo $form->getOutput();
                 }
             }

--- a/modules/Planner/planner_delete.php
+++ b/modules/Planner/planner_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_delete.php
                     returnProcess($guid, $_GET['return'], null, null);
                 }
 
-                $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/planner_deleteProcess.php?gibbonPlannerEntryID=$gibbonPlannerEntryID");
+                $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/planner_deleteProcess.php?gibbonPlannerEntryID=$gibbonPlannerEntryID");
                 echo $form->getOutput();
             }
         }

--- a/modules/Planner/units_delete.php
+++ b/modules/Planner/units_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -94,7 +94,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_delete.php')
                         echo __($guid, 'The specified record cannot be found.');
                         echo '</div>';
                     } else {
-                        $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/units_deleteProcess.php?gibbonUnitID=$gibbonUnitID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID");
+                        $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/units_deleteProcess.php?gibbonUnitID=$gibbonUnitID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID");
                         echo $form->getOutput();
                     }
                 }

--- a/modules/Rubrics/rubrics_delete.php
+++ b/modules/Rubrics/rubrics_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_delete.php
                     echo __($guid, 'The selected record does not exist, or you do not have access to it.');
                     echo '</div>';
                 } else {
-                    $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/rubrics_deleteProcess.php?gibbonRubricID=$gibbonRubricID&search=$search&filter2=$filter2");
+                    $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/rubrics_deleteProcess.php?gibbonRubricID=$gibbonRubricID&search=$search&filter2=$filter2");
                     echo $form->getOutput();
                 }
             }

--- a/modules/School Admin/attendanceSettings_manage_delete.php
+++ b/modules/School Admin/attendanceSettings_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,9 +57,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteFormStart($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/attendanceSettings_manage_deleteProcess.php?gibbonAttendanceCodeID=$gibbonAttendanceCodeID");
-                $form->addRow()->addContent(__('These codes should not be changed during an active school year. Removing an attendace code after attendance has been recorded can result in lost information.'));
-                $form->addRow()->addElement(PrefabFormFactory::createDeleteFormSubmit($form));
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/attendanceSettings_manage_deleteProcess.php?gibbonAttendanceCodeID=$gibbonAttendanceCodeID", false, false);
+            $form->addRow()->addContent(__('These codes should not be changed during an active school year. Removing an attendace code after attendance has been recorded can result in lost information.'));
+            $form->addRow()->addConfirmSubmit();
+
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/department_manage_delete.php
+++ b/modules/School Admin/department_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/department_manage_deleteProcess.php?gibbonDepartmentID=$gibbonDepartmentID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/department_manage_deleteProcess.php?gibbonDepartmentID=$gibbonDepartmentID", true);
 	        echo $form->getOutput();
         }
     }

--- a/modules/School Admin/externalAssessments_manage_delete.php
+++ b/modules/School Admin/externalAssessments_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/externalAssessments_manage_deleteProcess.php?gibbonExternalAssessmentID=$gibbonExternalAssessmentID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/externalAssessments_manage_deleteProcess.php?gibbonExternalAssessmentID=$gibbonExternalAssessmentID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/externalAssessments_manage_edit_field_delete.php
+++ b/modules/School Admin/externalAssessments_manage_edit_field_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
                 returnProcess($guid, $_GET['return'], null, null);
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/externalAssessments_manage_edit_field_deleteProcess.php?gibbonExternalAssessmentFieldID=$gibbonExternalAssessmentFieldID&gibbonExternalAssessmentID=$gibbonExternalAssessmentID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/externalAssessments_manage_edit_field_deleteProcess.php?gibbonExternalAssessmentFieldID=$gibbonExternalAssessmentFieldID&gibbonExternalAssessmentID=$gibbonExternalAssessmentID");
 	        echo $form->getOutput();
         }
     }

--- a/modules/School Admin/fileExtensions_manage_delete.php
+++ b/modules/School Admin/fileExtensions_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/fileExtensions_manage_deleteProcess.php?gibbonFileExtensionID=$gibbonFileExtensionID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/fileExtensions_manage_deleteProcess.php?gibbonFileExtensionID=$gibbonFileExtensionID");
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/gradeScales_manage_delete.php
+++ b/modules/School Admin/gradeScales_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/gradeScales_manage_deleteProcess.php?gibbonScaleID=$gibbonScaleID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/gradeScales_manage_deleteProcess.php?gibbonScaleID=$gibbonScaleID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/gradeScales_manage_edit_grade_delete.php
+++ b/modules/School Admin/gradeScales_manage_edit_grade_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
                 returnProcess($guid, $_GET['return'], null, null);
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/gradeScales_manage_edit_grade_deleteProcess.php?gibbonScaleGradeID=$gibbonScaleGradeID&gibbonScaleID=$gibbonScaleID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/gradeScales_manage_edit_grade_deleteProcess.php?gibbonScaleGradeID=$gibbonScaleGradeID&gibbonScaleID=$gibbonScaleID");
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/house_manage_delete.php
+++ b/modules/School Admin/house_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/house_manage_deleteProcess.php?gibbonHouseID=$gibbonHouseID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/house_manage_deleteProcess.php?gibbonHouseID=$gibbonHouseID");
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/inSettings_delete.php
+++ b/modules/School Admin/inSettings_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/inSettings_de
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/inSettings_deleteProcess.php?gibbonINDescriptorID=$gibbonINDescriptorID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/inSettings_deleteProcess.php?gibbonINDescriptorID=$gibbonINDescriptorID");
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/rollGroup_manage_delete.php
+++ b/modules/School Admin/rollGroup_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/rollGroup_man
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/rollGroup_manage_deleteProcess.php?gibbonRollGroupID=$gibbonRollGroupID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/rollGroup_manage_deleteProcess.php?gibbonRollGroupID=$gibbonRollGroupID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/schoolYearSpecialDay_manage_delete.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/schoolYearSpecialDay_manage_deleteProcess.php?gibbonSchoolYearSpecialDayID=$gibbonSchoolYearSpecialDayID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID']);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/schoolYearSpecialDay_manage_deleteProcess.php?gibbonSchoolYearSpecialDayID=$gibbonSchoolYearSpecialDayID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID']);
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/schoolYearTerm_manage_delete.php
+++ b/modules/School Admin/schoolYearTerm_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/schoolYearTerm_manage_deleteProcess.php?gibbonSchoolYearTermID=$gibbonSchoolYearTermID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/schoolYearTerm_manage_deleteProcess.php?gibbonSchoolYearTermID=$gibbonSchoolYearTermID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/schoolYear_manage_delete.php
+++ b/modules/School Admin/schoolYear_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/schoolYear_manage_deleteProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/schoolYear_manage_deleteProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/space_manage_delete.php
+++ b/modules/School Admin/space_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/space_manage_deleteProcess.php?gibbonSpaceID=$gibbonSpaceID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/space_manage_deleteProcess.php?gibbonSpaceID=$gibbonSpaceID");
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/studentsSettings_noteCategory_delete.php
+++ b/modules/School Admin/studentsSettings_noteCategory_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/studentsSettings_noteCategory_deleteProcess.php?gibbonStudentNoteCategoryID=$gibbonStudentNoteCategoryID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/studentsSettings_noteCategory_deleteProcess.php?gibbonStudentNoteCategoryID=$gibbonStudentNoteCategoryID");
             echo $form->getOutput();
         }
     }

--- a/modules/School Admin/yearGroup_manage_delete.php
+++ b/modules/School Admin/yearGroup_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/yearGroup_manage_deleteProcess.php?gibbonYearGroupID=$gibbonYearGroupID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/yearGroup_manage_deleteProcess.php?gibbonYearGroupID=$gibbonYearGroupID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/Staff/applicationForm_manage_delete.php
+++ b/modules/Staff/applicationForm_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/applicationForm_manage_deleteProcess.php??gibbonStaffApplicationFormID=$gibbonStaffApplicationFormID&search=$search", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/applicationForm_manage_deleteProcess.php??gibbonStaffApplicationFormID=$gibbonStaffApplicationFormID&search=$search", true);
             echo $form->getOutput();
         }
     }

--- a/modules/Staff/jobOpenings_manage_delete.php
+++ b/modules/Staff/jobOpenings_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage_d
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/jobOpenings_manage_deleteProcess.php?gibbonStaffJobOpeningID=$gibbonStaffJobOpeningID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/jobOpenings_manage_deleteProcess.php?gibbonStaffJobOpeningID=$gibbonStaffJobOpeningID");
             echo $form->getOutput();
         }
     }

--- a/modules/Staff/staff_manage_delete.php
+++ b/modules/Staff/staff_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_delete.
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_deleteProcess.php?gibbonStaffID=$gibbonStaffID&search=$search&allStaff=$allStaff");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_deleteProcess.php?gibbonStaffID=$gibbonStaffID&search=$search&allStaff=$allStaff");
             echo $form->getOutput();
         }
     }

--- a/modules/Staff/staff_manage_edit_facility_delete.php
+++ b/modules/Staff/staff_manage_edit_facility_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_fa
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_edit_facility_deleteProcess.php?gibbonStaffID=$gibbonStaffID&gibbonSpacePersonID=$gibbonSpacePersonID&search=$search&allStaff=$allStaff");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_edit_facility_deleteProcess.php?gibbonStaffID=$gibbonStaffID&gibbonSpacePersonID=$gibbonSpacePersonID&search=$search&allStaff=$allStaff");
             echo $form->getOutput();
         }
     }

--- a/modules/Students/applicationForm_manage_delete.php
+++ b/modules/Students/applicationForm_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
             echo __($guid, 'The selected record does not exist, or you do not have access to it.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/applicationForm_manage_deleteProcess.php?gibbonApplicationFormID=$gibbonApplicationFormID&search=$search", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/applicationForm_manage_deleteProcess.php?gibbonApplicationFormID=$gibbonApplicationFormID&search=$search", true);
             echo $form->getOutput();
         }
     }

--- a/modules/Students/medicalForm_manage_condition_delete.php
+++ b/modules/Students/medicalForm_manage_condition_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
                 echo '</div>';
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_condition_deleteProcess.php?gibbonPersonMedicalID=$gibbonPersonMedicalID&gibbonPersonMedicalConditionID=$gibbonPersonMedicalConditionID&search=$search");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_condition_deleteProcess.php?gibbonPersonMedicalID=$gibbonPersonMedicalID&gibbonPersonMedicalConditionID=$gibbonPersonMedicalConditionID&search=$search");
             echo $form->getOutput();
         }
     }

--- a/modules/Students/medicalForm_manage_delete.php
+++ b/modules/Students/medicalForm_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_deleteProcess.php?gibbonPersonMedicalID=$gibbonPersonMedicalID&search=$search");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_deleteProcess.php?gibbonPersonMedicalID=$gibbonPersonMedicalID&search=$search");
             echo $form->getOutput();
         }
     }

--- a/modules/Students/studentEnrolment_manage_delete.php
+++ b/modules/Students/studentEnrolment_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/studentEnrolment_manage_deleteProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&search=$search", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/studentEnrolment_manage_deleteProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&search=$search", true);
             echo $form->getOutput();
         }
     }

--- a/modules/System Admin/stringReplacement_manage_delete.php
+++ b/modules/System Admin/stringReplacement_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/stringReplacement_manage_deleteProcess.php?gibbonStringID=$gibbonStringID&search=$search");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/stringReplacement_manage_deleteProcess.php?gibbonStringID=$gibbonStringID&search=$search");
             echo $form->getOutput();
         }
     }

--- a/modules/System Admin/theme_manage_uninstall.php
+++ b/modules/System Admin/theme_manage_uninstall.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/theme_manage_
             echo 'The specified theme cannot be found or is active and so cannot be removed.';
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/theme_manage_uninstallProcess.php?gibbonThemeID=$gibbonThemeID&orphaned=$orphaned");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/theme_manage_uninstallProcess.php?gibbonThemeID=$gibbonThemeID&orphaned=$orphaned");
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -70,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             }
             echo '</div>';
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/courseEnrolment_manage_byPerson_edit_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&type=$type&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonPersonID=$gibbonPersonID&allUsers=$allUsers&search=$search");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/courseEnrolment_manage_byPerson_edit_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&type=$type&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonPersonID=$gibbonPersonID&allUsers=$allUsers&search=$search");
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/courseEnrolment_manage.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID']."'>".__($guid, 'Enrolment by Class')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/courseEnrolment_manage_class_edit.php&gibbonCourseClassID='.$_GET['gibbonCourseClassID'].'&gibbonCourseID='.$_GET['gibbonCourseID'].'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID']."'>".sprintf(__($guid, 'Edit %1$s.%2$s Enrolment'), $row['courseNameShort'], $row['name'])."</a> > </div><div class='trailEnd'>".__($guid, 'Delete Participant').'</div>';
             echo '</div>';
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/courseEnrolment_manage_class_edit_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonPersonID=$gibbonPersonID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/courseEnrolment_manage_class_edit_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonPersonID=$gibbonPersonID");
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_sync_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_delete.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 @session_start();
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         echo __($guid, 'You have not specified one or more required parameters.');
         echo '</div>';
     } else {
-        $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/courseEnrolment_sync_deleteProcess.php');
+        $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/courseEnrolment_sync_deleteProcess.php');
         echo $form->getOutput();
     }
 }

--- a/modules/Timetable Admin/course_manage_class_delete.php
+++ b/modules/Timetable Admin/course_manage_class_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/course_manage_class_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/course_manage_class_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID");
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/course_manage_delete.php
+++ b/modules/Timetable Admin/course_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/course_manage_deleteProcess.php?gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID']);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/course_manage_deleteProcess.php?gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID']);
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/ttColumn_delete.php
+++ b/modules/Timetable Admin/ttColumn_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_d
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/ttColumn_deleteProcess.php?gibbonTTColumnID=$gibbonTTColumnID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/ttColumn_deleteProcess.php?gibbonTTColumnID=$gibbonTTColumnID");
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/ttColumn_edit_row_delete.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                 returnProcess($guid, $_GET['return'], null, null);
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/ttColumn_edit_row_deleteProcess.php?gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTColumnID=$gibbonTTColumnID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/ttColumn_edit_row_deleteProcess.php?gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTColumnID=$gibbonTTColumnID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/ttDates_edit_delete.php
+++ b/modules/Timetable Admin/ttDates_edit_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
                 returnProcess($guid, $_GET['return'], null, null);
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/ttDates_edit_deleteProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&dateStamp=$dateStamp&gibbonTTDayID=$gibbonTTDayID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/ttDates_edit_deleteProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&dateStamp=$dateStamp&gibbonTTDayID=$gibbonTTDayID");
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/tt_delete.php
+++ b/modules/Timetable Admin/tt_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
             echo '</div>';
         } else {
             //Let's go!
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_deleteProcess.php?gibbonTTID=$gibbonTTID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID'], true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_deleteProcess.php?gibbonTTID=$gibbonTTID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID'], true);
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 returnProcess($guid, $_GET['return'], null, null);
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_edit_day_deleteProcess.php?gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_edit_day_deleteProcess.php?gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 returnProcess($guid, $_GET['return'], null, null);
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_edit_day_edit_class_deleteProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_edit_day_edit_class_deleteProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID");
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                         returnProcess($guid, $_GET['return'], null, null);
                     }
 
-                    $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_edit_day_edit_class_exception_deleteProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID&gibbonTTDayRowClassExceptionID=$gibbonTTDayRowClassExceptionID");
+                    $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/tt_edit_day_edit_class_exception_deleteProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID&gibbonTTDayRowClassExceptionID=$gibbonTTDayRowClassExceptionID");
                     echo $form->getOutput();
                 }
             }

--- a/modules/Timetable/spaceBooking_manage_delete.php
+++ b/modules/Timetable/spaceBooking_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                 echo __('The specified record cannot be found.');
                 echo '</div>';
             } else {
-                $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/spaceBooking_manage_deleteProcess.php?gibbonTTSpaceBookingID=$gibbonTTSpaceBookingID");
+                $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/spaceBooking_manage_deleteProcess.php?gibbonTTSpaceBookingID=$gibbonTTSpaceBookingID");
                 echo $form->getOutput();
             }
         }

--- a/modules/Timetable/spaceChange_manage_delete.php
+++ b/modules/Timetable/spaceChange_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
                 echo __($guid, 'The specified record cannot be found.');
                 echo '</div>';
             } else {
-                $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/spaceChange_manage_deleteProcess.php?gibbonTTSpaceChangeID=$gibbonTTSpaceChangeID");
+                $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/spaceChange_manage_deleteProcess.php?gibbonTTSpaceChangeID=$gibbonTTSpaceChangeID");
                 echo $form->getOutput();
             }
         }

--- a/modules/User Admin/district_manage_delete.php
+++ b/modules/User Admin/district_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/district_manage_deleteProcess.php?gibbonDistrictID=".$gibbonDistrictID);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/district_manage_deleteProcess.php?gibbonDistrictID=".$gibbonDistrictID);
             echo $form->getOutput();
         }
     }

--- a/modules/User Admin/family_manage_delete.php
+++ b/modules/User Admin/family_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -58,8 +58,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_d
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_deleteProcess.php?gibbonFamilyID=$gibbonFamilyID&search=$search", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_deleteProcess.php?gibbonFamilyID=$gibbonFamilyID&search=$search", true);
             echo $form->getOutput();
+
         }
     }
 }

--- a/modules/User Admin/family_manage_edit_deleteAdult.php
+++ b/modules/User Admin/family_manage_edit_deleteAdult.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
                 echo '</div>';
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_edit_deleteAdultProcess.php?gibbonFamilyID=$gibbonFamilyID&gibbonPersonID=$gibbonPersonID&search=$search");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_edit_deleteAdultProcess.php?gibbonFamilyID=$gibbonFamilyID&gibbonPersonID=$gibbonPersonID&search=$search");
             echo $form->getOutput();
         }
     }

--- a/modules/User Admin/family_manage_edit_deleteChild.php
+++ b/modules/User Admin/family_manage_edit_deleteChild.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -68,7 +68,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
                 echo '</div>';
             }
 
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_edit_deleteChildProcess.php?gibbonFamilyID=$gibbonFamilyID&gibbonPersonID=$gibbonPersonID&search=$search");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_edit_deleteChildProcess.php?gibbonFamilyID=$gibbonFamilyID&gibbonPersonID=$gibbonPersonID&search=$search");
             echo $form->getOutput();
         }
     }

--- a/modules/User Admin/role_manage_delete.php
+++ b/modules/User Admin/role_manage_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_delete.php') == false) {
     //Acess denied
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_del
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/role_manage_deleteProcess.php?gibbonRoleID=$gibbonRoleID", true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/role_manage_deleteProcess.php?gibbonRoleID=$gibbonRoleID", true);
             echo $form->getOutput();
         }
     }

--- a/modules/User Admin/userFields_delete.php
+++ b/modules/User Admin/userFields_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 @session_start();
 
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_dele
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/userFields_deleteProcess.php?gibbonPersonFieldID=$gibbonPersonFieldID");
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/userFields_deleteProcess.php?gibbonPersonFieldID=$gibbonPersonFieldID");
             echo $form->getOutput();
         }
     }

--- a/modules/User Admin/userSettings_usernameFormat_delete.php
+++ b/modules/User Admin/userSettings_usernameFormat_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.php') == false) {
     //Acess denied
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
         echo __($guid, 'You have not specified one or more required parameters.');
         echo '</div>';
     } else {
-        $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/userSettings_usernameFormat_deleteProcess.php");
+        $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/userSettings_usernameFormat_deleteProcess.php");
         echo $form->getOutput();
     }
 }

--- a/modules/User Admin/user_manage_delete.php
+++ b/modules/User Admin/user_manage_delete.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 @session_start();
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_delete.php') == false) {
     //Acess denied
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_del
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
-            $form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/user_manage_deleteProcess.php?gibbonPersonID=$gibbonPersonID&search=".$_GET['search'], true);
+            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/user_manage_deleteProcess.php?gibbonPersonID=$gibbonPersonID&search=".$_GET['search'], true);
             echo $form->getOutput();
         }
     }

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -215,7 +215,7 @@ class FormFactory implements FormFactoryInterface
 
     public function createSubmit($label = 'Submit')
     {
-        $content = sprintf('<input type="submit" value="%s">', $label);
+        $content = sprintf('<input type="submit" value="%s">', __($label));
         return $this->createContent($content)->setClass('right');
     }
 
@@ -223,12 +223,16 @@ class FormFactory implements FormFactoryInterface
     {
         $passParams[] = 'q';
         $parameters = array_intersect_key($_GET, array_flip($passParams));
-        $content = sprintf('<input type="submit" value="%s">', __('Go'));
-
         $clearURL = $session->get('absoluteURL').'/index.php?'.http_build_query($parameters);
         $clearLink = sprintf('<a href="%s" class="right">%s</a> &nbsp;', $clearURL, __($clearLabel));
 
-        return $this->createContent($content)->prepend($clearLink)->setClass('right');
+        return $this->createSubmit('Go')->prepend($clearLink);
+    }
+
+    public function createConfirmSubmit($label = 'Yes', $cancel = false)
+    {
+        $cancelLink = ($cancel)? sprintf('<a href="%s" class="right">%s</a> &nbsp;', $_SERVER['HTTP_REFERER'], __('Cancel')) : '';
+        return $this->createSubmit($label)->prepend($cancelLink);
     }
 
     public function createFooter($required = true)

--- a/src/Forms/Prefab/DeleteForm.php
+++ b/src/Forms/Prefab/DeleteForm.php
@@ -17,29 +17,21 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-namespace Gibbon\Forms;
+namespace Gibbon\Forms\Prefab;
+
+use Gibbon\Forms\Form;
 
 /**
- * PrefabFormFactory
+ * DeleteForm
  *
- * For building pre-made forms all at once.
- *
- * @version v14
- * @since   v14
+ * @version v15
+ * @since   v15
  */
-class PrefabFormFactory
+class DeleteForm extends Form
 {
-    public static function createDeleteForm($action, $confirmation = false)
+    public static function createForm($action, $confirmation = false, $submit = true)
     {
-        $form = self::createDeleteFormStart($action, $confirmation);
-        $form->addRow()->addElement(self::createDeleteFormSubmit($form));
-
-        return $form;
-    }
-
-    public static function createDeleteFormStart($action, $confirmation = false)
-    {
-        $form = Form::create('deleteRecord', $action);
+        $form = parent::create('deleteRecord', $action);
         $form->addHiddenValue('address', $_GET['q']);
 
         foreach ($_GET as $key => $value) {
@@ -47,9 +39,10 @@ class PrefabFormFactory
         }
 
         $row = $form->addRow();
-            $column = $row->addColumn();
-            $column->addContent(__('Are you sure you want to delete this record?'))->wrap('<strong>', '</strong>');
-            $column->addContent(__('This operation cannot be undone, and may lead to loss of vital data in your system. PROCEED WITH CAUTION!'))->wrap('<span style="color: #cc0000"><i>', '</i></span>');
+            $col = $row->addColumn();
+            $col->addContent(__('Are you sure you want to delete this record?'))->wrap('<strong>', '</strong>');
+            $col->addContent(__('This operation cannot be undone, and may lead to loss of vital data in your system. PROCEED WITH CAUTION!'))
+                ->wrap('<span style="color: #cc0000"><i>', '</i></span>');
 
         if ($confirmation) {
             $row = $form->addRow();
@@ -62,12 +55,10 @@ class PrefabFormFactory
                 ->addValidationOption('onlyOnSubmit: true');
         }
 
+        if ($submit) {
+            $form->addRow()->addConfirmSubmit();
+        }
+
         return $form;
     }
-
-    public static function createDeleteFormSubmit($form)
-    {
-        return $form->getFactory()->createSubmit(__('Yes'));
-    }
-
 }


### PR DESCRIPTION
Changed my mind 😅 Having predefined forms for common things like delete forms, bulk action, etc still makes a lot of sense, but I realized piling them all into one Factory class was going to get messy really quick.

This PR updates all the PrefabFormFactory instances to point to a DeleteForm. Luckily the feature is recent and only used in the core. Thanks in advance for bearing with me on this one 😁