### PR TITLE
Form Class: add reusable ajax-based isUnique method to TextField

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -17,9 +17,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 jQuery(function($){
-   /**
-   * Form Class: generic check All/None checkboxes
-   */
+    /**
+     * Form Class: generic check All/None checkboxes
+     */
     $('.checkall').click(function () {
         $(this).parents('fieldset:eq(0)').find(':checkbox').attr('checked', this.checked);
     });
@@ -35,7 +35,7 @@ jQuery(function($){
       columnHighlight.removeClass("hover");
     });
 
-    /*
+    /**
      * Password Generator. Requires data-source, data-confirm and data-alert attributes.
      */
     $(".generatePassword").click(function(){
@@ -54,4 +54,43 @@ jQuery(function($){
         $('input[name="' + $(this).data("confirm") + '"]').val(text).blur();
         prompt($(this).data("alert"), text);
     });
+
+    /**
+     * Generic Uniqueness Check.
+     */
+    $('input.checkUniqueness').after('<span></span><div class="LV_validation_message LV_invalid availability_result"></div>');
+
+    $('input.checkUniqueness').on('input', function () {
+        // First check the LV validation before proceeding
+        var self = $(this);
+        var validation = window[self.attr('id') + "Validate"];
+        if (validation != null) {
+            if (self.val() == '' || validation.doValidations() == false) {
+                self.parent().find('.availability_result').html('');
+                return;
+            }
+        }
+
+        if (self.data("ajax-url") == '') return;
+
+        $.ajax({
+            type: 'POST',
+            data: { username: self.val(), gibbonPersonID: 0 },
+            url: self.data("ajax-url"),
+            success: function (responseText) {
+                if (responseText == 0) {
+                    $(this).next('.LV_validation_message').hide();
+                    self.parent().find('.availability_result').html(self.data("alert-success"));
+                    self.parent().find('.availability_result').switchClass('LV_invalid', 'LV_valid');
+                } else {
+                    self.parent().find('.availability_result').html(self.data("alert-fail"));
+                    self.parent().find('.availability_result').switchClass('LV_valid', 'LV_invalid');
+                    
+                    // Prevent submitting form with a non-unique email
+                    validation.add(Validate.Exclusion, { within: [self.val()], failureMessage: self.data("alert-fail")});
+                }
+            }
+        });
+    });
+
 });

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -354,7 +354,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
 					$row = $form->addRow();
 						$row->addLabel('email', __('Email'));
-						$row->addEmail('email')->maxLength(50);
+						$email = $row->addEmail('email')->maxLength(50);
+
+					$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
+					if ($uniqueEmailAddress == 'Y') {
+						$email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('gibbonPersonID' => $gibbonPersonID));
+					}
 
 					$row = $form->addRow();
 						$row->addLabel('emailAlternate', __('Alternate Email'));

--- a/modules/Library/library_manage_catalog_add.php
+++ b/modules/Library/library_manage_catalog_add.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
         $row->addTextField('name')->isRequired()->maxLength(255);
 
     $row = $form->addRow()->addClass('general');
-        $row->addLabel('idCheck', __('ID'))->description(__('Must be unique.'));
+        $row->addLabel('idCheck', __('ID'));
         $row->addTextField('idCheck')
             ->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php')
             ->isRequired()

--- a/modules/Library/library_manage_catalog_add.php
+++ b/modules/Library/library_manage_catalog_add.php
@@ -79,7 +79,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('idCheck', __('ID'))->description(__('Must be unique.'));
-        $row->addTextField('idCheck')->isRequired()->maxLength(255);
+        $row->addTextField('idCheck')
+            ->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php')
+            ->isRequired()
+            ->maxLength(255);
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('producer', __('Author/Brand'))->description(__('Who created the item?'));

--- a/modules/Library/library_manage_catalog_duplicate.php
+++ b/modules/Library/library_manage_catalog_duplicate.php
@@ -138,7 +138,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
                 for ($i = 1; $i <= $number; ++$i) {
                     $row = $form->addRow();
                         $row->addLabel('id'.$i, sprintf(__('Copy %1$s ID'), $i));
-                        $row->addTextField('id'.$i)->isRequired()->maxLength(255);
+                        $row->addTextField('id'.$i)
+                            ->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php', array('fieldName' => 'id'))
+                            ->isRequired()
+                            ->maxLength(255);
                 }
 
                 $row = $form->addRow();

--- a/modules/Library/library_manage_catalog_edit.php
+++ b/modules/Library/library_manage_catalog_edit.php
@@ -96,7 +96,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 				$row->addTextField('name')->isRequired()->maxLength(255);
 
 			$row = $form->addRow();
-				$row->addLabel('id', __('ID'))->description(__('Must be unique.'));
+				$row->addLabel('id', __('ID'));
 				$row->addTextField('id')
 					->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php', array('gibbonLibraryItemID' => $gibbonLibraryItemID))
 					->isRequired()

--- a/modules/Library/library_manage_catalog_edit.php
+++ b/modules/Library/library_manage_catalog_edit.php
@@ -97,7 +97,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 
 			$row = $form->addRow();
 				$row->addLabel('id', __('ID'))->description(__('Must be unique.'));
-				$row->addTextField('id')->isRequired()->maxLength(255);
+				$row->addTextField('id')
+					->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php', array('gibbonLibraryItemID' => $gibbonLibraryItemID))
+					->isRequired()
+					->maxLength(255);
 
 			$row = $form->addRow();
 				$row->addLabel('producer', __('Author/Brand'))->description(__('Who created the item?'));

--- a/modules/Library/library_manage_catalog_idCheckAjax.php
+++ b/modules/Library/library_manage_catalog_idCheckAjax.php
@@ -1,0 +1,34 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//Gibbon system-wide include
+include '../../gibbon.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_catalog.php') == false) {
+    die(__('Your request failed because you do not have access to this action.'));
+} else {
+    $gibbonLibraryItemID = isset($_POST['gibbonLibraryItemID'])? $_POST['gibbonLibraryItemID'] : '';
+    $id = isset($_POST['id'])? $_POST['id'] : (isset($_POST['idCheck'])? $_POST['idCheck'] : '');
+
+    $data = array('gibbonLibraryItemID' => $gibbonLibraryItemID, 'id' => $id);
+    $sql = "SELECT COUNT(*) FROM gibbonLibraryItem WHERE gibbonLibraryItemID<>:gibbonLibraryItemID AND id=:id";
+    $result = $pdo->executeQuery($data, $sql);
+
+    echo ($result && $result->rowCount() == 1)? $result->fetchColumn(0) : -1;
+}

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -374,7 +374,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('email', __('Email'));
-        $row->addEmail('email')->maxLength(50);
+        $email = $row->addEmail('email')->maxLength(50);
+
+    $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
+    if ($uniqueEmailAddress == 'Y') {
+        $email->isUnique('./modules/User Admin/user_manage_emailAjax.php');
+    }
 
     for ($i = 1; $i < 3; ++$i) {
         $row = $form->addRow();
@@ -622,7 +627,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}email", __('Email'));
-                $row->addEmail("parent{$i}email")->isRequired()->maxLength(50);
+                $email = $row->addEmail("parent{$i}email")->isRequired()->maxLength(50);
+
+                if ($uniqueEmailAddress == 'Y') {
+                    $email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('fieldName' => 'email'));
+                }
 
             for ($y = 1; $y < 3; ++$y) {
                 $row = $form->addRow()->setClass("parentSection{$i}");

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -134,8 +134,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addTextField('username')
             ->isRequired()
             ->maxLength(20)
-            ->append('<span></span><div class="LV_validation_message LV_invalid" id="username_availability_result"></div>')
-            ->append($generateUsername->getOutput());
+            ->append($generateUsername->getOutput())
+            ->isUnique('./publicRegistrationCheck.php');
 
     $policy = getPasswordPolicy($guid, $connection2);
     if ($policy != false) {
@@ -177,8 +177,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         
     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
     if ($uniqueEmailAddress == 'Y') {
-        $emailLabel->description(__('Must be unique.'));
-        $email->append('<span></span><div class="LV_validation_message LV_invalid" id="email_availability_result"></div>');
+        $email->isUnique('./modules/User Admin/user_manage_emailAjax.php');
     }
 
     $row = $form->addRow();
@@ -509,57 +508,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
                 }
             });
         });
