### PR TITLE
Form Class: add the username and role category to SelectUsers list

### DIFF
--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -257,8 +257,9 @@ class DatabaseFormFactory extends FormFactory
 
     public function createSelectUsers($name)
     {
-        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, username, gibbonRole.category
                 FROM gibbonPerson
+                JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary)
                 WHERE status='Full' ORDER BY surname, preferredName";
 
         $results = $this->pdo->executeQuery(array(), $sql);
@@ -266,7 +267,7 @@ class DatabaseFormFactory extends FormFactory
         $values = array();
         if ($results && $results->rowCount() > 0) {
             while ($row = $results->fetch()) {
-                $values[$row['gibbonPersonID']] = formatName(htmlPrep($row['title']), ($row['preferredName']), htmlPrep($row['surname']), 'Staff', true, true);
+                $values[$row['gibbonPersonID']] = formatName(htmlPrep($row['title']), ($row['preferredName']), htmlPrep($row['surname']), 'Staff', true, true).' ('.$row['username'].', '.$row['category'].')';
             }
         }
 


### PR DESCRIPTION
On the Manage Staff > Add Staff page there's currently no way to differentiate between users with the same name. This updates the options for SelectUsers to include the username and role category, making it easier to ensure the correct user is selected. Also applies to the library catalogue, and any page using this type of select in the future.