### PR TITLE
Form Class: markbook-related additions and changes

### DIFF
--- a/modules/Formal Assessment/internalAssessment_manage_add.php
+++ b/modules/Formal Assessment/internalAssessment_manage_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -63,6 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
             }
 
             $form = Form::create('internalAssessment', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/internalAssessment_manage_addProcess.php?gibbonCourseClassID='.$gibbonCourseClassID.'&address='.$_SESSION[$guid]['address']);
+            $form->setFactory(DatabaseFormFactory::create($pdo));
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $form->addRow()->addHeading(__('Basic Information'));
@@ -99,10 +101,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
 
             $form->addRow()->addHeading(__('Assessment'));
 
-            $sql = "SELECT gibbonScaleID as value, name FROM gibbonScale WHERE (active='Y') ORDER BY name";
-            $result = $pdo->executeQuery(array(), $sql);
-            $gradeScales = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
-
             $attainmentLabel = !empty($attainmentAlternativeName)? sprintf(__('Assess %1$s?'), $attainmentAlternativeName) : __('Assess Attainment?');
             $row = $form->addRow();
                 $row->addLabel('attainment', $attainmentLabel);
@@ -113,11 +111,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
             $attainmentScaleLabel = !empty($attainmentAlternativeName)? $attainmentAlternativeName.' '.__('Scale') : __('Attainment Scale');
             $row = $form->addRow()->addClass('attainmentRow');
                 $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
-                $row->addSelect('gibbonScaleIDAttainment')
-                    ->fromArray($gradeScales)
-                    ->selected($_SESSION[$guid]['defaultAssessmentScale'])
-                    ->isRequired()
-                    ->placeholder();
+                $row->addSelectGradeScale('gibbonScaleIDAttainment')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
 
             $effortLabel = !empty($effortAlternativeName)? sprintf(__('Assess %1$s?'), $effortAlternativeName) : __('Assess Effort?');
             $row = $form->addRow();
@@ -129,11 +123,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
             $effortScaleLabel = !empty($effortAlternativeName)? $effortAlternativeName.' '.__('Scale') : __('Effort Scale');
             $row = $form->addRow()->addClass('effortRow');
                 $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
-                $row->addSelect('gibbonScaleIDEffort')
-                    ->fromArray($gradeScales)
-                    ->selected($_SESSION[$guid]['defaultAssessmentScale'])
-                    ->isRequired()
-                    ->placeholder();
+                $row->addSelectGradeScale('gibbonScaleIDEffort')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
 
             $row = $form->addRow();
                 $row->addLabel('comment', __('Include Comment?'));

--- a/modules/Formal Assessment/internalAssessment_manage_edit.php
+++ b/modules/Formal Assessment/internalAssessment_manage_edit.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -86,6 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     }
 
                     $form = Form::create('internalAssessment', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/internalAssessment_manage_editProcess.php?gibbonInternalAssessmentColumnID='.$gibbonInternalAssessmentColumnID.'&gibbonCourseClassID='.$gibbonCourseClassID.'&address='.$_SESSION[$guid]['address']);
+                    $form->setFactory(DatabaseFormFactory::create($pdo));
                     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
         
                     $form->addRow()->addHeading(__('Basic Information'));
@@ -115,10 +117,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
         
                     $form->addRow()->addHeading(__('Assessment'));
         
-                    $sql = "SELECT gibbonScaleID as value, name FROM gibbonScale WHERE (active='Y') ORDER BY name";
-                    $result = $pdo->executeQuery(array(), $sql);
-                    $gradeScales = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
-        
                     $attainmentLabel = !empty($attainmentAlternativeName)? sprintf(__('Assess %1$s?'), $attainmentAlternativeName) : __('Assess Attainment?');
                     $row = $form->addRow();
                         $row->addLabel('attainment', $attainmentLabel);
@@ -129,11 +127,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     $attainmentScaleLabel = !empty($attainmentAlternativeName)? $attainmentAlternativeName.' '.__('Scale') : __('Attainment Scale');
                     $row = $form->addRow()->addClass('attainmentRow');
                         $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
-                        $row->addSelect('gibbonScaleIDAttainment')
-                            ->fromArray($gradeScales)
-                            ->selected($_SESSION[$guid]['defaultAssessmentScale'])
-                            ->isRequired()
-                            ->placeholder();
+                        $row->addSelectGradeScale('gibbonScaleIDAttainment')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
         
                     $effortLabel = !empty($effortAlternativeName)? sprintf(__('Assess %1$s?'), $effortAlternativeName) : __('Assess Effort?');
                     $row = $form->addRow();
@@ -145,11 +139,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     $effortScaleLabel = !empty($effortAlternativeName)? $effortAlternativeName.' '.__('Scale') : __('Effort Scale');
                     $row = $form->addRow()->addClass('effortRow');
                         $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
-                        $row->addSelect('gibbonScaleIDEffort')
-                            ->fromArray($gradeScales)
-                            ->selected($_SESSION[$guid]['defaultAssessmentScale'])
-                            ->isRequired()
-                            ->placeholder();
+                        $row->addSelectGradeScale('gibbonScaleIDEffort')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
         
                     $row = $form->addRow();
                         $row->addLabel('comment', __('Include Comment?'));

--- a/modules/Formal Assessment/internalAssessment_write_data.php
+++ b/modules/Formal Assessment/internalAssessment_write_data.php
@@ -155,8 +155,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                             $header->addTableCell(__('Student'))->rowSpan(2);
                             $header->addTableCell($values['name'])
                                 ->setTitle($values['description'])
-                                ->append('<br>'.$completeText)
-                                ->append('<br>'.$detailsText)
+                                ->append('<br><span class="small emphasis" style="font-weight:normal;">'.$completeText.'</span>')
+                                ->append('<br><span class="small emphasis" style="font-weight:normal;">'.$detailsText.'</span>')
                                 ->setClass('textCenter')
                                 ->colSpan(3);
 
@@ -188,7 +188,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                             }
         
                             if ($hasComment || $hasUpload) {
-                                $header->addContent(__('Com'))->setClass('textCenter');
+                                $header->addContent(__('Com'))->setTitle(__('Comment'))->setClass('textCenter');
                             }
                     }
 
