### PR TITLE
Form Class: add a BulkActionForm class

### DIFF
--- a/modules/Activities/activities_manage.php
+++ b/modules/Activities/activities_manage.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\Prefab\BulkActionForm;
 
 @session_start();
 
@@ -132,35 +133,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             } catch (PDOException $e) {
             }
 
-            $form = Form::create('bulkAction', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/activities_manageProcessBulk.php');
-            $form->getRenderer()->setWrapper('form', 'div');
-            $form->getRenderer()->setWrapper('row', 'div');
-            $form->getRenderer()->setWrapper('cell', 'fieldset');
-
-            $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+            $form = BulkActionForm::create('bulkAction', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/activities_manageProcessBulk.php');
             $form->addHiddenValue('search', $search);
 
-            $actions = array(
+            $bulkActions = array(
                 'Duplicate' => __('Duplicate'),
                 'DuplicateParticipants' => __('Duplicate With Participants'),
                 'Delete' => __('Delete'),
             );
             $sql = "SELECT gibbonSchoolYearID as value, gibbonSchoolYear.name FROM gibbonSchoolYear WHERE (status='Upcoming' OR status='Current') ORDER BY sequenceNumber LIMIT 0, 2";
             
-            $row = $form->addRow()->setClass('right');
-            $bulkAction = $row->addColumn()->addClass('inline right');
-                $bulkAction->addSelect('action')
-                    ->fromArray($actions)
-                    ->isRequired()
-                    ->setClass('mediumWidth')
-                    ->placeholder(__('Select action'));
-                $bulkAction->addSelect('gibbonSchoolYearIDCopyTo')
+            $row = $form->addBulkActionRow($bulkActions);
+                $row->addSelect('gibbonSchoolYearIDCopyTo')
                     ->fromQuery($pdo, $sql)
                     ->setClass('shortWidth schoolYear');
-                $bulkAction->addSubmit(__('Go'));
+                $row->addSubmit(__('Go'));
         
             $form->toggleVisibilityByClass('schoolYear')->onSelect('action')->when(array('Duplicate', 'DuplicateParticipants'));
-            $form->addConfirmation(__('Are you sure you wish to process this action? It cannot be undone.'));
 
             $table = $form->addRow()->addTable()->addClass('colorOddEven');
 
@@ -175,7 +164,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             $header->addContent(__('Provider'));
             $header->addContent(__('Waiting'));
             $header->addContent(__('Actions'));
-            $header->addCheckbox('checkall')->setClass('floatNone textCenter checkall');
+            $header->addCheckAll();
 
             while ($activity = $resultPage->fetch()) {
                 $rowClass = ($activity['active'] == 'N')? 'error' : '';

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -184,8 +184,7 @@ class FormFactory implements FormFactoryInterface
     {
         $button = new Input\Button($label, $onClick);
         if(!empty($id)) {
-            $button->setID($id);
-            $button->setName($id);
+            $button->setID($id)->setName($id);
         }
         
         return $button;

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -182,17 +182,13 @@ class FormFactory implements FormFactoryInterface
 
     public function createButton($label = 'Button', $onClick = '', $id = null)
     {
-        if($id == null)
-        {
-            return new Input\Button($label, $onClick);
-        }
-        else
-        {
-            $button = new Input\Button($label, $onClick);
+        $button = new Input\Button($label, $onClick);
+        if(!empty($id)) {
             $button->setID($id);
             $button->setName($id);
-            return $button;
         }
+        
+        return $button;
     }
 
     public function createCustomBlocks($name, OutputableInterface $block, \Gibbon\Session $session)
@@ -245,6 +241,11 @@ class FormFactory implements FormFactoryInterface
     public function createYesNo($name)
     {
         return $this->createSelect($name)->fromArray(array( 'Y' => __('Yes'), 'N' => __('No') ));
+    }
+
+    public function createCheckAll($name = 'checkall')
+    {
+        return $this->createCheckbox($name)->setClass('floatNone textCenter checkall');
     }
 
     public function createSelectTitle($name)

--- a/src/Forms/Prefab/BulkActionForm.php
+++ b/src/Forms/Prefab/BulkActionForm.php
@@ -1,0 +1,59 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Forms\Prefab;
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\FormFactory;
+use Gibbon\Forms\FormRenderer;
+
+/**
+ * BulkActionForm
+ *
+ * @version v15
+ * @since   v15
+ */
+class BulkActionForm extends Form
+{
+    public static function create($id, $action, $method = 'post', $class = 'smallIntBorder fullWidth standardForm')
+    {
+        $factory = FormFactory::create();
+        $renderer = FormRenderer::create();
+
+        $renderer->setWrapper('form', 'div');
+        $renderer->setWrapper('row', 'div');
+        $renderer->setWrapper('cell', 'fieldset');
+
+        $form = new BulkActionForm($factory, $renderer, $action, $method);
+
+        $form->setID($id);
+        $form->setClass($class);
+
+        $form->addConfirmation(__('Are you sure you wish to process this action? It cannot be undone.'));
+        $form->addHiddenValue('address', $_GET['q']);
+
+        return $form;
+    }
+
+    public function addActionRow($id = '')
+    {
+        $row = $this->addRow($id)->setClass('right');
+        return $row->addColumn()->addClass('inline right');
+    }
+}

--- a/src/Forms/Prefab/BulkActionForm.php
+++ b/src/Forms/Prefab/BulkActionForm.php
@@ -51,9 +51,17 @@ class BulkActionForm extends Form
         return $form;
     }
 
-    public function addActionRow($id = '')
+    public function addBulkActionRow($actions = array())
     {
-        $row = $this->addRow($id)->setClass('right');
-        return $row->addColumn()->addClass('inline right');
+        $row = $this->addRow()->setClass('right');
+        $col = $row->addColumn()->addClass('inline right');
+
+        $col->addSelect('action')
+            ->fromArray($actions)
+            ->isRequired()
+            ->setClass('shortWidth')
+            ->placeholder(__('Select action'));
+
+        return $col;
     }
 }


### PR DESCRIPTION
Following up on the previous PR, this one adds the BulkActionForm class to pull together the logic and layout elements into one prefab form. Makes things easier to maintain and implement.

Also updates the one ooified bulk action form so-far, with some more forms in the works for a future Timetable Admin PR.