-
-        // Username Uniqueness
-        $('#username').on('input', function(){
-            if ($('#username').val() == '') {
-                $('#username_availability_result').html('');
-                return;
-            }
-            $.ajax({
-                type : 'POST',
-                data : { username: $('#username').val() },
-                url: "./publicRegistrationCheck.php",
-                success: function(responseText){
-                    if(responseText == 0){
-                        $('#username_availability_result').html('<?php echo __('Username available'); ?>');
-                        $('#username_availability_result').switchClass('LV_invalid', 'LV_valid');
-                    }else if(responseText > 0){
-                        $('#username_availability_result').html('<?php echo __('Username already taken'); ?>');
-                        $('#username_availability_result').switchClass('LV_valid', 'LV_invalid');
-                    }
-                }
-            });
-        });
-
-        <?php if ($uniqueEmailAddress == 'Y') : ?>
-        // Email Uniqueness
-        $('#email').on('input', function(){
-            if (emailValidate.doValidations() == false || $('#email').val() == '') {
-                $('#email_availability_result').html('');
-                return;
-            }
-
-            $.ajax({
-                type : 'POST',
-                data : { email: $('#email').val(), gibbonPersonID: 0 },
-                url: "./modules/User Admin/user_manage_emailAjax.php",
-                success: function(responseText){
-                    if(responseText == 0){
-                        $('#email + .LV_validation_message').hide();
-                        $('#email_availability_result').html('<?php echo sprintf(__('%1$s available'), __('Email')); ?>');
-                        $('#email_availability_result').switchClass('LV_invalid', 'LV_valid');
-                    } else if(responseText > 0){
-                        $('#email_availability_result').html('');
-                        $('#email_availability_result').switchClass('LV_valid', 'LV_invalid');
-                        // Prevent submitting form with a non-unique email
-                        $('#email').switchClass('LV_valid_field', 'LV_invalid_field');
-                        emailValidate.add(Validate.Exclusion, { within: [$('#email').val()], failureMessage: "<?php echo sprintf(__('%1$s already in use'), __('Email')); ?>" });
-                    }
-                }
-            });
-        });
-        <?php endif; ?>
     </script>
     <?php
 }

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -130,7 +130,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 
     $generateUsername = $form->getFactory()->createButton(__('Generate'))->addClass('generateUsername alignRight')->setTabIndex(-1);
     $row = $form->addRow();