@@ -204,12 +204,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                             ->prepend($count.') ');
 
                         if ($hasAttainment) {
-                            $attainment = $row->addSelectScaleGrade($count.'-attainmentValue', $values['gibbonScaleIDAttainment'])->setClass('textCenter gradeSelect');
+                            $attainment = $row->addSelectGradeScaleGrade($count.'-attainmentValue', $values['gibbonScaleIDAttainment'])->setClass('textCenter gradeSelect');
                             if (!empty($student['attainmentValue'])) $attainment->selected($student['attainmentValue']);
                         }
     
                         if ($hasEffort) {
-                            $effort = $row->addSelectScaleGrade($count.'-effortValue', $values['gibbonScaleIDEffort'])->setClass('textCenter gradeSelect');
+                            $effort = $row->addSelectGradeScaleGrade($count.'-effortValue', $values['gibbonScaleIDEffort'])->setClass('textCenter gradeSelect');
                             if (!empty($student['effortValue'])) $effort->selected($student['effortValue']);
                         }
     

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -400,6 +400,17 @@ class DatabaseFormFactory extends FormFactory
         return $this->createSelect($name)->fromArray($gradeOptions)->selected($selected)->placeholder();
     }
 
+    public function createSelectRubric($name, $gibbonYearGroupIDList = '', $gibbonDepartmentID = '')
+    {
+        $data = array('gibbonYearGroupIDList' => $gibbonYearGroupIDList, 'rubrics' => __('Rubrics'));
+        $sql = "SELECT CONCAT(scope, ' ', :rubrics) as groupBy, gibbonRubricID as value, (CASE WHEN category <> '' THEN CONCAT(category, ' - ', name) ELSE name END) as name 
+                FROM gibbonRubric WHERE active='Y' 
+                AND FIND_IN_SET(:gibbonYearGroupIDList, gibbonYearGroupIDList) 
+                ORDER BY category, name";
+
+        return $this->createSelect($name)->fromQuery($pdo, $sql, $data, 'groupBy')->placeholder();
+    }
+
     public function createPhoneNumber($name)
     {
         $countryCodes = $this->getCachedQuery('phoneNumber');

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -370,10 +370,20 @@ class DatabaseFormFactory extends FormFactory
         return $this->createSelect($name)->fromArray($values);
     }
 
