### PR TITLE
Attendance: add a delete option to Manage Attendance Logs permission

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -884,4 +884,6 @@ UPDATE gibbonAction SET precedence=2 WHERE name='Student History_all' AND gibbon
 UPDATE gibboni18n SET active='Y' WHERE code='zh_CN';end
 ALTER TABLE `gibboni18n` DROP `maintainerName`, DROP `maintainerWebsite`;end
 UPDATE gibbonSetting SET description='Should department information be made available to the public, via the Gibbon homepage?' WHERE scope='Departments' AND name='makeDepartmentsPublic';end
+UPDATE gibbonAction SET URLList='attendance_take_byPerson_edit.php,attendance_take_byPerson_delete.php' WHERE name='Manage Attendance Logs' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Attendance');end
+
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ v16.0.00
 		Attendance: added option for redirect to message wall after self registration has been taken
 		Attendance: added year group selectors to reports for not present and not onsite
 		Attendance: added ability for students to view their own attendance data for the current year
+		Attendance: added ability to delete attendance with Manage Attendance Logs permission in Attendance by Person
 		Finance: added logging for failed bulk email sends
 		Form Group: added link to print listing of students in form group detail view
 		Markbook: fixed multi-byte string length issue causing automatic comment expansion in Markbook view

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -119,7 +119,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                         echo '<th>'.__($guid, 'Recorded By').'</th>';
 
                         if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_edit.php') == true) {
-                            echo '<th style="width: 50px;">'.__($guid, 'Actions').'</th>';
+                            echo '<th style="width: 60px;">'.__($guid, 'Actions').'</th>';
                         }
                     echo '</tr>';
                     while ($rowLog = $resultLog->fetch()) {
@@ -158,6 +158,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                         if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_edit.php') == true) {
                             echo '<td>';
                                 echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/attendance_take_byPerson_edit.php&gibbonAttendanceLogPersonID='.$rowLog['gibbonAttendanceLogPersonID']."&gibbonPersonID=$gibbonPersonID&currentDate=$currentDate'><img title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
+                                echo "<a class='thickbox' href='".$_SESSION[$guid]['absoluteURL']. '/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/attendance_take_byPerson_delete.php&gibbonAttendanceLogPersonID='.$rowLog['gibbonAttendanceLogPersonID']."&gibbonPersonID=$gibbonPersonID&currentDate=$currentDate&width=650&height=135'><img title='".__('Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']. "/img/garbage.png'/></a> ";
                             echo '</td>';
                         }
 

--- a/modules/Attendance/attendance_take_byPerson_delete.php
+++ b/modules/Attendance/attendance_take_byPerson_delete.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\PrefabFormFactory;
+use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
             echo __($guid, 'The specified record does not exist.');
             echo '</div>';
 	    } else {
-			$form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']. '/attendance_take_byPerson_deleteProcess.php?gibbonAttendanceLogPersonID='.$gibbonAttendanceLogPersonID.'&gibbonPersonID='.$gibbonPersonID.'&currentDate='.$currentDate);
+			$form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']. '/attendance_take_byPerson_deleteProcess.php?gibbonAttendanceLogPersonID='.$gibbonAttendanceLogPersonID.'&gibbonPersonID='.$gibbonPersonID.'&currentDate='.$currentDate);
 			echo $form->getOutput();
 	    }
 	}

