### PR TITLE
Attendance, Staff, Theme, System: form fixes and display tweaks 

### DIFF
--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -467,7 +467,11 @@ else {
 									} else {
 										print '<img src="./themes/' . $_SESSION[$guid]["gibbonThemeName"] . '/img/iconTick.png"/>' ;
 									}
-								}
+								} else if (isset($logHistory[$row['gibbonCourseClassID']][$currentDate])) {
+                                    echo '<span title="'.__('This class is not timetabled to run on the specified date. Attendance may still be taken for this group however it currently falls outside the regular schedule for this class.').'">';
+                                        echo __('N/A');
+                                    echo '</span>';
+                                }
 								print "</td>" ;
 
 								print "<td style='text-align: center'>" ;

--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -66,9 +66,13 @@ else {
 	    $row->addLabel('currentDate', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
 	    $row->addDate('currentDate')->setValue(dateConvertBack($guid, $currentDate))->isRequired();
 
-	$row = $form->addRow();
-	    $row->addLabel('gibbonPersonID', __('Staff'));
-	    $row->addSelectStaff('gibbonPersonID')->selected($gibbonPersonID)->placeholder()->isRequired();
+    if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_rollGroupsNotRegistered_byDate.php')) {
+        $row = $form->addRow();
+            $row->addLabel('gibbonPersonID', __('Staff'));
+            $row->addSelectStaff('gibbonPersonID')->selected($gibbonPersonID)->placeholder()->isRequired();
+    } else {
+        $form->addHiddenValue('gibbonPersonID', $_SESSION[$guid]['gibbonPersonID']);
+    }
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -79,7 +79,10 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
 
     $row = $form->addRow();
         $row->addLabel('gibbonCourseClassID', __('Class'));
-        $row->addSelectClass('gibbonCourseClassID', $_SESSION[$guid]['gibbonSchoolYearID'], $_SESSION[$guid]['gibbonPersonID'])->isRequired()->selected($gibbonCourseClassID)->placeholder();
+        $row->addSelectClass('gibbonCourseClassID', $_SESSION[$guid]['gibbonSchoolYearID'], $_SESSION[$guid]['gibbonPersonID'], array('attendance' => 'Y'))
+            ->isRequired()
+            ->selected($gibbonCourseClassID)
+            ->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('currentDate', __('Date'));

--- a/modules/Staff/staff_manage_edit.php
+++ b/modules/Staff/staff_manage_edit.php
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
         } else {
             try {
                 $data = array('gibbonStaffID' => $gibbonStaffID);
-                $sql = 'SELECT gibbonStaff.*, surname, preferredName, initials, dateStart, dateEnd FROM gibbonStaff JOIN gibbonPerson ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonStaffID=:gibbonStaffID';
+                $sql = 'SELECT gibbonStaff.*, title, surname, preferredName, initials, dateStart, dateEnd FROM gibbonStaff JOIN gibbonPerson ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonStaffID=:gibbonStaffID';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -85,12 +85,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
                 $form->setClass('smallIntBorder fullWidth');
 
                 $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+                $form->addHiddenValue('gibbonPersonID', $values['gibbonPersonID']);
 
                 $form->addRow()->addHeading(__('Basic Information'));
 
                 $row = $form->addRow();
-                    $row->addLabel('gibbonPersonID', __('Person'))->description(__('Must be unique.'));
-                    $row->addSelectUsers('gibbonPersonID')->placeholder()->isRequired();
+                    $row->addLabel('gibbonPersonName', __('Person'))->description(__('Must be unique.'));
+                    $row->addTextField('gibbonPersonName')->readOnly()->setValue(formatName($values['title'], $values['preferredName'], $values['surname'], 'Staff', false, true));
 
                 $row = $form->addRow();
                     $row->addLabel('initials', __('Initials'))->description(__('Must be unique if set.'));

--- a/preferencesProcess.php
+++ b/preferencesProcess.php
@@ -33,16 +33,15 @@ if (isset($_SESSION[$guid]['gibbonAcademicYearID']) == false or isset($_SESSION[
 }
 
 $calendarFeedPersonal = isset($_POST['calendarFeedPersonal'])? $_POST['calendarFeedPersonal'] : '';
-$personalBackground = isset($_POST['personalBackground'])? filter_var($_POST['personalBackground'], FILTER_VALIDATE_URL) : '';
+$personalBackground = isset($_POST['personalBackground'])? $_POST['personalBackground'] : '';
 $gibbonThemeIDPersonal = isset($_POST['gibbonThemeIDPersonal'])? $_POST['gibbonThemeIDPersonal'] : '';
 $gibboni18nIDPersonal = isset($_POST['gibboni18nIDPersonal'])? $_POST['gibboni18nIDPersonal'] : '';
 $receiveNotificationEmails = isset($_POST['receiveNotificationEmails'])? $_POST['receiveNotificationEmails'] : 'N';
 
 $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=preferences.php';
 
-// Validate that the personal background URL points to an image
-$personalBackgroundFiletype = strtolower(strrchr($personalBackground, '.'));
-if (!empty($personalBackground) && !in_array($personalBackgroundFiletype, array('.jpg','.jpeg','.png','.gif'))) {
+// Validate the personal background URL
+if (!empty($personalBackground) && filter_var($personalBackground, FILTER_VALIDATE_URL) === false) {
     $URL .= '&return=error1';
     header("Location: {$URL}");
     exit();

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -104,12 +104,21 @@ class DatabaseFormFactory extends FormFactory
             return $this->createSelect($name)->fromArray(array("*" => "All"))->fromResults($results)->placeholder();
     }
 
-    public function createSelectClass($name, $gibbonSchoolYearID, $gibbonPersonID = null)
+    public function createSelectClass($name, $gibbonSchoolYearID, $gibbonPersonID = null, $params = array())
     {
         $classes = array();
         if (!empty($gibbonPersonID)) {
             $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonID' => $gibbonPersonID);
-            $sql = "SELECT gibbonCourseClass.gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name FROM gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID AND gibbonCourseClass.attendance='Y' ORDER BY name";
+            $sql = "SELECT gibbonCourseClass.gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name FROM gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID";
+            if (isset($params['attendance'])) {
+                $data['attendance'] = $params['attendance'];
+                $sql .= " AND gibbonCourseClass.attendance=:attendance";
+            }
+            if (isset($params['reportable'])) {
+                $data['reportable'] = $params['reportable'];
+                $sql .= " AND gibbonCourseClass.reportable=:reportable";
+            }
+            $sql .= " ORDER BY name";
             $result = $this->pdo->executeQuery($data, $sql);
             if ($result->rowCount() > 0) {
                 $classes['--'. __('My Classes') . '--'] = $result->fetchAll(\PDO::FETCH_KEY_PAIR);
@@ -117,7 +126,16 @@ class DatabaseFormFactory extends FormFactory
         }
 
         $data=array('gibbonSchoolYearID'=>$gibbonSchoolYearID);
-        $sql= "SELECT gibbonCourseClass.gibbonCourseClassID AS value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.attendance='Y' ORDER BY name" ;
+        $sql= "SELECT gibbonCourseClass.gibbonCourseClassID AS value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID";
+        if (isset($params['attendance'])) {
+            $data['attendance'] = $params['attendance'];
+            $sql .= " AND gibbonCourseClass.attendance=:attendance";
+        }
+        if (isset($params['reportable'])) {
+            $data['reportable'] = $params['reportable'];
+            $sql .= " AND gibbonCourseClass.reportable=:reportable";
+        }
+        $sql .= " ORDER BY name";
         $result = $this->pdo->executeQuery($data, $sql);
 
         if ($result->rowCount() > 0) {

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1511,7 +1511,7 @@ fieldset {
 }
 
 /* Fixes an odd colspan-related width bug in Chrome */
-td.fullWidth {
+td.fullWidth[colspan] {
     width: auto;
 }
 


### PR DESCRIPTION
Attendance:
- Fixes an issue where attendance='Y' was hardcoded into addSelectClass in DatabaseFormFactory. Adds params to the method to optionally filter for attendance/reportable flags and applies the attendance='Y' flag to the Take Attendance by Class form.
- Display N/A in the Today column for instances where attendance has been taken on a non-timetabled day (and borrows the hover-over text from Take Attendance by Class)
- Adds a permission check back to the staff selector in View Daily Attendance - the intent being that for most staff it only shows their own attendance, and management-type roles with 'View Not Registered' permission can select and see daily attendance for any staff member.  

Staff:
- Removes the gibbonPersonID drop-down from Edit Staff and sets the field to readonly (the original behaviour).

Theme:
- Fixes a visual glitch with select widths in Departments by making the css bug-fix selector for `td.fullWidth[colspan]` more specific.

System:
- Adjust the URL validation for personalBackground in Preferences - removes the check for image extension to allow for URLs that stream images without a specific extension