### PR TITLE
System: fix MainMenu objects with case-sensitive class names

### DIFF
--- a/modules/System Admin/module_manage_installProcess.php
+++ b/modules/System Admin/module_manage_installProcess.php
@@ -282,7 +282,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
                         }
 
                         //Update main menu
-                        $mainMenu = new Gibbon\menuMain($gibbon, $pdo);
+                        $mainMenu = new Gibbon\MenuMain($gibbon, $pdo);
                         $mainMenu->setMenu();
 
                         //We made it!

--- a/modules/System Admin/module_manage_uninstallProcess.php
+++ b/modules/System Admin/module_manage_uninstallProcess.php
@@ -167,7 +167,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
                 header("Location: {$URL}");
             } else {
                 //Update main menu
-                $mainMenu = new Gibbon\menuMain($gibbon, $pdo);
+                $mainMenu = new Gibbon\MenuMain($gibbon, $pdo);
                 $mainMenu->setMenu();
 
                 if ($orphaned != 'true') {

--- a/roleSwitcherProcess.php
+++ b/roleSwitcherProcess.php
@@ -64,7 +64,7 @@ if (empty(intval($role))) {
         $gibbon->session->cacheFastFinderActions($role);
 
         // Reload the cached menu
-        $mainMenu = new Gibbon\menuMain($gibbon, $pdo);
+        $mainMenu = new Gibbon\MenuMain($gibbon, $pdo);
         $mainMenu->setMenu();
 
         $URL .= '?return=success0';


### PR DESCRIPTION
A small post-PR fix for a couple class names I missed in #454