-        $row->addLabel('username', __('Username'))->description(__('Must be unique. System login name. Cannot be changed.'));
+        $row->addLabel('username', __('Username'))->description(__('System login name. Cannot be changed.'));
         $row->addTextField('username')
             ->isRequired()
             ->maxLength(20)

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
             ->isRequired()
             ->maxLength(20)
             ->append($generateUsername->getOutput())
-            ->isUnique('./publicRegistrationCheck.php');
+            ->isUnique($_SESSION[$guid]['absoluteURL'].'/publicRegistrationCheck.php');
 
     $policy = getPasswordPolicy($guid, $connection2);
     if ($policy != false) {
@@ -177,7 +177,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         
     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
     if ($uniqueEmailAddress == 'Y') {
-        $email->isUnique('./modules/User Admin/user_manage_emailAjax.php');
+        $email->isUnique($_SESSION[$guid]['absoluteURL'].'/modules/User Admin/user_manage_emailAjax.php');
     }
 
     $row = $form->addRow();

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -210,7 +210,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 			}
 
 			$row = $form->addRow();
-				$row->addLabel('username', __('Username'))->description(__('Must be unique. System login name. Cannot be changed.'));
+				$row->addLabel('username', __('Username'));
 				$row->addTextField('username')->readOnly()->maxLength(20);
 
 			$row = $form->addRow();

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -234,8 +234,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
 			if ($uniqueEmailAddress == 'Y') {
-                $emailLabel->description(__('Must be unique.'));
-                $email->append('<span></span><div class="LV_validation_message LV_invalid" id="email_availability_result"></div>');
+				$email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('gibbonPersonID' => $gibbonPersonID));
 			}
 
 			$row = $form->addRow();
