### PR TITLE
System Admin: apply translation function to timezones in System Settings

### DIFF
--- a/installer/install.php
+++ b/installer/install.php
@@ -577,7 +577,10 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
                                                     $row->addSelectCurrency($setting['name'])->isRequired();
 
-                                                $tzlist = DateTimeZone::listIdentifiers(DateTimeZone::ALL);
+                                                $tzlist = array_reduce(DateTimeZone::listIdentifiers(DateTimeZone::ALL), function($group, $item) {
+                                                    $group[$item] = __($item);
+                                                    return $group;
+                                                }, array());
                                                 $setting = getSettingByScope($connection2, 'System', 'timezone', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));

--- a/modules/System Admin/systemSettings.php
+++ b/modules/System Admin/systemSettings.php
@@ -216,7 +216,10 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addSelect($setting['name'])->fromString('Monday, Sunday')->selected($setting['value'])->isRequired();
 
-    $tzlist = DateTimeZone::listIdentifiers(DateTimeZone::ALL);
+    $tzlist = array_reduce(DateTimeZone::listIdentifiers(DateTimeZone::ALL), function($group, $item) {
+        $group[$item] = __($item);
+        return $group;
+    }, array());
     $setting = getSettingByScope($connection2, 'System', 'timezone', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));


### PR DESCRIPTION
Fixed the timezone array so the keys are kept the same and the values are run through __() to translate.

_I'll add my 2¢ here and then drop the issue: I do wonder if come release time every translator (and every future translator) is going to get hit with a pile of 400+ unnecessary translations, making it harder to maintain 100% translation. If it was a commonly used feature it would make sense, but timezone is pretty much set once and never changed again. Perhaps string replacement may be a decent compromise in cases where an admin really wanted that single value translated.`</soapbox>`_ 