### PR TITLE
Sundays show following days for Sunday people

### DIFF
--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -514,9 +514,9 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                 }
             }
 
-            //Sunday week adjust for timetable on home page (so Sunday's show next week if week starts on Monday, it's Sunday now and Sunday is not a school day)
+            //Sunday week adjust for timetable on home page (so Sundays show next week i.e. it's Sunday now and Sunday is not a school day)
             $homeSunday = true ;
-            if ($q == '' && $_SESSION[$guid]['firstDayOfTheWeek'] == 'Monday') {
+            if ($q == '') {
                 try {
                     $dataDays = array();
                     $sqlDays = "SELECT nameShort FROM gibbonDaysOfWeek WHERE nameShort='Sun' AND schoolDay='N'";

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -514,9 +514,9 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                 }
             }
 
-            //Sunday week adjust for timetable on home page (so Sundays show next week i.e. it's Sunday now and Sunday is not a school day)
+            //Sunday week adjust for timetable on home page (so Sundays show next week if the week starts on Sunday or Monday—i.e. it's Sunday now and Sunday is not a school day)
             $homeSunday = true ;
-            if ($q == '') {
+            if ($q == '' && ($_SESSION[$guid]['firstDayOfTheWeek'] == 'Monday' || $_SESSION[$guid]['firstDayOfTheWeek'] == 'Sunday')) {
                 try {
                     $dataDays = array();
                     $sqlDays = "SELECT nameShort FROM gibbonDaysOfWeek WHERE nameShort='Sun' AND schoolDay='N'";


### PR DESCRIPTION
Sundays show following days in Timetable regardless of which day of the week is the "first". Previously, Sundays only showed following days if Monday was the "first" day. Sunday "first" people were feeling a little excluded!

