### PR TITLE
Form Class: tweak Select class logic, add TextArea methods

### DIFF
--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -190,7 +190,7 @@ class Select extends Input
 
         if (isset($this->placeholder) && $this->getAttribute('multiple') == false) {
             // Add a placeholder only if the first option is not already blank
-            if (count($this->getOptions()) == 0 || key($this->getOptions()) != '') {
+            if (count($this->getOptions()) == 0 || key($this->getOptions()) !== '') {
                 $output .= '<option value="'.$this->placeholder.'">'.$this->placeholder.'</option>';
             }
 

--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -158,7 +158,7 @@ class Select extends Input
         if (is_array($this->selected)) {
             return in_array($value, $this->selected);
         } else {
-            $selected = ($value == $this->selected);
+            $selected = strval($value) == strval($this->selected);
             if ($selected && $this->getAttribute('multiple') == false) $this->hasSelected = true;
             return $selected;
         }

--- a/src/Forms/Input/TextArea.php
+++ b/src/Forms/Input/TextArea.php
@@ -53,6 +53,18 @@ class TextArea extends Input
     }
 
     /**
+     * Set the textarea cols attribute to control the width of the input box.
+     * @param  int  $count
+     * @return self
+     */
+    public function setCols($count)
+    {
+        $this->setAttribute('cols', $count);
+
+        return $this;
+    }
+
+    /**
      * Set a max character count for this textarea.
      * @param   string  $value
      * @return  self

--- a/src/Forms/Input/TextArea.php
+++ b/src/Forms/Input/TextArea.php
@@ -80,6 +80,18 @@ class TextArea extends Input
     }
 
     /**
+     * Set the default text that appears before any text has been entered.
+     * @param   string  $value
+     * @return  self
+     */
+    public function placeholder($value = '')
+    {
+        $this->setAttribute('placeholder', $value);
+
+        return $this;
+    }
+
+    /**
      * Enables the jQuery autosize function for this textarea.
      * @param   string  $value
      * @return  self


### PR DESCRIPTION
A couple minor adjustments to the Select and TextArea classes.

- Fixes an issue where the Select placeholder would not appear if the first option was a numeric 0
- Fixes an issue where a null value in the option list prevented other options from being selected (as seen in Trip Planner): changes the option values to always compare as strings.
- Adds the setCols and placeholder methods to TextArea, to make those HTML attributes usable.