### PR TITLE
System: cleanup PHP notices, minor fixes

### DIFF
--- a/fullscreen.php
+++ b/fullscreen.php
@@ -18,13 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Gibbon system-wide includes
-include './functions.php';
-include './config.php';
-include './version.php';
-
-//New PDO DB connection
-$pdo = new Gibbon\sqlConnection();
-$connection2 = $pdo->getConnection();
+include './gibbon.php';
 
 @session_start();
 $_SESSION[$guid]['sidebarExtra'] = '';
@@ -56,6 +50,8 @@ if ($_SESSION[$guid]['systemSettingsSet'] == false) {
     $themeJS = "<script type='text/javascript' src='./themes/Default/js/common.js'></script>";
     $_SESSION[$guid]['gibbonThemeID'] = '001';
     $_SESSION[$guid]['gibbonThemeName'] = 'Default';
+    $_SESSION[$guid]['module'] = getModuleName($_SESSION[$guid]['address']);
+    $_SESSION[$guid]['action'] = getActionName($_SESSION[$guid]['address']);
     try {
         if (@$_SESSION[$guid]['gibbonThemeIDPersonal'] != null) {
             $dataTheme = array('gibbonThemeIDPersonal' => $_SESSION[$guid]['gibbonThemeIDPersonal']);
@@ -117,8 +113,6 @@ if ($_SESSION[$guid]['systemSettingsSet'] == false) {
 		<body style='background-image: none'>
 			<?php
             $_SESSION[$guid]['address'] = $_GET['q'];
-    $_SESSION[$guid]['module'] = getModuleName($_SESSION[$guid]['address']);
-    $_SESSION[$guid]['action'] = getActionName($_SESSION[$guid]['address']);
     if ($_SESSION[$guid]['address'] == '') {
         echo '<h1>';
         echo __($guid, 'There is no content to display');

--- a/fullscreen.php
+++ b/fullscreen.php
@@ -24,11 +24,11 @@ include './gibbon.php';
 $_SESSION[$guid]['sidebarExtra'] = '';
 
 //Check to see if system settings are set from databases
-if ($_SESSION[$guid]['systemSettingsSet'] == false) {
+if (empty($_SESSION[$guid]['systemSettingsSet'])) {
     getSystemSettings($guid, $connection2);
 }
 //If still false, show warning, otherwise display page
-if ($_SESSION[$guid]['systemSettingsSet'] == false) {
+if (empty($_SESSION[$guid]['systemSettingsSet'])) {
     echo __($guid, 'System Settings are not set: the system cannot be displayed');
 } else {
     ?>

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -89,14 +89,15 @@ if (isset($_SESSION[$guid]['googleAPIAccessToken'] ) && $_SESSION[$guid]['google
 
 if (isset($authUrl)){
 	//show login url
-	echo '<div>';
-		print '<a target=\'_top\' class="login" href="' . $authUrl . '" onclick="addGoogleLoginParams(this)"><img style=\'width: 260px; height: 55px; margin-left: -4px\' src="themes/' . $_SESSION[$guid]["gibbonThemeName"] . '/img/g_login_btn.png" /></a>';
+    echo '<div>';
+        $themeName = isset($_SESSION[$guid]['gibbonThemeName'])? $_SESSION[$guid]['gibbonThemeName'] : 'Default';
+		print '<a target=\'_top\' class="login" href="' . $authUrl . '" onclick="addGoogleLoginParams(this)"><img style=\'width: 260px; height: 55px; margin-left: -4px\' src="themes/' . $themeName . '/img/g_login_btn.png" /></a>';
 
         $form = \Gibbon\Forms\Form::create('loginFormGoogle', '#');
         $form->setFactory(\Gibbon\Forms\DatabaseFormFactory::create($pdo));
         $form->setClass('blank fullWidth loginTableGoogle');
 
-        $loginIcon = '<img src="'.$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/%1$s.png" style="width:20px;height:20px;margin:-2px 0 0 2px;" title="%2$s">';
+        $loginIcon = '<img src="'.$_SESSION[$guid]['absoluteURL'].'/themes/'.$themeName.'/img/%1$s.png" style="width:20px;height:20px;margin:-2px 0 0 2px;" title="%2$s">';
 
         $row = $form->addRow()->setClass('loginOptionsGoogle');
             $row->addContent(sprintf($loginIcon, 'planner', __('School Year')));

--- a/login.php
+++ b/login.php
@@ -44,10 +44,10 @@ $validator = new \Gibbon\Data\Validator();
 $_POST = $validator->sanitize($_POST);
 
 //Get and store POST variables from calling page
-$username = $_POST['username'];
-$password = $_POST['password'];
+$username = isset($_POST['username'])? $_POST['username'] : '';
+$password = isset($_POST['password'])? $_POST['password'] : '';
 
-if (($username == '') or ($password == '')) {
+if (empty($username) or empty($password)) {
     $URL .= '?loginReturn=fail0b';
     header("Location: {$URL}");
     exit;

--- a/modules/Activities/activities_view.php
+++ b/modules/Activities/activities_view.php
@@ -389,18 +389,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
                             }
                             echo $termList;
                         } else {
-                            if (substr($row['programStart'], 0, 4) == substr($row['programEnd'], 0, 4)) {
-                                if (substr($row['programStart'], 5, 2) == substr($row['programEnd'], 5, 2)) {
-                                    echo date('F', mktime(0, 0, 0, substr($row['programStart'], 5, 2))).' '.substr($row['programStart'], 0, 4);
-                                } else {
-                                    echo date('F', mktime(0, 0, 0, substr($row['programStart'], 5, 2))).' - '.date('F', mktime(0, 0, 0, substr($row['programEnd'], 5, 2))).'<br/>'.substr($row['programStart'], 0, 4);
-                                }
-                            } else {
-                                echo date('F', mktime(0, 0, 0, substr($row['programStart'], 5, 2))).' '.substr($row['programStart'], 0, 4).' -<br/>'.date('F', mktime(0, 0, 0, substr($row['programEnd'], 5, 2))).' '.substr($row['programEnd'], 0, 4);
-                            }
+                            echo formatDateRange($row['programStart'], $row['programEnd']);
                         }
 
-                        echo "<span style='font-style: italic; font-size: 85%'>";
+                        echo "<br/><span style='font-style: italic; font-size: 85%'>";
                         try {
                             $dataSlots = array('gibbonActivityID' => $row['gibbonActivityID']);
                             $sqlSlots = 'SELECT DISTINCT nameShort, sequenceNumber FROM gibbonActivitySlot JOIN gibbonDaysOfWeek ON (gibbonActivitySlot.gibbonDaysOfWeekID=gibbonDaysOfWeek.gibbonDaysOfWeekID) WHERE gibbonActivityID=:gibbonActivityID ORDER BY sequenceNumber';

--- a/modules/Activities/moduleFunctions.php
+++ b/modules/Activities/moduleFunctions.php
@@ -107,15 +107,15 @@ function formatDateRange($start, $end)
     $output = '';
     if (empty($start) || empty($end)) return $output;
 
-    $startDate = ($start instanceof DateTime)? $start : DateTime::createFromFormat('Y-m-d', $start);
-    $endDate = ($end instanceof DateTime)? $end : DateTime::createFromFormat('Y-m-d', $end);
+    $startDate = ($start instanceof DateTime)? $start : new DateTime($start);
+    $endDate = ($end instanceof DateTime)? $end : new DateTime($end);
 
     if ($startDate->format('Y-m') == $endDate->format('Y-m')) {
-        $output = $startDate->format('F Y');
+        $output = $startDate->format('M Y');
     } else if ($startDate->format('Y') == $endDate->format('Y')) {
-        $output = $startDate->format('F').' - '.$endDate->format('F Y');
+        $output = $startDate->format('M').' - '.$endDate->format('M Y');
     } else {
-        $output = $startDate->format('F Y').' - '.$endDate->format('F Y');
+        $output = $startDate->format('M Y').' - '.$endDate->format('M Y');
     }
 
     return $output;

--- a/modules/Behaviour/behaviour_manage_add.php
+++ b/modules/Behaviour/behaviour_manage_add.php
@@ -45,10 +45,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
         echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Behaviour/behaviour_manage.php'>".__($guid, 'Manage Behaviour Records')."</a> > </div><div class='trailEnd'>".__($guid, 'Add').'</div>';
         echo '</div>';
 
+        $gibbonBehaviourID = isset($_GET['gibbonBehaviourID'])? $_GET['gibbonBehaviourID'] : null;
+        $gibbonPersonID = isset($_GET['gibbonPersonID'])? $_GET['gibbonPersonID'] : '';
+        $gibbonRollGroupID = isset($_GET['gibbonRollGroupID'])? $_GET['gibbonRollGroupID'] : '';
+        $gibbonYearGroupID = isset($_GET['gibbonYearGroupID'])? $_GET['gibbonYearGroupID'] : '';
+        $type = isset($_GET['type'])? $_GET['type'] : '';
+
         $editLink = '';
         $editID = '';
         if (isset($_GET['editID'])) {
-            $editLink = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Behaviour/behaviour_manage_edit.php&gibbonBehaviourID='.$_GET['editID'].'&gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type'];
+            $editLink = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Behaviour/behaviour_manage_edit.php&gibbonBehaviourID='.$_GET['editID'].'&gibbonPersonID='.$gibbonPersonID.'&gibbonRollGroupID='.$gibbonRollGroupID.'&gibbonYearGroupID='.$gibbonYearGroupID.'&type='.$type;
             $editID = $_GET['editID'];
         }
         if (isset($_GET['return'])) {
@@ -62,10 +68,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
         if ($step != 1 and $step != 2) {
             $step = 1;
         }
-        $gibbonBehaviourID = null;
-        if (isset($_GET['gibbonBehaviourID'])) {
-            $gibbonBehaviourID = $_GET['gibbonBehaviourID'];
-        }
 
         //Step 1
         if ($step == 1 or $gibbonBehaviourID == null) {
@@ -74,15 +76,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             if ($policyLink != '') {
                 echo "<a target='_blank' href='$policyLink'>".__($guid, 'View Behaviour Policy').'</a>';
             }
-            if ($_GET['gibbonPersonID'] != '' or $_GET['gibbonRollGroupID'] != '' or $_GET['gibbonYearGroupID'] != '' or $_GET['type'] != '') {
+            if ($gibbonPersonID != '' or $gibbonRollGroupID != '' or $gibbonYearGroupID != '' or $type != '') {
                 if ($policyLink != '') {
                     echo ' | ';
                 }
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Behaviour/behaviour_manage.php&gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']."'>".__($guid, 'Back to Search Results').'</a>';
+                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Behaviour/behaviour_manage.php&gibbonPersonID='.$gibbonPersonID.'&gibbonRollGroupID='.$gibbonRollGroupID.'&gibbonYearGroupID='.$gibbonYearGroupID.'&type='.$type."'>".__($guid, 'Back to Search Results').'</a>';
             }
             echo '</div>';
 
-            $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_addProcess.php?step=1&gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
+            $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_addProcess.php?step=1&gibbonPersonID='.$gibbonPersonID.'&gibbonRollGroupID='.$gibbonRollGroupID.'&gibbonYearGroupID='.$gibbonYearGroupID.'&type='.$type);
                 $form->setClass('smallIntBorder fullWidth');
                 $form->setFactory(DatabaseFormFactory::create($pdo));
                 $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
@@ -91,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             //Student
             $row = $form->addRow();
             	$row->addLabel('gibbonPersonID', __('Student'));
-            	$row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->placeholder(__('Please select...'))->isRequired();
+            	$row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->placeholder(__('Please select...'))->selected($gibbonPersonID)->isRequired();
 
             //Date
             $row = $form->addRow();
@@ -101,7 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             //Type
             $row = $form->addRow();
             	$row->addLabel('type', __('Type'));
-            	$row->addSelect('type')->fromArray(array('Positive' => __('Positive'), 'Negative' => __('Negative')))->isRequired();
+            	$row->addSelect('type')->fromArray(array('Positive' => __('Positive'), 'Negative' => __('Negative')))->selected($type)->isRequired();
 
             //Descriptor
             if ($enableDescriptors == 'Y') {
@@ -175,7 +177,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 } else {
                     $values = $result->fetch();
 
-                    $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_addProcess.php?step=2&gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
+                    $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_addProcess.php?step=2&gibbonPersonID='.$gibbonPersonID.'&gibbonRollGroupID='.$gibbonRollGroupID.'&gibbonYearGroupID='.$gibbonYearGroupID.'&type='.$type);
                         $form->setClass('smallIntBorder fullWidth');
                         $form->setFactory(DatabaseFormFactory::create($pdo));
                         $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");

--- a/modules/Markbook/markbook_view_myMarks.php
+++ b/modules/Markbook/markbook_view_myMarks.php
@@ -366,7 +366,7 @@
                                 if (date('Y-m-d H:i:s') < $rowSub['homeworkDueDateTime']) {
                                     echo "<span title='Pending'>".__($guid, 'Pending').'</span>';
                                 } else {
-                                    if ($row['dateStart'] > $rowSub['date']) {
+                                    if (!empty($row['dateStart']) && $row['dateStart'] > $rowSub['date']) {
                                         echo "<span title='".__($guid, 'Student joined school after assessment was given.')."' style='color: #000; font-weight: normal; border: 2px none #ff0000; padding: 2px 4px'>".__($guid, 'NA').'</span>';
                                     } else {
                                         if ($rowSub['homeworkSubmissionRequired'] == 'Compulsory') {

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
         echo __($guid, 'The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        $gibbonPersonID = $_GET['gibbonPersonID'];
+        $gibbonPersonID = isset($_GET['gibbonPersonID'])? $_GET['gibbonPersonID'] : '';
         $search = null;
         if (isset($_GET['search'])) {
             $search = $_GET['search'];
@@ -51,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
             $sort = $_GET['sort'];
         }
 
-        if ($gibbonPersonID == false) {
+        if (empty($gibbonPersonID)) {
             echo "<div class='error'>";
             echo __($guid, 'You have not specified one or more required parameters.');
             echo '</div>';

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -159,7 +159,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $setting = getSettingByScope($connection2, 'System', 'mailerSMTPPassword', true);
     $row = $form->addRow()->addClass('smtpSettings');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextField($setting['name'])->setValue($setting['value']);
+        $row->addPassword($setting['name'])->setValue($setting['value']);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -1010,7 +1010,7 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                         $title = "title='".date('H:i', $event[2]).' to '.date('H:i', $event[3])."'";
                         $height = ceil(($event[3] - $event[2]) / 60).'px';
                         $charCut = 20;
-                        if (height < 20) {
+                        if ($height < 20) {
                             $charCut = 12;
                         }
                         if (strlen($label) > $charCut) {

--- a/modules/Timetable/report_viewAvailableSpaces.php
+++ b/modules/Timetable/report_viewAvailableSpaces.php
@@ -289,7 +289,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 							$rowClosure = $resultClosure->fetch();
 							$dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";
 							$dayOut .= "<div style='position: relative'>";
-							$dayOut .= "<div style='z-index: $zCount; position: absolute; top: 0; width: $width ; border: 1px solid rgba(136,136,136,$ttAlpha); height: ".ceil($diffTime / 60)."px; margin: 0px; padding: 0px; background-color: rgba(255,196,202,$ttAlpha)'>";
+							$dayOut .= "<div style='z-index: 1; position: absolute; top: 0; width: $width ; border: 1px solid rgba(136,136,136,$ttAlpha); height: ".ceil($diffTime / 60)."px; margin: 0px; padding: 0px; background-color: rgba(255,196,202,$ttAlpha)'>";
 							$dayOut .= "<div style='position: relative; top: 50%'>";
 							$dayOut .= "<span style='color: rgba(255,0,0,$ttAlpha);'>".$rowClosure['name'].'</span>';
 							$dayOut .= '</div>';

--- a/modules/User Admin/family_manage_edit_editAdult.php
+++ b/modules/User Admin/family_manage_edit_editAdult.php
@@ -144,7 +144,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
                             $(\"#contactEmail\").removeAttr(\"disabled\");
                             $(\"#contactMail\").removeAttr(\"disabled\");
                         }
-                     });
+                    });
+                    $(\"#contactPriority\").change();
                 });
             </script>";
 

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -36,10 +36,7 @@ $_GET = $validator->sanitize($_GET);
 $_POST = $validator->sanitize($_POST);
 
 //Check email address is not blank
-if (isset($_GET['input']))
-    $input = $_GET['input'];
-else
-    $input = $_POST['email'];
+$input = isset($_GET['input'])? $_GET['input'] : (isset($_POST['email'])? $_POST['email'] : '');
 $step = $_GET['step'];
 
 $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=passwordReset.php';


### PR DESCRIPTION
Several small fixes to cleanup PHP notices, plus:
- Added a .change() event to contactPriority to fix the initial disabled state when editing family adults
- Adjusted how formatDateRange handles creating dates and tweaked the output format
- Changed the SMTP password field type from TextField to Password in Third Party Settings