### PR TITLE
System: update Session class handling of address/module/action values

### DIFF
--- a/src/Gibbon/Session.php
+++ b/src/Gibbon/Session.php
@@ -60,10 +60,13 @@ class Session
         $this->guid = (isset($config))? $config->guid() : $guid; // Backwards compatability for external modules
         
         // Detect the current module - TODO: replace this logic when switching to routing.
-        $address = isset($_GET['q'])? $_GET['q'] : '';
+        $address = isset($_GET['q'])? $_GET['q'] : (isset($_POST['address'])? $_POST['address'] : '');
         $this->set('address', $address);
-        $this->set('module',  getModuleName($address));
-        $this->set('action', getActionName($address));
+
+        if (!empty($address)) {
+            $this->set('module',  getModuleName($address));
+            $this->set('action', getActionName($address));
+        }
     }
 
     /**


### PR DESCRIPTION
Adjusts the code that sets the current module & action in the Session class to be more backwards-compatible for the Reporting module. Most process pages pass a POST value and use `getModuleName($_POST['address'])` to determine the current module. The Reporting module currently uses the `$_SESSION[$guid]['module']` value having been set on the previous page prior to form submission.