### PR TITLE
Students: remove unnecessary isUnique in Manage Application Form

### DIFF
--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -494,9 +494,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $form->addHiddenValue('parent1email', $application['parent1email']);
             $email = $form->addHiddenValue('parent1gibbonPersonID', $application['parent1gibbonPersonID']);
-            if ($uniqueEmailAddress == 'Y') {
-                $email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('fieldName' => 'email'));
-            }
 
             $row = $form->addRow();
                 $row->addLabel('parent1surname', __('Surname'))->description(__('Family name as shown in ID documents.'));


### PR DESCRIPTION
Minor bug fix (v16 only). I must have been a little overzealous applying the isUnique check to _all_ the email fields 😏 