### PR TITLE
User Admin: add settings to adjust formatting of staff names

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -863,4 +863,8 @@ UPDATE gibbonAction SET entryURL='staff_view.php' WHERE entryURL='staff_view' AN
 INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES ('Planner', 'parentWeeklyEmailSummaryIncludeMarkbook', 'Parent Weekly Email Summary Include Markbook', 'Should Markbook information be included in the weekly planner email summary that goes out to parents?', 'N');end
 ALTER TABLE `gibbonMarkbookColumn` ADD INDEX(`completeDate`);end
 ALTER TABLE `gibbonMarkbookColumn` ADD INDEX(`complete`);end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('System', 'nameFormatStaffFormal', 'Formal Name Format', '', '[title] [preferredName:1]. [surname]');end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('System', 'nameFormatStaffFormalReversed', 'Formal Name Reversed', '', '[title] [surname], [preferredName:1].');end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('System', 'nameFormatStaffInformal', 'Informal Name Format', '', '[preferredName] [surname]');end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('System', 'nameFormatStaffInformalReversed', 'Informal Name Reversed', '', '[surname], [preferredName]');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -100,6 +100,7 @@ v15.0.00
         User Admin: added a button to generate usernames in Add User
         User Admin: added an Available Years of Entry setting to select which years are available in the student application
 		User Admin: added a setting to require a user's primary email address to be unique
+		User Admin: added a settings to adjust the formatting of staff names in Manage Staff Settings
 
 v14.0.01
 --------

--- a/functions.php
+++ b/functions.php
@@ -2454,22 +2454,23 @@ function getModuleEntry($address, $connection2, $guid)
 
 function formatName($title, $preferredName, $surname, $roleCategory, $reverse = false, $informal = false)
 {
+    global $guid;
     $output = false;
 
     if ($roleCategory == 'Staff' or $roleCategory == 'Other') {
-        if ($informal == false) {
-            if ($reverse == true) {
-                $output = $title.' '.$surname.', '.strtoupper(mb_substr($preferredName, 0, 1)).'.';
-            } else {
-                $output = $title.' '.strtoupper(mb_substr($preferredName, 0, 1)).'. '.$surname;
-            }
-        } else {
-            if ($reverse == true) {
-                $output = $surname.', '.$preferredName;
-            } else {
-                $output = $preferredName.' '.$surname;
-            }
-        }
+        
+        $setting = 'nameFormatStaff' . ($informal? 'Informal' : 'Formal') . ($reverse? 'Reversed' : '');
+        $format = isset($_SESSION[$guid][$setting])? $_SESSION[$guid][$setting] : '[title] [preferredName:1]. [surname]';
+
+        $output = preg_replace_callback('/\[+([^\]]*)\]+/u', 
+            function ($matches) use ($title, $preferredName, $surname) {
+                list($token, $length) = array_pad(explode(':', $matches[1], 2), 2, false);
+                return isset($$token)
+                    ? (!empty($length)? mb_substr($$token, 0, intval($length)) : $$token)
+                    : $matches[0];
+            }, 
+        $format);
+
     } elseif ($roleCategory == 'Parent') {
         if ($informal == false) {
             if ($reverse == true) {
@@ -2492,7 +2493,7 @@ function formatName($title, $preferredName, $surname, $roleCategory, $reverse = 
         }
     }
 
-    return $output;
+    return trim($output);
 }
 
 //$tinymceInit indicates whether or not tinymce should be initialised, or whether this will be done else where later (this can be used to improve page load.

--- a/modules/User Admin/staffSettings.php
+++ b/modules/User Admin/staffSettings.php
@@ -57,6 +57,39 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
+    $row = $form->addRow()->addHeading(__('Name Formats'))->append(__('How should staff names be formatted?').' '.__('Choose from [title], [preferredName], [surname].').' '.__('Use a colon to limit the number of letters, for example [preferredName:1] will use the first initial.'));
+
+    $data = array('gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
+    $sql = "SELECT title, preferredName, surname FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID";
+    $result = $pdo->executeQuery($data, $sql);
+    if ($result->rowCount() > 0) {
+        list($title, $preferredName, $surname) = array_values($result->fetch());
+    }
+
+    $setting = getSettingByScope($connection2, 'System', 'nameFormatStaffFormal', true);
+    $settingRev = getSettingByScope($connection2, 'System', 'nameFormatStaffFormalReversed', true);
+
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']))->description(
+            __('Example').': '.formatName($title, $preferredName, $surname, 'Staff', false, false).'<br/>'.
+            __('Reversed').': '.formatName($title, $preferredName, $surname, 'Staff', true, false));
+        $col = $row->addColumn($setting['name'])->addClass('stacked');
+        $col->addTextField($setting['name'])->isRequired()->maxLength(60)->setValue($setting['value']);
+        $col->addTextField($settingRev['name'])->isRequired()->maxLength(60)->setTitle(__('Reversed'))->setValue($settingRev['value']);
+
+    $setting = getSettingByScope($connection2, 'System', 'nameFormatStaffInformal', true);
+    $settingRev = getSettingByScope($connection2, 'System', 'nameFormatStaffInformalReversed', true);
+
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']))->description(
+            __('Example').': '.formatName($title, $preferredName, $surname, 'Staff', false, true).'<br/>'.
+            __('Reversed').': '.formatName($title, $preferredName, $surname, 'Staff', true, true));
+        $col = $row->addColumn($setting['name'])->addClass('stacked right');
+        $col->addTextField($setting['name'])->isRequired()->maxLength(60)->setValue($setting['value']);
+        $col->addTextField($settingRev['name'])->isRequired()->maxLength(60)->setTitle(__('Reversed'))->setValue($settingRev['value']);
+
+    $form->loadAllValuesFrom($formats);
+
     $row = $form->addRow();
         $row->addFooter();
         $row->addSubmit();

--- a/modules/User Admin/staffSettingsProcess.php
+++ b/modules/User Admin/staffSettingsProcess.php
@@ -37,6 +37,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
     $responsibilityPosts = $_POST['responsibilityPosts'];
     $jobOpeningDescriptionTemplate = $_POST['jobOpeningDescriptionTemplate'];
 
+    $nameFormatStaffFormal = $_POST['nameFormatStaffFormal'];
+    $nameFormatStaffFormalReversed = $_POST['nameFormatStaffFormalReversed'];
+    $nameFormatStaffInformal = $_POST['nameFormatStaffInformal'];
+    $nameFormatStaffInformalReversed = $_POST['nameFormatStaffInformalReversed'];
+
     //Write to database
     $fail = false;
 
@@ -66,6 +71,44 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
     } catch (PDOException $e) {
         $fail = true;
     }
+
+
+    try {
+        $data = array('value' => $nameFormatStaffFormal);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='System' AND name='nameFormatStaffFormal'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
+    try {
+        $data = array('value' => $nameFormatStaffFormalReversed);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='System' AND name='nameFormatStaffFormalReversed'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
+    try {
+        $data = array('value' => $nameFormatStaffInformal);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='System' AND name='nameFormatStaffInformal'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
+    try {
+        $data = array('value' => $nameFormatStaffInformalReversed);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='System' AND name='nameFormatStaffInformalReversed'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
 
     if ($fail == true) {
         $URL .= '&return=error2';


### PR DESCRIPTION
**New Feature**

A requested feature. This is an interim solution until we have a more system-wide oo approach. PR adds settings to User Admin > Manage Staff Settings to allow editing the formal and informal name formats in a similar pattern as the username formats.

## Motivation and Context
Adds flexibility, different schools have specific formats for addressing teachers.
