### PR TITLE
System: add error handling and prevent error messages in Production

### DIFF
--- a/error.php
+++ b/error.php
@@ -19,10 +19,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 ?>
 
 <h1>
-	<?php echo __($guid, 'Oh no!'); ?><br/>
+	<?php echo __('Oh no!'); ?><br/>
 </h1>
 <p>
-	<?php echo __($guid, 'Something has gone wrong: the Gibbons have escaped!') ?><br/>
+	<?php echo __('Something has gone wrong: the Gibbons have escaped!') ?><br/>
 	<br/>
-	<?php echo __($guid, 'An error has occurred. This could mean a number of different things, but generally indicates that you have a misspelt address, or are trying to access a page that you are not permitted to access.').' '.__($guid, 'If you cannot solve this problem by retyping the address, or through other means, please contact your system administrator.') ?><br/>
+	<?php echo __('An error has occurred. This could mean a number of different things, but generally indicates that you have a misspelt address, or are trying to access a page that you are not permitted to access.').' '.__('If you cannot solve this problem by retyping the address, or through other means, please contact your system administrator.') ?><br/>
 </p>

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -833,6 +833,17 @@ div.success {
 	margin: 10px 0px 15px 0px;
 	box-shadow: 2px 2px 2px rgba(50,50,50,0.15);
 }
+
+div.fatal {
+	border-left: 6px solid #444;
+	color: #444;
+	background-color: #f9f9f9;
+	font-size: 12px;
+	padding: 10px;
+	margin: 10px 0px 15px 0px;
+	box-shadow: 2px 2px 2px rgba(50,50,50,0.15);
+}
+
 div.paginationTop {
 	text-align: right;
 	font-size: 12px;


### PR DESCRIPTION
Two main purposes for this PR: to always prevent the display of error messages in Production (regardless of server config), and to improve the display of error messages in Development and Testing installs.

## Description
- Uses the built-in set_exception_handler and set_error_handler functions to define custom behaviour for error handling.
- In Production any fatal errors will fallback to the generic Gibbon error page. Any notices and warnings will not display.
- In Development and Testing, any code errors/warnings/notices are wrapped in an error div and the stack trace is formatted for improved readability.
- Fixes the visual glitch where sidebars don't render after a fatal error or exception.

## Motivation and Context
It's likely a good idea to ensure the display_errors setting is always off for Production, especially security-wise by preventing leaked info through error messages, as well as the odd 'broken' page caused by a PHP notice.

## Screenshots:
![screen shot 2018-01-05 at 2 32 34 pm](https://user-images.githubusercontent.com/897700/34598711-46219c56-f229-11e7-9ee7-73a9197124d7.png)
![screen shot 2018-01-05 at 3 16 59 pm](https://user-images.githubusercontent.com/897700/34599072-8301e02a-f22b-11e7-92a2-df02e4037839.png)
![screen shot 2018-01-05 at 2 03 30 pm](https://user-images.githubusercontent.com/897700/34598713-4a7c3f0e-f229-11e7-8635-5ea94a2045ac.png)