### PR TITLE
Highlight current day of week...

### DIFF
--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -811,7 +811,11 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                         }
                     }
 
+                    if (date($_SESSION[$guid]['i18n']['dateFormatPHP'], ($startDayStamp + (86400 * $dateCorrection))) == date($_SESSION[$guid]['i18n']['dateFormatPHP'], (time() + (86400)))){ 
+                    $output .= "<th style='color:#390; vertical-align: top; text-align: center; width: ";
+                    } else{
                     $output .= "<th style='vertical-align: top; text-align: center; width: ";
+                    }
                     if ($narrow == 'trim') {
                         $output .= (550 / $daysInWeek);
                     } elseif ($narrow == 'narrow') {


### PR DESCRIPTION
...for people who really do not want to read!

This patch makes the current day of the week green (#390) so it is obvious to time surfers that they are back to reality (i.e. current time). Useful for people who browse forward and back through weeks a lot.