@@ -653,35 +652,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 						}
 						});
 				});
-
-				<?php if ($uniqueEmailAddress == 'Y') : ?>
-				// Email Uniqueness
-				$('#email').on('input', function(){
-					if (emailValidate.doValidations() == false || $('#email').val() == '') {
-						$('#email_availability_result').html('');
-						return;
-					}
-
-					$.ajax({
-						type : 'POST',
-						data : { email: $('#email').val(), gibbonPersonID: '<?php echo $gibbonPersonID; ?>' },
-						url: "./modules/User Admin/user_manage_emailAjax.php",
-						success: function(responseText){
-							if(responseText == 0){
-								$('#email + .LV_validation_message').hide();
-								$('#email_availability_result').html('<?php echo sprintf(__('%1$s available'), __('Email')); ?>');
-								$('#email_availability_result').switchClass('LV_invalid', 'LV_valid');
-							} else if(responseText > 0){
-								$('#email_availability_result').html('');
-								$('#email_availability_result').switchClass('LV_valid', 'LV_invalid');
-								// Prevent submitting form with a non-unique email
-								$('#email').switchClass('LV_valid_field', 'LV_invalid_field');
-								emailValidate.add(Validate.Exclusion, { within: [$('#email').val()], failureMessage: "<?php echo sprintf(__('%1$s already in use'), __('Email')); ?>" });
-							}
-						}
-					});
-				});
-				<?php endif; ?>
 			</script>
 
 			<?php

