### PR TITLE
Finance: Manage Invoices OOification, update CustomBlocks feature

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -181,7 +181,6 @@ CustomBlocks.prototype.init = function() {
         })
         .on('hideAll', function(event, block, button) {
             $('.showHide').hide();
-            $(".blocks .blockTemplate").css('height', '80px');
             $('a.blockButton[data-event="showHide"]').each(function(index, element){
                 $(element).removeClass('showHidden');
                 $('img', element).prop('src', $(element).data('off'));

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -156,6 +156,8 @@ CustomBlocks.prototype.init = function() {
         $(_.blockTemplate).prepend('<div class="sortHandle floatLeft"></div>');
     }
 
+    $('.showHide', _.blockTemplate).hide();
+
     // Initialize existing blocks from JSON data
     for (var index in _.settings.currentBlocks) {
         _.addBlock(_.settings.currentBlocks[index]);

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -145,6 +145,17 @@ CustomBlocks.prototype.init = function() {
         });
     });
 
+    // Enable sortable drag-drop
+    if (_.settings.sortable) {
+        $(".blocks", _.container).sortable({
+            placeholder: "sortHighlight",
+            handle: ".sortHandle",
+        }).bind('sortstart', function(event, ui) {
+            $(_.container).trigger('hideAll');
+        });
+        $(_.blockTemplate).prepend('<div class="sortHandle floatLeft"></div>');
+    }
+
     // Initialize existing blocks from JSON data
     for (var index in _.settings.currentBlocks) {
         _.addBlock(_.settings.currentBlocks[index]);
@@ -167,17 +178,15 @@ CustomBlocks.prototype.init = function() {
                 $('img', button).prop('src', $(button).data('on'));
                 block.find('.showHide').show();
             }
-            
+        })
+        .on('hideAll', function(event, block, button) {
+            $('.showHide').hide();
+            $(".blocks .blockTemplate").css('height', '80px');
+            $('a.blockButton[data-event="showHide"]').each(function(index, element){
+                $(element).removeClass('showHidden');
+                $('img', element).prop('src', $(element).data('off'));
+            });
         });
-
-    // Enable sortable
-    if (_.settings.sortable) {
-        $(".blocks", _.container).sortable({
-            placeholder: "sortHighlight",
-            handle: ".sortHandle",
-        });
-        $(_.blockTemplate).prepend('<div class="sortHandle floatLeft"></div>');
-    }
 
     _.refresh();
 };

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -116,9 +116,15 @@ CustomBlocks = (function(element, settings) {
     _.tools = $('.inputTools', element);
     _.blockTemplate = $('.blockTemplate', element);
     _.blockCount = 0;
+    _.validation = [];
     _.defaults = {
-        deleteConfirm: "Delete?",
-        animationSpeed: 600,
+        inputNameStrategy: "object",    // array | object | string
+        addSelector: ".addBlock",       // The selector to trigger an add block action on
+        addOnEvent: "click",            // The event type to trigger an add block action on
+        deleteMessage: "Delete?",       // The confirmation message when deleting a block
+        animationSpeed: 600,            // The speed for block animations
+        currentBlocks: [],              // Blocks that should be initialized when creating is object
+        predefinedBlocks: [],           // Data to add for new blocks if the identifier matches a key.
     }
     _.settings = $.extend({}, _.defaults, settings);
 
@@ -129,29 +135,53 @@ CustomBlocks.prototype.init = function() {
     var _ = this;
 
     // Setup tool actions
-    $(".addBlock", _.container).each(function(){
-        $(this).on($(this).data("event"), function(){
-            _.addBlock($(this).val());
+    $(_.settings.addSelector, _.container).each(function(){
+        $(this).on(_.settings.addOnEvent, function(){
+            var identifier = $(this).val();
+            if (!identifier) return;
+
+            var data = _.settings.predefinedBlocks[identifier] || {};
+            _.addBlock(data);
         });
     });
 
-    // Initialize existing blocks
-    $(".blockPrefab", _.container).each(function(){
-        _.blockCount++;
-        _.initBlock($(this), $(this).data('identifier'));
-    });
+    // Initialize existing blocks from JSON data
+    for (var index in _.settings.currentBlocks) {
+        _.addBlock(_.settings.currentBlocks[index]);
+    }
+
+    // Built-in Button Events
+    $(_.container)
+        .on('deleteClicked', function(event, block) {
+            if (confirm(_.settings.deleteMessage)) {
+                _.removeBlock(block);
+            }
+        })
+        .on('showHideClicked', function(event, block, button) {
+            if ($(button).hasClass('showHidden')) {
+                $(button).removeClass('showHidden');
+                $('img', button).prop('src', $(button).data('off'));
+                block.find('.showHide').hide();
+            } else {
+                $(button).addClass('showHidden');
+                $('img', button).prop('src', $(button).data('on'));
+                block.find('.showHide').show();
+            }
+            
+        });
 
     _.refresh();
 };
 
-CustomBlocks.prototype.addBlock = function(identifier) {
+CustomBlocks.prototype.addBlock = function(data = {}) {
     var _ = this;
 
     _.blockCount++;
 
     var block = $(_.blockTemplate).clone().css("display", "block").insertBefore($(_.tools));
+    $(_.container).append('<input type="hidden" name="order[]" value="'+_.blockCount+'" />');
 
-    _.initBlock(block, block.blockNumber);
+    _.initBlock(block, data);
     _.refresh();
 };
 
@@ -166,28 +196,28 @@ CustomBlocks.prototype.removeBlock = function(block) {
     });
 };
 
-CustomBlocks.prototype.initBlock = function(block, identifier) {
+CustomBlocks.prototype.initBlock = function(block, data = {}) {
     var _ = this;
 
     block.blockNumber = _.blockCount;
-    block.identifier = identifier;
 
+    _.loadBlockInputData(block, data);
     _.renameBlockFields(block);
+    _.addBlockValidation(block);
+    _.addBlockEvents(block);
+};
 
-    $("a.deleteButton", block).click(function(event){
-        event.preventDefault();
-        if (confirm(_.settings.deleteConfirm)) {
-            _.removeBlock(block);
-        }
-    });
+CustomBlocks.prototype.loadBlockInputData = function(block, data = {}) {
+    var _ = this;
 
-    $("a.blockButton", block).each(function(index, element) {
-        $(element).click(function(event){
-            event.preventDefault();
-            if (callback = window[$(this).data('function')]) {
-                callback(block);
-            }
-        });
+    for (key in data) {
+        $("[name='"+key+"']", block).val(data[key]);
+    }
+
+    var readonly = data.readonly || [];
+    readonly.forEach(function(element){
+        $("[name='"+element+"']", block).prop('readonly', true).addClass('readonly');
+        $("select[name='"+element+"'] option:not(:selected)", block).prop('disabled', true);
     });
 };
 
@@ -195,12 +225,43 @@ CustomBlocks.prototype.renameBlockFields = function(block) {
     var _ = this;
 
     $("input, textarea, select", block).each(function(index, element) {
-        $(this).prop("name", $(this).prop("name")+"["+block.identifier+"]");
-        $(this).prop("id", $(this).prop("id")+block.identifier);
+        var name;
+        switch(_.settings.inputNameStrategy) {
+            case 'object':  name = $(_.container).prop("id")+"["+block.blockNumber+"]["+$(this).prop("name")+"]"; break;
+            case 'array':   name = $(this).prop("name")+"["+block.blockNumber+"]"; break;
+            case 'string':  name = $(this).prop("name")+block.blockNumber; break;
+        }
+
+        $(this).prop("name", name);
+        $(this).prop("id", $(this).prop("id")+block.blockNumber);
     });
 
     $("label", block).each(function(index, element) {
-        $(this).prop("for", $(this).prop("for")+block.identifier);
+        $(this).prop("for", $(this).prop("for")+block.blockNumber);
+    });
+};
+
+CustomBlocks.prototype.addBlockValidation = function(block) {
+    var _ = this;
+    
+    $("input, textarea, select", block).each(function(index, element) {
+        if ($(this).data('validation') && !$(this).prop('readonly')) {
+            var validate = new LiveValidation($(this).prop("id"), {});
+            $(this).data('validation').forEach(function(item) {
+                eval("validate.add("+item.type+", {"+item.params+"});");
+            });
+        }
+    });
+};
+
+CustomBlocks.prototype.addBlockEvents = function(block) {
+    var _ = this;
+
+    $("a.blockButton", block).each(function(index, element) {
+        $(element).click(function(event){
+            event.preventDefault();
+            $(_.container).trigger($(this).data('event'), [ block, this ]);
+        });
     });
 };
 

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -114,7 +114,7 @@ CustomBlocks = (function(element, settings) {
 
     _.container = $(element);
     _.tools = $('.inputTools', element);
-    _.template = $('.blockTemplate', element);
+    _.blockTemplate = $('.blockTemplate', element);
     _.blockCount = 0;
     _.defaults = {
         deleteConfirm: "Delete?",
@@ -128,11 +128,20 @@ CustomBlocks = (function(element, settings) {
 CustomBlocks.prototype.init = function() {
     var _ = this;
 
+    // Setup tool actions
     $(".addBlock", _.container).each(function(){
         $(this).on($(this).data("event"), function(){
             _.addBlock($(this).val());
         });
     });
+
+    // Initialize existing blocks
+    $(".blockPrefab", _.container).each(function(){
+        _.blockCount++;
+        _.initBlock($(this), $(this).data('identifier'));
+    });
+
+    _.refresh();
 };
 
 CustomBlocks.prototype.addBlock = function(identifier) {
@@ -140,11 +149,9 @@ CustomBlocks.prototype.addBlock = function(identifier) {
 
     _.blockCount++;
 
-    var block = $(_.template).clone().css("display", "block").insertBefore($(_.tools));
-    block.blockNumber = _.blockCount;
-    block.identifier = identifier;
+    var block = $(_.blockTemplate).clone().css("display", "block").insertBefore($(_.tools));
 
-    _.initBlock(block);
+    _.initBlock(block, block.blockNumber);
     _.refresh();
 };
 
@@ -159,8 +166,13 @@ CustomBlocks.prototype.removeBlock = function(block) {
     });
 };
 
-CustomBlocks.prototype.initBlock = function(block) {
+CustomBlocks.prototype.initBlock = function(block, identifier) {
     var _ = this;
+
+    block.blockNumber = _.blockCount;
+    block.identifier = identifier;
+
+    _.renameBlockFields(block);
 
     $("a.deleteButton", block).click(function(event){
         event.preventDefault();
@@ -177,14 +189,18 @@ CustomBlocks.prototype.initBlock = function(block) {
             }
         });
     });
+};
+
+CustomBlocks.prototype.renameBlockFields = function(block) {
+    var _ = this;
 
     $("input, textarea, select", block).each(function(index, element) {
-        $(this).prop("name", $(this).prop("name")+"["+block.blockNumber+"]");
-        $(this).prop("id", $(this).prop("id")+block.blockNumber);
+        $(this).prop("name", $(this).prop("name")+"["+block.identifier+"]");
+        $(this).prop("id", $(this).prop("id")+block.identifier);
     });
 
     $("label", block).each(function(index, element) {
-        $(this).prop("for", $(this).prop("for")+block.blockNumber);
+        $(this).prop("for", $(this).prop("for")+block.identifier);
     });
 };
 

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -102,3 +102,101 @@ $.prototype.gibbonUniquenessCheck = function (settings) {
         };
     });
 };
+
+/**
+ * Custom Blocks
+ */
+// Define the CustomBlocks behaviour
+var CustomBlocks = window.CustomBlocks || {};
+
+CustomBlocks = (function(element, settings) {
+    var _ = this;
+
+    _.container = $(element);
+    _.tools = $('.inputTools', element);
+    _.template = $('.blockTemplate', element);
+    _.blockCount = 0;
+    _.defaults = {
+        deleteConfirm: "Delete?",
+        animationSpeed: 600,
+    }
+    _.settings = $.extend({}, _.defaults, settings);
+
+    _.init();
+});
+
+CustomBlocks.prototype.init = function() {
+    var _ = this;
+
+    $(".addBlock", _.container).each(function(){
+        $(this).on($(this).data("event"), function(){
+            _.addBlock($(this).val());
+        });
+    });
+};
+
+CustomBlocks.prototype.addBlock = function(identifier) {
+    var _ = this;
+
+    _.blockCount++;
+
+    var block = $(_.template).clone().css("display", "block").insertBefore($(_.tools));
+    block.blockNumber = _.blockCount;
+    block.identifier = identifier;
+
+    _.initBlock(block);
+    _.refresh();
+};
+
+CustomBlocks.prototype.removeBlock = function(block) {
+    var _ = this;
+
+    _.blockCount--;
+
+    $(block).fadeOut(_.settings.animationSpeed, function(){
+        $(block).detach().remove();
+        _.refresh();
+    });
+};
+
+CustomBlocks.prototype.initBlock = function(block) {
+    var _ = this;
+
+    $("a.deleteButton", block).click(function(event){
+        event.preventDefault();
+        if (confirm(_.settings.deleteConfirm)) {
+            _.removeBlock(block);
+        }
+    });
+
+    $("a.blockButton", block).each(function(index, element) {
+        $(element).click(function(event){
+            event.preventDefault();
+            if (callback = window[$(this).data('function')]) {
+                callback(block);
+            }
+        });
+    });
+
+    $("input, textarea, select", block).each(function(index, element) {
+        $(this).prop("name", $(this).prop("name")+"["+block.blockNumber+"]");
+        $(this).prop("id", $(this).prop("id")+block.blockNumber);
+    });
+
+    $("label", block).each(function(index, element) {
+        $(this).prop("for", $(this).prop("for")+block.blockNumber);
+    });
+};
+
+CustomBlocks.prototype.refresh = function() {
+    var _ = this;
+
+    $(".blockCount", _.container).val(_.blockCount);
+    $(".blockPlaceholder", _.container).css("display", (_.blockCount > 0)? "none" : "block");
+    $("select.addBlock", _.container).val(''); // Deselect after action
+};
+
+// Add the prototype method to jQuery
+$.prototype.gibbonCustomBlocks = function(settings) {
+    this.gibbonCustomBlocks = new CustomBlocks(this, settings);
+};

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -152,12 +152,12 @@ CustomBlocks.prototype.init = function() {
 
     // Built-in Button Events
     $(_.container)
-        .on('deleteClicked', function(event, block) {
+        .on('delete', function(event, block) {
             if (confirm(_.settings.deleteMessage)) {
                 _.removeBlock(block);
             }
         })
-        .on('showHideClicked', function(event, block, button) {
+        .on('showHide', function(event, block, button) {
             if ($(button).hasClass('showHidden')) {
                 $(button).removeClass('showHidden');
                 $('img', button).prop('src', $(button).data('off'));

--- a/gibbon.php
+++ b/gibbon.php
@@ -42,16 +42,21 @@ $guid = $gibbon->guid();
 $caching = $gibbon->getCaching();
 $version = $gibbon->getVersion();
 
+// Require the system-wide functions
+require_once $basePath.'/functions.php';
+
+
+// Detect the current module - TODO: replace this logic when switching to routing.
+$_SESSION[$guid]['address'] = isset($_GET['q'])? $_GET['q'] : str_replace($basePath, '', $_SERVER['SCRIPT_FILENAME']);
+$_SESSION[$guid]['module'] = getModuleName($_SESSION[$guid]['address']);
+$_SESSION[$guid]['action'] = getActionName($_SESSION[$guid]['address']);
+
 // Autoload the current module namespace
 if (isset($_SESSION[$guid]['module'])) {
     $moduleNamespace = preg_replace('/[^a-zA-Z0-9]/', '', $_SESSION[$guid]['module']);
     $autoloader->addPsr4('Gibbon\\'.$moduleNamespace.'\\', $basePath.'/modules/'.$_SESSION[$guid]['module']);
     $autoloader->register(true);
 }
-
-// Require the system-wide functions
-require_once $basePath.'/functions.php';
-
 
 if ($gibbon->isInstalled() == true) {
 

--- a/modules/Finance/Forms/FinanceFormFactory.php
+++ b/modules/Finance/Forms/FinanceFormFactory.php
@@ -1,0 +1,175 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Finance\Forms;
+
+use Gibbon\Forms\DatabaseFormFactory;
+
+/**
+ * FinanceFormFactory
+ *
+ * @version v16
+ * @since   v16
+ */
+class FinanceFormFactory extends DatabaseFormFactory
+{
+    /**
+     * Create and return an instance of DatabaseFormFactory.
+     * @return  object DatabaseFormFactory
+     */
+    public static function create(\Gibbon\sqlConnection $pdo = null)
+    {
+        return new FinanceFormFactory($pdo);
+    }
+
+    public function createSelectInvoicee($name, $gibbonSchoolYearID = '', $params = array())
+    {
+        $values = array();
+
+        $data = array();
+        $sql = "SELECT gibbonFinanceInvoiceeID, preferredName, surname, gibbonRollGroup.nameShort AS rollGroupName, dayType 
+                FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup, gibbonFinanceInvoicee
+                WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID 
+                AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID 
+                AND gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID";
+        
+        if (!empty($gibbonSchoolYearID)) {
+            $data['gibbonSchoolYearID'] = $gibbonSchoolYearID;
+            $sql .= " AND status='Full' AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID";
+        }
+
+        $sql .= " ORDER BY rollGroupName, surname, preferredName";
+
+        $results = $this->pdo->executeQuery($data, $sql);
+
+        $byRollGroup = array();
+        if ($results && $results->rowCount() > 0) {
+            while ($student = $results->fetch()) {
+                $byRollGroup[$student['gibbonFinanceInvoiceeID']] = $student['rollGroupName'].' - '.formatName('', $student['preferredName'], $student['surname'], 'Student', true);
+            }
+        }
+
+        $values[__('All Enrolled Students by Roll Group')] = $byRollGroup;
+                
+        return $this->createSelect($name)->fromArray($values)->placeholder();
+    }
+
+    public function createSelectInvoiceStatus($name, $currentStatus = 'All')
+    {
+        if ($currentStatus == 'Pending' || $currentStatus == 'Cancelled' || $currentStatus == 'Refunded') {
+            return $this->createTextField($name)->readonly()->setValue(__($currentStatus));
+        }
+
+        $statuses = array();
+        if ($currentStatus == 'All') {
+            $statuses = array(
+                '%'                => __('All'),
+                'Pending'          => __('Pending'),
+                'Issued'           => __('Issued'),
+                'Issued - Overdue' => __('Issued - Overdue'),
+                'Paid'             => __('Paid'),
+                'Paid - Partial'   => __('Paid - Partial'),
+                'Paid - Late'      => __('Paid - Late'),
+                'Cancelled'        => __('Cancelled'),
+                'Refunded'         => __('Refunded'),
+            );
+        } else if ($currentStatus == 'Issued') {
+            $statuses = array(
+                'Issued'         => __('Issued'),
+                'Paid'           => __('Paid'),
+                'Paid - Partial' => __('Paid - Partial'),
+                'Cancelled'      => __('Cancelled'),
+            );
+        } else if ($currentStatus == 'Paid') {
+            $statuses = array(
+                'Paid'     => __('Paid'),
+                'Refunded' => __('Refunded'),
+            );
+        } else if ($currentStatus == 'Paid - Partial') {
+            $statuses = array(
+                'Paid - Partial'  => __('Paid - Partial'),
+                'Paid - Complete' => __('Paid - Complete'),
+                'Refunded'        => __('Refunded'),
+            );
+        }
+
+        return $this->createSelect($name)->fromArray($statuses)->placeholder();
+    }
+
+    public function createSelectBillingSchedule($name, $gibbonSchoolYearID)
+    {
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
+        $sql = "SELECT gibbonFinanceBillingScheduleID as value, name FROM gibbonFinanceBillingSchedule 
+                WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
+
+        return $this->createSelect($name)->fromQuery($this->pdo, $sql, $data)->fromArray(array('Ad Hoc' => __('Ad Hoc')))->placeholder();
+    }
+
+    public function createSelectFee($name, $gibbonSchoolYearID)
+    {
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
+        $sql = "SELECT gibbonFinanceFeeCategory.name as groupBy, gibbonFinanceFee.gibbonFinanceFeeID as value, gibbonFinanceFee.name 
+                FROM gibbonFinanceFee 
+                JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) 
+                WHERE gibbonFinanceFee.gibbonSchoolYearID=:gibbonSchoolYearID
+                ORDER BY gibbonFinanceFeeCategory.name, gibbonFinanceFee.name";
+
+        return $this->createSelect($name)
+            ->fromArray(array('' => __('Choose a fee to add it')))
+            ->fromArray(array('Ad Hoc Fee' => __('Ad Hoc Fee')))
+            ->fromQuery($this->pdo, $sql, $data, 'groupBy');
+    }
+
+    public function createSelectFeeCategory($name)
+    {
+        $sql = "SELECT gibbonFinanceFeeCategoryID as value, name FROM gibbonFinanceFeeCategory WHERE active='Y' ORDER BY (gibbonFinanceFeeCategoryID=1) DESC, name";
+
+        return $this->createSelect($name)->fromQuery($this->pdo, $sql);
+    }
+
+    public function createSelectPaymentMethod($name)
+    {
+        $methods = array(
+            'Online'        => __('Online'),
+            'Bank Transfer' => __('Bank Transfer'),
+            'Cash'          => __('Cash'),
+            'Cheque'        => __('Cheque'),
+            'Credit Card'   => __('Credit Card'),
+            'Other'         => __('Other')
+        );
+
+        return $this->createSelect($name)->fromArray($methods)->placeholder();
+    }
+
+    public function createSelectMonth($name)
+    {
+        $months = array_reduce(range(1,12), function($group, $item){
+            $month = date('m', mktime(0, 0, 0, $item, 1, 0));
+            $group[$month] = $month.' - '.date('F', mktime(0, 0, 0, $item, 1, 0));
+            return $group;
+        }, array());
+
+        return $this->createSelect($name)->fromArray($months)->placeholder();
+    }
+
+    public function createRowEmail($name)
+    {
+        return $this->createRow();
+    }
+}

--- a/modules/Finance/Forms/FinanceFormFactory.php
+++ b/modules/Finance/Forms/FinanceFormFactory.php
@@ -228,13 +228,13 @@ class FinanceFormFactory extends DatabaseFormFactory
                     $name = formatName(htmlPrep($person['title']), htmlPrep($person['preferredName']), htmlPrep($person['surname']), 'Parent', false);
                     $row = $table->addRow();
                         $row->addLabel($checkboxName, $name)->description($values['invoiceTo'] == 'Company'? __('(Family CC)') : '')->description($person['relationship']);
-                        $row->if(!empty($person['email']))
+                        $row->onlyIf(!empty($person['email']))
                             ->addCheckbox($checkboxName)
                             ->description($person['email'])
                             ->setValue($person['email'])
                             ->checked($person['email'])
                             ->append('<input type="hidden" name="'.$hiddenValueName.'" value="'.$name.'">');
-                        $row->if(empty($person['email']))
+                        $row->onlyIf(empty($person['email']))
                             ->addContent(__('No email address.'))
                             ->addClass('right')
                             ->wrap('<span class="small emphasis">', '</span>');

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -126,11 +126,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
 
         $row = $form->addRow();
             $row->addLabel('gibbonFinanceBillingScheduleID', __('Billing Schedule'));
-            $row->addSelectBillingSchedule('gibbonFinanceBillingScheduleID', $gibbonSchoolYearID)->selected($gibbonFinanceBillingScheduleID);
+            $row->addSelectBillingSchedule('gibbonFinanceBillingScheduleID', $gibbonSchoolYearID)
+                ->fromArray(array('Ad Hoc' => __('Ad Hoc')))
+                ->selected($gibbonFinanceBillingScheduleID);
 
         $row = $form->addRow();
             $row->addLabel('gibbonFinanceFeeCategoryID', __('Fee Category'));
-            $row->addSelectFeeCategory('gibbonFinanceFeeCategoryID')->selected($gibbonFinanceFeeCategoryID);
+            $row->addSelectFeeCategory('gibbonFinanceFeeCategoryID')->placeholder()->selected($gibbonFinanceFeeCategoryID);
         
         $row = $form->addRow();
             $row->addSearchSubmit($gibbon->session, __('Clear Filters'), array('gibbonSchoolYearID'));
@@ -341,7 +343,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
                 if (!is_null($totalFee)) {
                     $fee = $row->addContent(number_format($totalFee, 2, '.', ','));
                     if (!empty($invoice['paidAmount'])) {
-                        $fee->setClass($invoice['paidAmount'] != $totalFee ? 'textOverBudget' : '')
+                        $fee->setClass(number_format($invoice['paidAmount']) != number_format($totalFee)? 'textOverBudget' : '')
                             ->append('<br/><span class="small emphasis">'.number_format($invoice['paidAmount'], 2, '.', ',').'</span>');
                     }
                 } else {

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -17,7 +17,11 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-@session_start();
+use Gibbon\Forms\Form;
+use Gibbon\Forms\Prefab\BulkActionForm;
+
+//Module includes
+include './modules/Finance/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.php') == false) {
     //Acess denied
@@ -89,602 +93,348 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
         }
         echo '</div>';
 
-        $status = null;
-        if (isset($_GET['status'])) {
-            $status = $_GET['status'];
-        }
-        if ($status == '') {
-            $status = 'Pending';
-        }
-        $gibbonFinanceInvoiceeID = null;
-        if (isset($_GET['gibbonFinanceInvoiceeID'])) {
-            $gibbonFinanceInvoiceeID = $_GET['gibbonFinanceInvoiceeID'];
-        }
-        $monthOfIssue = null;
-        if (isset($_GET['monthOfIssue'])) {
-            $monthOfIssue = $_GET['monthOfIssue'];
-        }
-        $gibbonFinanceBillingScheduleID = null;
-        if (isset($_GET['gibbonFinanceBillingScheduleID'])) {
-            $gibbonFinanceBillingScheduleID = $_GET['gibbonFinanceBillingScheduleID'];
-        }
-        $gibbonFinanceFeeCategoryID = null;
-        if (isset($_GET['gibbonFinanceFeeCategoryID'])) {
-            $gibbonFinanceFeeCategoryID = $_GET['gibbonFinanceFeeCategoryID'];
-        }
+        $status = isset($_GET['status'])? $_GET['status'] : null;
+        if ($status == '') $status = 'Pending';
 
-        //SEARCH FOR gibbonFinanceFeeCategoryIDList SET TO NULL, AND UPDATE
-        //This is to facilitate the new fee category filter in v13, and can be removed in v14 or after
-        try {
-            $dataTemp = array();
-            $sqlTemp = 'SELECT gibbonFinanceInvoiceID, gibbonFinanceFeeCategoryIDList FROM gibbonFinanceInvoice WHERE gibbonFinanceFeeCategoryIDList IS NULL';
-            $resultTemp = $connection2->prepare($sqlTemp);
-            $resultTemp->execute($dataTemp);
-        } catch (PDOException $e) {}
-        while ($rowTemp = $resultTemp->fetch()) {
-            try {
-                $dataTemp2 = array('gibbonFinanceInvoiceID' => $rowTemp['gibbonFinanceInvoiceID']);
-                $sqlTemp2 = 'SELECT gibbonFinanceFeeCategoryID FROM gibbonFinanceInvoiceFee WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID';
-                $resultTemp2 = $connection2->prepare($sqlTemp2);
-                $resultTemp2->execute($dataTemp2);
-            } catch (PDOException $e) {}
-
-            $gibbonFinanceFeeCategoryIDList = '';
-            while ($rowTemp2 = $resultTemp2->fetch()) {
-                $gibbonFinanceFeeCategoryIDList .= $rowTemp2['gibbonFinanceFeeCategoryID'].",";
-            }
-
-            $gibbonFinanceFeeCategoryIDList = substr($gibbonFinanceFeeCategoryIDList, 0, -1);
-            if ($gibbonFinanceFeeCategoryIDList != '') {
-                try {
-                    $dataTemp3 = array('gibbonFinanceFeeCategoryIDList' => $gibbonFinanceFeeCategoryIDList, 'gibbonFinanceInvoiceID' => $rowTemp['gibbonFinanceInvoiceID']);
-                    $sqlTemp3 = 'UPDATE gibbonFinanceInvoice SET gibbonFinanceFeeCategoryIDList=:gibbonFinanceFeeCategoryIDList WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID';
-                    $resultTemp3 = $connection2->prepare($sqlTemp3);
-                    $resultTemp3->execute($dataTemp3);
-                } catch (PDOException $e) {}
-            }
-        }
+        $gibbonFinanceInvoiceeID = isset($_GET['gibbonFinanceInvoiceeID'])? $_GET['gibbonFinanceInvoiceeID'] : '';
+        $monthOfIssue = isset($_GET['monthOfIssue'])? $_GET['monthOfIssue'] : '';
+        $gibbonFinanceBillingScheduleID = isset($_GET['gibbonFinanceBillingScheduleID'])? $_GET['gibbonFinanceBillingScheduleID'] : '';
+        $gibbonFinanceFeeCategoryID = isset($_GET['gibbonFinanceFeeCategoryID'])? $_GET['gibbonFinanceFeeCategoryID'] : '';
 
         echo '<h3>';
         echo __($guid, 'Filters');
         echo '</h3>';
-        echo "<form method='get' action='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php'>";
-        echo "<table class='noIntBorder' cellspacing='0' style='width: 100%'>";
-        ?>
-		<tr>
-			<td>
-				<b><?php echo __($guid, 'Status') ?></b><br/>
-				<span class="emphasis small"></span>
-			</td>
-			<td class="right">
-				<?php
-				echo "<select name='status' id='status' style='width:302px'>";
-					$selected = '';
-					if ($status == '%') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='%'>".__($guid, 'All').'</option>';
-					$selected = '';
-					if ($status == 'Pending') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Pending'>".__($guid, 'Pending').'</option>';
-					$selected = '';
-					if ($status == 'Issued') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Issued'>".__($guid, 'Issued').'</option>';
-					$selected = '';
-					if ($status == 'Issued - Overdue') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Issued - Overdue'>".__($guid, 'Issued - Overdue').'</option>';
-					$selected = '';
-					if ($status == 'Paid') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Paid'>".__($guid, 'Paid').'</option>';
-					$selected = '';
-					if ($status == 'Paid - Partial') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Paid - Partial'>".__($guid, 'Paid - Partial').'</option>';
-					$selected = '';
-					if ($status == 'Paid - Late') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Paid - Late'>".__($guid, 'Paid - Late').'</option>';
-					$selected = '';
-					if ($status == 'Cancelled') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Cancelled'>".__($guid, 'Cancelled').'</option>';
-					$selected = '';
-					if ($status == 'Refunded') {
-						$selected = 'selected';
-					}
-					echo "<option $selected value='Refunded'>".__($guid, 'Refunded').'</option>';
-					echo '</select>';
-					?>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<b><?php echo __($guid, 'Student') ?></b><br/>
-						<span class="emphasis small"></span>
-					</td>
-					<td class="right">
-						<?php
-                        try {
-                            $dataPurpose = array();
-                            $sqlPurpose = 'SELECT surname, preferredName, gibbonFinanceInvoiceeID FROM gibbonFinanceInvoicee JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) ORDER BY surname, preferredName';
-                            $resultPurpose = $connection2->prepare($sqlPurpose);
-                            $resultPurpose->execute($dataPurpose);
-                        } catch (PDOException $e) {
-                        }
 
-						echo "<select name='gibbonFinanceInvoiceeID' id='gibbonFinanceInvoiceeID' style='width:302px'>";
-						echo "<option value=''></option>";
-						while ($rowPurpose = $resultPurpose->fetch()) {
-							$selected = '';
-							if ($rowPurpose['gibbonFinanceInvoiceeID'] == $gibbonFinanceInvoiceeID) {
-								$selected = 'selected';
-							}
-							echo "<option $selected value='".$rowPurpose['gibbonFinanceInvoiceeID']."'>".formatName('', htmlPrep($rowPurpose['preferredName']), htmlPrep($rowPurpose['surname']), 'Student', true).'</option>';
-						}
-						echo '</select>';
-						?>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<b><?php echo __($guid, 'Month of Issue') ?></b><br/>
-						<span class="emphasis small"></span>
-					</td>
-					<td class="right">
-						<?php
-                        echo "<select name='monthOfIssue' id='monthOfIssue' style='width:302px'>";
-						echo "<option value=''></option>";
-						for ($i = 1; $i <= 12; ++$i) {
-							$selected = '';
-							if ($monthOfIssue == $i) {
-								$selected = 'selected';
-							}
-							echo "<option $selected value=\"".date('m', mktime(0, 0, 0, $i, 1, 0)).'">'.date('m', mktime(0, 0, 0, $i, 1, 0)).' - '.date('F', mktime(0, 0, 0, $i, 1, 0)).'</option>';
-						}
-						echo '</select>';
-						?>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<b><?php echo __($guid, 'Billing Schedule') ?></b><br/>
-						<span class="emphasis small"></span>
-					</td>
-					<td class="right">
-						<?php
-                        try {
-                            $dataPurpose = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-                            $sqlPurpose = 'SELECT * FROM gibbonFinanceBillingSchedule WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name';
-                            $resultPurpose = $connection2->prepare($sqlPurpose);
-                            $resultPurpose->execute($dataPurpose);
-                        } catch (PDOException $e) {
-                        }
+        $form = Form::create('manageInvoices', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+        $form->setClass('noIntBorder fullWidth');
 
-						echo "<select name='gibbonFinanceBillingScheduleID' id='gibbonFinanceBillingScheduleID' style='width:302px'>";
-						echo "<option value=''></option>";
-						while ($rowPurpose = $resultPurpose->fetch()) {
-							$selected = '';
-							if ($rowPurpose['gibbonFinanceBillingScheduleID'] == $gibbonFinanceBillingScheduleID) {
-								$selected = 'selected';
-							}
-							echo "<option $selected value='".$rowPurpose['gibbonFinanceBillingScheduleID']."'>".$rowPurpose['name'].'</option>';
-						}
-						$selected = '';
-						if ($gibbonFinanceBillingScheduleID == 'Ad Hoc') {
-							$selected = 'selected';
-						}
-						echo "<option $selected value='Ad Hoc'>".__($guid, 'Ad Hoc').'</option>';
-						echo '</select>';
-						?>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<b><?php echo __($guid, 'Fee Category') ?></b><br/>
-						<span class="emphasis small"></span>
-					</td>
-					<td class="right">
-						<?php
-                        try {
-                            $dataPurpose = array();
-                            $sqlPurpose = 'SELECT * FROM gibbonFinanceFeeCategory ORDER BY name';
-                            $resultPurpose = $connection2->prepare($sqlPurpose);
-                            $resultPurpose->execute($dataPurpose);
-                        } catch (PDOException $e) {
-                        }
+        $form->addHiddenValue('q', '/modules/Finance/invoices_manage.php');
 
-						echo "<select name='gibbonFinanceFeeCategoryID' id='gibbonFinanceFeeCategoryID' style='width:302px'>";
-						echo "<option value=''></option>";
-						while ($rowPurpose = $resultPurpose->fetch()) {
-							$selected = '';
-							if ($rowPurpose['gibbonFinanceFeeCategoryID'] == $gibbonFinanceFeeCategoryID) {
-								$selected = 'selected';
-							}
-							echo "<option $selected value='".$rowPurpose['gibbonFinanceFeeCategoryID']."'>".$rowPurpose['name'].'</option>';
-						}
-						echo '</select>';
-						?>
-					</td>
-				</tr>
-				<?php
+        $statuses = array(
+            '%' => __('All'),
+            'Pending' => __('Pending'),
+            'Issued' => __('Issued'),
+            'Issued - Overdue' => __('Issued - Overdue'),
+            'Paid' => __('Paid'),
+            'Paid - Partial' => __('Paid - Partial'),
+            'Paid - Late' => __('Paid - Late'),
+            'Cancelled' => __('Cancelled'),
+            'Refunded' => __('Refunded'),
+        );
+        $row = $form->addRow();
+            $row->addLabel('status', __('Status'));
+            $row->addSelect('status')->fromArray($statuses)->selected($status);
 
-                echo '<tr>';
-					echo "<td class='right' colspan=2>";
-					echo "<input type='hidden' name='gibbonSchoolYearID' value='$gibbonSchoolYearID'>";
-					echo "<input type='hidden' name='q' value='".$_GET['q']."'>";
-					echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php&gibbonSchoolYearID=$gibbonSchoolYearID'>".__($guid, 'Clear Filters').'</a> ';
-					echo "<input type='submit' value='".__($guid, 'Go')."'>";
-					echo '</td>';
-					echo '</tr>';
-					echo '</table>';
-					echo '</form>';
+        $sql = "SELECT surname, preferredName, gibbonFinanceInvoiceeID FROM gibbonFinanceInvoicee JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) ORDER BY surname, preferredName";
+        $result = $pdo->executeQuery(array(), $sql);
 
-					try {
-						//Add in filter wheres
-						$data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonSchoolYearID2' => $gibbonSchoolYearID);
-						$whereSched = '';
-						$whereAdHoc = '';
-						$whereNotPending = '';
-						$today = date('Y-m-d');
-						if ($status != '') {
-							if ($status == 'Pending') {
-								$data['status1'] = 'Pending';
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
-								$data['status2'] = 'Pending';
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
-								$data['status3'] = 'Pending';
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
-							} elseif ($status == 'Issued') {
-								$data['status1'] = 'Issued';
-								$data['dateTest1'] = $today;
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate>=:dateTest1';
-								$data['status2'] = 'Issued';
-								$data['dateTest2'] = $today;
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate>=:dateTest2';
-								$data['status3'] = 'Issued';
-								$data['dateTest3'] = $today;
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate>=:dateTest3';
-							} elseif ($status == 'Issued - Overdue') {
-								$data['status1'] = 'Issued';
-								$data['dateTest1'] = $today;
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate<:dateTest1';
-								$data['status2'] = 'Issued';
-								$data['dateTest2'] = $today;
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate<:dateTest2';
-								$data['status3'] = 'Issued';
-								$data['dateTest3'] = $today;
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate<:dateTest3';
-							} elseif ($status == 'Paid') {
-								$data['status1'] = 'Paid';
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate>=paidDate';
-								$data['status2'] = 'Paid';
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate>=paidDate';
-								$data['status3'] = 'Paid';
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate>=paidDate';
-							} elseif ($status == 'Paid - Partial') {
-								$data['status1'] = 'Paid - Partial';
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
-								$data['status2'] = 'Paid - Partial';
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
-								$data['status3'] = 'Paid - Partial';
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
-							} elseif ($status == 'Paid - Late') {
-								$data['status1'] = 'Paid';
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate<paidDate';
-								$data['status2'] = 'Paid';
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate<paidDate';
-								$data['status3'] = 'Paid';
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate<paidDate';
-							} elseif ($status == 'Cancelled') {
-								$data['status1'] = 'Cancelled';
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
-								$data['status2'] = 'Cancelled';
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
-								$data['status3'] = 'Cancelled';
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
-							} elseif ($status == 'Refunded') {
-								$data['status1'] = 'Refunded';
-								$whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
-								$data['status2'] = 'Refunded';
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
-								$data['status3'] = 'Refunded';
-								$whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
-							}
-						}
-						if ($gibbonFinanceInvoiceeID != '') {
-							$data['gibbonFinanceInvoiceeID1'] = $gibbonFinanceInvoiceeID;
-							$whereSched .= ' AND gibbonFinanceInvoice.gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID1';
-							$data['gibbonFinanceInvoiceeID2'] = $gibbonFinanceInvoiceeID;
-							$whereAdHoc .= ' AND gibbonFinanceInvoice.gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID2';
-							$data['gibbonFinanceInvoiceeID3'] = $gibbonFinanceInvoiceeID;
-							$whereNotPending .= ' AND gibbonFinanceInvoice.gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID3';
-						}
-						if ($monthOfIssue != '') {
-							$data['monthOfIssue1'] = "%-$monthOfIssue-%";
-							$whereSched .= ' AND gibbonFinanceInvoice.invoiceIssueDate LIKE :monthOfIssue1';
-							$data['monthOfIssue2'] = "%-$monthOfIssue-%";
-							$whereAdHoc .= ' AND gibbonFinanceInvoice.invoiceIssueDate LIKE :monthOfIssue2';
-							$data['monthOfIssue3'] = "%-$monthOfIssue-%";
-							$whereNotPending .= ' AND gibbonFinanceInvoice.invoiceIssueDate LIKE :monthOfIssue3';
-						}
-						if ($gibbonFinanceBillingScheduleID != '') {
-							if ($gibbonFinanceBillingScheduleID == 'Ad Hoc') {
-								$data['billingScheduleType1'] = 'Ah Hoc';
-								$whereSched .= ' AND gibbonFinanceInvoice.billingScheduleType=:billingScheduleType1';
-								$data['billingScheduleType2'] = 'Ad Hoc';
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.billingScheduleType=:billingScheduleType2';
-								$data['billingScheduleType3'] = 'Ad Hoc';
-								$whereNotPending .= ' AND gibbonFinanceInvoice.billingScheduleType=:billingScheduleType3';
-							} elseif ($gibbonFinanceBillingScheduleID != '') {
-								$data['gibbonFinanceBillingScheduleID1'] = $gibbonFinanceBillingScheduleID;
-								$whereSched .= ' AND gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID1';
-								$data['gibbonFinanceBillingScheduleID2'] = $gibbonFinanceBillingScheduleID;
-								$whereAdHoc .= ' AND gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID2';
-								$data['gibbonFinanceBillingScheduleID3'] = $gibbonFinanceBillingScheduleID;
-								$whereNotPending .= ' AND gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID3';
-							}
-						}
-                        if ($gibbonFinanceFeeCategoryID != '') {
-							$data['gibbonFinanceFeeCategoryID1'] = '%'.$gibbonFinanceFeeCategoryID.'%';
-							$whereSched .= ' AND gibbonFinanceInvoice.gibbonFinanceFeeCategoryIDList LIKE :gibbonFinanceFeeCategoryID1';
-							$data['gibbonFinanceFeeCategoryID2'] = '%'.$gibbonFinanceFeeCategoryID.'%';
-							$whereAdHoc .= ' AND gibbonFinanceInvoice.gibbonFinanceFeeCategoryIDList LIKE :gibbonFinanceFeeCategoryID2';
-							$data['gibbonFinanceFeeCategoryID3'] = '%'.$gibbonFinanceFeeCategoryID.'%';
-							$whereNotPending .= ' AND gibbonFinanceInvoice.gibbonFinanceFeeCategoryIDList LIKE :gibbonFinanceFeeCategoryID3';
-						}
+        $students = $result->rowCount() > 0? $result->fetchAll() : array();
+        $students = array_reduce($students, function($group, $item){
+            $group[$item['gibbonFinanceInvoiceeID']] = formatName('', htmlPrep($item['preferredName']), htmlPrep($item['surname']), 'Student', true);
+            return $group;
+        }, array());
 
-                        //SQL for billing schedule AND pending
-						$sql = "(SELECT gibbonFinanceInvoice.gibbonFinanceInvoiceID, surname, preferredName, gibbonFinanceInvoice.invoiceTo, gibbonFinanceInvoice.status, gibbonFinanceInvoice.invoiceIssueDate, gibbonFinanceBillingSchedule.invoiceDueDate, paidDate, paidAmount, gibbonFinanceBillingSchedule.name AS billingSchedule, NULL AS billingScheduleExtra, notes, gibbonRollGroup.name AS rollGroup FROM gibbonFinanceInvoice JOIN gibbonFinanceBillingSchedule ON (gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=gibbonFinanceBillingSchedule.gibbonFinanceBillingScheduleID) JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND billingScheduleType='Scheduled' AND gibbonFinanceInvoice.status='Pending' $whereSched)";
-						$sql .= ' UNION ';
-						//SQL for Ad Hoc AND pending
-						$sql .= "(SELECT gibbonFinanceInvoice.gibbonFinanceInvoiceID, surname, preferredName, gibbonFinanceInvoice.invoiceTo, gibbonFinanceInvoice.status, invoiceIssueDate, invoiceDueDate, paidDate, paidAmount, 'Ad Hoc' AS billingSchedule, NULL AS billingScheduleExtra, notes, gibbonRollGroup.name AS rollGroup FROM gibbonFinanceInvoice JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)  WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND billingScheduleType='Ad Hoc' AND gibbonFinanceInvoice.status='Pending' $whereAdHoc)";
-						$sql .= ' UNION ';
-						//SQL for NOT Pending
-						$sql .= "(SELECT gibbonFinanceInvoice.gibbonFinanceInvoiceID, surname, preferredName, gibbonFinanceInvoice.invoiceTo, gibbonFinanceInvoice.status, gibbonFinanceInvoice.invoiceIssueDate, gibbonFinanceInvoice.invoiceDueDate, paidDate, paidAmount, billingScheduleType AS billingSchedule, gibbonFinanceBillingSchedule.name AS billingScheduleExtra, notes, gibbonRollGroup.name AS rollGroup FROM gibbonFinanceInvoice LEFT JOIN gibbonFinanceBillingSchedule ON (gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=gibbonFinanceBillingSchedule.gibbonFinanceBillingScheduleID) JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)  WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND NOT gibbonFinanceInvoice.status='Pending' $whereNotPending)";
-						$sql .= " ORDER BY FIND_IN_SET(status, 'Pending,Issued,Paid,Refunded,Cancelled'), invoiceIssueDate, surname, preferredName";
-						$result = $connection2->prepare($sql);
-						$result->execute($data);
-					} catch (PDOException $e) {
-						echo "<div class='error'>".$e->getMessage().'</div>';
-					}
+        $row = $form->addRow();
+            $row->addLabel('gibbonFinanceInvoiceeID', __('Student'));
+            $row->addSelect('gibbonFinanceInvoiceeID')
+                ->fromArray($students)
+                ->placeholder()
+                ->selected($gibbonFinanceInvoiceeID);
 
-					if ($result->rowCount() < 1) {
-						echo '<h3>';
-						echo __($guid, 'View');
-						echo '</h3>';
+        $months = array_reduce(range(1,12), function($group, $item){
+            $month = date('m', mktime(0, 0, 0, $item, 1, 0));
+            $group[$month] = $month.' - '.date('F', mktime(0, 0, 0, $item, 1, 0));
+            return $group;
+        }, array());
+        $row = $form->addRow();
+            $row->addLabel('monthOfIssue', __('Month of Issue'));
+            $row->addSelect('monthOfIssue')
+                ->fromArray($months)
+                ->placeholder()
+                ->selected($monthOfIssue);
 
-						echo "<div class='linkTop' style='text-align: right'>";
-						echo "<a style='margin-right: 3px' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/invoices_manage_add.php&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new_multi.png'/></a><br/>";
-						echo '</div>';
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
+        $sql = "SELECT gibbonFinanceBillingScheduleID as value, name FROM gibbonFinanceBillingSchedule WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
+        $row = $form->addRow();
+            $row->addLabel('gibbonFinanceBillingScheduleID', __('Billing Schedule'));
+            $row->addSelect('gibbonFinanceBillingScheduleID')
+                ->fromQuery($pdo, $sql, $data)
+                ->fromArray(array('Ad Hoc' => __('Ad Hoc')))
+                ->placeholder()
+                ->selected($gibbonFinanceBillingScheduleID);
 
-						echo "<div class='error'>";
-						echo __($guid, 'There are no records to display.');
-						echo '</div>';
-					} else {
-						echo '<h3>';
-						echo __($guid, 'View');
-						echo "<span style='font-weight: normal; font-style: italic; font-size: 55%'> ".sprintf(__($guid, '%1$s records(s) in current view'), $result->rowCount()).'</span>';
-						echo '</h3>';
+        $sql = "SELECT gibbonFinanceFeeCategoryID as value, name FROM gibbonFinanceFeeCategory ORDER BY name";
+        $row = $form->addRow();
+            $row->addLabel('gibbonFinanceFeeCategoryID', __('Fee Category'));
+            $row->addSelect('gibbonFinanceFeeCategoryID')
+                ->fromQuery($pdo, $sql)
+                ->placeholder()
+                ->selected($gibbonFinanceFeeCategoryID);
+        
+        $row = $form->addRow();
+            $row->addSearchSubmit($gibbon->session, __('Clear Filters'), array('gibbonSchoolYearID'));
 
-						echo "<form onsubmit='return confirm(\"".__($guid, 'Are you sure you wish to process this action? It cannot be undone.')."\")' method='post' action='".$_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/invoices_manage_processBulk.php?gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>";
-						echo "<fieldset style='border: none'>";
-						echo "<div class='linkTop' style='text-align: right; margin-bottom: 40px'>";
-						echo "<div style='margin: 0 0 3px 0'>";
-						echo "<a style='margin-right: 3px' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/invoices_manage_add.php&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new_multi.png'/></a><br/>";
-						echo '</div>'; ?>
-						<input style='margin-top: 0px; float: right' type='submit' value='<?php echo __($guid, 'Go') ?>'>
-						<select name="action" id="action" style='width:120px; float: right; margin-right: 1px;'>
-							<option value="Select action"><?php echo __($guid, 'Select action') ?></option>
-							<?php
-                            if ($status == 'Pending') {
-                                echo '<option value="delete">'.__($guid, 'Delete').'</option>';
-                                echo '<option value="issue">'.__($guid, 'Issue').'</option>';
-                                echo '<option value="issueNoEmail">'.__($guid, 'Issue (Without Email)').'</option>';
-                            }
-							if ($status == 'Issued - Overdue') {
-								echo '<option value="reminders">'.__($guid, 'Issue Reminders').'</option>';
-							}
-							echo '<option value="export">'.__($guid, 'Export').'</option>'; ?>
-						</select>
-						<script type="text/javascript">
-							var action=new LiveValidation('action');
-							action.add(Validate.Exclusion, { within: ['Select action'], failureMessage: "<?php echo __($guid, 'Select something!') ?>"});
-						</script>
-						<?php
-						echo '</div>';
+        echo $form->getOutput();
 
-						echo "<table cellspacing='0' style='width: 100%'>";
-						echo "<tr class='head'>";
-						echo "<th style='width: 110px'>";
-						echo __($guid, 'Student').'<br/>';
-						echo "<span style='font-style: italic; font-size: 85%'>".__($guid, 'Invoice To').'</span>';
-						echo '</th>';
-						echo "<th style='width: 110px'>";
-						echo __($guid, 'Roll Group');
-						echo '</th>';
-						echo "<th style='width: 100px'>";
-						echo __($guid, 'Status');
-						echo '</th>';
-						echo "<th style='width: 90px'>";
-						echo __($guid, 'Schedule');
-						echo '</th>';
-						echo "<th style='width: 120px'>";
-						echo __($guid, 'Total')." <span style='font-style: italic; font-size: 75%'>(".$_SESSION[$guid]['currency'].')</span><br/>';
-						echo "<span style='font-style: italic; font-size: 75%'>".__($guid, 'Paid').' ('.$_SESSION[$guid]['currency'].')</span>';
-						echo '</th>';
-						echo "<th style='width: 80px'>";
-						echo __($guid, 'Issue Date').'<br/>';
-						echo "<span style='font-style: italic; font-size: 75%'>".__($guid, 'Due Date').'</span>';
-						echo '</th>';
-						echo "<th style='width: 140px'>";
-						echo __($guid, 'Actions');
-						echo '</th>';
-						echo '<th>'; ?>
-							<script type="text/javascript">
-								$(function () {
-									$('.checkall').click(function () {
-										$(this).parents('fieldset:eq(0)').find(':checkbox').attr('checked', this.checked);
-									});
-								});
-							</script>
-						<?php
-						echo "<input type='checkbox' class='checkall'>";
-						echo '</th>';
-						echo '</tr>';
-
-						$count = 0;
-						$rowNum = 'odd';
-						while ($row = $result->fetch()) {
-							if ($count % 2 == 0) {
-								$rowNum = 'even';
-							} else {
-								$rowNum = 'odd';
-							}
-							++$count;
-
-                            //Work out extra status information
-                            $statusExtra = '';
-							if ($row['status'] == 'Issued' and $row['invoiceDueDate'] < date('Y-m-d')) {
-								$statusExtra = 'Overdue';
-							}
-							if ($row['status'] == 'Paid' and $row['invoiceDueDate'] < $row['paidDate']) {
-								$statusExtra = 'Late';
-							}
-
-                            //Color row by status
-                            if ($row['status'] == 'Paid') {
-                                $rowNum = 'current';
-                            }
-                if ($row['status'] == 'Issued' and $statusExtra == 'Overdue') {
-                    $rowNum = 'error';
-                }
-
-                echo "<tr class=$rowNum>";
-                echo '<td>';
-                echo '<b>'.formatName('', htmlPrep($row['preferredName']), htmlPrep($row['surname']), 'Student', true).'</b><br/>';
-                echo "<span style='font-style: italic; font-size: 85%'>".$row['invoiceTo'].'</span>';
-                echo '</td>';
-                echo '<td>';
-                echo $row['rollGroup'];
-                echo '</td>';
-                echo '<td>';
-                echo $row['status'];
-                if ($statusExtra != '') {
-                    echo " - $statusExtra";
-                }
-                echo '</td>';
-                echo '<td>';
-                if ($row['billingScheduleExtra'] != '') {
-                    echo $row['billingScheduleExtra'];
-                } else {
-                    echo $row['billingSchedule'];
-                }
-                echo '</td>';
-                echo '<td>';
-                                    //Calculate total value
-                                    $totalFee = 0;
-                $feeError = false;
-                try {
-                    $dataTotal = array('gibbonFinanceInvoiceID' => $row['gibbonFinanceInvoiceID']);
-                    if ($row['status'] == 'Pending') {
-                        $sqlTotal = 'SELECT gibbonFinanceInvoiceFee.fee AS fee, gibbonFinanceFee.fee AS fee2 FROM gibbonFinanceInvoiceFee LEFT JOIN gibbonFinanceFee ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeID=gibbonFinanceFee.gibbonFinanceFeeID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID';
-                    } else {
-                        $sqlTotal = 'SELECT gibbonFinanceInvoiceFee.fee AS fee, NULL AS fee2 FROM gibbonFinanceInvoiceFee WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID';
-                    }
-                    $resultTotal = $connection2->prepare($sqlTotal);
-                    $resultTotal->execute($dataTotal);
-                } catch (PDOException $e) {
-                    echo $e->getMessage();
-                    echo '<i>Error calculating total</i>';
-                    $feeError = true;
-                }
-                while ($rowTotal = $resultTotal->fetch()) {
-                    if (is_numeric($rowTotal['fee2'])) {
-                        $totalFee += $rowTotal['fee2'];
-                    } else {
-                        $totalFee += $rowTotal['fee'];
-                    }
-                }
-                if ($feeError == false) {
-                    if (substr($_SESSION[$guid]['currency'], 4) != '') {
-                        echo substr($_SESSION[$guid]['currency'], 4).' ';
-                    }
-                    echo number_format($totalFee, 2, '.', ',').'<br/>';
-                    if ($row['paidAmount'] != '') {
-                        $styleExtra = '';
-                        if ($row['paidAmount'] != $totalFee) {
-                            $styleExtra = 'color: #c00;';
-                        }
-                        echo "<span style='$styleExtra font-style: italic; font-size: 85%'>";
-                        if (substr($_SESSION[$guid]['currency'], 4) != '') {
-                            echo substr($_SESSION[$guid]['currency'], 4).' ';
-                        }
-                        echo number_format($row['paidAmount'], 2, '.', ',').'</span>';
-                    }
-                }
-                echo '</td>';
-                echo '<td>';
-                if (is_null($row['invoiceIssueDate'])) {
-                    echo 'NA<br/>';
-                } else {
-                    echo dateConvertBack($guid, $row['invoiceIssueDate']).'<br/>';
-                }
-                echo "<span style='font-style: italic; font-size: 75%'>".dateConvertBack($guid, $row['invoiceDueDate']).'</span>';
-                echo '</td>';
-                echo '<td>';
-                if ($row['status'] != 'Cancelled' and $row['status'] != 'Refunded') {
-                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_edit.php&gibbonFinanceInvoiceID='.$row['gibbonFinanceInvoiceID']."&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'><img title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
-                }
-                if ($row['status'] == 'Pending') {
-                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_issue.php&gibbonFinanceInvoiceID='.$row['gibbonFinanceInvoiceID']."&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'><img title='Issue' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_right.png'/></a><br/>";
-                    echo "<a class='thickbox' href='".$_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_delete.php&gibbonFinanceInvoiceID='.$row['gibbonFinanceInvoiceID']."&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID&width=650&height=135'><img title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a> ";
-                    echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/report.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_print_print.php&type=invoice&gibbonFinanceInvoiceID='.$row['gibbonFinanceInvoiceID']."&gibbonSchoolYearID=$gibbonSchoolYearID&preview=true'><img title='Preview Invoice' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/print.png'/></a>";
-                }
-                if ($row['status'] != 'Pending') {
-                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_print.php&gibbonFinanceInvoiceID='.$row['gibbonFinanceInvoiceID']."&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'><img title='Print Invoices, Receipts & Reminders' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/print.png'/></a>";
-                }
-                echo "<script type='text/javascript'>";
-                echo '$(document).ready(function(){';
-                echo "\$(\".comment-$count\").hide();";
-                echo "\$(\".show_hide-$count\").fadeIn(1000);";
-                echo "\$(\".show_hide-$count\").click(function(){";
-                echo "\$(\".comment-$count\").fadeToggle(1000);";
-                echo '});';
-                echo '});';
-                echo '</script>';
-                if ($row['notes'] != '') {
-                    echo "<a title='View Notes' class='show_hide-$count' onclick='false' href='#'><img style='margin-left: 5px' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
-                }
-                echo '</td>';
-                echo '<td>';
-                echo "<input type='checkbox' name='gibbonFinanceInvoiceIDs[]' value='".$row['gibbonFinanceInvoiceID']."'>";
-                echo '</td>';
-                echo '</tr>';
-                if ($row['notes'] != '') {
-                    echo "<tr class='comment-$count' id='comment-$count'>";
-                    echo '<td colspan=8>';
-                    echo $row['notes'];
-                    echo '</td>';
-                    echo '</tr>';
+        try {
+            //Add in filter wheres
+            $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonSchoolYearID2' => $gibbonSchoolYearID);
+            $whereSched = '';
+            $whereAdHoc = '';
+            $whereNotPending = '';
+            $today = date('Y-m-d');
+            if ($status != '') {
+                if ($status == 'Pending') {
+                    $data['status1'] = 'Pending';
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
+                    $data['status2'] = 'Pending';
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
+                    $data['status3'] = 'Pending';
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
+                } elseif ($status == 'Issued') {
+                    $data['status1'] = 'Issued';
+                    $data['dateTest1'] = $today;
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate>=:dateTest1';
+                    $data['status2'] = 'Issued';
+                    $data['dateTest2'] = $today;
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate>=:dateTest2';
+                    $data['status3'] = 'Issued';
+                    $data['dateTest3'] = $today;
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate>=:dateTest3';
+                } elseif ($status == 'Issued - Overdue') {
+                    $data['status1'] = 'Issued';
+                    $data['dateTest1'] = $today;
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate<:dateTest1';
+                    $data['status2'] = 'Issued';
+                    $data['dateTest2'] = $today;
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate<:dateTest2';
+                    $data['status3'] = 'Issued';
+                    $data['dateTest3'] = $today;
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate<:dateTest3';
+                } elseif ($status == 'Paid') {
+                    $data['status1'] = 'Paid';
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate>=paidDate';
+                    $data['status2'] = 'Paid';
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate>=paidDate';
+                    $data['status3'] = 'Paid';
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate>=paidDate';
+                } elseif ($status == 'Paid - Partial') {
+                    $data['status1'] = 'Paid - Partial';
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
+                    $data['status2'] = 'Paid - Partial';
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
+                    $data['status3'] = 'Paid - Partial';
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
+                } elseif ($status == 'Paid - Late') {
+                    $data['status1'] = 'Paid';
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1 AND gibbonFinanceInvoice.invoiceDueDate<paidDate';
+                    $data['status2'] = 'Paid';
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2 AND gibbonFinanceInvoice.invoiceDueDate<paidDate';
+                    $data['status3'] = 'Paid';
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3 AND gibbonFinanceInvoice.invoiceDueDate<paidDate';
+                } elseif ($status == 'Cancelled') {
+                    $data['status1'] = 'Cancelled';
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
+                    $data['status2'] = 'Cancelled';
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
+                    $data['status3'] = 'Cancelled';
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
+                } elseif ($status == 'Refunded') {
+                    $data['status1'] = 'Refunded';
+                    $whereSched .= ' AND gibbonFinanceInvoice.status=:status1';
+                    $data['status2'] = 'Refunded';
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.status=:status2';
+                    $data['status3'] = 'Refunded';
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.status=:status3';
                 }
             }
-            echo '<input type="hidden" name="address" value="'.$_SESSION[$guid]['address'].'">';
+            if ($gibbonFinanceInvoiceeID != '') {
+                $data['gibbonFinanceInvoiceeID1'] = $gibbonFinanceInvoiceeID;
+                $whereSched .= ' AND gibbonFinanceInvoice.gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID1';
+                $data['gibbonFinanceInvoiceeID2'] = $gibbonFinanceInvoiceeID;
+                $whereAdHoc .= ' AND gibbonFinanceInvoice.gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID2';
+                $data['gibbonFinanceInvoiceeID3'] = $gibbonFinanceInvoiceeID;
+                $whereNotPending .= ' AND gibbonFinanceInvoice.gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID3';
+            }
+            if ($monthOfIssue != '') {
+                $data['monthOfIssue1'] = "%-$monthOfIssue-%";
+                $whereSched .= ' AND gibbonFinanceInvoice.invoiceIssueDate LIKE :monthOfIssue1';
+                $data['monthOfIssue2'] = "%-$monthOfIssue-%";
+                $whereAdHoc .= ' AND gibbonFinanceInvoice.invoiceIssueDate LIKE :monthOfIssue2';
+                $data['monthOfIssue3'] = "%-$monthOfIssue-%";
+                $whereNotPending .= ' AND gibbonFinanceInvoice.invoiceIssueDate LIKE :monthOfIssue3';
+            }
+            if ($gibbonFinanceBillingScheduleID != '') {
+                if ($gibbonFinanceBillingScheduleID == 'Ad Hoc') {
+                    $data['billingScheduleType1'] = 'Ah Hoc';
+                    $whereSched .= ' AND gibbonFinanceInvoice.billingScheduleType=:billingScheduleType1';
+                    $data['billingScheduleType2'] = 'Ad Hoc';
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.billingScheduleType=:billingScheduleType2';
+                    $data['billingScheduleType3'] = 'Ad Hoc';
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.billingScheduleType=:billingScheduleType3';
+                } elseif ($gibbonFinanceBillingScheduleID != '') {
+                    $data['gibbonFinanceBillingScheduleID1'] = $gibbonFinanceBillingScheduleID;
+                    $whereSched .= ' AND gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID1';
+                    $data['gibbonFinanceBillingScheduleID2'] = $gibbonFinanceBillingScheduleID;
+                    $whereAdHoc .= ' AND gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID2';
+                    $data['gibbonFinanceBillingScheduleID3'] = $gibbonFinanceBillingScheduleID;
+                    $whereNotPending .= ' AND gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID3';
+                }
+            }
+            if ($gibbonFinanceFeeCategoryID != '') {
+                $data['gibbonFinanceFeeCategoryID1'] = '%'.$gibbonFinanceFeeCategoryID.'%';
+                $whereSched .= ' AND gibbonFinanceInvoice.gibbonFinanceFeeCategoryIDList LIKE :gibbonFinanceFeeCategoryID1';
+                $data['gibbonFinanceFeeCategoryID2'] = '%'.$gibbonFinanceFeeCategoryID.'%';
+                $whereAdHoc .= ' AND gibbonFinanceInvoice.gibbonFinanceFeeCategoryIDList LIKE :gibbonFinanceFeeCategoryID2';
+                $data['gibbonFinanceFeeCategoryID3'] = '%'.$gibbonFinanceFeeCategoryID.'%';
+                $whereNotPending .= ' AND gibbonFinanceInvoice.gibbonFinanceFeeCategoryIDList LIKE :gibbonFinanceFeeCategoryID3';
+            }
 
-            echo '</fieldset>';
-            echo '</table>';
-            echo '</form>';
+            //SQL for billing schedule AND pending
+            $sql = "(SELECT gibbonFinanceInvoice.gibbonFinanceInvoiceID, surname, preferredName, gibbonFinanceInvoice.invoiceTo, gibbonFinanceInvoice.status, gibbonFinanceInvoice.invoiceIssueDate, gibbonFinanceBillingSchedule.invoiceDueDate, paidDate, paidAmount, gibbonFinanceBillingSchedule.name AS billingSchedule, NULL AS billingScheduleExtra, notes, gibbonRollGroup.name AS rollGroup FROM gibbonFinanceInvoice JOIN gibbonFinanceBillingSchedule ON (gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=gibbonFinanceBillingSchedule.gibbonFinanceBillingScheduleID) JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND billingScheduleType='Scheduled' AND gibbonFinanceInvoice.status='Pending' $whereSched)";
+            $sql .= ' UNION ';
+            //SQL for Ad Hoc AND pending
+            $sql .= "(SELECT gibbonFinanceInvoice.gibbonFinanceInvoiceID, surname, preferredName, gibbonFinanceInvoice.invoiceTo, gibbonFinanceInvoice.status, invoiceIssueDate, invoiceDueDate, paidDate, paidAmount, 'Ad Hoc' AS billingSchedule, NULL AS billingScheduleExtra, notes, gibbonRollGroup.name AS rollGroup FROM gibbonFinanceInvoice JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)  WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND billingScheduleType='Ad Hoc' AND gibbonFinanceInvoice.status='Pending' $whereAdHoc)";
+            $sql .= ' UNION ';
+            //SQL for NOT Pending
+            $sql .= "(SELECT gibbonFinanceInvoice.gibbonFinanceInvoiceID, surname, preferredName, gibbonFinanceInvoice.invoiceTo, gibbonFinanceInvoice.status, gibbonFinanceInvoice.invoiceIssueDate, gibbonFinanceInvoice.invoiceDueDate, paidDate, paidAmount, billingScheduleType AS billingSchedule, gibbonFinanceBillingSchedule.name AS billingScheduleExtra, notes, gibbonRollGroup.name AS rollGroup FROM gibbonFinanceInvoice LEFT JOIN gibbonFinanceBillingSchedule ON (gibbonFinanceInvoice.gibbonFinanceBillingScheduleID=gibbonFinanceBillingSchedule.gibbonFinanceBillingScheduleID) JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)  WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND NOT gibbonFinanceInvoice.status='Pending' $whereNotPending)";
+            $sql .= " ORDER BY FIND_IN_SET(status, 'Pending,Issued,Paid,Refunded,Cancelled'), invoiceIssueDate, surname, preferredName";
+            $result = $connection2->prepare($sql);
+            $result->execute($data);
+        } catch (PDOException $e) {
+            echo "<div class='error'>".$e->getMessage().'</div>';
         }
+
+
+        echo '<h3>';
+        echo __($guid, 'View');
+        echo "<span style='font-weight: normal; font-style: italic; font-size: 55%'> ".sprintf(__($guid, '%1$s records(s) in current view'), $result->rowCount()).'</span>';
+        echo '</h3>';
+        
+        echo "<div class='linkTop'>";
+        echo "<a style='margin-right: 3px' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/invoices_manage_add.php&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new_multi.png'/></a><br/>";
+        echo '</div>'; 
+
+        $linkParams = array(
+            'gibbonSchoolYearID'             => $gibbonSchoolYearID,
+            'status'                         => $status,
+            'gibbonFinanceInvoiceeID'        => $gibbonFinanceInvoiceeID,
+            'monthOfIssue'                   => $monthOfIssue,
+            'gibbonFinanceBillingScheduleID' => $gibbonFinanceBillingScheduleID,
+            'gibbonFinanceFeeCategoryID'     => $gibbonFinanceFeeCategoryID,
+        );
+
+        $form = BulkActionForm::create('bulkAction', $_SESSION[$guid]['absoluteURL'] . '/modules/' . $_SESSION[$guid]['module'] . '/invoices_manage_processBulk.php?'.http_build_query($linkParams));
+
+        $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+
+        $bulkActions = array('export' => __('Export'));
+        if ($status == 'Pending') {
+            $bulkActions = array('delete' => __('Delete'), 'issue' => __('Issue'), 'issueNoEmail' => __('Issue (Without Email)')) + $bulkActions;
+        } else if ($status == 'Issued - Overdue') {
+            $bulkActions = array('reminders' => __('Issue Reminders')) + $bulkActions;
+        }
+
+        $row = $form->addBulkActionRow($bulkActions);
+            $row->addSubmit(__('Go'));
+
+        $table = $form->addRow()->addTable()->setClass('colorOddEven fullWidth');
+
+        $header = $table->addHeaderRow();
+            $header->addContent(__('Student'))->append('<br/><small><i>'.__('Invoice To').'</i></small>');
+            $header->addContent(__('Roll Group'));
+            $header->addContent(__('Status'));
+            $header->addContent(__('Schedule'));
+            $header->addContent(__('Total'))
+                ->append(' <small><i>('.$_SESSION[$guid]['currency'].')</i></small>')
+                ->append('<br/><small><i>'.__('Paid').' ('.$_SESSION[$guid]['currency'].')</i></small>');
+            $header->addContent(__('Issue Date'))->append('<br/><small><i>'.__('Due Date').'</i></small>');
+            $header->addContent(__('Actions'))->addClass('shortWidth');
+            $header->addCheckAll();
+
+        $invoices = $result->rowCount() > 0? $result->fetchAll() : array();
+
+        if (count($invoices) == 0) {
+            $table->addRow()->addTableCell(__('There are no records to display.'))->colSpan(8);
+        }
+
+        foreach ($invoices as $invoice) {
+            $statusExtra = '';
+            if ($invoice['status'] == 'Issued' and $invoice['invoiceDueDate'] < date('Y-m-d')) {
+                $statusExtra = 'Overdue';
+            } else if ($invoice['status'] == 'Paid' and $invoice['invoiceDueDate'] < $invoice['paidDate']) {
+                $statusExtra = 'Late';
+            }
+            
+            $rowClass = ($invoice['status'] == 'Paid')? 'current' : (($invoice['status'] == 'Issued' and $statusExtra == 'Overdue')? 'error' : '');
+
+            $totalFee = getInvoiceTotalFee($pdo, $invoice['gibbonFinanceInvoiceID'], $invoice['status']);
+
+            $row = $table->addRow()->addClass($rowClass);
+                $row->addContent(formatName('', htmlPrep($invoice['preferredName']), htmlPrep($invoice['surname']), 'Student', true))
+                    ->wrap('<b>', '</b>')
+                    ->append('<br/><span class="small emphasis">'.$invoice['invoiceTo'].'</span>');
+                $row->addContent($invoice['rollGroup']);
+                $row->addContent($invoice['status'])->append(!empty($statusExtra)? ' - '.$statusExtra : '');
+                $row->addContent(!empty($invoice['billingScheduleExtra'])? $invoice['billingScheduleExtra'] : $invoice['billingSchedule']);
+                if (!is_null($totalFee)) {
+                    $fee = $row->addContent(number_format($totalFee, 2, '.', ','));
+                    if (!empty($invoice['paidAmount'])) {
+                        $fee->setClass($invoice['paidAmount'] != $totalFee ? 'textOverBudget' : '')
+                            ->append('<br/><span class="small emphasis">'.number_format($invoice['paidAmount'], 2, '.', ',').'</span>');
+                    }
+                } else {
+                    $row->addContent('');
+                }
+                $row->addContent(!is_null($invoice['invoiceIssueDate'])? dateConvertBack($guid, $invoice['invoiceIssueDate']) : __('N/A') )
+                    ->append('<br/><span class="small emphasis">'.dateConvertBack($guid, $invoice['invoiceDueDate']).'</span>');
+
+                $col = $row->addColumn()->addClass('inline');
+                    $col->if($invoice['status'] != 'Cancelled' && $invoice['status'] != 'Refunded')
+                        ->addWebLink('<img title="'.__('Edit').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/config.png" style="margin-right:4px;" />')
+                        ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_edit.php')
+                        ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
+                        ->addParams($linkParams);
+
+                    $col->if($invoice['status'] == 'Pending')
+                        ->addWebLink('<img title="'.__('Issue').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/page_right.png" style="margin-right:4px;" />')
+                        ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_issue.php')
+                        ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
+                        ->addParams($linkParams);
+
+                    $col->if($invoice['status'] == 'Pending')
+                        ->addWebLink('<img title="'.__('Delete').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/garbage.png" style="margin-right:4px;" />')
+                        ->setURL($_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_delete.php&width=650&height=135')
+                        ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
+                        ->addParams($linkParams)
+                        ->addClass('thickbox');
+
+                    $col->if($invoice['status'] == 'Pending')
+                        ->addWebLink('<img title="'.__('Preview Invoice').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/print.png" style="margin-right:4px;" />')
+                        ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_print_print.php&type=invoice')
+                        ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
+                        ->addParams($linkParams)
+                        ->addParams('preview', 'true');
+
+                    $col->if($invoice['status'] != 'Pending')
+                        ->addWebLink('<img title="'.__('Print Invoices, Receipts & Reminders').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/print.png" style="margin-right:4px;" />')
+                        ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_print.php')
+                        ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
+                        ->addParams($linkParams);
+
+                    $col->if(!empty($invoice['notes']))
+                        ->addWebLink('<img title="'.__('View Notes').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/page_down.png" style="margin-right:4px;"/>')
+                        ->setURL('#')->onClick('return false;')->addClass('invoiceNotesView');
+
+                $row->addCheckbox('gibbonFinanceInvoiceIDs[]')->setValue($invoice['gibbonFinanceInvoiceID'])->setClass('textCenter');
+
+                if (!empty($invoice['notes'])) {
+                    $table->addRow()->addClass('invoiceNotes')->addTableCell(htmlPrep($invoice['notes']))->colSpan(8);
+                }
+                
+        }
+
+        echo $form->getOutput();
+        echo '<br/>';
     }
 }
-?>

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -351,39 +351,39 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
                     ->append('<br/><span class="small emphasis">'.dateConvertBack($guid, $invoice['invoiceDueDate']).'</span>');
 
                 $col = $row->addColumn()->addClass('inline');
-                    $col->if($invoice['status'] != 'Cancelled' && $invoice['status'] != 'Refunded')
+                    $col->onlyIf($invoice['status'] != 'Cancelled' && $invoice['status'] != 'Refunded')
                         ->addWebLink('<img title="'.__('Edit').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/config.png" style="margin-right:4px;" />')
                         ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_edit.php')
                         ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
                         ->addParams($linkParams);
 
-                    $col->if($invoice['status'] == 'Pending')
+                    $col->onlyIf($invoice['status'] == 'Pending')
                         ->addWebLink('<img title="'.__('Issue').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/page_right.png" style="margin-right:4px;" />')
                         ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_issue.php')
                         ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
                         ->addParams($linkParams);
 
-                    $col->if($invoice['status'] == 'Pending')
+                    $col->onlyIf($invoice['status'] == 'Pending')
                         ->addWebLink('<img title="'.__('Delete').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/garbage.png" style="margin-right:4px;" />')
                         ->setURL($_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_delete.php&width=650&height=135')
                         ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
                         ->addParams($linkParams)
                         ->addClass('thickbox');
 
-                    $col->if($invoice['status'] == 'Pending')
+                    $col->onlyIf($invoice['status'] == 'Pending')
                         ->addWebLink('<img title="'.__('Preview Invoice').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/print.png" style="margin-right:4px;" />')
                         ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_print_print.php&type=invoice')
                         ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
                         ->addParam('preview', 'true')
                         ->addParams($linkParams);
 
-                    $col->if($invoice['status'] != 'Pending')
+                    $col->onlyIf($invoice['status'] != 'Pending')
                         ->addWebLink('<img title="'.__('Print Invoices, Receipts & Reminders').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/print.png" style="margin-right:4px;" />')
                         ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_print.php')
                         ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
                         ->addParams($linkParams);
 
-                    $col->if(!empty($invoice['notes']))
+                    $col->onlyIf(!empty($invoice['notes']))
                         ->addWebLink('<img title="'.__('View Notes').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/page_down.png" style="margin-right:4px;"/>')
                         ->setURL('#')->onClick('return false;')->addClass('invoiceNotesView');
 

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -374,8 +374,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
                         ->addWebLink('<img title="'.__('Preview Invoice').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/print.png" style="margin-right:4px;" />')
                         ->setURL($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_print_print.php&type=invoice')
                         ->addParam('gibbonFinanceInvoiceID', $invoice['gibbonFinanceInvoiceID'])
-                        ->addParams($linkParams)
-                        ->addParams('preview', 'true');
+                        ->addParam('preview', 'true')
+                        ->addParams($linkParams);
 
                     $col->if($invoice['status'] != 'Pending')
                         ->addWebLink('<img title="'.__('Print Invoices, Receipts & Reminders').'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/print.png" style="margin-right:4px;" />')

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -45,10 +45,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
     echo __($guid, 'When you create invoices using the billing schedule or pre-defined fee features, the invoice will remain linked to these areas whilst pending. Thus, changes made to the billing schedule and pre-defined fees will be reflected in any pending invoices. Once invoices are issued, this link is removed, and the values are fixed at the levels when the invoice was issued.');
     echo '</p>';
 
-    $gibbonSchoolYearID = '';
-    if (isset($_GET['gibbonSchoolYearID'])) {
-        $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
-    }
+    $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
+
     if ($gibbonSchoolYearID == '' or $gibbonSchoolYearID == $_SESSION[$guid]['gibbonSchoolYearID']) {
         $gibbonSchoolYearID = $_SESSION[$guid]['gibbonSchoolYearID'];
         $gibbonSchoolYearName = $_SESSION[$guid]['gibbonSchoolYearName'];
@@ -118,7 +116,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
 
         $row = $form->addRow();
             $row->addLabel('gibbonFinanceInvoiceeID', __('Student'));
-            $row->addSelectInvoicee('gibbonFinanceInvoiceeID')->selected($gibbonFinanceInvoiceeID);
+            $row->addSelectInvoicee('gibbonFinanceInvoiceeID', $gibbonSchoolYearID)->selected($gibbonFinanceInvoiceeID);
 
         $row = $form->addRow();
             $row->addLabel('monthOfIssue', __('Month of Issue'));

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -74,7 +75,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
         $linkParams = compact('gibbonSchoolYearID', 'status', 'gibbonFinanceInvoiceeID', 'monthOfIssue', 'gibbonFinanceBillingScheduleID', 'gibbonFinanceFeeCategoryID'); 
         
         $form = Form::create('invoice', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_addProcess.php?'.http_build_query($linkParams));
-                        
+        $form->setFactory(DatabaseFormFactory::create($pdo));
+
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
         $data= array('gibbonSchoolYearID' => $gibbonSchoolYearID);
@@ -90,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
         $row = $form->addRow();
             $row->addLabel('gibbonFinanceInvoiceeIDs', __('Invoicees'))->append(sprintf(__('Visit %1$sManage Invoicees%2$s to automatically generate missing students.'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoicees_manage.php'>", '</a>'));
-            $row->addSelect('gibbonFinanceInvoiceeIDs')->isRequired()->selectMultiple();
+            $row->addSelectFinanceInvoicee('gibbonFinanceInvoiceeIDs', $gibbonSchoolYearID)->isRequired()->selectMultiple();
 
         $scheduling = array('Scheduled' => __('Scheduled'), 'Ad Hoc' => __('Ad Hoc'));
         $row = $form->addRow();
@@ -120,350 +122,71 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
         $form->addRow()->addHeading(__('Fees'));
 
+        // Get fees and categories
+        $sql = "SELECT gibbonFinanceFeeCategory.name as category, gibbonFinanceFee.gibbonFinanceFeeCategoryID, gibbonFinanceFee.gibbonFinanceFeeID, gibbonFinanceFee.name, gibbonFinanceFee.description, gibbonFinanceFee.fee 
+                FROM gibbonFinanceFee 
+                JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) 
+                ORDER BY name";
+        $result = $pdo->executeQuery(array(), $sql);
+
+        $feeData = array();
+        $feesByCategory = $result->rowCount() > 0? $result->fetchAll() : array();
+        $feesByCategory = array_reduce($feesByCategory, function($group, $item) use (&$feeData) {
+            $feeData[$item['gibbonFinanceFeeID']] = $item;
+            $group[$item['category']][$item['gibbonFinanceFeeID']] = $item['name'];
+            return $group;
+        }, array());
+
         // Fee selector
-        $sql = "SELECT gibbonFinanceFeeCategory.name as groupBy, gibbonFinanceFee.gibbonFinanceFeeID as value, gibbonFinanceFee.name FROM gibbonFinanceFee 
-                JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) ORDER BY name";
-        $feeSelector = $form->getFactory()->createSelect('addNewFee')->addClass('addBlock')->addData('event', 'change')
+        $feeSelector = $form->getFactory()->createSelect('addNewFee')
+            ->addClass('addBlock')
             ->fromArray(array('' => __('Choose a fee to add it')))
             ->fromArray(array('Ad Hoc Fee' => __('Ad Hoc Fee')))
-            ->fromQuery($pdo, $sql, array(), 'groupBy');
+            ->fromArray($feesByCategory);
 
-        // Reusable block builder
-        $buildFeesBlock = function($feeName = '', $feeValue = '', $description = '', $readonly = false) use ($form) {
-            $block = $form->getFactory()->createTable()->setClass('blank');
-            $row = $block->addRow();
-                $row->addTextField('name')->setClass('mediumWidth floatNone')->placeholder(__('Fee Name'))->setValue($feeName)->readonly($readonly);
+        // Block template
+        $blockTemplate = $form->getFactory()->createTable()->setClass('blank');
+            $row = $blockTemplate->addRow();
+                $row->addTextField('name')->setClass('standardWidth floatLeft noMargin title')->isRequired()->placeholder(__('Fee Name'))
+                    ->append('<input type="hidden" id="gibbonFinanceFeeID" name="gibbonFinanceFeeID" value="">')
+                    ->append('<input type="hidden" id="feeType" name="feeType" value="">');
                 
-            $col = $block->addRow()->addColumn()->setClass('inline');
-                $col->addTextField('fee')->setClass('shortWidth floatNone')->placeholder(__('Value'))->setValue($feeValue)->readonly($readonly);
+            $col = $blockTemplate->addRow()->addColumn()->addClass('inline');
+                $sql = "SELECT gibbonFinanceFeeCategoryID as value, name FROM gibbonFinanceFeeCategory WHERE active='Y' AND NOT gibbonFinanceFeeCategoryID=1 ORDER BY name";
+                $col->addSelect('gibbonFinanceFeeCategoryID')
+                    ->fromArray(array('0001' => __('Other')))
+                    ->fromQuery($pdo, $sql)
+                    ->setClass('shortWidth floatLeft noMargin');
+
+                $col->addCurrency('fee')
+                    ->setClass('shortWidth floatLeft')
+                    ->isRequired()
+                    ->placeholder(__('Value').(!empty($_SESSION[$guid]['currency'])? ' ('.$_SESSION[$guid]['currency'].')' : ''));
                 
-            $col = $block->addRow()->addClass('showHide displayNone')->addColumn();
+            $col = $blockTemplate->addRow()->addClass('showHide displayNone fullWidth')->addColumn();
                 $col->addLabel('description', __('Description'));
-                $col->addTextArea('description')->setRows(3)->setClass('floatNone')->setValue($description);
+                $col->addTextArea('description')->setRows(3)->setClass('fullWidth floatNone noMargin');
 
-            return $block;
-        };
-
+        // Custom Blocks for Fees
         $row = $form->addRow();
-            $customBlocks = $row->addCustomBlocks('feesBlock', $buildFeesBlock(), $gibbon->session)
+            $customBlocks = $row->addCustomBlocks('feesBlock', $gibbon->session)
+                ->fromTemplate($blockTemplate)
+                ->settings(array('inputNameStrategy' => 'string', 'addOnEvent' => 'change'))
                 ->placeholder(__('Fees will be listed here...'))
                 ->addToolInput($feeSelector)
-                ->addBlockButton(__('Show/Hide'), 'plus.png', 'showHide');
+                ->addBlockButton('showHide', __('Show/Hide'), 'plus.png');
 
-        $customBlocks->addBlock( 'foo', $buildFeesBlock('Test', '123', 'This is a test.', true) );
+        // Add predefined block data (for templating new blocks)
+        $customBlocks->addPredefinedBlock('Ad Hoc Fee', array('feeType' => 'Ad Hoc', 'gibbonFinanceFeeID' => 0));
+        foreach ($feeData as $gibbonFinanceFeeID => $data) {
+            $customBlocks->addPredefinedBlock($gibbonFinanceFeeID, $data + array('feeType' => 'Standard', 'readonly' => ['name', 'fee', 'gibbonFinanceFeeCategoryID']) );
+        }
 
         $row = $form->addRow();
             $row->addFooter();
             $row->addSubmit();
 
         echo $form->getOutput();
-        ?>
-
-        <script>
-            function showHide(block) {
-                console.log("Show/Hide " + block.blockNumber);
-                block.find('.showHide').toggle('slideDown');
-            }
-        </script>
-
-		<form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/invoices_manage_addProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID" ?>">
-			<table class='smallIntBorder fullWidth' cellspacing='0'>
-				<tr class='break'>
-					<td colspan=2>
-						<h3><?php echo __($guid, 'Basic Information') ?></h3>
-					</td>
-				</tr>
-				<tr>
-					<td style='width: 275px'>
-						<b><?php echo __($guid, 'School Year') ?> *</b><br/>
-						<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-					</td>
-					<td class="right">
-						<?php
-                        $yearName = '';
-						try {
-							$dataYear = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-							$sqlYear = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
-							$resultYear = $connection2->prepare($sqlYear);
-							$resultYear->execute($dataYear);
-						} catch (PDOException $e) {
-							echo "<div class='error'>".$e->getMessage().'</div>';
-						}
-						if ($resultYear->rowCount() == 1) {
-							$rowYear = $resultYear->fetch();
-							$yearName = $rowYear['name'];
-						}
-						?>
-						<input readonly name="yearName" id="yearName" maxlength=20 value="<?php echo $yearName ?>" type="text" class="standardWidth">
-						<script type="text/javascript">
-							var yearName=new LiveValidation('yearName');
-							yearname2.add(Validate.Presence);
-						</script>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<b><?php echo __($guid, 'Invoicees') ?> *</b><br/>
-						<span class="emphasis small"><?php echo __($guid, 'Use Control, Command and/or Shift to select multiple.') ?><br/><?php echo sprintf(__($guid, 'Visit %1$sManage Invoicees%2$s to automatically generate missing students.'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoicees_manage.php'>", '</a>') ?></span>
-					</td>
-					<td class="right">
-						<select name="gibbonFinanceInvoiceeIDs[]" id="gibbonFinanceInvoiceeIDs[]" multiple class='standardWidth' style="height: 150px">
-							<optgroup label='--<?php echo __($guid, 'All Enrolled Students by Roll Group') ?>--'>
-							<?php
-                            $students = array();
-							$count = 0;
-							try {
-								$dataSelect = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-								$sqlSelect = "SELECT gibbonFinanceInvoiceeID, preferredName, surname, gibbonRollGroup.name AS name, dayType FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup, gibbonFinanceInvoicee WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID AND status='FULL' AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name, surname, preferredName";
-								$resultSelect = $connection2->prepare($sqlSelect);
-								$resultSelect->execute($dataSelect);
-							} catch (PDOException $e) {
-							}
-							while ($rowSelect = $resultSelect->fetch()) {
-								echo "<option value='".$rowSelect['gibbonFinanceInvoiceeID']."'>".htmlPrep($rowSelect['name']).' - '.formatName('', htmlPrep($rowSelect['preferredName']), htmlPrep($rowSelect['surname']), 'Student', true).'</option>';
-								$students[$count]['gibbonFinanceInvoiceeID'] = $rowSelect['gibbonFinanceInvoiceeID'];
-								$students[$count]['student'] = formatName('', htmlPrep($rowSelect['preferredName']), htmlPrep($rowSelect['surname']), 'Student', true);
-								$students[$count]['rollGroup'] = htmlPrep($rowSelect['name']);
-								$students[$count]['dayType'] = htmlPrep($rowSelect['dayType']);
-								++$count;
-							}
-							?>
-							</optgroup>
-							<?php
-                            $dayTypeOptions = getSettingByScope($connection2, 'User Admin', 'dayTypeOptions');
-							if ($dayTypeOptions != '') {
-								$dayTypes = explode(',', $dayTypeOptions);
-								foreach ($dayTypes as $dayType) {
-									echo "<optgroup label='--$dayType ".__($guid, 'Students by Roll Groups')."--'>";
-									foreach ($students as $student) {
-										if ($student['dayType'] == $dayType) {
-											echo "<option value='".$student['gibbonFinanceInvoiceeID']."'>".$student['rollGroup'].' - '.$student['student'].'</option>';
-										}
-									}
-									echo '</optgroup>';
-								}
-							}
-							?>
-							<optgroup label='--<?php echo __($guid, 'All Enrolled Students by Alphabet') ?>--'>
-							<?php
-                            $students = array();
-							$count = 0;
-							try {
-								$dataSelect = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-								$sqlSelect = "SELECT gibbonFinanceInvoiceeID, preferredName, surname, gibbonRollGroup.name AS name, dayType FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup, gibbonFinanceInvoicee WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID AND status='FULL' AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY surname, preferredName";
-								$resultSelect = $connection2->prepare($sqlSelect);
-								$resultSelect->execute($dataSelect);
-							} catch (PDOException $e) {
-							}
-							while ($rowSelect = $resultSelect->fetch()) {
-								echo "<option value='".$rowSelect['gibbonFinanceInvoiceeID']."'>".formatName('', htmlPrep($rowSelect['preferredName']), htmlPrep($rowSelect['surname']), 'Student', true).' - '.htmlPrep($rowSelect['name']).'</option>';
-							}
-							?>
-							</optgroup>
-
-						</select>
-					</td>
-				</tr>
-				<?php //BILLING TYPE CHOOSER ?>
-				<tr>
-					<td>
-						<b><?php echo __($guid, 'Scheduling') ?> *</b><br/>
-						<span class="emphasis small"><?php echo __($guid, 'When using scheduled, invoice due date is linked to and determined by the schedule.') ?></span>
-					</td>
-					<td class="right">
-						<input checked type="radio" name="scheduling" class="scheduling" value="Scheduled" /> Scheduled
-						<input type="radio" name="scheduling" class="scheduling" value="Ad Hoc" /> Ad Hoc
-					</td>
-				</tr>
-				<script type="text/javascript">
-					$(document).ready(function(){
-						$("#adHocRow").css("display","none");
-						invoiceDueDate.disable() ;
-						$("#schedulingRow").slideDown("fast", $("#schedulingRow").css("display","table-row"));
-
-						$(".scheduling").click(function(){
-							if ($('input[name=scheduling]:checked').val()=="Scheduled" ) {
-								$("#adHocRow").css("display","none");
-								invoiceDueDate.disable() ;
-								$("#schedulingRow").slideDown("fast", $("#schedulingRow").css("display","table-row"));
-								gibbonFinanceBillingScheduleID.enable() ;
-							} else {
-								$("#schedulingRow").css("display","none");
-								gibbonFinanceBillingScheduleID.disable() ;
-								$("#adHocRow").slideDown("fast", $("#adHocRow").css("display","table-row"));
-								invoiceDueDate.enable() ;
-							}
-						 });
-					});
-				</script>
-
-				<tr id="schedulingRow">
-					<td>
-						<b><?php echo __($guid, 'Billing Schedule') ?> *</b><br/>
-					</td>
-					<td class="right">
-						<select name="gibbonFinanceBillingScheduleID" id="gibbonFinanceBillingScheduleID" class="standardWidth">
-							<?php
-                            echo "<option value='Please select...'>".__($guid, 'Please select...').'</option>';
-							try {
-								$dataSelect = array();
-								$sqlSelect = "SELECT * FROM gibbonFinanceBillingSchedule WHERE active='Y' ORDER BY name";
-								$resultSelect = $connection2->prepare($sqlSelect);
-								$resultSelect->execute($dataSelect);
-							} catch (PDOException $e) {
-							}
-							while ($rowSelect = $resultSelect->fetch()) {
-								echo "<option value='".$rowSelect['gibbonFinanceBillingScheduleID']."'>".$rowSelect['name'].'</option>';
-							}
-							?>
-						</select>
-						<script type="text/javascript">
-							var gibbonFinanceBillingScheduleID=new LiveValidation('gibbonFinanceBillingScheduleID');
-							gibbonFinanceBillingScheduleID.add(Validate.Exclusion, { within: ['Please select...'], failureMessage: "<?php echo __($guid, 'Select something!') ?>"});
-						</script>
-					</td>
-				</tr>
-				<tr id="adHocRow">
-					<td>
-						<b><?php echo __($guid, 'Invoice Due Date') ?> *</b><br/>
-						<span class="emphasis small"><?php echo __($guid, 'For fees added to existing invoice, specified date will override existing due date.') ?></span>
-					</td>
-					<td class="right">
-						<input name="invoiceDueDate" id="invoiceDueDate" maxlength=10 value="" type="text" class="standardWidth">
-							<script type="text/javascript">
-							var invoiceDueDate=new LiveValidation('invoiceDueDate');
-							invoiceDueDate.add( Validate.Format, {pattern: <?php if ($_SESSION[$guid]['i18n']['dateFormatRegEx'] == '') {
-								echo "/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/i";
-							} else {
-								echo $_SESSION[$guid]['i18n']['dateFormatRegEx'];
-							}
-									?>, failureMessage: "Use <?php if ($_SESSION[$guid]['i18n']['dateFormat'] == '') {
-								echo 'dd/mm/yyyy';
-							} else {
-								echo $_SESSION[$guid]['i18n']['dateFormat'];
-							}
-							?>." } );
-							invoiceDueDate.add(Validate.Presence);
-						</script>
-						 <script type="text/javascript">
-							$(function() {
-								$( "#invoiceDueDate" ).datepicker();
-							});
-						</script>
-					</td>
-				</tr>
-				<tr>
-					<td colspan=2>
-						<b><?php echo __($guid, 'Notes') ?></b><br/>
-                        <span class="emphasis small"><?php echo __($guid, 'Notes will be displayed on the final invoice and receipt.') ?></span>
-						<textarea name='notes' id='notes' rows=5 style='width: 300px'></textarea>
-					</td>
-				</tr>
-
-				<tr class='break'>
-					<td colspan=2>
-						<h3><?php echo __($guid, 'Fees') ?></h3>
-					</td>
-				</tr>
-				<?php
-                $type = 'fee';
-        		?>
-				<style>
-					#<?php echo $type ?> { list-style-type: none; margin: 0; padding: 0; width: 100%; }
-					#<?php echo $type ?> div.ui-state-default { margin: 0 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-					div.ui-state-default_dud { margin: 5px 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-					html>body #<?php echo $type ?> li { min-height: 58px; line-height: 1.2em; }
-					.<?php echo $type ?>-ui-state-highlight { margin-bottom: 5px; min-height: 58px; line-height: 1.2em; width: 100%; }
-					.<?php echo $type ?>-ui-state-highlight {border: 1px solid #fcd3a1; background: #fbf8ee url(images/ui-bg_glass_55_fbf8ee_1x400.png) 50% 50% repeat-x; color: #444444; }
-				</style>
-				<tr>
-					<td colspan=2>
-						<div class="fee" id="fee" style='width: 100%; padding: 5px 0px 0px 0px; min-height: 66px'>
-							<div id="feeOuter0">
-								<div style='color: #ddd; font-size: 230%; margin: 15px 0 0 6px'><?php echo __($guid, 'Fees will be listed here...') ?></div>
-							</div>
-						</div>
-						<div style='width: 100%; padding: 0px 0px 0px 0px'>
-							<div class="ui-state-default_dud" style='padding: 0px; height: 40px'>
-								<table class='blank' cellspacing='0' style='width: 100%'>
-									<tr>
-										<td style='width: 50%'>
-											<script type="text/javascript">
-												var feeCount=1 ;
-											</script>
-											<select id='newFee' onChange='feeDisplayElements(this.value);' style='float: none; margin-left: 3px; margin-top: 0px; margin-bottom: 3px; width: 350px'>
-												<option class='all' value='0'><?php echo __($guid, 'Choose a fee to add it') ?></option>
-												<?php
-                                                echo "<option value='Ad Hoc'>Ad Hoc Fee</option>";
-												$switchContents = 'case "Ad Hoc": ';
-												$switchContents .= "$(\"#fee\").append('<div id=\'feeOuter' + feeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
-												$switchContents .= '$("#feeOuter" + feeCount).load("'.$_SESSION[$guid]['absoluteURL'].'/modules/Finance/invoices_manage_add_blockFeeAjax.php","mode=add&id=" + feeCount + "&feeType='.urlencode('Ad Hoc').'&gibbonFinanceFeeID=&name='.urlencode('Ad Hoc Fee').'&description=&gibbonFinanceFeeCategoryID=1&fee=") ;';
-												$switchContents .= 'feeCount++ ;';
-												$switchContents .= "$('#newFee').val('0');";
-												$switchContents .= 'break;';
-												$currentCategory = '';
-												$lastCategory = '';
-												for ($i = 0; $i < 2; ++$i) {
-													try {
-														$dataSelect = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-														if ($i == 0) {
-															$sqlSelect = "SELECT gibbonFinanceFee.*, gibbonFinanceFeeCategory.name AS category FROM gibbonFinanceFee LEFT JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceFee.active='Y' AND gibbonSchoolYearID=:gibbonSchoolYearID AND NOT gibbonFinanceFee.gibbonFinanceFeeCategoryID=1 ORDER BY gibbonFinanceFee.gibbonFinanceFeeCategoryID, gibbonFinanceFee.name";
-														} else {
-															$sqlSelect = "SELECT gibbonFinanceFee.*, gibbonFinanceFeeCategory.name AS category FROM gibbonFinanceFee LEFT JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceFee.active='Y' AND gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonFinanceFee.gibbonFinanceFeeCategoryID=1 ORDER BY gibbonFinanceFee.gibbonFinanceFeeCategoryID, gibbonFinanceFee.name";
-														}
-														$resultSelect = $connection2->prepare($sqlSelect);
-														$resultSelect->execute($dataSelect);
-													} catch (PDOException $e) {
-														echo "<div class='error'>".$e->getMessage().'</div>';
-													}
-													while ($rowSelect = $resultSelect->fetch()) {
-														$currentCategory = $rowSelect['category'];
-														if (($currentCategory != $lastCategory) and $currentCategory != '') {
-															echo "<optgroup label='--".$currentCategory."--'>";
-															$categories[$categoryCount] = $currentCategory;
-															++$categoryCount;
-														}
-														echo "<option value='".$rowSelect['gibbonFinanceFeeID']."'>".$rowSelect['name'].'</option>';
-														$switchContents .= 'case "'.$rowSelect['gibbonFinanceFeeID'].'": ';
-														$switchContents .= "$(\"#fee\").append('<div id=\'feeOuter' + feeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
-														$switchContents .= '$("#feeOuter" + feeCount).load("'.$_SESSION[$guid]['absoluteURL'].'/modules/Finance/invoices_manage_add_blockFeeAjax.php","mode=add&id=" + feeCount + "&feeType=Standard&gibbonFinanceFeeID='.urlencode($rowSelect['gibbonFinanceFeeID']).'&name='.urlencode($rowSelect['name']).'&description='.urlencode($rowSelect['description']).'&gibbonFinanceFeeCategoryID='.urlencode($rowSelect['gibbonFinanceFeeCategoryID']).'&fee='.urlencode($rowSelect['fee']).'&category='.urlencode($rowSelect['category']).'") ;';
-														$switchContents .= 'feeCount++ ;';
-														$switchContents .= "$('#newFee').val('0');";
-														$switchContents .= 'break;';
-														$lastCategory = $rowSelect['category'];
-													}
-												}
-												?>
-											</select>
-											<script type='text/javascript'>
-												function feeDisplayElements(number) {
-													$("#<?php echo $type ?>Outer0").css("display", "none") ;
-													switch(number) {
-														<?php echo $switchContents ?>
-													}
-												}
-											</script>
-										</td>
-									</tr>
-								</table>
-							</div>
-						</div>
-					</td>
-				</tr>
-
-				<tr>
-					<td>
-						<span class="emphasis small">* <?php echo __($guid, 'denotes a required field'); ?></span>
-					</td>
-					<td class="right">
-						<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
-						<input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
-					</td>
-				</tr>
-			</table>
-		</form>
-		<?php
-
     }
 }
-?>
+

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
-use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Finance\Forms\FinanceFormFactory;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -29,9 +29,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
     echo __($guid, 'You do not have access to this action.');
     echo '</div>';
 } else {
+    //Check if school year specified
+    $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
+    $status = isset($_GET['status'])? $_GET['status'] : '';
+    $gibbonFinanceInvoiceeID = isset($_GET['gibbonFinanceInvoiceeID'])? $_GET['gibbonFinanceInvoiceeID'] : '';
+    $monthOfIssue = isset($_GET['monthOfIssue'])? $_GET['monthOfIssue'] : '';
+    $gibbonFinanceBillingScheduleID = isset($_GET['gibbonFinanceBillingScheduleID'])? $_GET['gibbonFinanceBillingScheduleID'] : '';
+    $gibbonFinanceFeeCategoryID = isset($_GET['gibbonFinanceFeeCategoryID'])? $_GET['gibbonFinanceFeeCategoryID'] : '';
+
+    $linkParams = compact('gibbonSchoolYearID', 'status', 'gibbonFinanceInvoiceeID', 'monthOfIssue', 'gibbonFinanceBillingScheduleID', 'gibbonFinanceFeeCategoryID'); 
+
     //Proceed!
     echo "<div class='trail'>";
-    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Finance/invoices_manage.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID']."'>".__($guid, 'Manage Invoices')."</a> > </div><div class='trailEnd'>".__($guid, 'Add Fees & Invoices').'</div>';
+    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Finance/invoices_manage.php&'.http_build_query($linkParams)."'>".__($guid, 'Manage Invoices')."</a> > </div><div class='trailEnd'>".__($guid, 'Add Fees & Invoices').'</div>';
     echo '</div>';
 
     $error3 = __($guid, 'Some aspects of your update failed, effecting the following areas:').'<ul>';
@@ -54,35 +64,26 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
     echo __($guid, 'Here you can add fees to one or more students. These fees will be added to an existing invoice or used to form a new invoice, depending on the specified billing schedule and other details.');
     echo '</p>';
 
-    //Check if school year specified
-    $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
-    $status = isset($_GET['status'])? $_GET['status'] : '';
-    $gibbonFinanceInvoiceeID = isset($_GET['gibbonFinanceInvoiceeID'])? $_GET['gibbonFinanceInvoiceeID'] : '';
-    $monthOfIssue = isset($_GET['monthOfIssue'])? $_GET['monthOfIssue'] : '';
-    $gibbonFinanceBillingScheduleID = isset($_GET['gibbonFinanceBillingScheduleID'])? $_GET['gibbonFinanceBillingScheduleID'] : '';
-    $gibbonFinanceFeeCategoryID = isset($_GET['gibbonFinanceFeeCategoryID'])? $_GET['gibbonFinanceFeeCategoryID'] : '';
     if ($gibbonSchoolYearID == '') {
         echo "<div class='error'>";
         echo __($guid, 'You have not specified one or more required parameters.');
         echo '</div>';
     } else {
-        if ($status != '' or $gibbonFinanceInvoiceeID != '' or $monthOfIssue != '' or $gibbonFinanceBillingScheduleID != '') {
-            echo "<div class='linkTop'>";
-            echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Back to Search Results').'</a>';
-            echo '</div>';
-        }
-
-        $linkParams = compact('gibbonSchoolYearID', 'status', 'gibbonFinanceInvoiceeID', 'monthOfIssue', 'gibbonFinanceBillingScheduleID', 'gibbonFinanceFeeCategoryID'); 
-        
-        $form = Form::create('invoice', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_addProcess.php?'.http_build_query($linkParams));
-        $form->setFactory(DatabaseFormFactory::create($pdo));
-
-        $form->addHiddenValue('address', $_SESSION[$guid]['address']);
-
         $data= array('gibbonSchoolYearID' => $gibbonSchoolYearID);
         $sql = "SELECT name AS schoolYear FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID";
         $result = $pdo->executeQuery($data, $sql);
         $schoolYearName = $result->rowCount() > 0? $result->fetchColumn(0) : '';
+
+        if ($status != '' or $gibbonFinanceInvoiceeID != '' or $monthOfIssue != '' or $gibbonFinanceBillingScheduleID != '') {
+            echo "<div class='linkTop'>";
+            echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php&".http_build_query($linkParams)."'>".__($guid, 'Back to Search Results').'</a>';
+            echo '</div>';
+        }
+        
+        $form = Form::create('invoice', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_addProcess.php?'.http_build_query($linkParams));
+        $form->setFactory(FinanceFormFactory::create($pdo));
+
+        $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
         $form->addRow()->addHeading(__('Basic Information'));
 
@@ -92,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
         $row = $form->addRow();
             $row->addLabel('gibbonFinanceInvoiceeIDs', __('Invoicees'))->append(sprintf(__('Visit %1$sManage Invoicees%2$s to automatically generate missing students.'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoicees_manage.php'>", '</a>'));
-            $row->addSelectFinanceInvoicee('gibbonFinanceInvoiceeIDs', $gibbonSchoolYearID)->isRequired()->selectMultiple();
+            $row->addSelectInvoicee('gibbonFinanceInvoiceeIDs', $gibbonSchoolYearID)->isRequired()->selectMultiple();
 
         $scheduling = array('Scheduled' => __('Scheduled'), 'Ad Hoc' => __('Ad Hoc'));
         $row = $form->addRow();
@@ -102,15 +103,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
         $form->toggleVisibilityByClass('schedulingScheduled')->onRadio('scheduling')->when('Scheduled');
         $form->toggleVisibilityByClass('schedulingAdHoc')->onRadio('scheduling')->when('Ad Hoc');
 
-        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-        $sql = "SELECT gibbonFinanceBillingScheduleID as value, name FROM gibbonFinanceBillingSchedule WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
         $row = $form->addRow()->addClass('schedulingScheduled');
             $row->addLabel('gibbonFinanceBillingScheduleID', __('Billing Schedule'));
-            $row->addSelect('gibbonFinanceBillingScheduleID')
-                ->fromQuery($pdo, $sql, $data)
-                ->isRequired()
-                ->placeholder()
-                ->selected($gibbonFinanceBillingScheduleID);
+            $row->addSelectBillingSchedule('gibbonFinanceBillingScheduleID', $gibbonSchoolYearID)->isRequired()->selected($gibbonFinanceBillingScheduleID);
 
         $row = $form->addRow()->addClass('schedulingAdHoc');
             $row->addLabel('invoiceDueDate', __('Invoice Due Date'))->description(__('For fees added to existing invoice, specified date will override existing due date.'));
@@ -122,27 +117,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
         $form->addRow()->addHeading(__('Fees'));
 
-        // Get fees and categories
-        $sql = "SELECT gibbonFinanceFeeCategory.name as category, gibbonFinanceFee.gibbonFinanceFeeCategoryID, gibbonFinanceFee.gibbonFinanceFeeID, gibbonFinanceFee.name, gibbonFinanceFee.description, gibbonFinanceFee.fee 
-                FROM gibbonFinanceFee 
-                JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) 
-                ORDER BY name";
-        $result = $pdo->executeQuery(array(), $sql);
-
-        $feeData = array();
-        $feesByCategory = $result->rowCount() > 0? $result->fetchAll() : array();
-        $feesByCategory = array_reduce($feesByCategory, function($group, $item) use (&$feeData) {
-            $feeData[$item['gibbonFinanceFeeID']] = $item;
-            $group[$item['category']][$item['gibbonFinanceFeeID']] = $item['name'];
-            return $group;
-        }, array());
-
         // Fee selector
-        $feeSelector = $form->getFactory()->createSelect('addNewFee')
-            ->addClass('addBlock')
-            ->fromArray(array('' => __('Choose a fee to add it')))
-            ->fromArray(array('Ad Hoc Fee' => __('Ad Hoc Fee')))
-            ->fromArray($feesByCategory);
+        $feeSelector = $form->getFactory()->createSelectFee('addNewFee', $gibbonSchoolYearID)->addClass('addBlock');
 
         // Block template
         $blockTemplate = $form->getFactory()->createTable()->setClass('blank');
@@ -152,10 +128,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
                     ->append('<input type="hidden" id="feeType" name="feeType" value="">');
                 
             $col = $blockTemplate->addRow()->addColumn()->addClass('inline');
-                $sql = "SELECT gibbonFinanceFeeCategoryID as value, name FROM gibbonFinanceFeeCategory WHERE active='Y' AND NOT gibbonFinanceFeeCategoryID=1 ORDER BY name";
-                $col->addSelect('gibbonFinanceFeeCategoryID')
-                    ->fromArray(array('0001' => __('Other')))
-                    ->fromQuery($pdo, $sql)
+                $col->addSelectFeeCategory('gibbonFinanceFeeCategoryID')
                     ->setClass('shortWidth floatLeft noMargin');
 
                 $col->addCurrency('fee')
@@ -177,6 +150,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
                 ->addBlockButton('showHide', __('Show/Hide'), 'plus.png');
 
         // Add predefined block data (for templating new blocks, triggered with the feeSelector)
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
+        $sql = "SELECT gibbonFinanceFeeID as groupBy, gibbonFinanceFeeID, name, description, fee, gibbonFinanceFeeCategoryID FROM gibbonFinanceFee ORDER BY name";
+        $result = $pdo->executeQuery($data, $sql);
+        $feeData = $result->rowCount() > 0? $result->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
+
         $customBlocks->addPredefinedBlock('Ad Hoc Fee', array('feeType' => 'Ad Hoc', 'gibbonFinanceFeeID' => 0));
         foreach ($feeData as $gibbonFinanceFeeID => $data) {
             $customBlocks->addPredefinedBlock($gibbonFinanceFeeID, $data + array('feeType' => 'Standard', 'readonly' => ['name', 'fee', 'description', 'gibbonFinanceFeeCategoryID']) );

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -117,6 +117,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
         $form->addRow()->addHeading(__('Fees'));
 
+        // CUSTOM BLOCKS
+        
         // Fee selector
         $feeSelector = $form->getFactory()->createSelectFee('addNewFee', $gibbonSchoolYearID)->addClass('addBlock');
 

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -138,7 +138,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
                     ->isRequired()
                     ->placeholder(__('Value').(!empty($_SESSION[$guid]['currency'])? ' ('.$_SESSION[$guid]['currency'].')' : ''));
                 
-            $col = $blockTemplate->addRow()->addClass('showHide displayNone fullWidth')->addColumn();
+            $col = $blockTemplate->addRow()->addClass('showHide fullWidth')->addColumn();
                 $col->addLabel('description', __('Description'));
                 $col->addTextArea('description')->setRows('auto')->setClass('fullWidth floatNone noMargin');
 

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -165,21 +165,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
                 
             $col = $blockTemplate->addRow()->addClass('showHide displayNone fullWidth')->addColumn();
                 $col->addLabel('description', __('Description'));
-                $col->addTextArea('description')->setRows(3)->setClass('fullWidth floatNone noMargin');
+                $col->addTextArea('description')->setRows('auto')->setClass('fullWidth floatNone noMargin');
 
         // Custom Blocks for Fees
         $row = $form->addRow();
             $customBlocks = $row->addCustomBlocks('feesBlock', $gibbon->session)
                 ->fromTemplate($blockTemplate)
-                ->settings(array('inputNameStrategy' => 'string', 'addOnEvent' => 'change'))
+                ->settings(array('inputNameStrategy' => 'string', 'addOnEvent' => 'change', 'sortable' => true))
                 ->placeholder(__('Fees will be listed here...'))
                 ->addToolInput($feeSelector)
                 ->addBlockButton('showHide', __('Show/Hide'), 'plus.png');
 
-        // Add predefined block data (for templating new blocks)
+        // Add predefined block data (for templating new blocks, triggered with the feeSelector)
         $customBlocks->addPredefinedBlock('Ad Hoc Fee', array('feeType' => 'Ad Hoc', 'gibbonFinanceFeeID' => 0));
         foreach ($feeData as $gibbonFinanceFeeID => $data) {
-            $customBlocks->addPredefinedBlock($gibbonFinanceFeeID, $data + array('feeType' => 'Standard', 'readonly' => ['name', 'fee', 'gibbonFinanceFeeCategoryID']) );
+            $customBlocks->addPredefinedBlock($gibbonFinanceFeeID, $data + array('feeType' => 'Standard', 'readonly' => ['name', 'fee', 'description', 'gibbonFinanceFeeCategoryID']) );
         }
 
         $row = $form->addRow();

--- a/modules/Finance/invoices_manage_addProcess.php
+++ b/modules/Finance/invoices_manage_addProcess.php
@@ -51,7 +51,7 @@ if ($gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
             $invoiceDueDate = $_POST['invoiceDueDate'];
         }
         $notes = $_POST['notes'];
-        $order = $_POST['order'];
+        $order = isset($_POST['order'])? $_POST['order'] : array();
 
         if (count($gibbonFinanceInvoiceeIDs) == 0 or $scheduling == '' or ($scheduling == 'Scheduled' and $gibbonFinanceBillingScheduleID == '') or ($scheduling == 'Ad Hoc' and $invoiceDueDate == '') or count($order) == 0) {
             $URL .= '&return=error1';

--- a/modules/Finance/invoices_manage_edit.php
+++ b/modules/Finance/invoices_manage_edit.php
@@ -17,7 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-@session_start();
+use Gibbon\Forms\Form;
+use Gibbon\Finance\Forms\FinanceFormFactory;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -29,17 +30,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
     echo '</div>';
 } else {
     //Check if school year specified
-    $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
-    $gibbonFinanceInvoiceID = $_GET['gibbonFinanceInvoiceID'];
-    $status = $_GET['status'];
-    $gibbonFinanceInvoiceeID = $_GET['gibbonFinanceInvoiceeID'];
-    $monthOfIssue = $_GET['monthOfIssue'];
-    $gibbonFinanceBillingScheduleID = $_GET['gibbonFinanceBillingScheduleID'];
-    $gibbonFinanceFeeCategoryID = $_GET['gibbonFinanceFeeCategoryID'];
+    $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
+    $gibbonFinanceInvoiceID = isset($_GET['gibbonFinanceInvoiceID'])? $_GET['gibbonFinanceInvoiceID'] : '';
+    $status = isset($_GET['status'])? $_GET['status'] : '';
+    $gibbonFinanceInvoiceeID = isset($_GET['gibbonFinanceInvoiceeID'])? $_GET['gibbonFinanceInvoiceeID'] : '';
+    $monthOfIssue = isset($_GET['monthOfIssue'])? $_GET['monthOfIssue'] : '';
+    $gibbonFinanceBillingScheduleID = isset($_GET['gibbonFinanceBillingScheduleID'])? $_GET['gibbonFinanceBillingScheduleID'] : '';
+    $gibbonFinanceFeeCategoryID = isset($_GET['gibbonFinanceFeeCategoryID'])? $_GET['gibbonFinanceFeeCategoryID'] : '';
+
+    $linkParams = compact('gibbonSchoolYearID', 'status', 'gibbonFinanceInvoiceeID', 'monthOfIssue', 'gibbonFinanceBillingScheduleID', 'gibbonFinanceFeeCategoryID'); 
 
     //Proceed!
     echo "<div class='trail'>";
-    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Finance/invoices_manage.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID']."&gibbonFinanceInvoiceID=$gibbonFinanceInvoiceID&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Manage Invoices')."</a> > </div><div class='trailEnd'>".__($guid, 'Edit Invoice').'</div>';
+    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Finance/invoices_manage.php&'.http_build_query($linkParams)."'>".__($guid, 'Manage Invoices')."</a> > </div><div class='trailEnd'>".__($guid, 'Edit Invoice').'</div>';
     echo '</div>';
 
     if (isset($_GET['return'])) {
@@ -53,7 +56,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
     } else {
         try {
             $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonFinanceInvoiceID' => $gibbonFinanceInvoiceID);
-            $sql = 'SELECT gibbonFinanceInvoice.*, companyName, companyContact, companyEmail, companyCCFamily FROM gibbonFinanceInvoice LEFT JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID';
+            $sql = "SELECT gibbonFinanceInvoice.*, companyName, companyContact, companyEmail, companyCCFamily, gibbonSchoolYear.name as schoolYear, gibbonPerson.surname, gibbonPerson.preferredName, gibbonFinanceBillingSchedule.name as billingScheduleName
+                    FROM gibbonFinanceInvoice 
+                    JOIN gibbonSchoolYear ON (gibbonSchoolYear.gibbonSchoolYearID=gibbonFinanceInvoice.gibbonSchoolYearID)
+                    LEFT JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) 
+                    LEFT JOIN gibbonFinanceBillingSchedule ON (gibbonFinanceBillingSchedule.gibbonFinanceBillingScheduleID=gibbonFinanceInvoice.gibbonFinanceBillingScheduleID)
+                    LEFT JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonFinanceInvoicee.gibbonPersonID)
+                    WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID 
+                    AND gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
@@ -66,860 +76,263 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
             echo '</div>';
         } else {
             //Let's go!
-            $row = $result->fetch();
+            $values = $result->fetch();
 
             if ($status != '' or $gibbonFinanceInvoiceeID != '' or $monthOfIssue != '' or $gibbonFinanceBillingScheduleID != '') {
                 echo "<div class='linkTop'>";
-                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Back to Search Results').'</a>';
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php&".http_build_query($linkParams)."'>".__($guid, 'Back to Search Results').'</a>';
                 echo '</div>';
             }
-            ?>
 
-			<form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/invoices_manage_editProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID" ?>">
-				<table class='smallIntBorder fullWidth' cellspacing='0'>
-					<tr class='break'>
-						<td colspan=2>
-							<h3><?php echo __($guid, 'Basic Information') ?></h3>
-						</td>
-					</tr>
-					<tr>
-						<td style='width: 275px'>
-							<b><?php echo __($guid, 'School Year') ?> *</b><br/>
-							<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-						</td>
-						<td class="right">
-							<?php
-                            $yearName = '';
-							try {
-								$dataYear = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-								$sqlYear = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
-								$resultYear = $connection2->prepare($sqlYear);
-								$resultYear->execute($dataYear);
-							} catch (PDOException $e) {
-								echo "<div class='error'>".$e->getMessage().'</div>';
-							}
-							if ($resultYear->rowCount() == 1) {
-								$rowYear = $resultYear->fetch();
-								$yearName = $rowYear['name'];
-							}
-							?>
-							<input readonly name="yearName" id="yearName" value="<?php echo $yearName ?>" type="text" class="standardWidth">
-					</tr>
-					<tr>
-						<td>
-							<b><?php echo __($guid, 'Invoicee') ?> *</b><br/>
-							<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-						</td>
-						<td class="right">
-							<?php
-                            $personName = '';
-							try {
-								$dataInvoicee = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-								$sqlInvoicee = 'SELECT surname, preferredName FROM gibbonPerson JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID';
-								$resultInvoicee = $connection2->prepare($sqlInvoicee);
-								$resultInvoicee->execute($dataInvoicee);
-							} catch (PDOException $e) {
-								echo "<div class='error'>".$e->getMessage().'</div>';
-							}
-							if ($resultInvoicee->rowCount() == 1) {
-								$rowInvoicee = $resultInvoicee->fetch();
-								$personName = formatName('', htmlPrep($rowInvoicee['preferredName']), htmlPrep($rowInvoicee['surname']), 'Student', true);
-							}
-							?>
-							<input readonly name="personName" id="personName" value="<?php echo $personName ?>" type="text" class="standardWidth">
-						</td>
-					</tr>
-					<?php //BILLING TYPE CHOOSER ?>
-					<tr>
-						<td>
-							<b><?php echo __($guid, 'Scheduling') ?> *</b><br/>
-							<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-						</td>
-						<td class="right">
-							<input readonly name="billingScheduleType" id="billingScheduleType" value="<?php echo $row['billingScheduleType'] ?>" type="text" class="standardWidth">
-						</td>
-					</tr>
-					<?php
-                    if ($row['billingScheduleType'] == 'Scheduled') {
-                        ?>
-						<tr>
-							<td>
-								<b><?php echo __($guid, 'Billing Schedule') ?> *</b><br/>
-								<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-							</td>
-							<td class="right">
-								<?php
-                                $schedule = '';
-                        try {
-                            $dataSchedule = array('gibbonFinanceBillingScheduleID' => $row['gibbonFinanceBillingScheduleID']);
-                            $sqlSchedule = 'SELECT * FROM gibbonFinanceBillingSchedule WHERE gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID';
-                            $resultSchedule = $connection2->prepare($sqlSchedule);
-                            $resultSchedule->execute($dataSchedule);
-                        } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
-                        }
-                        if ($resultSchedule->rowCount() == 1) {
-                            $rowSchedule = $resultSchedule->fetch();
-                            $schedule = $rowSchedule['name'];
-                        }
-                        ?>
-								<input readonly name="schedule" id="schedule" value="<?php echo $schedule ?>" type="text" class="standardWidth">
-							</td>
-						</tr>
-						<?php
+            $linkParams = compact('gibbonSchoolYearID', 'status', 'gibbonFinanceInvoiceeID', 'monthOfIssue', 'gibbonFinanceBillingScheduleID', 'gibbonFinanceFeeCategoryID'); 
+        
+            $form = Form::create('invoice', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_editProcess.php?'.http_build_query($linkParams));
+            $form->setFactory(FinanceFormFactory::create($pdo));
 
+            $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+            $form->addHiddenValue('gibbonFinanceInvoiceID', $gibbonFinanceInvoiceID);
+
+            $form->addRow()->addHeading(__('Basic Information'));
+
+            $row = $form->addRow();
+                $row->addLabel('schoolYear', __('School Year'));
+                $row->addTextField('schoolYear')->isRequired()->readonly();
+
+            $row = $form->addRow();
+                $row->addLabel('personName', __('Invoicee'));
+                $row->addTextField('personName')->isRequired()->readonly()->setValue(formatName('', $values['preferredName'], $values['surname'], 'Student', true));
+
+            $row = $form->addRow();
+                $row->addLabel('billingScheduleType', __('Scheduling'));
+                $row->addTextField('billingScheduleType')->isRequired()->readonly();
+
+            if ($values['billingScheduleType'] == 'Scheduled') {
+                $row = $form->addRow();
+                    $row->addLabel('billingScheduleName', __('Billing Schedule'));
+                    $row->addTextField('billingScheduleName')->isRequired()->readonly();
+            } else {
+
+                if ($values['status'] == 'Pending' || $values['status'] == 'Issued') {
+                    $row = $form->addRow();
+                        $row->addLabel('invoiceDueDate', __('Invoice Due Date'));
+                        $row->addDate('invoiceDueDate')->isRequired();
+                } else {
+                    $row = $form->addRow();
+                        $row->addLabel('invoiceDueDateLabel', __('Invoice Due Date'));
+                        $row->addTextField('invoiceDueDateLabel')->isRequired()->readonly()->setValue(dateConvertBack($guid, $values['invoiceDueDate']));
+                }
+            }
+
+            $row = $form->addRow();
+                $row->addLabel('status', __('Status'))->description($values['status'] == 'Pending'
+                    ? __('This value cannot be changed. Use the Issue function to change the status from "Pending" to "Issued".') 
+                    : __('Available options are limited according to current status.'));
+                $row->addSelectInvoiceStatus('status', $values['status'])->isRequired();
+
+            // PAYMENT INFO
+            if ($values['status'] == 'Issued' or $values['status'] == 'Paid - Partial') {
+                $form->toggleVisibilityByClass('paymentInfo')->onSelect('status')->when(array('Paid', 'Paid - Partial', 'Paid - Complete'));
+                
+                $row = $form->addRow()->addClass('paymentInfo');
+                    $row->addLabel('paymentType', __('Payment Type'));
+                    $row->addSelectPaymentMethod('paymentType')->isRequired();       
+
+                $row = $form->addRow()->addClass('paymentInfo');
+                    $row->addLabel('paymentTransactionID', __('Transaction ID'))->description(__('Transaction ID to identify this payment.'));
+                    $row->addTextField('paymentTransactionID')->maxLength(50);
+
+                $row = $form->addRow()->addClass('paymentInfo');
+                    $row->addLabel('paidDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));
+                    $row->addDate('paidDate')->isRequired();
+
+                $remainingFee = getInvoiceTotalFee($pdo, $gibbonFinanceInvoiceID, $values['status']);
+                if ($values['status'] == 'Paid - Partial') {
+                    $alreadyPaid = getAmountPaid($connection2, $guid, 'gibbonFinanceInvoice', $gibbonFinanceInvoiceID);
+                    $remainingFee -= $alreadyPaid;
+                }
+
+                $row = $form->addRow()->addClass('paymentInfo');
+                    $row->addLabel('paidAmount', __('Amount Paid'))->description(__('Amount in current payment.'));
+                    $row->addCurrency('paidAmount')->maxLength(14)->isRequired()->setValue(number_format($remainingFee, 2));
+            }
+
+            $row = $form->addRow();
+                $row->addLabel('notes', __('Notes'))->description(__('Notes will be displayed on the final invoice and receipt.'));
+                $row->addTextArea('notes')->setRows(5);
+
+            $form->addRow()->addHeading(__('Fees'));
+
+            // GET FEES
+            // Ad Hoc OR Issued (Fixed Fees)
+            $dataFees = array('gibbonFinanceInvoiceID' => $values['gibbonFinanceInvoiceID']);
+            $sqlFees = "SELECT gibbonFinanceInvoiceFee.gibbonFinanceInvoiceFeeID, gibbonFinanceInvoiceFee.feeType, gibbonFinanceFeeCategory.name AS category, gibbonFinanceInvoiceFee.name AS name, gibbonFinanceInvoiceFee.fee, gibbonFinanceInvoiceFee.description AS description, NULL AS gibbonFinanceFeeID, gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID AS gibbonFinanceFeeCategoryID, sequenceNumber FROM gibbonFinanceInvoiceFee JOIN gibbonFinanceFeeCategory ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID";
+
+            // Union with Standard (Flexible Fees)
+            if ($values['status'] == 'Pending') {
+                $sqlFees = "(".$sqlFees." AND feeType='Ad Hoc')";
+                $sqlFees .= " UNION ";
+                $sqlFees .= "(SELECT gibbonFinanceInvoiceFee.gibbonFinanceInvoiceFeeID, gibbonFinanceInvoiceFee.feeType, gibbonFinanceFeeCategory.name AS category, gibbonFinanceFee.name AS name, gibbonFinanceFee.fee AS fee, gibbonFinanceFee.description AS description, gibbonFinanceInvoiceFee.gibbonFinanceFeeID AS gibbonFinanceFeeID, gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID AS gibbonFinanceFeeCategoryID, sequenceNumber FROM gibbonFinanceInvoiceFee JOIN gibbonFinanceFee ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeID=gibbonFinanceFee.gibbonFinanceFeeID) JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID AND feeType='Standard')";
+            }
+
+            $sqlFees .= " ORDER BY sequenceNumber";
+            $resultFees = $pdo->executeQuery($dataFees, $sqlFees);
+
+            // CUSTOM BLOCKS
+            if ($values['status'] == 'Pending') {
+                // Fee selector
+                $feeSelector = $form->getFactory()->createSelectFee('addNewFee', $gibbonSchoolYearID)->addClass('addBlock');
+
+                // Block template
+                $blockTemplate = $form->getFactory()->createTable()->setClass('blank');
+                $row = $blockTemplate->addRow();
+                    $row->addTextField('name')->setClass('standardWidth floatLeft noMargin title')->isRequired()->placeholder(__('Fee Name'))
+                        ->append('<input type="hidden" id="gibbonFinanceFeeID" name="gibbonFinanceFeeID" value="">')
+                        ->append('<input type="hidden" id="feeType" name="feeType" value="">');
+                    
+                $col = $blockTemplate->addRow()->addColumn()->addClass('inline');
+                    $col->addSelectFeeCategory('gibbonFinanceFeeCategoryID')
+                        ->setClass('shortWidth floatLeft noMargin');
+
+                    $col->addCurrency('fee')
+                        ->setClass('shortWidth floatLeft')
+                        ->isRequired()
+                        ->placeholder(__('Value').(!empty($_SESSION[$guid]['currency'])? ' ('.$_SESSION[$guid]['currency'].')' : ''));
+                    
+                $col = $blockTemplate->addRow()->addClass('showHide displayNone fullWidth')->addColumn();
+                    $col->addLabel('description', __('Description'));
+                    $col->addTextArea('description')->setRows('auto')->setClass('fullWidth floatNone noMargin');
+
+                // Custom Blocks for Fees
+                $row = $form->addRow();
+                    $customBlocks = $row->addCustomBlocks('feesBlock', $gibbon->session)
+                        ->fromTemplate($blockTemplate)
+                        ->settings(array('inputNameStrategy' => 'string', 'addOnEvent' => 'change', 'sortable' => true))
+                        ->placeholder(__('Fees will be listed here...'))
+                        ->addToolInput($feeSelector)
+                        ->addBlockButton('showHide', __('Show/Hide'), 'plus.png');
+
+                // Add existing blocks
+                while ($fee = $resultFees->fetch()) {
+                    $fee['readonly'] = ($fee['feeType'] == 'Standard')? array('name', 'fee', 'description', 'gibbonFinanceFeeCategoryID') : array('name', 'fee', 'gibbonFinanceFeeCategoryID');
+                    $fee['gibbonFinanceInvoiceFeeID'] = str_pad($fee['gibbonFinanceInvoiceFeeID'], 15, '0', STR_PAD_LEFT);
+                    $fee['gibbonFinanceFeeCategoryID'] = str_pad($fee['gibbonFinanceFeeCategoryID'], 4, '0', STR_PAD_LEFT);
+
+                    $customBlocks->addBlock($fee['gibbonFinanceInvoiceFeeID'], $fee);
+                }
+
+                // Add predefined block data (for templating new blocks, triggered with the feeSelector)
+                $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
+                $sql = "SELECT gibbonFinanceFeeID as groupBy, gibbonFinanceFeeID, name, description, fee, gibbonFinanceFeeCategoryID FROM gibbonFinanceFee ORDER BY name";
+                $result = $pdo->executeQuery($data, $sql);
+                $feeData = $result->rowCount() > 0? $result->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
+
+                $customBlocks->addPredefinedBlock('Ad Hoc Fee', array('feeType' => 'Ad Hoc', 'gibbonFinanceFeeID' => 0));
+                foreach ($feeData as $gibbonFinanceFeeID => $data) {
+                    $customBlocks->addPredefinedBlock($gibbonFinanceFeeID, $data + array('feeType' => 'Standard', 'readonly' => ['name', 'fee', 'description', 'gibbonFinanceFeeCategoryID']) );
+                }
+            } else {
+                // Display fees already issued (readonly)
+                if ($resultFees->rowCount() == 0) {
+                    $form->addRow()->addAlert(__('There are no records to display.'), 'error');
+                } else {
+                    $table = $form->addRow()->addTable()->addClass('colorOddEven');
+
+                    $header = $table->addHeaderRow();
+                        $header->addContent(__('Name'));
+                        $header->addContent(__('Category'));
+                        $header->addContent(__('Description'));
+                        $header->addContent(__('Fee'))->append(' <small><i>('.$_SESSION[$guid]['currency'].')</i></small>');
+
+                    $feeTotal = 0;
+                    while ($fee = $resultFees->fetch()) {
+                        $feeTotal += $fee['fee'];
+                        $row = $table->addRow();
+                            $row->addContent($fee['name']);
+                            $row->addContent($fee['category']);
+                            $row->addContent($fee['description']);
+                            $row->addContent(number_format($fee['fee'], 2, '.', ','))->prepend(substr($_SESSION[$guid]['currency'], 4).' ');
+                    }
+
+                    $row = $table->addRow()->addClass('current');
+                        $row->addTableCell(__('Invoice Total:'))->colspan(3)->wrap('<b class="floatRight">', '</b>');
+                        $row->addTableCell(number_format($feeTotal, 2, '.', ','))->prepend(substr($_SESSION[$guid]['currency'], 4).' ')->wrap('<b>', '</b>');
+                }
+            }
+
+            $form->addRow()->addHeading(__('Payment Log'));
+
+            $form->addRow()->addContent(getPaymentLog($connection2, $guid, 'gibbonFinanceInvoice', $gibbonFinanceInvoiceID));
+
+            // EMAIL RECEIPTS
+            if ($values['status'] == 'Issued' || $values['status'] == 'Paid - Partial') {
+                $form->toggleVisibilityByClass('emailReceipts')->onSelect('status')->when(array('Paid', 'Paid - Partial', 'Paid - Complete'));
+                $form->addRow()->addHeading(__('Email Receipt'))->addClass('emailReceipts');
+
+                $row = $form->addRow()->addClass('emailReceipts');
+                    $row->addYesNoRadio('emailReceipt')->checked($values['status'] == 'Issued'? 'Y' : 'N');
+
+                $form->toggleVisibilityByClass('emailReceiptsTable')->onRadio('emailReceipt')->when(array('Y'));
+
+                $row = $form->addRow()->addClass('emailReceipts emailReceiptsTable');
+
+                $email = getSettingByScope($connection2, 'Finance', 'email');
+                $form->addHiddenValue('email', $email);
+                if (empty($email)) {
+                    $row->addAlert(__('An outgoing email address has not been set up under Invoice & Receipt Settings, and so no emails can be sent.'), 'error');
+                } else {
+                    if ($values['invoiceTo'] == 'Company') {
+                        // EMAIL COMPANY
+                        if (empty($values['companyEmail']) || empty($values['companyContact']) || empty($values['companyName'])) {
+                            $row->addAlert(__('There is no company contact available to send this invoice to.'), 'warning');
+                        } else {
+                            $row->addInvoiceEmailCheckboxes('emails[]', 'names[]', $values, $gibbon->session);
+                        }
                     } else {
-                        if ($row['status'] == 'Pending' or $row['status'] == 'Issued') {
-                            ?>
-							<tr>
-								<td>
-									<b><?php echo __($guid, 'Invoice Due Date') ?> *</b><br/>
-								</td>
-								<td class="right">
-									<input name="invoiceDueDate" id="invoiceDueDate" value="<?php echo dateConvertBack($guid, $row['invoiceDueDate']) ?>" type="text" class="standardWidth">
-									<script type="text/javascript">
-										var invoiceDueDate=new LiveValidation('invoiceDueDate');
-										invoiceDueDate.add( Validate.Format, {pattern: <?php if ($_SESSION[$guid]['i18n']['dateFormatRegEx'] == '') {
-											echo "/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/i";
-										} else {
-											echo $_SESSION[$guid]['i18n']['dateFormatRegEx'];
-										}
-																	?>, failureMessage: "Use <?php if ($_SESSION[$guid]['i18n']['dateFormat'] == '') {
-											echo 'dd/mm/yyyy';
-										} else {
-											echo $_SESSION[$guid]['i18n']['dateFormat'];
-										}
-                            			?>." } );
-										invoiceDueDate.add(Validate.Presence);
-									</script>
-									 <script type="text/javascript">
-										$(function() {
-											$( "#invoiceDueDate" ).datepicker();
-										});
-									</script>
-								</td>
-							</tr>
-							<?php
+                        // EMAIL FAMILY
+                        $row->addInvoiceEmailCheckboxes('emails[]', 'names[]', $values, $gibbon->session);
+                    }
+                }
+            }
 
+            // EMAIL REMINDERS
+            if ($values['status'] == 'Issued' && $values['invoiceDueDate'] < date('Y-m-d')) {
+
+                $form->toggleVisibilityByClass('emailReminders')->onSelect('status')->when(array('Issued'));
+                $form->addRow()->addHeading(sprintf(__('Email Reminder %1$s'), ($values['reminderCount'])+1))->addClass('emailReminders');
+
+                $row = $form->addRow()->addClass('emailReminders');
+                    $row->addYesNoRadio('emailReminder')->checked($values['status'] == 'Issued'? 'Y' : 'N');
+
+                $form->toggleVisibilityByClass('emailRemindersTable')->onRadio('emailReminder')->when(array('Y'));
+
+                $row = $form->addRow()->addClass('emailReminders emailRemindersTable');
+
+                $email = getSettingByScope($connection2, 'Finance', 'email');
+                $form->addHiddenValue('email', $email);
+                if (empty($email)) {
+                    $row->addAlert(__('An outgoing email address has not been set up under Invoice & Receipt Settings, and so no emails can be sent.'), 'error');
+                } else {
+                    if ($values['invoiceTo'] == 'Company') {
+                        // EMAIL COMPANY
+                        if (empty($values['companyEmail']) || empty($values['companyContact']) || empty($values['companyName'])) {
+                            $row->addAlert(__('There is no company contact available to send this invoice to.'), 'warning');
                         } else {
-                            ?>
-							<tr>
-								<td>
-									<b><?php echo __($guid, 'Invoice Due Date') ?> *</b><br/>
-									<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-								</td>
-								<td class="right">
-									<input readonly name="invoiceDueDate" id="invoiceDueDate" value="<?php echo dateConvertBack($guid, $row['invoiceDueDate']) ?>" type="text" class="standardWidth">
-								</td>
-							</tr>
-							<?php
-
+                            $row->addInvoiceEmailCheckboxes('emails2[]', 'names[]', $values, $gibbon->session);
                         }
-					}
-					?>
-					<tr>
-						<td>
-							<b><?php echo __($guid, 'Status') ?> *</b><br/>
-							<?php
-                            if ($row['status'] == 'Pending') {
-                                echo '<span style="font-size: 90%"><i>'.__($guid, 'This value cannot be changed. Use the Issue function to change the status from "Pending" to "Issued".').'</span>';
-                            } else {
-                                echo '<span style="font-size: 90%"><i>'.__($guid, 'Available options are limited according to current status.').'</span>';
-                            }
-            				?>
-						</td>
-						<td class="right">
-							<?php
-                            if ($row['status'] == 'Pending' or $row['status'] == 'Cancelled' or $row['status'] == 'Refunded') {
-                                echo '<input readonly name="status" id="status" value="'.$row['status'].'" type="text" style="width: 300px">';
-                            } elseif ($row['status'] == 'Issued') {
-                                echo "<select name='status' id='status' style='width:302px'>";
-                                echo "<option selected value='Issued'>".__($guid, 'Issued').'</option>';
-                                echo "<option value='Paid'>".__($guid, 'Paid').'</option>';
-                                echo "<option value='Paid - Partial'>".__($guid, 'Paid - Partial').'</option>';
-                                echo "<option value='Cancelled'>".__($guid, 'Cancelled').'</option>';
-                                echo '</select>';
-                            } elseif ($row['status'] == 'Paid' or $row['status'] == 'Paid - Partial') {
-                                echo "<select name='status' id='status' style='width:302px'>";
-                                if ($row['status'] == 'Paid') {
-                                    echo "<option selected value='Paid'>".__($guid, 'Paid').'</option>';
-                                }
-                                if ($row['status'] == 'Paid - Partial') {
-                                    echo "<option value='Paid - Partial'>".__($guid, 'Paid - Partial').'</option>';
-                                    echo "<option value='Paid - Complete'>".__($guid, 'Paid - Complete').'</option>';
-                                }
-                                echo "<option value='Refunded'>".__($guid, 'Refunded').'</option>';
-                                echo '</select>';
-                            }
-            				?>
-						</td>
-					</tr>
-					<?php
-                    if ($row['status'] == 'Issued' or $row['status'] == 'Paid - Partial') {
-                        ?>
-						<script type="text/javascript">
-							$(document).ready(function(){
-								<?php
-                                if ($row['status'] == 'Issued') {
-                                    ?>
-									$("#paidDateRow").css("display","none");
-									$("#paidAmountRow").css("display","none");
-									$("#paymentTypeRow").css("display","none");
-									$("#paymentTransactionIDRow").css("display","none");
-									paidDate.disable() ;
-									paidAmount.disable() ;
-									paymentType.disable() ;
-									<?php
-
-                                }
-                        		?>
-								$("#status").change(function(){
-									if ($('#status').val()=="Paid" || $('#status').val()=="Paid - Partial" || $('#status').val()=="Paid - Complete") {
-										$("#paidDateRow").slideDown("fast", $("#paidDateRow").css("display","table-row"));
-										$("#paidAmountRow").slideDown("fast", $("#paidAmountRow").css("display","table-row"));
-										$("#paymentTypeRow").slideDown("fast", $("#paymentTypeRow").css("display","table-row"));
-										$("#paymentTransactionIDRow").slideDown("fast", $("#paymentTransactionIDRow").css("display","table-row"));
-										paidDate.enable() ;
-										paidAmount.enable() ;
-										paymentType.enable() ;
-									} else {
-										$("#paidDateRow").css("display","none");
-										$("#paidAmountRow").css("display","none");
-										$("#paymentTypeRow").css("display","none");
-										$("#paymentTransactionIDRow").css("display","none");
-										paidDate.disable() ;
-										paidAmount.disable() ;
-										paymentType.disable() ;
-									}
-								 });
-							});
-						</script>
-						<tr id="paymentTypeRow">
-							<td>
-								<b><?php echo __($guid, 'Payment Type') ?> *</b><br/>
-							</td>
-							<td class="right">
-								<?php
-                                echo "<select name='paymentType' id='paymentType' style='width:302px'>";
-								echo "<option value='Please select...'>".__($guid, 'Please select...').'</option>';
-								echo "<option value='Online'>".__($guid, 'Online').'</option>';
-								echo "<option value='Bank Transfer'>".__($guid, 'Bank Transfer').'</option>';
-								echo "<option value='Cash'>".__($guid, 'Cash').'</option>';
-								echo "<option value='Cheque'>".__($guid, 'Cheque').'</option>';
-								echo "<option value='Other'>".__($guid, 'Other').'</option>';
-								echo '</select>';
-								?>
-								<script type="text/javascript">
-									var paymentType=new LiveValidation('paymentType');
-									paymentType.add(Validate.Exclusion, { within: ['Please select...'], failureMessage: "<?php echo __($guid, 'Select something!') ?>"});
-								</script>
-							</td>
-						</tr>
-						<tr id="paymentTransactionIDRow">
-							<td>
-								<b><?php echo __($guid, 'Transaction ID') ?></b><br/>
-								<span class="emphasis small"><?php echo __($guid, 'Date of payment, not entry to system.') ?></span>
-							</td>
-							<td class="right">
-								<input name="paymentTransactionID" id="paymentTransactionID" maxlength=50 value="" type="text" class="standardWidth">
-							</td>
-						</tr>
-						<tr id="paidDateRow">
-							<td>
-								<b><?php echo __($guid, 'Date Paid') ?> *</b><br/>
-								<span class="emphasis small"><?php echo __($guid, 'Date of payment, not entry to system.') ?></span>
-							</td>
-							<td class="right">
-								<input name="paidDate" id="paidDate" maxlength=10 value="" type="text" class="standardWidth">
-								<script type="text/javascript">
-									var paidDate=new LiveValidation('paidDate');
-									paidDate.add( Validate.Format, {pattern: <?php if ($_SESSION[$guid]['i18n']['dateFormatRegEx'] == '') {
-										echo "/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/i";
-									} else {
-										echo $_SESSION[$guid]['i18n']['dateFormatRegEx'];
-									}
-															?>, failureMessage: "Use <?php if ($_SESSION[$guid]['i18n']['dateFormat'] == '') {
-										echo 'dd/mm/yyyy';
-									} else {
-										echo $_SESSION[$guid]['i18n']['dateFormat'];
-									}
-                       	 			?>." } );
-									paidDate.add(Validate.Presence);
-								</script>
-								 <script type="text/javascript">
-									$(function() {
-										$( "#paidDate" ).datepicker();
-									});
-								</script>
-							</td>
-						</tr>
-						<tr id="paidAmountRow">
-							<td>
-								<b><?php echo __($guid, 'Amount Paid') ?> *</b><br/>
-								<span class="emphasis small"><?php echo __($guid, 'Amount in current payment.') ?>
-								<?php
-                                if ($_SESSION[$guid]['currency'] != '') {
-                                    echo "<span style='font-style: italic; font-size: 85%'>".$_SESSION[$guid]['currency'].'</span>';
-                                }
-                        		?>
-								</span>
-							</td>
-							<td class="right">
-								<?php
-                                //Get default paidAmount
-                                try {
-                                    $dataFees['gibbonFinanceInvoiceID'] = $row['gibbonFinanceInvoiceID'];
-                                    $sqlFees = 'SELECT gibbonFinanceInvoiceFee.gibbonFinanceInvoiceFeeID, gibbonFinanceInvoiceFee.feeType, gibbonFinanceFeeCategory.name AS category, gibbonFinanceInvoiceFee.name AS name, gibbonFinanceInvoiceFee.fee, gibbonFinanceInvoiceFee.description AS description, NULL AS gibbonFinanceFeeID, gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID AS gibbonFinanceFeeCategoryID, sequenceNumber FROM gibbonFinanceInvoiceFee JOIN gibbonFinanceFeeCategory ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID ORDER BY sequenceNumber';
-                                    $resultFees = $connection2->prepare($sqlFees);
-                                    $resultFees->execute($dataFees);
-                                } catch (PDOException $e) {
-                                }
-								$paidAmountDefault = 0;
-								while ($rowFees = $resultFees->fetch()) {
-									$paidAmountDefault = $paidAmountDefault + $rowFees['fee'];
-								}
-                                //If some paid already, work out amount, and subtract it off
-                                if ($row['status'] == 'Paid - Partial') {
-                                    $alreadyPaid = getAmountPaid($connection2, $guid, 'gibbonFinanceInvoice', $gibbonFinanceInvoiceID);
-                                    $paidAmountDefault -= $alreadyPaid;
-                                }
-                        		?>
-								<input name="paidAmount" id="paidAmount" maxlength=14 value="<?php echo number_format($paidAmountDefault, 2, '.', '') ?>" type="text" class="standardWidth">
-								<script type="text/javascript">
-									var paidAmount=new LiveValidation('paidAmount');
-									paidAmount.add( Validate.Format, { pattern: /^(?:\d*\.\d{1,2}|\d+)$/, failureMessage: "Invalid number format!" } );
-									paidAmount.add(Validate.Presence);
-								</script>
-							</td>
-						</tr>
-						<?php
-					}
-                    ?>
-					<tr>
-						<td colspan=2>
-							<b><?php echo __($guid, 'Notes') ?></b> <br/>
-                            <span class="emphasis small"><?php echo __($guid, 'Notes will be displayed on the final invoice and receipt.') ?></span>
-							<textarea name='notes' id='notes' rows=5 style='width: 300px'><?php echo htmlPrep($row['notes']) ?></textarea>
-						</td>
-					</tr>
-
-					<tr class='break'>
-						<td colspan=2>
-							<h3><?php echo __($guid, 'Fees') ?></h3>
-						</td>
-					</tr>
-					<?php
-                    if ($row['status'] == 'Pending') {
-                        $type = 'fee';
-                        ?>
-						<style>
-							#<?php echo $type ?> { list-style-type: none; margin: 0; padding: 0; width: 100%; }
-							#<?php echo $type ?> div.ui-state-default { margin: 0 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-							div.ui-state-default_dud { margin: 5px 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-							html>body #<?php echo $type ?> li { min-height: 58px; line-height: 1.2em; }
-							.<?php echo $type ?>-ui-state-highlight { margin-bottom: 5px; min-height: 58px; line-height: 1.2em; width: 100%; }
-							.<?php echo $type ?>-ui-state-highlight {border: 1px solid #fcd3a1; background: #fbf8ee url(images/ui-bg_glass_55_fbf8ee_1x400.png) 50% 50% repeat-x; color: #444444; }
-						</style>
-						<tr>
-							<td colspan=2>
-								<div class="fee" id="fee" style='width: 100%; padding: 5px 0px 0px 0px; min-height: 66px'>
-									<?php
-                                    $feeCount = 0;
-                        try {
-                            //Standard
-                            $dataFees['gibbonFinanceInvoiceID1'] = $row['gibbonFinanceInvoiceID'];
-                            $sqlFees = "(SELECT gibbonFinanceInvoiceFee.gibbonFinanceInvoiceFeeID, gibbonFinanceInvoiceFee.feeType, gibbonFinanceFeeCategory.name AS category, gibbonFinanceFee.name AS name, gibbonFinanceFee.fee AS fee, gibbonFinanceFee.description AS description, gibbonFinanceInvoiceFee.gibbonFinanceFeeID AS gibbonFinanceFeeID, gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID AS gibbonFinanceFeeCategoryID, sequenceNumber FROM gibbonFinanceInvoiceFee JOIN gibbonFinanceFee ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeID=gibbonFinanceFee.gibbonFinanceFeeID) JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID1 AND feeType='Standard')";
-                            $sqlFees .= ' UNION ';
-							//Ad Hoc
-							$dataFees['gibbonFinanceInvoiceID2'] = $row['gibbonFinanceInvoiceID'];
-                            $sqlFees .= "(SELECT gibbonFinanceInvoiceFee.gibbonFinanceInvoiceFeeID, gibbonFinanceInvoiceFee.feeType, gibbonFinanceFeeCategory.name AS category, gibbonFinanceInvoiceFee.name AS name, gibbonFinanceInvoiceFee.fee, gibbonFinanceInvoiceFee.description AS description, NULL AS gibbonFinanceFeeID, gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID AS gibbonFinanceFeeCategoryID, sequenceNumber FROM gibbonFinanceInvoiceFee JOIN gibbonFinanceFeeCategory ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID2 AND feeType='Ad Hoc')";
-                            $sqlFees .= ' ORDER BY sequenceNumber';
-                            $resultFees = $connection2->prepare($sqlFees);
-                            $resultFees->execute($dataFees);
-                        } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
-                        }
-                        while ($rowFees = $resultFees->fetch()) {
-                            makeFeeBlock($guid, $connection2, $feeCount, 'edit', $rowFees['feeType'], $rowFees['gibbonFinanceFeeID'], $rowFees['name'], $rowFees['description'], $rowFees['gibbonFinanceFeeCategoryID'], $rowFees['fee'], $rowFees['category']);
-                            ++$feeCount;
-                        }
-                        ?>
-								</div>
-								<div style='width: 100%; padding: 0px 0px 0px 0px'>
-									<div class="ui-state-default_dud" style='padding: 0px; height: 40px'>
-										<table class='blank' cellspacing='0' style='width: 100%'>
-											<tr>
-												<td style='width: 50%'>
-													<script type="text/javascript">
-														var feeCount=<?php echo $feeCount ?> ;
-													</script>
-													<select id='newFee' onChange='feeDisplayElements(this.value);' style='float: none; margin-left: 3px; margin-top: 0px; margin-bottom: 3px; width: 350px'>
-														<option class='all' value='0'><?php echo __($guid, 'Choose a fee to add it') ?></option>
-														<?php
-                                                        echo "<option value='Ad Hoc'>Ad Hoc Fee</option>";
-														$switchContents = 'case "Ad Hoc": ';
-														$switchContents .= "$(\"#fee\").append('<div id=\'feeOuter' + feeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
-														$switchContents .= '$("#feeOuter" + feeCount).load("'.$_SESSION[$guid]['absoluteURL'].'/modules/Finance/invoices_manage_add_blockFeeAjax.php","mode=add&id=" + feeCount + "&feeType='.urlencode('Ad Hoc').'&gibbonFinanceFeeID=&name='.urlencode('Ad Hoc Fee').'&description=&gibbonFinanceFeeCategoryID=1&fee=") ;';
-														$switchContents .= 'feeCount++ ;';
-														$switchContents .= "$('#newFee').val('0');";
-														$switchContents .= 'break;';
-														$currentCategory = '';
-														$lastCategory = '';
-														for ($i = 0; $i < 2; ++$i) {
-															try {
-																$dataSelect = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-																if ($i == 0) {
-																	$sqlSelect = "SELECT gibbonFinanceFee.*, gibbonFinanceFeeCategory.name AS category FROM gibbonFinanceFee LEFT JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceFee.active='Y' AND gibbonSchoolYearID=:gibbonSchoolYearID AND NOT gibbonFinanceFee.gibbonFinanceFeeCategoryID=1 ORDER BY gibbonFinanceFee.gibbonFinanceFeeCategoryID, gibbonFinanceFee.name";
-																} else {
-																	$sqlSelect = "SELECT gibbonFinanceFee.*, gibbonFinanceFeeCategory.name AS category FROM gibbonFinanceFee LEFT JOIN gibbonFinanceFeeCategory ON (gibbonFinanceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceFee.active='Y' AND gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonFinanceFee.gibbonFinanceFeeCategoryID=1 ORDER BY gibbonFinanceFee.gibbonFinanceFeeCategoryID, gibbonFinanceFee.name";
-																}
-																$resultSelect = $connection2->prepare($sqlSelect);
-																$resultSelect->execute($dataSelect);
-															} catch (PDOException $e) {
-																echo "<div class='error'>".$e->getMessage().'</div>';
-															}
-															while ($rowSelect = $resultSelect->fetch()) {
-																$currentCategory = $rowSelect['category'];
-																if (($currentCategory != $lastCategory) and $currentCategory != '') {
-																	echo "<optgroup label='--".$currentCategory."--'>";
-																	$categories[$categoryCount] = $currentCategory;
-																	++$categoryCount;
-																}
-																echo "<option value='".$rowSelect['gibbonFinanceFeeID']."'>".$rowSelect['name'].'</option>';
-																$switchContents .= 'case "'.$rowSelect['gibbonFinanceFeeID'].'": ';
-																$switchContents .= "$(\"#fee\").append('<div id=\'feeOuter' + feeCount + '\'><img style=\'margin: 10px 0 5px 0\' src=\'".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/loading.gif\' alt=\'Loading\' onclick=\'return false;\' /><br/>Loading</div>');";
-																$switchContents .= '$("#feeOuter" + feeCount).load("'.$_SESSION[$guid]['absoluteURL'].'/modules/Finance/invoices_manage_add_blockFeeAjax.php","mode=add&id=" + feeCount + "&feeType=Standard&gibbonFinanceFeeID='.urlencode($rowSelect['gibbonFinanceFeeID']).'&name='.urlencode($rowSelect['name']).'&description='.urlencode($rowSelect['description']).'&gibbonFinanceFeeCategoryID='.urlencode($rowSelect['gibbonFinanceFeeCategoryID']).'&fee='.urlencode($rowSelect['fee']).'&category='.urlencode($rowSelect['category']).'") ;';
-																$switchContents .= 'feeCount++ ;';
-																$switchContents .= "$('#newFee').val('0');";
-																$switchContents .= 'break;';
-																$lastCategory = $rowSelect['category'];
-															}
-														}
-														?>
-													</select>
-													<script type='text/javascript'>
-														function feeDisplayElements(number) {
-															$("#<?php echo $type ?>Outer0").css("display", "none") ;
-															switch(number) {
-																<?php echo $switchContents ?>
-															}
-														}
-													</script>
-												</td>
-											</tr>
-										</table>
-									</div>
-								</div>
-							</td>
-						</tr>
-					<?php
-
                     } else {
-                        echo '<tr>';
-                        echo '<td colspan=2>';
-                        $feeTotal = 0;
-                        try {
-                            $dataFees['gibbonFinanceInvoiceID'] = $row['gibbonFinanceInvoiceID'];
-                            $sqlFees = 'SELECT gibbonFinanceInvoiceFee.gibbonFinanceInvoiceFeeID, gibbonFinanceInvoiceFee.feeType, gibbonFinanceFeeCategory.name AS category, gibbonFinanceInvoiceFee.name AS name, gibbonFinanceInvoiceFee.fee, gibbonFinanceInvoiceFee.description AS description, NULL AS gibbonFinanceFeeID, gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID AS gibbonFinanceFeeCategoryID, sequenceNumber FROM gibbonFinanceInvoiceFee JOIN gibbonFinanceFeeCategory ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeCategoryID=gibbonFinanceFeeCategory.gibbonFinanceFeeCategoryID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID ORDER BY sequenceNumber';
-                            $resultFees = $connection2->prepare($sqlFees);
-                            $resultFees->execute($dataFees);
-                        } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
-                        }
-                        if ($resultFees->rowCount() < 1) {
-                            echo "<div class='error'>";
-                            echo __($guid, 'There are no records to display.');
-                            echo '</div>';
-                        } else {
-                            echo "<table cellspacing='0' style='width: 100%'>";
-                            echo "<tr class='head'>";
-                            echo '<th>';
-                            echo __($guid, 'Name');
-                            echo '</th>';
-                            echo '<th>';
-                            echo __($guid, 'Category');
-                            echo '</th>';
-                            echo '<th>';
-                            echo __($guid, 'Description');
-                            echo '</th>';
-                            echo '<th>';
-                            echo __($guid, 'Fee').'<br/>';
-                            if ($_SESSION[$guid]['currency'] != '') {
-                                echo "<span style='font-style: italic; font-size: 85%'>".$_SESSION[$guid]['currency'].'</span>';
-                            }
-                            echo '</th>';
-                            echo '</tr>';
-
-                            $count = 0;
-                            $rowNum = 'odd';
-                            while ($rowFees = $resultFees->fetch()) {
-                                if ($count % 2 == 0) {
-                                    $rowNum = 'even';
-                                } else {
-                                    $rowNum = 'odd';
-                                }
-                                ++$count;
-
-                                echo "<tr style='height: 25px' class=$rowNum>";
-                                echo '<td>';
-                                echo $rowFees['name'];
-                                echo '</td>';
-                                echo '<td>';
-                                echo $rowFees['category'];
-                                echo '</td>';
-                                echo '<td>';
-                                echo $rowFees['description'];
-                                echo '</td>';
-                                echo '<td>';
-                                if (substr($_SESSION[$guid]['currency'], 4) != '') {
-                                    echo substr($_SESSION[$guid]['currency'], 4).' ';
-                                }
-                                echo number_format($rowFees['fee'], 2, '.', ',');
-                                $feeTotal += $rowFees['fee'];
-                                echo '</td>';
-                                echo '</tr>';
-                            }
-                            echo "<tr style='height: 35px' class='current'>";
-                            echo "<td colspan=3 style='text-align: right'>";
-                            echo '<b>'.__($guid, 'Invoice Total:').'</b>';
-                            echo '</td>';
-                            echo '<td>';
-                            if (substr($_SESSION[$guid]['currency'], 4) != '') {
-                                echo substr($_SESSION[$guid]['currency'], 4).' ';
-                            }
-                            echo '<b>'.number_format($feeTotal, 2, '.', ',').'</b>';
-                            echo '</td>';
-                            echo '</tr>';
-                            echo '</table>';
-                            echo '</td>';
-                            echo '</tr>';
-                        }
+                        // EMAIL FAMILY
+                        $row->addInvoiceEmailCheckboxes('emails2[]', 'names[]', $values, $gibbon->session);
                     }
+                }
+            }
 
-                    //PUT PAYMENT LOG
-                    echo "<tr class='break'>";
-					echo '<td colspan=2>';
-					echo '<h3>'.__($guid, 'Payment Log').'</h3>';
-					echo '</td>';
-					echo '</tr>';
-					echo '<tr>';
-					echo '<td colspan=2>';
-					echo getPaymentLog($connection2, $guid, 'gibbonFinanceInvoice', $gibbonFinanceInvoiceID);
-					echo '</td>';
-					echo '</tr>';
+            $row = $form->addRow();
+                $row->addFooter();
+                $row->addSubmit();
 
-                    //Receipt emailing
-                    if ($row['status'] == 'Issued' or $row['status'] == 'Paid - Partial') {
-                        ?>
-						<script type="text/javascript">
-							$(document).ready(function(){
-								if ($('#status').val()!="Paid - Partial") {
-									$(".emailReceipt").css("display","none");
-								}
-								$("#status").change(function(){
-									if ($('#status').val()=="Paid" || $('#status').val()=="Paid - Partial"  || $('#status').val()=="Paid - Complete") {
-										$(".emailReceipt").slideDown("fast", $(".emailReceipt").css("display","table-row"));
-										$("#emailReceipt").val('Y');
-									}
-									else {
-										$(".emailReceipt").css("display","none");
-										$("#emailReceipt").val('N');
-									}
-								 });
-							});
-						</script>
-						<tr class='break emailReceipt'>
-							<td colspan=2>
-								<h3><?php echo __($guid, 'Email Receipt') ?></h3>
-								<input type='hidden' id='emailReceipt' name='emailReceipt' value='N'/>
-							</td>
-						</tr>
-						<?php
-                        $email = getSettingByScope($connection2, 'Finance', 'email');
-                        if ($email == '') {
-                            echo "<tr class='emailReceipt'>";
-                            echo '<td colspan=2>';
-                            echo "<div class='error'>";
-                            echo __($guid, 'An outgoing email address has not been set up under Invoice & Receipt Settings, and so no emails can be sent.');
-                            echo '</div>';
-                            echo "<input type='hidden' name='email' value='$email'/>";
-                            echo '<td>';
-                            echo '<tr>';
-                        } else {
-                            echo "<input type='hidden' name='email' value='$email'/>";
-                            if ($row['invoiceTo'] == 'Company') {
-                                if ($row['companyEmail'] != '' and $row['companyContact'] != '' and $row['companyName'] != '') {
-                                    ?>
-									<tr class='emailReceipt'>
-										<td>
-											<b><?php echo $row['companyContact'] ?></b> (<?php echo $row['companyName'];
-                                    ?>)
-											<span class="emphasis small"></span>
-										</td>
-										<td class="right">
-											<?php echo $row['companyEmail'];
-                                    ?> <input checked type='checkbox' name='emails[]' value='<?php echo htmlPrep($row['companyEmail']);
-                                    ?>'/>
-											<input type='hidden' name='names[]' value='<?php echo htmlPrep($row['companyContact']);
-                                    ?>'/>
-										</td>
-									</tr>
-									<?php
-                                    if ($row['companyCCFamily'] == 'Y') {
-                                        try {
-                                            $dataParents = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-                                            $sqlParents = "SELECT parent.title, parent.surname, parent.preferredName, parent.email, parent.address1, parent.address1District, parent.address1Country, homeAddress, homeAddressDistrict, homeAddressCountry FROM gibbonFinanceInvoicee JOIN gibbonPerson AS student ON (gibbonFinanceInvoicee.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamilyChild ON (gibbonFamilyChild.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID) JOIN gibbonPerson AS parent ON (gibbonFamilyAdult.gibbonPersonID=parent.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID AND (contactPriority=1 OR (contactPriority=2 AND contactEmail='Y')) ORDER BY contactPriority, surname, preferredName";
-                                            $resultParents = $connection2->prepare($sqlParents);
-                                            $resultParents->execute($dataParents);
-                                        } catch (PDOException $e) {
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
-                                        }
-                                        if ($resultParents->rowCount() < 1) {
-                                            echo "<div class='warning'>".__($guid, 'There are no family members available to send this receipt to.').'</div>';
-                                        } else {
-                                            while ($rowParents = $resultParents->fetch()) {
-                                                if ($rowParents['preferredName'] != '' and $rowParents['surname'] != '' and $rowParents['email'] != '') {
-                                                    ?>
-													<tr class='emailReceipt'>
-														<td>
-															<b><?php echo formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false) ?></b> <i><?php echo __($guid, '(Family CC)') ?></i>
-															<span class="emphasis small"></span>
-														</td>
-														<td class="right">
-															<?php echo $rowParents['email'];
-                                                    ?> <input checked type='checkbox' name='emails[]' value='<?php echo htmlPrep($rowParents['email']);
-                                                    ?>'/>
-															<input type='hidden' name='names[]' value='<?php echo htmlPrep(formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false));
-                                                    ?>'/>
-														</td>
-													</tr>
-													<?php
+            $form->loadAllValuesFrom($values);
 
-                                                }
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    echo "<div class='warning'>".__($guid, 'There is no company contact available to send this invoice to.').'</div>';
-                                }
-                            } else {
-                                try {
-                                    $dataParents = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-                                    $sqlParents = "SELECT parent.title, parent.surname, parent.preferredName, parent.email, parent.address1, parent.address1District, parent.address1Country, homeAddress, homeAddressDistrict, homeAddressCountry FROM gibbonFinanceInvoicee JOIN gibbonPerson AS student ON (gibbonFinanceInvoicee.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamilyChild ON (gibbonFamilyChild.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID) JOIN gibbonPerson AS parent ON (gibbonFamilyAdult.gibbonPersonID=parent.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID AND (contactPriority=1 OR (contactPriority=2 AND contactEmail='Y')) ORDER BY contactPriority, surname, preferredName";
-                                    $resultParents = $connection2->prepare($sqlParents);
-                                    $resultParents->execute($dataParents);
-                                } catch (PDOException $e) {
-                                    echo "<div class='error'>".$e->getMessage().'</div>';
-                                }
-                                if ($resultParents->rowCount() < 1) {
-                                    echo "<div class='warning'>".__($guid, 'There are no family members available to send this receipt to.').'</div>';
-                                } else {
-                                    while ($rowParents = $resultParents->fetch()) {
-                                        if ($rowParents['preferredName'] != '' and $rowParents['surname'] != '' and $rowParents['email'] != '') {
-                                            ?>
-											<tr class='emailReceipt'>
-												<td>
-													<b><?php echo formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false) ?></b>
-													<span class="emphasis small"></span>
-												</td>
-												<td class="right">
-													<?php echo $rowParents['email'];
-                                            ?> <input checked type='checkbox' name='emails[]' value='<?php echo htmlPrep($rowParents['email']);
-                                            ?>'/>
-													<input type='hidden' name='names[]' value='<?php echo htmlPrep(formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false));
-                                            ?>'/>
-												</td>
-											</tr>
-											<?php
-
-                                        }
-                                    }
-                                }
-                            }
-                            //CC self?
-                            if ($_SESSION[$guid]['email'] != '') {
-                                ?>
-								<tr class='emailReceipt'>
-									<td>
-										<b><?php echo formatName('', htmlPrep($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Parent', false) ?></b>
-										<span class="emphasis small"><?php echo __($guid, '(CC Self?)') ?></span>
-									</td>
-									<td class="right">
-										<?php echo $_SESSION[$guid]['email'];
-                                ?> <input type='checkbox' name='emails[]' value='<?php echo $_SESSION[$guid]['email'];
-                                ?>'/>
-										<input type='hidden' name='names[]' value='<?php echo formatName('', htmlPrep($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Parent', false);
-                                ?>'/>
-									</td>
-								</tr>
-								<?php
-
-                            }
-                        }
-                    }
-
-                    //Reminder emailing
-                    if ($row['status'] == 'Issued' and $row['invoiceDueDate'] < date('Y-m-d')) {
-                        ?>
-						<script type="text/javascript">
-							$(document).ready(function(){
-								$("#status").change(function(){
-									if ($('#status').val()=="Paid" || $('#status').val()=="Cancelled" ) {
-										$(".emailReminder").css("display","none");
-										$("#emailReminder").val('N');
-									}
-									else {
-										$(".emailReminder").slideDown("fast", $(".emailReminder").css("display","table-row"));
-										$("#emailReminder").val('Y');
-									}
-								 });
-							});
-						</script>
-						<tr class='break emailReminder'>
-							<td colspan=2>
-								<h3><?php echo sprintf(__($guid, 'Email Reminder %1$s'), ($row['reminderCount'])+1) ?></h3>
-								<input type='hidden' id='emailReminder' name='emailReminder' value='Y'/>
-							</td>
-						</tr>
-						<?php
-                        $email = getSettingByScope($connection2, 'Finance', 'email');
-                        if ($email == '') {
-                            echo "<tr class='emailReminder'>";
-                            echo '<td colspan=2>';
-                            echo "<div class='error'>";
-                            echo __($guid, 'An outgoing email address has not been set up under Invoice & Receipt Settings, and so no emails can be sent.');
-                            echo '</div>';
-                            echo "<input type='hidden' name='email' value='$email'/>";
-                            echo '<td>';
-                            echo '<tr>';
-                        } else {
-                            echo "<input type='hidden' name='email' value='$email'/>";
-                            if ($row['invoiceTo'] == 'Company') {
-                                if ($row['companyEmail'] != '' and $row['companyContact'] != '' and $row['companyName'] != '') {
-                                    ?>
-									<tr class='emailReminder'>
-										<td>
-											<b><?php echo $row['companyContact'] ?></b> (<?php echo $row['companyName'];
-                                    ?>)
-											<span class="emphasis small"></span>
-										</td>
-										<td class="right">
-											<?php echo $row['companyEmail'];
-                                    ?> <input checked type='checkbox' name='emails2[]' value='<?php echo htmlPrep($row['companyEmail']);
-                                    ?>'/>
-											<input type='hidden' name='names[]' value='<?php echo htmlPrep($row['companyContact']);
-                                    ?>'/>
-										</td>
-									</tr>
-									<?php
-                                    if ($row['companyCCFamily'] == 'Y') {
-                                        try {
-                                            $dataParents = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-                                            $sqlParents = "SELECT parent.title, parent.surname, parent.preferredName, parent.email, parent.address1, parent.address1District, parent.address1Country, homeAddress, homeAddressDistrict, homeAddressCountry FROM gibbonFinanceInvoicee JOIN gibbonPerson AS student ON (gibbonFinanceInvoicee.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamilyChild ON (gibbonFamilyChild.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID) JOIN gibbonPerson AS parent ON (gibbonFamilyAdult.gibbonPersonID=parent.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID AND (contactPriority=1 OR (contactPriority=2 AND contactEmail='Y')) ORDER BY contactPriority, surname, preferredName";
-                                            $resultParents = $connection2->prepare($sqlParents);
-                                            $resultParents->execute($dataParents);
-                                        } catch (PDOException $e) {
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
-                                        }
-                                        if ($resultParents->rowCount() < 1) {
-                                            echo "<div class='warning'>".__($guid, 'There are no family members available to send this receipt to.').'</div>';
-                                        } else {
-                                            while ($rowParents = $resultParents->fetch()) {
-                                                if ($rowParents['preferredName'] != '' and $rowParents['surname'] != '' and $rowParents['email'] != '') {
-                                                    ?>
-													<tr class='emailReminder'>
-														<td>
-															<b><?php echo formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false) ?></b> <i><?php echo __($guid, '(Family CC)') ?></i>
-															<span class="emphasis small"></span>
-														</td>
-														<td class="right">
-															<?php echo $rowParents['email'];
-                                                    ?> <input checked type='checkbox' name='emails2[]' value='<?php echo htmlPrep($rowParents['email']);
-                                                    ?>'/>
-															<input type='hidden' name='names[]' value='<?php echo htmlPrep(formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false));
-                                                    ?>'/>
-														</td>
-													</tr>
-													<?php
-
-                                                }
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    echo "<div class='warning'>".__($guid, 'There is no company contact available to send this invoice to.').'</div>';
-                                }
-                            } else {
-                                try {
-                                    $dataParents = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-                                    $sqlParents = "SELECT parent.title, parent.surname, parent.preferredName, parent.email, parent.address1, parent.address1District, parent.address1Country, homeAddress, homeAddressDistrict, homeAddressCountry FROM gibbonFinanceInvoicee JOIN gibbonPerson AS student ON (gibbonFinanceInvoicee.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamilyChild ON (gibbonFamilyChild.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID) JOIN gibbonPerson AS parent ON (gibbonFamilyAdult.gibbonPersonID=parent.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID AND (contactPriority=1 OR (contactPriority=2 AND contactEmail='Y')) ORDER BY contactPriority, surname, preferredName";
-                                    $resultParents = $connection2->prepare($sqlParents);
-                                    $resultParents->execute($dataParents);
-                                } catch (PDOException $e) {
-                                    echo "<div class='error'>".$e->getMessage().'</div>';
-                                }
-                                if ($resultParents->rowCount() < 1) {
-                                    echo "<div class='warning'>".__($guid, 'There are no family members available to send this receipt to.').'</div>';
-                                } else {
-                                    while ($rowParents = $resultParents->fetch()) {
-                                        if ($rowParents['preferredName'] != '' and $rowParents['surname'] != '' and $rowParents['email'] != '') {
-                                            ?>
-											<tr class='emailReminder'>
-												<td>
-													<b><?php echo formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false) ?></b>
-													<span class="emphasis small"></span>
-												</td>
-												<td class="right">
-													<?php echo $rowParents['email'];
-                                            ?> <input checked type='checkbox' name='emails2[]' value='<?php echo htmlPrep($rowParents['email']);
-                                            ?>'/>
-													<input type='hidden' name='names[]' value='<?php echo htmlPrep(formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false));
-                                            ?>'/>
-												</td>
-											</tr>
-											<?php
-
-                                        }
-                                    }
-                                }
-                            }
-                            //CC self?
-                            if ($_SESSION[$guid]['email'] != '') {
-                                ?>
-								<tr class='emailReminder'>
-									<td>
-										<b><?php echo formatName('', htmlPrep($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Parent', false) ?></b>
-										<span class="emphasis small"><?php echo __($guid, '(CC Self?)') ?></span>
-									</td>
-									<td class="right">
-										<?php echo $_SESSION[$guid]['email'];
-                                ?> <input type='checkbox' name='emails[]' value='<?php echo $_SESSION[$guid]['email'];
-                                ?>'/>
-										<input type='hidden' name='names[]' value='<?php echo formatName('', htmlPrep($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Parent', false);
-                                ?>'/>
-									</td>
-								</tr>
-								<?php
-
-                            }
-                        }
-                    }
-            		?>
-					<tr>
-						<td>
-							<span class="emphasis small">* <?php echo __($guid, 'denotes a required field'); ?></span>
-						</td>
-						<td class="right">
-							<input name="gibbonFinanceInvoiceID" id="gibbonFinanceInvoiceID" value="<?php echo $gibbonFinanceInvoiceID ?>" type="hidden">
-							<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
-							<input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
-						</td>
-					</tr>
-				</table>
-			</form>
-			<?php
-
+            echo $form->getOutput();
         }
     }
 }
-?>

--- a/modules/Finance/invoices_manage_edit.php
+++ b/modules/Finance/invoices_manage_edit.php
@@ -198,7 +198,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
                         ->isRequired()
                         ->placeholder(__('Value').(!empty($_SESSION[$guid]['currency'])? ' ('.$_SESSION[$guid]['currency'].')' : ''));
                     
-                $col = $blockTemplate->addRow()->addClass('showHide displayNone fullWidth')->addColumn();
+                $col = $blockTemplate->addRow()->addClass('showHide fullWidth')->addColumn();
                     $col->addLabel('description', __('Description'));
                     $col->addTextArea('description')->setRows('auto')->setClass('fullWidth floatNone noMargin');
 

--- a/modules/Finance/invoices_manage_editProcess.php
+++ b/modules/Finance/invoices_manage_editProcess.php
@@ -269,6 +269,7 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                         $from = $_POST['email'];
                         if ($partialFail == false and $from != '') {
                             //Send emails
+                            $emails = array() ;
                             if (isset($_POST['emails'])) {
                                 $emails = $_POST['emails'];
                                 for ($i = 0; $i < count($emails); ++$i) {

--- a/modules/Finance/invoices_manage_issue.php
+++ b/modules/Finance/invoices_manage_issue.php
@@ -17,7 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-@session_start();
+use Gibbon\Forms\Form;
+use Gibbon\Finance\Forms\FinanceFormFactory;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -30,16 +31,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
 } else {
     //Proceed!
     //Check if school year specified
-    $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
-    $gibbonFinanceInvoiceID = $_GET['gibbonFinanceInvoiceID'];
-    $status = $_GET['status'];
-    $gibbonFinanceInvoiceeID = $_GET['gibbonFinanceInvoiceeID'];
-    $monthOfIssue = $_GET['monthOfIssue'];
-    $gibbonFinanceBillingScheduleID = $_GET['gibbonFinanceBillingScheduleID'];
-    $gibbonFinanceFeeCategoryID = $_GET['gibbonFinanceFeeCategoryID'];
+    $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
+    $gibbonFinanceInvoiceID = isset($_GET['gibbonFinanceInvoiceID'])? $_GET['gibbonFinanceInvoiceID'] : '';
+    $status = isset($_GET['status'])? $_GET['status'] : '';
+    $gibbonFinanceInvoiceeID = isset($_GET['gibbonFinanceInvoiceeID'])? $_GET['gibbonFinanceInvoiceeID'] : '';
+    $monthOfIssue = isset($_GET['monthOfIssue'])? $_GET['monthOfIssue'] : '';
+    $gibbonFinanceBillingScheduleID = isset($_GET['gibbonFinanceBillingScheduleID'])? $_GET['gibbonFinanceBillingScheduleID'] : '';
+    $gibbonFinanceFeeCategoryID = isset($_GET['gibbonFinanceFeeCategoryID'])? $_GET['gibbonFinanceFeeCategoryID'] : '';
+
+    $linkParams = compact('gibbonSchoolYearID', 'status', 'gibbonFinanceInvoiceeID', 'monthOfIssue', 'gibbonFinanceBillingScheduleID', 'gibbonFinanceFeeCategoryID'); 
 
     echo "<div class='trail'>";
-    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Finance/invoices_manage.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID']."&gibbonFinanceInvoiceID=$gibbonFinanceInvoiceID&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Manage Invoices')."</a> > </div><div class='trailEnd'>".__($guid, 'Issue Invoice').'</div>';
+    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Finance/invoices_manage.php&'.http_build_query($linkParams)."'>".__($guid, 'Manage Invoices')."</a> > </div><div class='trailEnd'>".__($guid, 'Issue Invoice').'</div>';
     echo '</div>';
 
     echo '<p>';
@@ -57,7 +60,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
     } else {
         try {
             $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonFinanceInvoiceID' => $gibbonFinanceInvoiceID);
-            $sql = "SELECT gibbonFinanceInvoice.*, companyName, companyContact, companyEmail, companyCCFamily FROM gibbonFinanceInvoice LEFT JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID AND status='Pending'";
+            $sql = "SELECT gibbonFinanceInvoice.*, companyName, companyContact, companyEmail, companyCCFamily, gibbonSchoolYear.name as schoolYear, gibbonPerson.surname, gibbonPerson.preferredName, gibbonFinanceBillingSchedule.name as billingScheduleName, gibbonFinanceBillingSchedule.invoiceDueDate as billingScheduleInvoiceDueDate
+					FROM gibbonFinanceInvoice 
+					JOIN gibbonSchoolYear ON (gibbonSchoolYear.gibbonSchoolYearID=gibbonFinanceInvoice.gibbonSchoolYearID)
+					LEFT JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoice.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) 
+					LEFT JOIN gibbonFinanceBillingSchedule ON (gibbonFinanceBillingSchedule.gibbonFinanceBillingScheduleID=gibbonFinanceInvoice.gibbonFinanceBillingScheduleID)
+					LEFT JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonFinanceInvoicee.gibbonPersonID)
+					WHERE gibbonFinanceInvoice.gibbonSchoolYearID=:gibbonSchoolYearID 
+					AND gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID
+					AND gibbonFinanceInvoice.status='Pending'";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
@@ -70,288 +81,81 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
             echo '</div>';
         } else {
             //Let's go!
-            $row = $result->fetch();
+            $values = $result->fetch();
 
             if ($status != '' or $gibbonFinanceInvoiceeID != '' or $monthOfIssue != '' or $gibbonFinanceBillingScheduleID != '') {
                 echo "<div class='linkTop'>";
-                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php&gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID'>".__($guid, 'Back to Search Results').'</a>';
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoices_manage.php&".http_build_query($linkParams)."'>".__($guid, 'Back to Search Results').'</a>';
                 echo '</div>';
-            }
-            ?>
+			}
+			
+			$form = Form::create('invoice', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/invoices_manage_issueProcess.php?'.http_build_query($linkParams));
+			$form->setFactory(FinanceFormFactory::create($pdo));
+			
+			$form->addHiddenValue('address', $_SESSION[$guid]['address']);
+            $form->addHiddenValue('gibbonFinanceInvoiceID', $gibbonFinanceInvoiceID);
 
-			<form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/invoices_manage_issueProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&status=$status&gibbonFinanceInvoiceeID=$gibbonFinanceInvoiceeID&monthOfIssue=$monthOfIssue&gibbonFinanceBillingScheduleID=$gibbonFinanceBillingScheduleID&gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID" ?>">
-				<table class='smallIntBorder fullWidth' cellspacing='0'>
-					<tr>
-						<td colspan=2>
-							<h3><?php echo __($guid, 'Basic Information') ?></h3>
-						</td>
-					</tr>
-					<tr>
-						<td style='width: 275px'>
-							<b><?php echo __($guid, 'School Year') ?> *</b><br/>
-							<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-						</td>
-						<td class="right">
-							<?php
-                            $yearName = '';
-            try {
-                $dataYear = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-                $sqlYear = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
-                $resultYear = $connection2->prepare($sqlYear);
-                $resultYear->execute($dataYear);
-            } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
-            }
-            if ($resultYear->rowCount() == 1) {
-                $rowYear = $resultYear->fetch();
-                $yearName = $rowYear['name'];
-            }
-            ?>
-							<input readonly name="yearName" id="yearName" value="<?php echo $yearName ?>" type="text" class="standardWidth">
-					</tr>
-					<tr>
-						<td>
-							<b><?php echo __($guid, 'Invoicee') ?> *</b><br/>
-							<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-						</td>
-						<td class="right">
-							<?php
-                            $personName = '';
-							try {
-								$dataInvoicee = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-								$sqlInvoicee = 'SELECT surname, preferredName FROM gibbonPerson JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID';
-								$resultInvoicee = $connection2->prepare($sqlInvoicee);
-								$resultInvoicee->execute($dataInvoicee);
-							} catch (PDOException $e) {
-								echo "<div class='error'>".$e->getMessage().'</div>';
-							}
-							if ($resultInvoicee->rowCount() == 1) {
-								$rowInvoicee = $resultInvoicee->fetch();
-								$personName = formatName('', htmlPrep($rowInvoicee['preferredName']), htmlPrep($rowInvoicee['surname']), 'Student', true);
-							}
-							?>
-							<input readonly name="personName" id="personName" value="<?php echo $personName ?>" type="text" class="standardWidth">
-						</td>
-					</tr>
-					<?php //BILLING TYPE CHOOSER ?>
-					<tr>
-						<td>
-							<b><?php echo __($guid, 'Scheduling') ?> *</b><br/>
-							<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-						</td>
-						<td class="right">
-							<input readonly name="billingScheduleType" id="billingScheduleType" value="<?php echo $row['billingScheduleType'] ?>" type="text" class="standardWidth">
-						</td>
-					</tr>
-					<?php
-                    if ($row['billingScheduleType'] == 'Scheduled') {
-                        ?>
-						<tr>
-							<td>
-								<b><?php echo __($guid, 'Billing Schedule') ?> *</b><br/>
-								<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-							</td>
-							<td class="right">
-								<?php
-                                $schedule = '';
-								try {
-									$dataSchedule = array('gibbonFinanceBillingScheduleID' => $row['gibbonFinanceBillingScheduleID']);
-									$sqlSchedule = 'SELECT * FROM gibbonFinanceBillingSchedule WHERE gibbonFinanceBillingScheduleID=:gibbonFinanceBillingScheduleID';
-									$resultSchedule = $connection2->prepare($sqlSchedule);
-									$resultSchedule->execute($dataSchedule);
-								} catch (PDOException $e) {
-									echo "<div class='error'>".$e->getMessage().'</div>';
-								}
-								if ($resultSchedule->rowCount() == 1) {
-									$rowSchedule = $resultSchedule->fetch();
-									$schedule = $rowSchedule['name'];
-									$invoiceDueDate = $rowSchedule['invoiceDueDate'];
-								}
-								?>
-								<input readonly name="schedule" id="schedule" value="<?php echo $schedule ?>" type="text" class="standardWidth">
-								<input name="invoiceDueDate" id="invoiceDueDate" value="<?php echo dateConvertBack($guid, $invoiceDueDate) ?>" type="hidden" class="standardWidth">
-							</td>
-						</tr>
-						<?php
+			$form->addRow()->addHeading(__('Basic Information'));
 
-                    } else {
-                        ?>
-						<tr>
-							<td>
-								<b><?php echo __($guid, 'Invoice Due Date') ?> *</b><br/>
-								<span class="emphasis small"><?php echo __($guid, 'This value cannot be changed.') ?></span>
-							</td>
-							<td class="right">
-								<input readonly name="invoiceDueDate" id="invoiceDueDate" value="<?php echo dateConvertBack($guid, $row['invoiceDueDate']) ?>" type="text" class="standardWidth">
-							</td>
-						</tr>
-						<?php
-					}
-                    ?>
-					<tr>
-						<td>
-							<b><?php echo __($guid, 'Status') ?> *</b><br/>
-							<?php
-                            if ($row['status'] == 'Pending') {
-                                echo '<span style="font-size: 90%"><i>'.__($guid, 'This value cannot be changed. Use the Issue function to change the status from "Pending" to "Issued".').'</span>';
-                            } else {
-                                echo '<span style="font-size: 90%"><i>'.__($guid, 'Available options are limited according to current status.').'</span>';
-                            }
-            				?>
-						</td>
-						<td class="right">
-							<?php
-                            if ($row['status'] == 'Pending') {
-                                echo '<input readonly name="status" id="status" value="'.$row['status'].'" type="text" style="width: 300px">';
-                            } else {
-                            }
-            				?>
-						</td>
-					</tr>
-					<tr>
-						<td colspan=2>
-							<b><?php echo __($guid, 'Notes') ?></b>
-							<textarea name='notes' id='notes' rows=5 style='width: 300px'><?php echo htmlPrep($row['notes']) ?></textarea>
-						</td>
-					</tr>
+			$row = $form->addRow();
+                $row->addLabel('schoolYear', __('School Year'));
+				$row->addTextField('schoolYear')->isRequired()->readonly();
+				
+			$row = $form->addRow();
+                $row->addLabel('personName', __('Invoicee'));
+                $row->addTextField('personName')->isRequired()->readonly()->setValue(formatName('', $values['preferredName'], $values['surname'], 'Student', true));
 
-					<tr>
-						<td colspan=2>
-							<h3><?php echo __($guid, 'Email Invoice') ?></h3>
-						</td>
-					</tr>
-					<?php
-                    $email = getSettingByScope($connection2, 'Finance', 'email');
-					if ($email == '') {
-						echo '<tr>';
-						echo '<td colspan=2>';
-						echo "<div class='error'>";
-						echo 'An outgoing email address has not been set up under Invoice & Receipt Settings, and so no emails can be sent.';
-						echo '</div>';
-						echo "<input type='hidden' name='email' value='$email'/>";
-						echo '<td>';
-						echo '<tr>';
-					} else {
-						echo "<input type='hidden' name='email' value='$email'/>";
-						if ($row['invoiceTo'] == 'Company') {
-							if ($row['companyEmail'] != '' and $row['companyContact'] != '' and $row['companyName'] != '') {
-								?>
-								<tr>
-									<td>
-										<b><?php echo $row['companyContact'] ?></b> (<?php echo $row['companyName']; ?>)
-										<span class="emphasis small"></span>
-									</td>
-									<td class="right">
-										<?php echo $row['companyEmail'];
-										?> <input checked type='checkbox' name='emails[]' value='<?php echo htmlPrep($row['companyEmail']); ?>'/>
-										<input type='hidden' name='names[]' value='<?php echo htmlPrep($row['companyContact']); ?>'/>
-									</td>
-								</tr>
-								<?php
-                                //CC family
-                                if ($row['companyCCFamily'] == 'Y') {
-                                    try {
-                                        $dataParents = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-                                        $sqlParents = "SELECT parent.title, parent.surname, parent.preferredName, parent.email, parent.address1, parent.address1District, parent.address1Country, homeAddress, homeAddressDistrict, homeAddressCountry FROM gibbonFinanceInvoicee JOIN gibbonPerson AS student ON (gibbonFinanceInvoicee.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamilyChild ON (gibbonFamilyChild.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID) JOIN gibbonPerson AS parent ON (gibbonFamilyAdult.gibbonPersonID=parent.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID AND (contactPriority=1 OR (contactPriority=2 AND contactEmail='Y')) ORDER BY contactPriority, surname, preferredName";
-                                        $resultParents = $connection2->prepare($sqlParents);
-                                        $resultParents->execute($dataParents);
-                                    } catch (PDOException $e) {
-                                        $return .= "<div class='error'>".$e->getMessage().'</div>';
-                                    }
-                                    if ($resultParents->rowCount() < 1) {
-                                        $return .= "<div class='warning'>There are no family members available to send this receipt to.</div>";
-                                    } else {
-                                        while ($rowParents = $resultParents->fetch()) {
-                                            if ($rowParents['preferredName'] != '' and $rowParents['surname'] != '' and $rowParents['email'] != '') {
-                                                ?>
-												<tr>
-													<td>
-														<b><?php echo formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false) ?></b> <i>(Family CC)</i>
-														<span class="emphasis small"></span>
-													</td>
-													<td class="right">
-														<?php echo $rowParents['email'];
-                                                ?> <input checked type='checkbox' name='emails[]' value='<?php echo htmlPrep($rowParents['email']);
-                                                ?>'/>
-														<input type='hidden' name='names[]' value='<?php echo htmlPrep(formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false));
-                                                ?>'/>
-													</td>
-												</tr>
-												<?php
+            $row = $form->addRow();
+                $row->addLabel('billingScheduleType', __('Scheduling'));
+				$row->addTextField('billingScheduleType')->isRequired()->readonly();
+				
+			if ($values['billingScheduleType'] == 'Scheduled') {
+				$row = $form->addRow();
+					$row->addLabel('billingScheduleName', __('Billing Schedule'));
+					$row->addTextField('billingScheduleName')->isRequired()->readonly();
+					$form->addHiddenValue('invoiceDueDate', dateConvertBack($guid, $values['billingScheduleInvoiceDueDate']));
+			} else {
+				$row = $form->addRow();
+					$row->addLabel('invoiceDueDate', __('Invoice Due Date'));
+					$row->addDate('invoiceDueDate')->isRequired()->readonly();
+			}
 
-                                            }
-                                        }
-                                    }
-                                }
-                    } else {
-                        $return .= "<div class='warning'>There is no company contact available to send this invoice to.</div>";
-                    }
-                } else {
-                    try {
-                        $dataParents = array('gibbonFinanceInvoiceeID' => $row['gibbonFinanceInvoiceeID']);
-                        $sqlParents = "SELECT parent.title, parent.surname, parent.preferredName, parent.email, parent.address1, parent.address1District, parent.address1Country, homeAddress, homeAddressDistrict, homeAddressCountry FROM gibbonFinanceInvoicee JOIN gibbonPerson AS student ON (gibbonFinanceInvoicee.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamilyChild ON (gibbonFamilyChild.gibbonPersonID=student.gibbonPersonID) JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID) JOIN gibbonPerson AS parent ON (gibbonFamilyAdult.gibbonPersonID=parent.gibbonPersonID) WHERE gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID AND (contactPriority=1 OR (contactPriority=2 AND contactEmail='Y')) ORDER BY contactPriority, surname, preferredName";
-                        $resultParents = $connection2->prepare($sqlParents);
-                        $resultParents->execute($dataParents);
-                    } catch (PDOException $e) {
-                        $return .= "<div class='error'>".$e->getMessage().'</div>';
-                    }
-                    if ($resultParents->rowCount() < 1) {
-                        $return .= "<div class='warning'>There are no family members available to send this receipt to.</div>";
-                    } else {
-                        while ($rowParents = $resultParents->fetch()) {
-                            if ($rowParents['preferredName'] != '' and $rowParents['surname'] != '' and $rowParents['email'] != '') {
-                                ?>
-								<tr>
-									<td>
-										<b><?php echo formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false) ?></b>
-										<span class="emphasis small"></span>
-									</td>
-									<td class="right">
-										<?php echo $rowParents['email']; ?> <input checked type='checkbox' name='emails[]' value='<?php echo htmlPrep($rowParents['email']); ?>'/>
-										<input type='hidden' name='names[]' value='<?php echo htmlPrep(formatName(htmlPrep($rowParents['title']), htmlPrep($rowParents['preferredName']), htmlPrep($rowParents['surname']), 'Parent', false)); ?>'/>
-									</td>
-								</tr>
-								<?php
+			$row = $form->addRow();
+				$row->addLabel('status', __('Status'));
+				$row->addTextField('status')->isRequired()->readonly();
 
-                            }
-                        }
-                    }
-                }
-            }
-                    //CC self?
-                    if ($_SESSION[$guid]['email'] != '') {
-                        ?>
-						<tr>
-							<td>
-								<b><?php echo formatName('', htmlPrep($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Parent', false) ?></b>
-								<span class="emphasis small"><?php echo __($guid, '(CC Self?)') ?></span>
-							</td>
-							<td class="right">
-								<?php echo $_SESSION[$guid]['email'];
-                        ?> <input type='checkbox' name='emails[]' value='<?php echo $_SESSION[$guid]['email'];
-                        ?>'/>
-								<input type='hidden' name='names[]' value='<?php echo formatName('', htmlPrep($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Parent', false);
-                        ?>'/>
-							</td>
-						</tr>
-						<?php
-					}
-                    ?>
-					<tr>
-						<td>
-							<span class="emphasis small">* <?php echo __($guid, 'denotes a required field'); ?></span>
-						</td>
-						<td class="right">
-							<input name="gibbonFinanceInvoiceID" id="gibbonFinanceInvoiceID" value="<?php echo $gibbonFinanceInvoiceID ?>" type="hidden">
-							<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
-							<input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
-						</td>
-					</tr>
-				</table>
-			</form>
-			<?php
+			$row = $form->addRow();
+                $row->addLabel('notes', __('Notes'))->description(__('Notes will be displayed on the final invoice and receipt.'));
+				$row->addTextArea('notes')->setRows(5);
+				
+			$form->addRow()->addHeading(__('Fees'));
 
+			$totalFee = getInvoiceTotalFee($pdo, $gibbonFinanceInvoiceID, $values['status']);
+			$row = $form->addRow();
+				$row->addLabel('totalFee', __('Total'))->description('<small><i>('.$_SESSION[$guid]['currency'].')</i></small>');
+				$row->addTextField('totalFee')->isRequired()->readonly()->setValue(number_format($totalFee, 2));
+
+			$row = $form->addRow();
+				$row->addLabel('invoiceTo', __('Invoice To'));
+				$row->addTextField('invoiceTo')->isRequired()->readonly();
+
+			$form->addRow()->addHeading(__('Email Invoice'));
+
+			$email = getSettingByScope($connection2, 'Finance', 'email');
+			$form->addHiddenValue('email', $email);
+			if (empty($email)) {
+				$form->addRow()->addAlert(__('An outgoing email address has not been set up under Invoice & Receipt Settings, and so no emails can be sent.'), 'error');
+			} else {
+				$form->addRow()->addInvoiceEmailCheckboxes('emails[]', 'names[]', $values, $gibbon->session);
+			}
+
+			$row = $form->addRow();
+                $row->addFooter();
+                $row->addSubmit();
+
+            $form->loadAllValuesFrom($values);
+
+            echo $form->getOutput();
         }
     }
 }
-?>

--- a/modules/Finance/invoices_manage_issueProcess.php
+++ b/modules/Finance/invoices_manage_issueProcess.php
@@ -107,7 +107,8 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                     }
 
                     $partialFail = false;
-
+                    $emailFail = false;
+                    
                     //Read & Organise Fees
                     $fees = array();
                     $count = 0;
@@ -185,7 +186,6 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                     $from = $_POST['email'];
                     if ($partialFail == false and $from != '') {
                         //Send emails
-                        $emailFail = false;
                         $emails = null;
                         if (isset($_POST['emails'])) {
                             $emails = $_POST['emails'];

--- a/modules/Finance/invoices_manage_issueProcess.php
+++ b/modules/Finance/invoices_manage_issueProcess.php
@@ -186,7 +186,7 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                     $from = $_POST['email'];
                     if ($partialFail == false and $from != '') {
                         //Send emails
-                        $emails = null;
+                        $emails = array() ;
                         if (isset($_POST['emails'])) {
                             $emails = $_POST['emails'];
                             for ($i = 0; $i < count($emails); ++$i) {

--- a/modules/Finance/invoices_payOnline.php
+++ b/modules/Finance/invoices_payOnline.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-@session_start();
+use Gibbon\Forms\Form;
 
 //Get variables
 $gibbonFinanceInvoiceID = '';
@@ -96,13 +96,18 @@ if (!isset($_GET['return'])) { //No return message, so must just be landing to m
                         echo '<p>';
                         if ($financeOnlinePaymentThreshold == '' or $financeOnlinePaymentThreshold >= $feeTotal) {
                             echo sprintf(__($guid, 'Payment can be made by credit card, using our secure PayPal payment gateway. When you press Pay Online Now, you will be directed to PayPal in order to make payment. During this process we do not see or store your credit card details. Once the transaction is complete you will be returned to %1$s.'), $_SESSION[$guid]['systemName']).' ';
-                            echo "<form method='post' action='".$_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/invoices_payOnlineProcess.php'>";
-                            echo "<input type='hidden' name='gibbonFinanceInvoiceID' value='$gibbonFinanceInvoiceID'>";
-                            echo "<input type='hidden' name='key' value='$key'>";
-                            echo "<div class='linkTop'>";
-                            echo $currency.$feeTotal." <input type='submit' value='Pay Online Now'>";
-                            echo '</div>';
-                            echo '</form>';
+
+                            $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/invoices_payOnlineProcess.php');
+                
+                            $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+                            $form->addHiddenValue('gibbonFinanceInvoiceID', $gibbonFinanceInvoiceID);
+                            $form->addHiddenValue('key', $key);
+
+                            $row = $form->addRow();
+                                $row->addContent($currency.$feeTotal);
+                                $row->addSubmit(__('Pay Online Now'));
+
+                            echo $form->getOutput();
                         } else {
                             echo "<div class='error'>".__($guid, 'Payment is not permitted for this invoice, as the total amount is greater than the permitted online payment threshold.').'</div>';
                         }

--- a/modules/Finance/invoices_view.php
+++ b/modules/Finance/invoices_view.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_view.php'
                     echo __($guid, 'Access denied.');
                     echo '</div>';
                 } elseif (count($options) == 1) {
-                    $_GET['search'] = $gibbonPersonID[0];
+                    $_GET['search'] = key($options);
                 } else {
                     echo '<h2>';
                     echo 'Choose Student';

--- a/modules/Finance/js/module.js
+++ b/modules/Finance/js/module.js
@@ -15,3 +15,11 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
+
+$(function(){
+    $('.invoiceNotes').hide();
+
+    $('a.invoiceNotesView').click(function(){
+        $(this).parents('tr').next('tr').toggle();
+    });
+});

--- a/modules/Finance/moduleFunctions.php
+++ b/modules/Finance/moduleFunctions.php
@@ -1161,7 +1161,7 @@ function invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
         $paypalAPIPassword = getSettingByScope($connection2, 'System', 'paypalAPIPassword');
         $paypalAPISignature = getSettingByScope($connection2, 'System', 'paypalAPISignature');
 
-        if ($enablePayments == 'Y' and $paypalAPIUsername != '' and $paypalAPIPassword != '' and $paypalAPISignature != '' and $row['status'] != 'Paid' and $row['status'] != 'Cancelled' and $row['status'] != 'Refunded') {
+        if (!$preview && $enablePayments == 'Y' and $paypalAPIUsername != '' and $paypalAPIPassword != '' and $paypalAPISignature != '' and $row['status'] != 'Paid' and $row['status'] != 'Cancelled' and $row['status'] != 'Refunded') {
             $financeOnlinePaymentEnabled = getSettingByScope($connection2, 'Finance', 'financeOnlinePaymentEnabled');
             $financeOnlinePaymentThreshold = getSettingByScope($connection2, 'Finance', 'financeOnlinePaymentThreshold');
             if ($financeOnlinePaymentEnabled == 'Y') {

--- a/modules/Finance/moduleFunctions.php
+++ b/modules/Finance/moduleFunctions.php
@@ -1681,3 +1681,25 @@ function getBudgetAllocated($pdo, $gibbonFinanceBudgetCycleID, $gibbonFinanceBud
     return $budgetAllocated;
 }
 
+function getInvoiceTotalFee($pdo, $gibbonFinanceInvoiceID, $status)
+{
+    try {
+        $dataTotal = array('gibbonFinanceInvoiceID' => $gibbonFinanceInvoiceID);
+        if ($status == 'Pending') {
+            $sqlTotal = 'SELECT gibbonFinanceInvoiceFee.fee AS fee, gibbonFinanceFee.fee AS fee2 FROM gibbonFinanceInvoiceFee LEFT JOIN gibbonFinanceFee ON (gibbonFinanceInvoiceFee.gibbonFinanceFeeID=gibbonFinanceFee.gibbonFinanceFeeID) WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID';
+        } else {
+            $sqlTotal = 'SELECT gibbonFinanceInvoiceFee.fee AS fee, NULL AS fee2 FROM gibbonFinanceInvoiceFee WHERE gibbonFinanceInvoiceID=:gibbonFinanceInvoiceID';
+        }
+        $resultTotal = $pdo->executeQuery($dataTotal, $sqlTotal);
+    } catch (PDOException $e) {
+        return null;
+    }
+
+    $totalFee = 0;
+
+    while ($rowTotal = $resultTotal->fetch()) {
+        $totalFee += is_numeric($rowTotal['fee2'])? $rowTotal['fee2'] : $rowTotal['fee'];
+    }
+
+    return $totalFee;
+}

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -379,34 +379,6 @@ class DatabaseFormFactory extends FormFactory
         return $this->createSelect($name)->fromArray($values);
     }
 
-    public function createSelectFinanceInvoicee($name, $gibbonSchoolYearID, $params = array())
-    {
-        $values = array();
-
-        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
-        $sql = "SELECT gibbonFinanceInvoiceeID, preferredName, surname, gibbonRollGroup.nameShort AS rollGroupName, dayType 
-                FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup, gibbonFinanceInvoicee
-                WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID 
-                AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID 
-                AND gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID 
-                AND status='FULL' 
-                AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID 
-                ORDER BY rollGroupName, surname, preferredName";
-
-        $results = $this->pdo->executeQuery($data, $sql);
-
-        $byRollGroup = array();
-        if ($results && $results->rowCount() > 0) {
-            while ($student = $results->fetch()) {
-                $byRollGroup[$student['gibbonFinanceInvoiceeID']] = $student['rollGroupName'].' - '.formatName('', $student['preferredName'], $student['surname'], 'Student', true);
-            }
-        }
-
-        $values[__('All Enrolled Students by Roll Group')] = $byRollGroup;
-                
-        return $this->createSelect($name)->fromArray($values);
-    }
-
     public function createSelectGradeScale($name)
     {
         $sql = "SELECT gibbonScaleID as value, name FROM gibbonScale WHERE (active='Y') ORDER BY name";

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -379,6 +379,34 @@ class DatabaseFormFactory extends FormFactory
         return $this->createSelect($name)->fromArray($values);
     }
 
+    public function createSelectFinanceInvoicee($name, $gibbonSchoolYearID, $params = array())
+    {
+        $values = array();
+
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
+        $sql = "SELECT gibbonFinanceInvoiceeID, preferredName, surname, gibbonRollGroup.nameShort AS rollGroupName, dayType 
+                FROM gibbonPerson, gibbonStudentEnrolment, gibbonRollGroup, gibbonFinanceInvoicee
+                WHERE gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID 
+                AND gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID 
+                AND gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID 
+                AND status='FULL' 
+                AND gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID 
+                ORDER BY rollGroupName, surname, preferredName";
+
+        $results = $this->pdo->executeQuery($data, $sql);
+
+        $byRollGroup = array();
+        if ($results && $results->rowCount() > 0) {
+            while ($student = $results->fetch()) {
+                $byRollGroup[$student['gibbonFinanceInvoiceeID']] = $student['rollGroupName'].' - '.formatName('', $student['preferredName'], $student['surname'], 'Student', true);
+            }
+        }
+
+        $values[__('All Enrolled Students by Roll Group')] = $byRollGroup;
+                
+        return $this->createSelect($name)->fromArray($values);
+    }
+
     public function createSelectGradeScale($name)
     {
         $sql = "SELECT gibbonScaleID as value, name FROM gibbonScale WHERE (active='Y') ORDER BY name";

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -195,9 +195,9 @@ class FormFactory implements FormFactoryInterface
         return $button;
     }
 
-    public function createCustomBlocks($name, OutputableInterface $block, \Gibbon\Session $session)
+    public function createCustomBlocks($name, \Gibbon\Session $session)
     {
-        return new Input\CustomBlocks($this, $name, $block, $session);
+        return new Input\CustomBlocks($this, $name, $session);
     }
 
     /* PRE-DEFINED LAYOUT --------------------------- */

--- a/src/Forms/FormRenderer.php
+++ b/src/Forms/FormRenderer.php
@@ -85,8 +85,9 @@ class FormRenderer implements FormRendererInterface
             // Output each element inside the row
             foreach ($row->getElements() as $element) {
                 $colspan = ($row->isLastElement($element) && $row->getElementCount() < $totalColumns)? 'colspan="'.($totalColumns + 1 - $row->getElementCount()).'"' : '';
-
-                $output .= sprintf('<%1$s class="%2$s" %3$s>', $this->wrappers['cell'], $element->getClass(), $colspan);
+                $class = (method_exists($element, 'getClass'))? $element->getClass() : '';
+                
+                $output .= sprintf('<%1$s class="%2$s" %3$s>', $this->wrappers['cell'], $class, $colspan);
                 $output .= $element->getOutput();
                 $output .= sprintf('</%1$s>', $this->wrappers['cell']);
 

--- a/src/Forms/Input/CustomBlocks.php
+++ b/src/Forms/Input/CustomBlocks.php
@@ -38,6 +38,8 @@ class CustomBlocks implements OutputableInterface
     protected $placeholder;
 
     protected $blockTemplate;
+    protected $blocks;
+
     protected $toolsTable;
     protected $blockButtons;
 
@@ -57,7 +59,9 @@ class CustomBlocks implements OutputableInterface
         $this->placeholder = __('Blocks will appear here...'); 
 
         $this->blockTemplate = $block->setClass('blank fullWidth');
-        $this->toolsTable = $factory->createTable()->setClass('inputTools blank fullWidth');
+        $this->blocks = array();
+
+        $this->toolsTable = $factory->createTable()->setClass('inputTools fullWidth');
         $this->blockButtons = $factory->createGrid()->setClass('blockButtons blank fullWidth')->setColumns(2);
         $this->addBlockButton(__('Delete'), 'garbage.png', '', 'deleteButton');
 
@@ -121,6 +125,18 @@ class CustomBlocks implements OutputableInterface
         return $this;
     }
 
+    /**
+     * Adds a predefined block.
+     * @param  OutputableInterface  $block
+     * @return self
+     */
+    public function addBlock($id, OutputableInterface $block)
+    {
+        $this->blocks[$id] = $block;
+
+        return $this;
+    }
+
     public function getClass()
     {
         return '';
@@ -146,7 +162,7 @@ class CustomBlocks implements OutputableInterface
         $output .= '<div class="customBlocks" id="' . $this->name. '" style="width: 100%; padding: 5px 0px 0px 0px; min-height: 66px">';
 
             $output .= '<input type="hidden" class="blockCount" name="'.$this->name.'Count" value="0" />';
-            $output .= '<div class="blockPlaceholder" style="color: #ddd; font-size: 230%; padding: 15px 0 15px 6px">'.$this->placeholder.'</div>';
+            $output .= '<div class="blockPlaceholder '.(count($this->blocks) > 0 ? 'displayNone' : '').'" style="color: #ddd; font-size: 230%; padding: 15px 0 15px 6px">'.$this->placeholder.'</div>';
 
             $output .= '<div class="blockTemplate displayNone hiddenReveal" style="overflow:hidden; border: 1px solid #d8dcdf; margin: 0 0 5px">';
                 $output .= '<div class="blockInputs" style="float:left; width:92%; padding: 5px; box-sizing: border-box;">';
@@ -157,6 +173,18 @@ class CustomBlocks implements OutputableInterface
                     $output .= $this->blockButtons->getOutput();
                 $output .= '</div>';
             $output .= '</div>';
+
+            foreach ($this->blocks as $id => $block) {
+                $output .= '<div class="blockPrefab hiddenReveal" data-identifier="'.$id.'" style="overflow:hidden; border: 1px solid #d8dcdf; margin: 0 0 5px">';
+                    $output .= '<div class="blockInputs" style="float:left; width:92%; padding: 5px; box-sizing: border-box;">';
+                        $output .= $block->getOutput();
+                    $output .= '</div>';
+
+                    $output .= '<div class="blockSidebar" style="float:right; width: 8%; ">';
+                        $output .= $this->blockButtons->getOutput();
+                    $output .= '</div>';
+                $output .= '</div>';
+            }
             
             $output .= $this->toolsTable->getOutput();
         $output .= '</div>';

--- a/src/Forms/Input/CustomBlocks.php
+++ b/src/Forms/Input/CustomBlocks.php
@@ -114,6 +114,7 @@ class CustomBlocks implements OutputableInterface
      * Adds the given button to the sidebar of each block.
      * Note: The name of the button is triggered as an event on the Block element when clicked, as function(event, block, button)
      * @param  string  $name
+     * @param  string  $title
      * @param  string  $icon
      * @param  string  $function
      * @return self
@@ -176,9 +177,9 @@ class CustomBlocks implements OutputableInterface
         $output .= '<div class="customBlocks" id="' . $this->name. '">';
 
             $output .= '<input type="hidden" class="blockCount" name="'.$this->name.'Count" value="0" />';
-            $output .= '<div class="blockPlaceholder '.(count($this->settings['currentBlocks']) > 0 ? 'displayNone' : '').'">'.$this->settings['placeholder'].'</div>';
+            $output .= '<div class="blockPlaceholder" style="'.(count($this->settings['currentBlocks']) > 0 ? 'display: none;' : '').'">'.$this->settings['placeholder'].'</div>';
    
-            $output .= '<div class="blockTemplate displayNone">';
+            $output .= '<div class="blockTemplate" style="display: none;">';
                 $output .= '<div class="blockInputs floatLeft">';
                 $output .= $this->getTemplateOutput($this->blockTemplate);
                 $output .= '</div>';

--- a/src/Forms/Input/CustomBlocks.php
+++ b/src/Forms/Input/CustomBlocks.php
@@ -174,28 +174,29 @@ class CustomBlocks implements OutputableInterface
     {
         $output = '';
 
-        $output .= '<style>
-                #' . $this->name . ' { list-style-type: none; margin: 0; padding: 0; width: 100%; }
-                #' . $this->name . ' div.ui-state-default { margin: 0 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-                div.ui-state-default_dud { margin: 5px 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-                #' . $this->name . ' li { min-height: 58px; line-height: 1.2em; }
-                .' . $this->name . '-ui-state-highlight { margin-bottom: 5px; min-height: 58px; line-height: 1.2em; width: 100%; }
-                .' . $this->name . '-ui-state-highlight {border: 1px solid #fcd3a1; background: #fbf8ee url(images/ui-bg_glass_55_fbf8ee_1x400.png) 50% 50% repeat-x; color: #444444; }
-            </style>';
+        // $output .= '<style>
+        //         #' . $this->name . ' { list-style-type: none; margin: 0; padding: 0; width: 100%; }
+        //         #' . $this->name . ' div.ui-state-default { margin: 0 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
+        //         div.ui-state-default_dud { margin: 5px 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
+        //         #' . $this->name . ' li { min-height: 58px; line-height: 1.2em; }
+        //     </style>';
 
-        $output .= '<div class="customBlocks" id="' . $this->name. '" style="width: 100%; padding: 5px 0px 0px 0px; min-height: 66px">';
+        $output .= '<div class="customBlocks" id="' . $this->name. '">';
 
             $output .= '<input type="hidden" class="blockCount" name="'.$this->name.'Count" value="0" />';
-            $output .= '<div class="blockPlaceholder '.(count($this->settings['currentBlocks']) > 0 ? 'displayNone' : '').'" style="color: #ddd; font-size: 230%; padding: 15px 0 15px 6px">'.$this->settings['placeholder'].'</div>';
-
-            $output .= '<div class="blockTemplate displayNone hiddenReveal" style="overflow:hidden; border: 1px solid #d8dcdf; margin: 0 0 5px">';
-                $output .= '<div class="blockInputs" style="float:left; width:92%; padding: 5px; box-sizing: border-box;">';
+            $output .= '<div class="blockPlaceholder '.(count($this->settings['currentBlocks']) > 0 ? 'displayNone' : '').'">'.$this->settings['placeholder'].'</div>';
+   
+            $output .= '<div class="blockTemplate displayNone">';
+                $output .= '<div class="blockInputs floatLeft">';
                 $output .= $this->getTemplateOutput($this->blockTemplate);
                 $output .= '</div>';
 
-                $output .= '<div class="blockSidebar" style="float:right; width: 8%; ">';
+                $output .= '<div class="blockSidebar floatRight">';
                     $output .= $this->blockButtons->getOutput();
                 $output .= '</div>';
+            $output .= '</div>';
+
+            $output .= '<div class="blocks">';
             $output .= '</div>';
             
             $output .= $this->toolsTable->getOutput();

--- a/src/Forms/Input/CustomBlocks.php
+++ b/src/Forms/Input/CustomBlocks.php
@@ -30,14 +30,16 @@ use Gibbon\Forms\FormFactoryInterface;
  */
 class CustomBlocks implements OutputableInterface
 {
-
-    protected $name;
-    protected $placeholder;
-    protected $toolInputs;
-    protected $blockButtons;
-    protected $blockTemplate;
     protected $factory;
     protected $session;
+
+    protected $name;
+    protected $settings;
+    protected $placeholder;
+
+    protected $blockTemplate;
+    protected $toolsTable;
+    protected $blockButtons;
 
     /**
      * Create a Blocks input with a given template.
@@ -48,13 +50,20 @@ class CustomBlocks implements OutputableInterface
      */
     public function __construct(FormFactoryInterface &$factory, $name, OutputableInterface $block, \Gibbon\Session $session)
     {
-        $this->session = $session;
         $this->factory = $factory;
+        $this->session = $session;
+
         $this->name = $name;
-        $this->placeholder = __("Blocks will appear here..."); 
-        $this->toolInputs = array($factory->createButton(__("Add Block"), 'add'. $this->name .'Block()'));
-        $this->blockButtons = array();
-        $this->blockTemplate = $block->setClass("blank fullWidth")->getOutput();
+        $this->placeholder = __('Blocks will appear here...'); 
+
+        $this->blockTemplate = $block->setClass('blank fullWidth');
+        $this->toolsTable = $factory->createTable()->setClass('inputTools blank fullWidth');
+        $this->blockButtons = $factory->createGrid()->setClass('blockButtons blank fullWidth')->setColumns(2);
+        $this->addBlockButton(__('Delete'), 'garbage.png', '', 'deleteButton');
+
+        $this->settings = array(
+            'deleteConfirm' => __('Are you sure you want to delete this record?'),
+        );
     }
 
     /**
@@ -69,13 +78,24 @@ class CustomBlocks implements OutputableInterface
     }
 
     /**
+     * Updates the settings array which is passed as json params to JS.
+     * @param  string  $value
+     * @return self
+     */
+    public function settings($value)
+    {
+        $this->settings = array_replace($this->settings, $value);
+        return $this;
+    }
+
+    /**
      * Adds the given input into the tool bar.
      * @param  OutputableInterface  $value
      * @return self
      */
     public function addToolInput(OutputableInterface $input)
     {
-        $this->toolInputs[] = $input;
+        $this->toolsTable->addRow()->addElement($input)->addClass('floatNone');
         return $this;
     }
 
@@ -87,9 +107,17 @@ class CustomBlocks implements OutputableInterface
      * @param  string  $function
      * @return self
      */
-    public function addBlockButton($name, $icon, $function)
+    public function addBlockButton($name, $icon, $function = '', $class = '')
     {
-        $this->blockButtons[] = array("name" => $name, "icon" => $icon, "function" => $function);
+        $iconSrc = stripos($icon, '/') === false? './themes/'.$this->session->get("gibbonThemeName").'/img/'.$icon : $icon;
+        $button = $this->factory->createWebLink('<img title="'.$name.'" src="'.$iconSrc.'" style="margin-right:4px;" />')
+            ->setURL('#')
+            ->addClass('blockButton');
+
+        if (!empty($function)) $button->addData('function', $function);
+        if (!empty($class)) $button->addClass($class);
+
+        $this->blockButtons->addCell()->addElement($button);
         return $this;
     }
 
@@ -110,96 +138,33 @@ class CustomBlocks implements OutputableInterface
                 #' . $this->name . ' { list-style-type: none; margin: 0; padding: 0; width: 100%; }
                 #' . $this->name . ' div.ui-state-default { margin: 0 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
                 div.ui-state-default_dud { margin: 5px 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-                html>body #' . $this->name . ' li { min-height: 58px; line-height: 1.2em; }
+                #' . $this->name . ' li { min-height: 58px; line-height: 1.2em; }
                 .' . $this->name . '-ui-state-highlight { margin-bottom: 5px; min-height: 58px; line-height: 1.2em; width: 100%; }
                 .' . $this->name . '-ui-state-highlight {border: 1px solid #fcd3a1; background: #fbf8ee url(images/ui-bg_glass_55_fbf8ee_1x400.png) 50% 50% repeat-x; color: #444444; }
             </style>';
 
-        $output .= '<div class="' . $this->name. '" id="' . $this->name. '" style="width: 100%; padding: 5px 0px 0px 0px; min-height: 66px">
-            <div id="' . $this->name . 'Outer0">
-                <div style="color: #ddd; font-size: 230%; margin: 15px 0 15px 6px">' . $this->placeholder . '</div>
-           </div>
+        $output .= '<div class="customBlocks" id="' . $this->name. '" style="width: 100%; padding: 5px 0px 0px 0px; min-height: 66px">';
 
-           <div id="'. $this->name .'Template" class="hiddenReveal" style="display:none; overflow:hidden; border: 1px solid #d8dcdf; margin: 0 0 5px">
-                <div style="float:left; width:92%;">'. $this->blockTemplate .'</div>
-                <div style="float:right; width: 8%; ">
-                    <table class="blank">
-                        <tr>
-                            <td>
-                                <img id="' . $this->name . 'deleteTemplate" title="' . __('Delete') . '" src="./themes/' . $this->session->get("gibbonThemeName") . '/img/garbage.png"/>
-                            </td>
-                            ';
-                            $count = 1;
-                            foreach ($this->blockButtons as $blockButton) {
-                                if ($count % 2 == 0) {
-                                    $output.= '</tr><tr>';
-                                }
-                                $output .= '<td>
-                                    <img id="' . $this->name . $count . 'ButtonTemplate" title="' . $blockButton["name"] . '" src="' . $blockButton["icon"] . '"/>
-                                </td>';
-                                $count++;
-                            }
+            $output .= '<input type="hidden" class="blockCount" name="'.$this->name.'Count" value="0" />';
+            $output .= '<div class="blockPlaceholder" style="color: #ddd; font-size: 230%; padding: 15px 0 15px 6px">'.$this->placeholder.'</div>';
 
-                            if ($count % 2 == 1) {
-                                $output .= '<td></td>';
-                            }
+            $output .= '<div class="blockTemplate displayNone hiddenReveal" style="overflow:hidden; border: 1px solid #d8dcdf; margin: 0 0 5px">';
+                $output .= '<div class="blockInputs" style="float:left; width:92%; padding: 5px; box-sizing: border-box;">';
+                $output .= $this->blockTemplate->getOutput();
+                $output .= '</div>';
 
-                            $output .= '
-                        </tr>
-                    </table>
-                </div>
-            </div>
+                $output .= '<div class="blockSidebar" style="float:right; width: 8%; ">';
+                    $output .= $this->blockButtons->getOutput();
+                $output .= '</div>';
+            $output .= '</div>';
             
-            <div id="'. $this->name .'Tools" class="ui-state-default_dud" style="width: 100%; padding: 0px; height: 40px; display: table">
-                <table class="blank" cellspacing="0" style="width: 100%">
-                    <tr>';
-                        foreach ($this->toolInputs as $toolInput) {
-                            $output .= '<td style="float: left">' . $toolInput->getOutput() . '</td>';
-                        }
-                    $output .= '</tr>
-                </table>
-            </div>
-        </div>';
+            $output .= $this->toolsTable->getOutput();
+        $output .= '</div>';
 
         $output .= '<script type="text/javascript">
-            var ' . $this->name . 'Count = 1;
-            function add'. $this->name .'Block() {
-                $("#' . $this->name . 'Outer0").css("display", "none");
-                $("#'. $this->name . 'Template").clone().css("display", "block").prop("id", "'. $this->name .'Outer" + ' . $this->name . 'Count).insertBefore($("#'. $this->name .'Tools"));
-                $("#'. $this->name .'Outer" + ' . $this->name . 'Count + " input[id], #'. $this->name .'Outer" + ' . $this->name . 'Count + " textarea[id]").each(function () { $(this).prop("name", $(this).prop("id") + "[" + ' . $this->name . 'Count + "]"); });
-                $("#'. $this->name .'Outer" + ' . $this->name . 'Count + " label").each(function () { $(this).prop("for", $(this).prop("for") + "[" + ' . $this->name . 'Count + "]"); });
-                $(\'<input>\').attr({
-                            type: \'hidden\',
-                            name: \'' . $this->name . 'Order[]\'
-                        }).val(' . $this->name . 'Count).appendTo($("#'. $this->name .'Outer" + ' . $this->name . 'Count));
-                $("#'. $this->name .'Outer" + ' . $this->name . 'Count + " img[id*= '. $this->name . 'deleteTemplate]").each(function () {
-                    $(this).prop("id", "' . $this->name . 'Delete" + ' . $this->name . 'Count);
-                    $(this).unbind("click").click(function() {
-                        if (confirm("Are you sure you want to delete this record?")) {
-                            $("#'. $this->name .'Outer" + $(this).attr("id").split("Delete")[1]).fadeOut(600, function(){
-                               $(this).remove();
-                                if ($("#'. $this->name .'").children().length == 3) {
-                                    $("#' . $this->name . 'Outer0").css("display", "block");
-                                }
-                            });
-                        }
-                    });
-                });';
-
-                $count = 1;
-                foreach ($this->blockButtons as $blockButton)
-                {
-                    $output .= '$("#'. $this->name .'Outer" + ' . $this->name . 'Count + " img[id*= '. $this->name . $count . 'ButtonTemplate]").each(function () {
-                        $(this).prop("id", "' . $this->name . $count . 'Button" + ' . $this->name . 'Count);
-                        $(this).unbind("click").click(function() {
-                           ' . $blockButton["function"] . '($(this).attr("id").split("Button")[1]);
-                        });
-                    });';
-                    $count++;
-                }
-
-                $output .= $this->name . 'Count++;
-            }
+            $(function(){
+                $("#'.$this->name.'").gibbonCustomBlocks('.json_encode($this->settings).');
+            });
         </script>';
 
         return $output;

--- a/src/Forms/Input/CustomBlocks.php
+++ b/src/Forms/Input/CustomBlocks.php
@@ -100,7 +100,7 @@ class CustomBlocks implements OutputableInterface
     }
 
     /**
-     * Adds the given input into the tool bar.
+     * Adds the given input into the tool bar at the bottom.
      * @param  OutputableInterface  $value
      * @return self
      */
@@ -111,8 +111,8 @@ class CustomBlocks implements OutputableInterface
     }
 
     /**
-     * Adds the given button to each block. 
-     * Note: $function must be the name of the function (i.e. "func" not "func()"). The function must only take in one input (the id of the block).
+     * Adds the given button to the sidebar of each block.
+     * Note: The name of the button is triggered as an event on the Block element when clicked, as function(event, block, button)
      * @param  string  $name
      * @param  string  $icon
      * @param  string  $function
@@ -120,15 +120,14 @@ class CustomBlocks implements OutputableInterface
      */
     public function addBlockButton($name, $title, $icon, $class = '')
     {
-        $iconImg = '<img title=%1$s src="%2$s" style="margin-right:4px;" />';
         $iconPath = './themes/'.$this->session->get("gibbonThemeName").'/img/';
         $iconSrc = stripos($icon, '/') === false? $iconPath.$icon : $icon;
         
-        $button = $this->factory->createWebLink(sprintf($iconImg, $title, $iconSrc))
+        $button = $this->factory->createWebLink(sprintf('<img title=%1$s src="%2$s" style="margin-right:4px;" />', $title, $iconSrc))
             ->setURL('#')
             ->addClass('blockButton');
 
-        if (!empty($name)) $button->addData('event', $name."Clicked");
+        if (!empty($name)) $button->addData('event', $name);
         if (!empty($class)) $button->addClass($class);
 
         if ($name == 'showHide') {
@@ -154,7 +153,7 @@ class CustomBlocks implements OutputableInterface
     }
 
     /**
-     * Add a set of data that a new block can be created from via identifier.
+     * Add a set of data that a new block can be created from via an identifier + add block trigger.
      * @param string  $id
      * @param array   $data
      * @return self
@@ -173,13 +172,6 @@ class CustomBlocks implements OutputableInterface
     public function getOutput()
     {
         $output = '';
-
-        // $output .= '<style>
-        //         #' . $this->name . ' { list-style-type: none; margin: 0; padding: 0; width: 100%; }
-        //         #' . $this->name . ' div.ui-state-default { margin: 0 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-        //         div.ui-state-default_dud { margin: 5px 0px 5px 0px; padding: 5px; font-size: 100%; min-height: 58px; }
-        //         #' . $this->name . ' li { min-height: 58px; line-height: 1.2em; }
-        //     </style>';
 
         $output .= '<div class="customBlocks" id="' . $this->name. '">';
 
@@ -218,10 +210,7 @@ class CustomBlocks implements OutputableInterface
      */
     protected function getTemplateOutput(OutputableInterface $template)
     {
-        // Trigger the output before adding validations: some Inputs add these on getOutput();
-        $output = 
-
-        // Look for and jsonify the validations recursivly
+        // Look for and jsonify all nested validations recursivly
         $addValidation = function($element) use (&$addValidation) {
             if (method_exists($element, 'getElements')) {
                 foreach ($element->getElements() as $innerElement) {
@@ -230,6 +219,7 @@ class CustomBlocks implements OutputableInterface
             }
 
             if ($element instanceof Input && $element->hasValidation()) {
+                // Trigger the output before getting validations: some Inputs add these on getOutput();
                 $elementOutput = $element->getOutput();
                 $element->addData('validation', $element->getValidationAsJSON());
             }

--- a/src/Forms/Input/Number.php
+++ b/src/Forms/Input/Number.php
@@ -94,7 +94,7 @@ class Number extends TextField
         $this->addValidation('Validate.Numericality', implode(', ', $validateParams));
 
         if (!empty($this->decimalPlaces) && $this->decimalPlaces > 0) {
-            $this->addValidation('Validate.Format', 'pattern: /^[0-9\-]+\.([0-9]{1,'.$this->decimalPlaces.'})?$/, failureMessage: "'.sprintf(__('Must be in format %1$s'), str_pad('0.', $this->decimalPlaces+2, '0')).'"');
+            $this->addValidation('Validate.Format', 'pattern: /^[0-9\-]+(\.[0-9]{1,'.$this->decimalPlaces.'})?$/, failureMessage: "'.sprintf(__('Must be in format %1$s'), str_pad('0.', $this->decimalPlaces+2, '0')).'"');
         }
 
         $output = '<input type="text" '.$this->getAttributeString().'>';

--- a/src/Forms/Layout/Grid.php
+++ b/src/Forms/Layout/Grid.php
@@ -80,7 +80,7 @@ class Grid implements OutputableInterface, ValidatableInterface
      * Get all cells in the grid.
      * @return  array
      */
-    public function getCells()
+    public function getElements()
     {
         return $this->elements;
     }
@@ -96,7 +96,7 @@ class Grid implements OutputableInterface, ValidatableInterface
 
         $cellWidth = 100 / $this->columns;
         $emptyCell = $this->factory->createColumn();
-        $rows = array_chunk($this->getCells(), $this->columns);
+        $rows = array_chunk($this->getElements(), $this->columns);
         
         foreach ($rows as $cells) {
             $cells = array_pad($cells, $this->columns, $emptyCell);
@@ -133,7 +133,7 @@ class Grid implements OutputableInterface, ValidatableInterface
     {
         $output = '';
 
-        foreach ($this->getCells() as $cell) {
+        foreach ($this->getElements() as $cell) {
             foreach ($cell->getElements() as $element) {
                 if ($element instanceof ValidatableInterface) {
                     $output .= $element->getValidationOutput();
@@ -151,7 +151,7 @@ class Grid implements OutputableInterface, ValidatableInterface
      */
     public function loadFrom(&$data)
     {
-        foreach ($this->getCells() as $cell) {
+        foreach ($this->getElements() as $cell) {
             $cell->loadFrom($data);
         }
 

--- a/src/Forms/Layout/Table.php
+++ b/src/Forms/Layout/Table.php
@@ -90,7 +90,7 @@ class Table implements OutputableInterface, ValidatableInterface
      * Get all rows in the table.
      * @return  array
      */
-    public function getRows()
+    public function getElements()
     {
         return $this->rows;
     }
@@ -124,7 +124,7 @@ class Table implements OutputableInterface, ValidatableInterface
 
         // Output table rows
         $output .= '<tbody>';
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getElements() as $row) {
             $output .= '<tr '.$row->getAttributeString().'>';
 
             // Output each element inside the row
@@ -152,7 +152,7 @@ class Table implements OutputableInterface, ValidatableInterface
             $count = max($count, $row->getElementCount());
         }
 
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getElements() as $row) {
             $count = max($count, $row->getElementCount());
         }
 
@@ -177,7 +177,7 @@ class Table implements OutputableInterface, ValidatableInterface
     {
         $output = '';
 
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getElements() as $row) {
             foreach ($row->getElements() as $element) {
                 if ($element instanceof ValidatableInterface) {
                     $output .= $element->getValidationOutput();
@@ -195,7 +195,7 @@ class Table implements OutputableInterface, ValidatableInterface
      */
     public function loadFrom(&$data)
     {
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getElements() as $row) {
             $row->loadFrom($data);
         }
 

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1514,6 +1514,10 @@ fieldset {
     display: inline-block;
 }
 
+.displayNone {
+    display: none;
+}
+
 /* Fixes an odd colspan-related width bug in Chrome */
 td.fullWidth[colspan] {
     width: auto;

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1432,11 +1432,11 @@ input[name*="phone"] ~ .LV_invalid {
 }
 
 .floatLeft {
-	float: left;
+	float: left!important;
 }
 
 .floatRight {
-	float: right;
+	float: right!important;
 }
 
 .floatNone {

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1518,10 +1518,6 @@ fieldset {
     display: inline-block;
 }
 
-.displayNone {
-    display: none;
-}
-
 /* Fixes an odd colspan-related width bug in Chrome */
 td.fullWidth[colspan] {
     width: auto;

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1432,11 +1432,11 @@ input[name*="phone"] ~ .LV_invalid {
 }
 
 .floatLeft {
-	float: left!important;
+	float: left;
 }
 
 .floatRight {
-	float: right!important;
+	float: right;
 }
 
 .floatNone {
@@ -1539,6 +1539,50 @@ table.smallIntBorder td.noPadding {
 
 .noBorder {
     border: 0!important; 
+}
+
+/* CUSTOM BLOCKS v16 */
+.customBlocks .sortHighlight {
+    margin-bottom: 5px; 
+    min-height: 80px; 
+    line-height: 1.2em; 
+    width: 100%;
+    border: 1px solid #fcd3a1; 
+    background: #fbf8ee;
+    color: #444444;
+}
+
+.customBlocks .sortHandle {
+    width: 2px;
+    height: 70px;
+    margin: 5px;
+    border-color: #c7dae9;
+    border-style: dotted;
+    border-width: 0px 3px 0px 3px;
+    cursor: move;
+}
+
+.blockPlaceholder {
+    color: #ddd;
+    font-size: 230%;
+    padding: 15px 0 15px 6px;
+}
+
+.blockTemplate {
+    overflow:hidden;
+    background: #EDF7FF;
+    border: 1px solid #d8dcdf;
+    margin: 0 0 5px;
+}
+
+.blockSidebar {
+    width: 8%;
+}
+
+.blockInputs {
+    width:88%;
+    padding: 5px;
+    box-sizing: border-box;
 }
 
 .blockInputs input, .blockInputs textarea, .blockInputs select {

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -679,7 +679,7 @@ input[type="text"], input[type="password"], input[type="file"] {
 	background-color: #ffffff ;
 	height: 28px;
 	float:right;
-	margin-left: 5px ;
+	margin-left: 4px ;
 	font-size: 13px ;
     box-sizing: border-box;
 }
@@ -702,7 +702,7 @@ textarea {
 	border: 1px solid #BFBFBF;
 	background-color: #ffffff ;
 	float:right;
-	margin-left: 5px ;
+	margin-left: 4px ;
 	font-size: 13px ;
     box-sizing: border-box;
     padding: 4px;
@@ -711,9 +711,9 @@ textarea {
 select {
 	border: 1px solid #BFBFBF;
 	background-color: #ffffff ;
-	height: 30px;
+	height: 28px;
 	float:right;
-	margin-left: 5px ;
+	margin-left: 4px ;
 	font-size: 13px ;
     box-sizing: border-box;
 }
@@ -1431,8 +1431,12 @@ input[name*="phone"] ~ .LV_invalid {
 	line-height: 22px;
 }
 
+.floatLeft {
+	float: left!important;
+}
+
 .floatRight {
-	float: right;
+	float: right!important;
 }
 
 .floatNone {
@@ -1535,4 +1539,27 @@ table.smallIntBorder td.noPadding {
 
 .noBorder {
     border: 0!important; 
+}
+
+.blockInputs input, .blockInputs textarea, .blockInputs select {
+    border: 1px solid #BFBFBF;
+    font-style: italic;
+}
+
+.blockInputs .readonly {
+    color: #222222;
+    border: 1px dotted #aaa;
+    background: none;
+}
+
+.blockInputs select.readonly {
+    pointer-events: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+
+.blockInputs .title {
+    font-style: normal;
+	font-weight: bold;
+	font-size: 16px;
 }

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1575,6 +1575,10 @@ table.smallIntBorder td.noPadding {
     margin: 0 0 5px;
 }
 
+.blockTemplate.ui-sortable-helper {
+	max-height: 80px !important;
+}
+
 .blockSidebar {
     width: 8%;
 }


### PR DESCRIPTION
_"It's just five pages, how hard could it be..."_ 😬 

This PR completes the ooification for the finance module, and adds in the reusable js and css for CustomBlocks which are the final piece of the puzzle for the remaining Planner forms. This builds on Ray's work on CustomBlocks and primarily separates out the inline code into reusable functions.

It ended up being a fairly large change set, although many of the files have only had a couple lines updated. Some of the notable changes are:

- Custom Blocks:
  - Blocks are defined by passing a template into the CustomBlocks class, which is cloned for each new block. The contents of a block can be any `OutputableInterface` object, which includes all Form API elements. 
  - Button clicks are dispatched as events so they can be handled in js with `.on()`. There's two built-in button events: delete and showHide.
  - Drag-drop sorting can be enabled with the `sortable: true` setting.
  - Validations inside added and removed blocks are hooked up and destroyed as necessary.
  - Adds some settings so the add block event and input naming behaviors aren't fixed to one implementation.
  - No ajax required: all the elements are defined through the Form API or as json data.
- Adds a FinanceFormFactory for the many types of inputs that are common between finance forms but only used in this one module.
- Tidies up the validations logic in the Input class, and updates the methods for nested elements so they can be traversed recursively. 

_Edit: I absolutely intend to tackle the bizarrely complex filtering query in the middle of invoices_manage.php ... just, not today!_