### PR TITLE
System: remove stray calls to IsSMTP outside getGibbonMailer function

### DIFF
--- a/cli/planner_parentWeeklyEmailSummary.php
+++ b/cli/planner_parentWeeklyEmailSummary.php
@@ -287,7 +287,6 @@ else {
                                                 $bodyPlain = emailBodyConvert($body);
 
                                                 $mail = getGibbonMailer($guid);
-                                                $mail->IsSMTP();
                                                 if ($replyTo != '') {
                                                     $mail->AddReplyTo($replyTo, $replyToName);
                                                 }

--- a/functions.php
+++ b/functions.php
@@ -1904,7 +1904,6 @@ function setNotification($connection2, $guid, $gibbonPersonID, $text, $moduleNam
         $bodyPlain = emailBodyConvert($body);
 
         $mail = getGibbonMailer($guid);
-        $mail->IsSMTP();
         if (isset($_SESSION[$guid]['organisationEmail']) && $_SESSION[$guid]['organisationEmail'] != '') {
             $mail->SetFrom($_SESSION[$guid]['organisationEmail'], $_SESSION[$guid]['organisationName']);
         }

--- a/modules/Finance/invoices_manage_editProcess.php
+++ b/modules/Finance/invoices_manage_editProcess.php
@@ -243,7 +243,6 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                                 $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the receipt. Please reply to this email if you have any questions.';
 
                                 $mail = getGibbonMailer($guid);
-                                $mail->IsSMTP();
                                 $mail->SetFrom($from, sprintf(__($guid, '%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);
@@ -317,7 +316,6 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                                 }
 
                                 $mail = getGibbonMailer($guid);
-                                $mail->IsSMTP();
                                 $mail->SetFrom($from, sprintf(__($guid, '%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);

--- a/modules/Finance/invoices_manage_issueProcess.php
+++ b/modules/Finance/invoices_manage_issueProcess.php
@@ -209,7 +209,6 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                             $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the invoice. Please reply to this email if you have any questions.';
 
                             $mail = getGibbonMailer($guid);
-                            $mail->IsSMTP();
                             $mail->SetFrom($from, sprintf(__($guid, '%1$s Finance'), $_SESSION[$guid]['organisationName']));
                             foreach ($emails as $address) {
                                 $mail->AddBCC($address);

--- a/modules/Finance/invoices_manage_processBulk.php
+++ b/modules/Finance/invoices_manage_processBulk.php
@@ -315,7 +315,6 @@ if ($gibbonSchoolYearID == '' or $action == '') { echo 'Fatal error loading this
                                 $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the invoice. Please reply to this email if you have any questions.';
 
                                 $mail = getGibbonMailer($guid);
-                                $mail->IsSMTP();
                                 $mail->SetFrom($from, sprintf(__($guid, '%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);
@@ -462,7 +461,6 @@ if ($gibbonSchoolYearID == '' or $action == '') { echo 'Fatal error loading this
                         }
 
                         $mail = getGibbonMailer($guid);
-                        $mail->IsSMTP();
                         $mail->SetFrom($from, sprintf(__($guid, '%1$s Finance'), $_SESSION[$guid]['organisationName']));
                         foreach ($emails as $address) {
                             $mail->AddBCC($address);

--- a/modules/Finance/invoices_payOnlineProcess.php
+++ b/modules/Finance/invoices_payOnlineProcess.php
@@ -294,7 +294,6 @@ if ($paid != 'Y') { //IF PAID IS NOT Y, LET'S REDIRECT TO MAKE PAYMENT
                 $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the receipt. Please reply to this email if you have any questions.';
 
                 $mail = getGibbonMailer($guid);
-                $mail->IsSMTP();
                 $mail->SetFrom(getSettingByScope($connection2, 'Finance', 'email'), sprintf(__($guid, '%1$s Finance'), $_SESSION[$guid]['organisationName']));
                 foreach ($emails as $address) {
                     $mail->AddBCC($address);

--- a/modules/Messenger/messenger_manage_report_processBulk.php
+++ b/modules/Messenger/messenger_manage_report_processBulk.php
@@ -72,7 +72,6 @@ if ($gibbonMessengerID == '' or $action == '') { echo 'Fatal error loading this 
                 $bodyReminder = "<p style='font-style: italic; font-weight: bold'>" . __($guid, 'This is a reminder for an email that requires your action. Please look for the link in the email, and click it to confirm receipt and reading of this email.') ."</p>" ;
                 $bodyFin = "<p style='font-style: italic'>" . sprintf(__($guid, 'Email sent via %1$s at %2$s.'), $_SESSION[$guid]["systemName"], $_SESSION[$guid]["organisationName"]) ."</p>" ;
                 $mail=getGibbonMailer($guid);
-				$mail->IsSMTP();
 				$mail->SetFrom($_SESSION[$guid]["email"], $_SESSION[$guid]["preferredName"] . " " . $_SESSION[$guid]["surname"]);
 				$mail->CharSet="UTF-8";
 				$mail->Encoding="base64" ;

--- a/modules/Staff/applicationFormProcess.php
+++ b/modules/Staff/applicationFormProcess.php
@@ -319,7 +319,6 @@ if ($proceed == false) {
                             $bodyPlain = emailBodyConvert($body);
 
                             $mail = getGibbonMailer($guid);
-                            $mail->IsSMTP();
                             $mail->SetFrom($_SESSION[$guid]['organisationHREmail'], $_SESSION[$guid]['organisationHRName']);
                             if ($referenceEmail1 != '') {
                                 $mail->AddBCC($referenceEmail1);

--- a/modules/Staff/applicationForm_manage_accept.php
+++ b/modules/Staff/applicationForm_manage_accept.php
@@ -237,7 +237,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                                 $bodyPlain = emailBodyConvert($body);
 
                                 $mail = getGibbonMailer($guid);
-                                $mail->IsSMTP();
                                 $mail->SetFrom($_SESSION[$guid]['organisationAdministratorEmail'], $_SESSION[$guid]['organisationAdministratorName']);
                                 $mail->AddAddress($to);
                                 $mail->CharSet = 'UTF-8';
@@ -352,7 +351,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                                     $bodyPlain = emailBodyConvert($body);
 
                                     $mail = getGibbonMailer($guid);
-                                    $mail->IsSMTP();
                                     $mail->SetFrom($_SESSION[$guid]['organisationAdministratorEmail'], $_SESSION[$guid]['organisationAdministratorName']);
                                     $mail->AddAddress($to);
                                     $mail->CharSet = 'UTF-8';

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -335,7 +335,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             $bodyPlain = emailBodyConvert($body);
 
                             $mail = getGibbonMailer($guid);
-                            $mail->IsSMTP();
                             $mail->SetFrom($_SESSION[$guid]['organisationAdministratorEmail'], $_SESSION[$guid]['organisationAdministratorName']);
                             $mail->AddAddress($to);
                             $mail->CharSet = 'UTF-8';
@@ -1210,7 +1209,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 $bodyPlain = emailBodyConvert($body);
 
                                 $mail = getGibbonMailer($guid);
-                                $mail->IsSMTP();
                                 $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                                 $mail->AddAddress($to);
                                 $mail->CharSet = 'UTF-8';
@@ -1258,7 +1256,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 $bodyPlain = emailBodyConvert($body);
 
                                 $mail = getGibbonMailer($guid);
-                                $mail->IsSMTP();
                                 $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                                 $mail->AddAddress($to);
                                 $mail->CharSet = 'UTF-8';


### PR DESCRIPTION
Fixes a [sendmail issue](https://ask.gibbonedu.org/discussion/2081/sendmail-send-mail-gibbon-14-0) where some scripts were still manually calling the PHPMailer IsSMTP() method. The mailer config is already handled inside the getGibbonMailer function so it will default to the built-in PHP mail function (using sendmail) if SMTP is turned off in Third Party Settings.