--- a/modules/Attendance/attendance_take_byPerson_delete.php
+++ b/modules/Attendance/attendance_take_byPerson_delete.php
@@ -1,0 +1,64 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\PrefabFormFactory;
+
+//Module includes
+include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_delete.php') == false) {
+    //Acess denied
+    echo "<div class='error'>";
+    echo __($guid, 'You do not have access to this action.');
+    echo '</div>';
+} else {
+
+	$gibbonAttendanceLogPersonID = isset($_GET['gibbonAttendanceLogPersonID'])? $_GET['gibbonAttendanceLogPersonID'] : '';
+	$gibbonPersonID = isset($_GET['gibbonPersonID'])? $_GET['gibbonPersonID'] : '';
+	$currentDate = isset($_GET['currentDate']) ? $_GET['currentDate'] : '';
+
+	if ( empty($gibbonAttendanceLogPersonID) || empty($gibbonPersonID) || empty($currentDate) ) {
+		echo "<div class='error'>";
+        echo __($guid, 'You have not specified one or more required parameters.');
+        echo '</div>';
+	} else {
+	    //Proceed!
+	    echo "<div class='trail'>";
+	    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > </div><div class='trailEnd'>".__($guid, 'Attendance by Person').'</div>';
+	    echo '</div>';
+
+	    try {
+			$dataPerson = array('gibbonPersonID' => $gibbonPersonID, 'gibbonAttendanceLogPersonID' => $gibbonAttendanceLogPersonID );
+			$sqlPerson = "SELECT gibbonAttendanceLogPersonID FROM gibbonAttendanceLogPerson WHERE gibbonPersonID=:gibbonPersonID AND gibbonAttendanceLogPersonID=:gibbonAttendanceLogPersonID ";
+			$resultPerson = $connection2->prepare($sqlPerson);
+			$resultPerson->execute($dataPerson);
+		} catch (PDOException $e) {
+			echo "<div class='error'>".$e->getMessage().'</div>';
+		}
+
+	    if ($resultPerson->rowCount() != 1) {
+	    	echo "<div class='error'>";
+            echo __($guid, 'The specified record does not exist.');
+            echo '</div>';
+	    } else {
+			$form = PrefabFormFactory::createDeleteForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']. '/attendance_take_byPerson_deleteProcess.php?gibbonAttendanceLogPersonID='.$gibbonAttendanceLogPersonID.'&gibbonPersonID='.$gibbonPersonID.'&currentDate='.$currentDate);
+			echo $form->getOutput();
+	    }
+	}
+}

--- a/modules/Attendance/attendance_take_byPerson_deleteProcess.php
+++ b/modules/Attendance/attendance_take_byPerson_deleteProcess.php
@@ -1,0 +1,55 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//Gibbon system-wide includes
+include '../../gibbon.php';
+
+//Module includes
+include './moduleFunctions.php';
+
+$gibbonAttendanceLogPersonID = isset($_GET['gibbonAttendanceLogPersonID'])? $_GET['gibbonAttendanceLogPersonID'] : '';
+$gibbonPersonID = isset($_GET['gibbonPersonID'])? $_GET['gibbonPersonID'] : '';
+$currentDate = isset($_GET['currentDate'])? dateConvertBack($guid, $_GET['currentDate']) : '';
+
+$URL = $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Attendance/attendance_take_byPerson.php&gibbonPersonID=$gibbonPersonID&currentDate=$currentDate";
+
+if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_delete.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+}
+else if ($gibbonAttendanceLogPersonID == '' or $gibbonPersonID == '' or $currentDate == '') {
+    $URL .= '&return=error1';
+    header("Location: {$URL}");
+} else {
+    //Proceed!
+    try {
+        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonAttendanceLogPersonID' => $gibbonAttendanceLogPersonID);
+        $sql = "DELETE FROM gibbonAttendanceLogPerson WHERE gibbonPersonID=:gibbonPersonID AND gibbonAttendanceLogPersonID=:gibbonAttendanceLogPersonID";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit();
+    }
+
+    //Success 0
+    $URL .= '&return=success0';
+    header("Location: {$URL}");
+}


### PR DESCRIPTION
**New Feature**

A small but useful change. We have on occasion had the odd attendance logs recorded that were in error (on the wrong day, wrong class, etc). Currently attendance logs can only be edited but not deleted; the only way to delete them is via the database. The Manage Attendance Logs permission is separate from Attendance by Person, allowing it to be selectively given to the appropriate roles, and makes the most sense as a way to allow attendance deletion without giving wide access to the ability.