--- a/modules/User Admin/user_manage_emailAjax.php
+++ b/modules/User Admin/user_manage_emailAjax.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
     die(__('Your request failed because you do not have access to this action.'));
 } else {
     $gibbonPersonID = isset($_POST['gibbonPersonID'])? $_POST['gibbonPersonID'] : '';
-    $email = isset($_POST['email'])? $_POST['email'] : '';
+    $email = isset($_POST['email'])? $_POST['email'] : (isset($_POST['value'])? $_POST['value'] : '');
 
     $data = array('gibbonPersonID' => $gibbonPersonID, 'email' => $email);
     $sql = "SELECT COUNT(*) FROM gibbonPerson WHERE email=:email AND gibbonPersonID<>:gibbonPersonID";

--- a/modules/User Admin/user_manage_emailAjax.php
+++ b/modules/User Admin/user_manage_emailAjax.php
@@ -20,7 +20,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //Gibbon system-wide include
 include '../../gibbon.php';
 
-if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php') == false) {
+if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php') == false 
+    || isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal.php') == false
+    || isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_manage_edit.php') == false) {
     die(__('Your request failed because you do not have access to this action.'));
 } else {
     $gibbonPersonID = isset($_POST['gibbonPersonID'])? $_POST['gibbonPersonID'] : '';

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -63,7 +63,7 @@ if ($proceed == false) {
         echo '</p>';
     }
 
-    $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/publicRegistrationProcess.php');
+    $form = Form::create('publicRegistration', $_SESSION[$guid]['absoluteURL'].'/publicRegistrationProcess.php');
 
     $form->setClass('smallIntBorder fullWidth');
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
@@ -91,11 +91,11 @@ if ($proceed == false) {
         $row->addDate('dob')->isRequired();
 
     $row = $form->addRow();
-        $row->addLabel('username', __('Username'));
-        $row->addTextField('username')
+        $row->addLabel('usernameCheck', __('Username'));
+        $row->addTextField('usernameCheck')
             ->maxLength(20)
             ->isRequired()
-            ->isUnique('./publicRegistrationCheck.php');
+            ->isUnique('./publicRegistrationCheck.php', array('fieldName' => 'username'));
 
     $policy = getPasswordPolicy($guid, $connection2);
     if ($policy != false) {

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -91,7 +91,7 @@ if ($proceed == false) {
         $row->addDate('dob')->isRequired();
 
     $row = $form->addRow();
-        $row->addLabel('username', __('Username'))->description(__('Must be unique.'));
+        $row->addLabel('username', __('Username'));
         $row->addTextField('username')
             ->maxLength(20)
             ->isRequired()
@@ -143,4 +143,3 @@ if ($proceed == false) {
         echo '</p>';
     }
 }
-?>

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -79,8 +79,13 @@ if ($proceed == false) {
         $row->addTextField('firstName')->isRequired()->maxLength(30);
 
     $row = $form->addRow();
-        $row->addLabel('email', __('Email'))->description(__('Must be unique.'));
-        $row->addEmail('email')->maxLength(50)->isRequired();
+        $row->addLabel('email', __('Email'));
+        $email = $row->addEmail('email')->maxLength(50)->isRequired();
+
+    $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
+    if ($uniqueEmailAddress == 'Y') {
+        $email->isUnique('./publicRegistrationCheck.php');
+    }
 
     $row = $form->addRow();
         $row->addLabel('gender', __('Gender'));

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -95,7 +95,7 @@ if ($proceed == false) {
         $row->addTextField('username')
             ->maxLength(20)
             ->isRequired()
-            ->append('<span></span><div class="LV_validation_message LV_invalid" id="username_availability_result"></div><br/>');
+            ->isUnique('./publicRegistrationCheck.php');
 
     $policy = getPasswordPolicy($guid, $connection2);
     if ($policy != false) {
@@ -132,33 +132,6 @@ if ($proceed == false) {
 
     echo $form->getOutput();
 
-    ?>
-    <script type="text/javascript">
-        $(document).ready(function(){
-            $('#username').on('input', function(){
-                if ($('#username').val() == '') {
-                    $('#username_availability_result').html('');
-                    return;
-                }
-                $('#username_availability_result').html('<?php echo __($guid, "Checking availability...") ?>');
-                $.ajax({
-                    type : 'POST',
-                    data : { username: $('#username').val() },
-                    url: "./publicRegistrationCheck.php",
-                    success: function(responseText){
-                        if(responseText == 0){
-                            $('#username_availability_result').html('<?php echo __('Username available'); ?>');
-                            $('#username_availability_result').switchClass('LV_invalid', 'LV_valid');
-                        }else if(responseText > 0){
-                            $('#username_availability_result').html('<?php echo __('Username already taken'); ?>');
-                            $('#username_availability_result').switchClass('LV_valid', 'LV_invalid');
-                        }
-                    }
-                });
-            });
-        });
-    </script>
-    <?php
     //Get postscrript
     $postscript = getSettingByScope($connection2, 'User Admin', 'publicRegistrationPostscript');
     if ($postscript != '') {

--- a/publicRegistrationCheck.php
+++ b/publicRegistrationCheck.php
@@ -21,7 +21,7 @@ use Gibbon\Data\UsernameGenerator;
 
 include './gibbon.php';
 
-$username = (isset($_POST['username']))? $_POST['username'] : '';
+$username = (isset($_POST['username']))? $_POST['username'] : (isset($_POST['value'])? $_POST['value'] : '');
 $generator = new UsernameGenerator($pdo);
 
 echo $generator->isUsernameUnique($username)? '0' : '1';

--- a/publicRegistrationCheck.php
+++ b/publicRegistrationCheck.php
@@ -21,9 +21,19 @@ use Gibbon\Data\UsernameGenerator;
 
 include './gibbon.php';
 
-$username = (isset($_POST['username']))? $_POST['username'] : (isset($_POST['value'])? $_POST['value'] : '');
-$generator = new UsernameGenerator($pdo);
+$username = (isset($_POST['username']))? $_POST['username'] : '';
 
-echo $generator->isUsernameUnique($username)? '0' : '1';
+if (!empty($username)) {
+    $generator = new UsernameGenerator($pdo);
+    echo $generator->isUsernameUnique($username)? '0' : '1';
+}
 
-?>
+$email = (isset($_POST['email']))? $_POST['email']: '';
+
+if (!empty($email)) {
+    $data = array('email' => $email);
+    $sql = "SELECT COUNT(*) FROM gibbonPerson WHERE email=:email";
+    $result = $pdo->executeQuery($data, $sql);
+
+    echo ($result && $result->rowCount() == 1)? $result->fetchColumn(0) : -1;
+}

--- a/publicRegistrationProcess.php
+++ b/publicRegistrationProcess.php
@@ -72,7 +72,7 @@ if ($proceed == false) {
         $dob = dateConvert($guid, $dob);
     }
     $email = trim($_POST['email']);
-    $username = trim($_POST['username']);
+    $username = trim($_POST['usernameCheck']);
     $password = $_POST['passwordNew'];
     $salt = getSalt();
     $passwordStrong = hash('sha256', $salt.$password);

--- a/src/Forms/Input/TextField.php
+++ b/src/Forms/Input/TextField.php
@@ -30,7 +30,7 @@ use Gibbon\Forms\Element;
 class TextField extends Input
 {
     protected $autocomplete;
-    protected $isUnique = false;
+    protected $unique;
 
     /**
      * Set a max character count for this text field.
@@ -77,13 +77,14 @@ class TextField extends Input
         $label = $this->row->getElement('label'.$this->getName());
         $fieldName = (!empty($label))? $label->getLabel() : ucfirst($this->getName());
 
-        $this->isUnique = true;
-        $this->addClass('checkUniqueness')
-            ->addData('ajax-url', $ajaxURL)
-            ->addData('ajax-data', array_replace(array('fieldName' => $this->getName()), $data), true)
-            ->addData('alert-success', sprintf(__('%1$s available'), $fieldName))
-            ->addData('alert-fail', sprintf(__('%1$s already in use'), $fieldName))
-            ->addData('alert-error', __('An error has occurred.'));
+        $this->unique = array(
+            'fieldName'    => $fieldName,
+            'ajaxURL'      => $ajaxURL,
+            'ajaxData'     => array_replace(array('fieldName' => $this->getName()), $data),
+            'alertSuccess' => sprintf(__('%1$s available'), $fieldName),
+            'alertFailure' => sprintf(__('%1$s already in use'), $fieldName),
+            'alertError'   => __('An error has occurred.'),
+        );
 
         return $this;
     }
@@ -94,7 +95,7 @@ class TextField extends Input
      */
     public function getLabelContext($label)
     {
-        if ($this->isUnique && stristr($label->getDescription(), __('Must be unique.')) === false) {
+        if (!empty($this->unique)) {
             return __('Must be unique.');
         }
 
@@ -114,6 +115,12 @@ class TextField extends Input
             $output .= '<script type="text/javascript">';
             $output .= '$("#'.$this->getID().'").autocomplete({source: ['.$source.']});';
             $output .= '</script>';
+        }
+
+        if (!empty($this->unique)) {
+            $output .= '<script type="text/javascript">
+                $("#'.$this->getID().'").gibbonUniquenessCheck('.json_encode($this->unique).');
+            </script>';
         }
 
         return $output;

--- a/src/Forms/Input/TextField.php
+++ b/src/Forms/Input/TextField.php
@@ -75,7 +75,7 @@ class TextField extends Input
     public function isUnique($ajaxURL, $data = array())
     {
         $label = $this->row->getElement('label'.$this->getName());
-        $fieldLabel = (!empty($label))? $label->getLabel() : ucfirst($this->getName());
+        $fieldLabel = (!empty($label))? $label->getLabelText() : ucfirst($this->getName());
 
         $this->unique = array(
             'ajaxURL'      => $ajaxURL,

--- a/src/Forms/Input/TextField.php
+++ b/src/Forms/Input/TextField.php
@@ -75,14 +75,13 @@ class TextField extends Input
     public function isUnique($ajaxURL, $data = array())
     {
         $label = $this->row->getElement('label'.$this->getName());
-        $fieldName = (!empty($label))? $label->getLabel() : ucfirst($this->getName());
+        $fieldLabel = (!empty($label))? $label->getLabel() : ucfirst($this->getName());
 
         $this->unique = array(
-            'fieldName'    => $fieldName,
             'ajaxURL'      => $ajaxURL,
             'ajaxData'     => array_replace(array('fieldName' => $this->getName()), $data),
-            'alertSuccess' => sprintf(__('%1$s available'), $fieldName),
-            'alertFailure' => sprintf(__('%1$s already in use'), $fieldName),
+            'alertSuccess' => sprintf(__('%1$s available'), $fieldLabel),
+            'alertFailure' => sprintf(__('%1$s already in use'), $fieldLabel),
             'alertError'   => __('An error has occurred.'),
         );
 

--- a/src/Forms/Input/TextField.php
+++ b/src/Forms/Input/TextField.php
@@ -71,6 +71,16 @@ class TextField extends Input
         return $this;
     }
 
+    public function isUnique($ajaxURL)
+    {
+        $this->addClass('checkUniqueness')
+            ->addData('ajax-url', $ajaxURL)
+            ->addData('alert-success', 'Success')
+            ->addData('alert-fail', 'Fail');
+
+        return $this;
+    }
+
     /**
      * Gets the HTML output for this form element.
      * @return  string

--- a/src/Forms/Input/TextField.php
+++ b/src/Forms/Input/TextField.php
@@ -30,6 +30,7 @@ use Gibbon\Forms\Element;
 class TextField extends Input
 {
     protected $autocomplete;
+    protected $isUnique = false;
 
     /**
      * Set a max character count for this text field.
@@ -71,14 +72,33 @@ class TextField extends Input
         return $this;
     }
 
-    public function isUnique($ajaxURL)
+    public function isUnique($ajaxURL, $data = array())
     {
+        $label = $this->row->getElement('label'.$this->getName());
+        $fieldName = (!empty($label))? $label->getLabel() : ucfirst($this->getName());
+
+        $this->isUnique = true;
         $this->addClass('checkUniqueness')
             ->addData('ajax-url', $ajaxURL)
-            ->addData('alert-success', 'Success')
-            ->addData('alert-fail', 'Fail');
+            ->addData('ajax-data', array_replace(array('fieldName' => $this->getName()), $data), true)
+            ->addData('alert-success', sprintf(__('%1$s available'), $fieldName))
+            ->addData('alert-fail', sprintf(__('%1$s already in use'), $fieldName))
+            ->addData('alert-error', __('An error has occurred.'));
 
         return $this;
+    }
+
+    /**
+     * Adds uniqueness text to the label description (if not already present)
+     * @return string|bool
+     */
+    public function getLabelContext($label)
+    {
+        if ($this->isUnique && stristr($label->getDescription(), __('Must be unique.')) === false) {
+            return __('Must be unique.');
+        }
+
+        return false;
     }
 
     /**

--- a/src/Forms/Layout/Label.php
+++ b/src/Forms/Layout/Label.php
@@ -74,6 +74,15 @@ class Label extends Element implements RowDependancyInterface
     }
 
     /**
+     * Get the label text.
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
      * Set the smaller description text to be output with the label.
      * @param   string  $value
      * @return  self

--- a/src/Forms/Layout/Label.php
+++ b/src/Forms/Layout/Label.php
@@ -77,7 +77,7 @@ class Label extends Element implements RowDependancyInterface
      * Get the label text.
      * @return string
      */
-    public function getLabel()
+    public function getLabelText()
     {
         return $this->label;
     }


### PR DESCRIPTION
Adds a uniqueness method to the TextField class in the Form API:
`isUnique($ajaxURL [, $data = array() ])`

The first parameter is an ajax url for a script takes in the POST value of the current field and returns the number of matching entries. It can also pass an additional data array to POST, such as the current item ID to ensure uniqueness doesn't fail when editing an item.

Implemented in:
- Username - Public Registration
- Username - Add User
- Email - Public Registration
- Email - Add User, Edit User
- Email - Data Updater Personal
- Email - Application Form Manage
- Library ID - Add, Edit & Duplicate