-    public function createSelectScaleGrade($name, $gibbonScaleID, $params = array())
+    public function createSelectGradeScale($name)
+    {
+        $sql = "SELECT gibbonScaleID as value, name FROM gibbonScale WHERE (active='Y') ORDER BY name";
+
+        return $this->createSelect($name)->fromQuery($this->pdo, $sql)->placeholder();
+    }
+
+    public function createSelectGradeScaleGrade($name, $gibbonScaleID, $params = array())
     {
         // Check params and set defaults if not defined
-        $params = array_replace(array('honourDefault' => true, 'valueMode' => 'value'), $params);
+        $params = array_replace(array(
+            'honourDefault' => true, 
+            'valueMode' => 'value'
+        ), $params);
 
         $valueQuery = ($params['valueMode'] == 'id')? 'gibbonScaleGradeID as value' : 'value';
 

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -189,6 +189,15 @@ class DatabaseFormFactory extends FormFactory
         return $this->createSelect($name)->fromArray($departments)->placeholder();
     }
 
+    public function createSelectSchoolYearTerm($name, $gibbonSchoolYearID)
+    {
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
+        $sql = "SELECT gibbonSchoolYearTermID as `value`, name FROM gibbonSchoolYearTerm WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY sequenceNumber";
+        $results = $this->pdo->executeQuery($data, $sql);
+
+        return $this->createSelect($name)->fromResults($results)->placeholder();
+    }
+
     public function createSelectLanguage($name)
     {
         $sql = "SELECT name as value, name FROM gibbonLanguage ORDER BY name";

--- a/src/Forms/Input/TextArea.php
+++ b/src/Forms/Input/TextArea.php
@@ -27,7 +27,6 @@ namespace Gibbon\Forms\Input;
  */
 class TextArea extends Input
 {
-    protected $text;
     protected $maxLength;
     protected $autosize = false;
 
@@ -39,27 +38,6 @@ class TextArea extends Input
     {
         $this->setRows(6);
         parent::__construct($name);
-    }
-
-    /**
-     * Sets the textarea value. Overridden from default: textarea doesn't use input value attribute.
-     * @param  string  $value
-     * @return self
-     */
-    public function setValue($value = '')
-    {
-        $this->text = $value;
-
-        return $this;
-    }
-
-    /**
-     * Gets the textarea value. Overridden from default: textarea doesn't use input value attribute.
-     * @return  mixed
-     */
-    public function getValue()
-    {
-        return $this->text;
     }
 
     /**
@@ -106,8 +84,11 @@ class TextArea extends Input
      */
     protected function getElement()
     {
+        $text = $this->getAttribute('value');
+        $this->setAttribute('value', '');
+
         $output = '<textarea '.$this->getAttributeString().'>';
-        $output .= htmlentities($this->getValue(), ENT_QUOTES, 'UTF-8');
+        $output .= htmlentities($text, ENT_QUOTES, 'UTF-8');
         $output .= '</textarea>';
 
         if ($this->autosize) {

--- a/src/Forms/Input/TextArea.php
+++ b/src/Forms/Input/TextArea.php
@@ -27,7 +27,9 @@ namespace Gibbon\Forms\Input;
  */
 class TextArea extends Input
 {
+    protected $text;
     protected $maxLength;
+    protected $autosize = false;
 
     /**
      * Create a textarea with a default height of 6 rows.
@@ -37,6 +39,27 @@ class TextArea extends Input
     {
         $this->setRows(6);
         parent::__construct($name);
+    }
+
+    /**
+     * Sets the textarea value. Overridden from default: textarea doesn't use input value attribute.
+     * @param  string  $value
+     * @return self
+     */
+    public function setValue($value = '')
+    {
+        $this->text = $value;
+
+        return $this;
+    }
+
+    /**
+     * Gets the textarea value. Overridden from default: textarea doesn't use input value attribute.
+     * @return  mixed
+     */
+    public function getValue()
+    {
+        return $this->text;
     }
 
     /**
@@ -67,18 +90,29 @@ class TextArea extends Input
     }
 
     /**
+     * Enables the jQuery autosize function for this textarea.
+     * @param   string  $value
+     * @return  self
+     */
+    public function autosize($autosize = true)
+    {
+        $this->autosize = $autosize;
+        return $this;
+    }
+
+    /**
      * Gets the HTML output for this form element.
      * @return  string
      */
     protected function getElement()
     {
-        // Unset the value attribute, textarea doesn't use them
-        $text = $this->getValue();
-        $this->setValue('');
-
         $output = '<textarea '.$this->getAttributeString().'>';
-        $output .= htmlentities($text, ENT_QUOTES, 'UTF-8');
+        $output .= htmlentities($this->getValue(), ENT_QUOTES, 'UTF-8');
         $output .= '</textarea>';
+
+        if ($this->autosize) {
+            $output .= '<script type="text/javascript">autosize($("#'.$this->getID().'"));</script>';
+        }
 
         return $output;
     }

--- a/src/Forms/Layout/Element.php
+++ b/src/Forms/Layout/Element.php
@@ -35,9 +35,7 @@ class Element implements OutputableInterface
     protected $content;
     protected $appended;
     protected $prepended;
-    protected $before;
-    protected $after;
-
+    
     /**
      * Create a generic form element that only holds content.
      * @param  string  $content
@@ -65,7 +63,7 @@ class Element implements OutputableInterface
      */
     public function prepend($value)
     {
-        $this->prepended .= $value;
+        $this->prepended = $value . $this->prepended;
         return $this;
     }
 
@@ -87,10 +85,7 @@ class Element implements OutputableInterface
      */
     public function wrap($before, $after)
     {
-        $this->before = $before . $this->before;
-        $this->after = $this->after . $after;
-
-        return $this;
+        return $this->prepend($before)->append($after);
     }
 
     /**
@@ -99,7 +94,7 @@ class Element implements OutputableInterface
      */
     public function getOutput()
     {
-        return $this->before.$this->prepended.$this->getElement().$this->appended.$this->after;
+        return $this->prepended.$this->getElement().$this->appended;
     }
 
     /**

--- a/src/Forms/Layout/Element.php
+++ b/src/Forms/Layout/Element.php
@@ -45,6 +45,14 @@ class Element implements OutputableInterface
         $this->content = $content;
     }
 
+    public function __call($name, $arguments) 
+    {
+        if (!method_exists($this, $name)) {
+            trigger_error(sprintf('Undefined Method: Trying to call %1$s on %2$s. This is most likely caused by an incorrect or missing FormFactory.', $name, __CLASS__), E_USER_WARNING);
+        }
+        return $this;
+    }
+
     /**
      * Set the content of the element, replaces existing content.
      * @param  string  $value

--- a/src/Forms/Layout/NullElement.php
+++ b/src/Forms/Layout/NullElement.php
@@ -1,0 +1,41 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Forms\Layout;
+
+use Gibbon\Forms\OutputableInterface;
+
+/**
+ * NullElement
+ *
+ * @version v16
+ * @since   v16
+ */
+class NullElement implements OutputableInterface
+{
+    public function __call($name, $arguments)
+    {
+        return $this;
+    }
+
+    public function getOutput()
+    {
+        return '';
+    }
+}

--- a/src/Forms/Layout/Row.php
+++ b/src/Forms/Layout/Row.php
@@ -81,6 +81,16 @@ class Row
     }
 
     /**
+     * Allows a conditional to be chained into the form row elements, rather than wrapping the whole section in an if statement.
+     * @param bool $conditional
+     * @return object OutputableInterface   
+     */
+    public function if($conditional)
+    {
+        return $conditional? $this : new NullElement();
+    }
+
+    /**
      * Adds an outputtable element to the row's internal collection.
      * @param  OutputableInterface  $element
      */


### PR DESCRIPTION
The markbook OOification is done but the change set ended up pretty big so I've split it into two parts. The first is just the related Form API changes, and some Formal Assessment updates that overlap with the same functionality:

Adds the following form elements to DatabaseFormFactory, and implements the change where needed:
- SelectSchoolYearTerm
- SelectGradeScale
- SelectGradeScaleGrade
- SelectRubric

Adjusts the append/prepend handlin g in Element class to be more succinct and allow nested wrap()s.

Adds the auto-resize functionality found in the markbook to the TextArera class as a method. 

Adds a conditional method which can be chained into form elements. This improves the overall readability of a form that has lots of conditionals, and allows for easier implementation of forms that have many different optional components. See it in action in Part 2 of this PR ;)