### PR TITLE
Data Updater: workflow improvements for submitting & managing updates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ v16.0.00
         Attendance: added ability for students to view their own attendance data for the current year
         Attendance: added ability to delete attendance with Manage Attendance Logs permission in Attendance by Person
         Attendance: fixed date format for links in View Daily Attendance
+        Data Updater: added links to Manage Update pages to easily find and edit the associated records
         Finance: added logging for failed bulk email sends
         Finance: add a Mark as Paid bulk action in Manage Invoices
         Finance: add Credit Card payment type to gibbonPayment table

--- a/modules/Data Updater/data_familyProcess.php
+++ b/modules/Data Updater/data_familyProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\DataUpdater\Domain\DataUpdaterGateway;
 
 include '../../gibbon.php';
 
@@ -98,6 +99,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
                 $event->setActionLink('/index.php?q=/modules/Data Updater/data_family_manage.php');
 
                 $event->sendNotifications($pdo, $gibbon->session);
+
+                // Redirect this user to the My Data Updates page if there are any required updates pending
+                $requiredUpdates = getSettingByScope($connection2, 'Data Updater', 'requiredUpdates');
+                if ($requiredUpdates == 'Y') {
+                    $gateway = new DataUpdaterGateway($pdo);
+                    $updatesRequiredCount = $gateway->countAllRequiredUpdatesByPerson($_SESSION[$guid]['gibbonPersonID']);
+                    if ($updatesRequiredCount > 0) {
+                        $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Data Updater/data_updates.php';
+                    }
+                }
 
                 $URL .= '&return=success0';
                 header("Location: {$URL}");

--- a/modules/Data Updater/data_family_manage_edit.php
+++ b/modules/Data Updater/data_family_manage_edit.php
@@ -65,6 +65,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_m
             //Let's go!
 			$oldValues = $result->fetch(); 
 			$newValues = $newResult->fetch();
+            
+            // Provide a link back to edit the associated record
+            if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_edit.php') == true) {
+                echo "<div class='linkTop'>";
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/User Admin/family_manage_edit.php&gibbonFamilyID=".$oldValues['gibbonFamilyID']."'>".__('Edit Family')."<img style='margin: 0 0 -4px 5px' title='".__('Edit Family')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
+                echo '</div>';
+            }
 
 			$compare = array(
 				'nameAddress'           => __('Address Name'),

--- a/modules/Data Updater/data_financeProcess.php
+++ b/modules/Data Updater/data_financeProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\DataUpdater\Domain\DataUpdaterGateway;
 
 include '../../gibbon.php';
 
@@ -138,6 +139,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
                 $event->setActionLink('/index.php?q=/modules/Data Updater/data_finance_manage.php');
 
                 $event->sendNotifications($pdo, $gibbon->session);
+
+                // Redirect this user to the My Data Updates page if there are any required updates pending
+                $requiredUpdates = getSettingByScope($connection2, 'Data Updater', 'requiredUpdates');
+                if ($requiredUpdates == 'Y') {
+                    $gateway = new DataUpdaterGateway($pdo);
+                    $updatesRequiredCount = $gateway->countAllRequiredUpdatesByPerson($_SESSION[$guid]['gibbonPersonID']);
+                    if ($updatesRequiredCount > 0) {
+                        $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Data Updater/data_updates.php';
+                    }
+                }
 
                 $URL .= '&return=success0';
                 header("Location: {$URL}");

--- a/modules/Data Updater/data_finance_manage_edit.php
+++ b/modules/Data Updater/data_finance_manage_edit.php
@@ -65,6 +65,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
             //Let's go!
             $oldValues = $result->fetch();
             $newValues = $newResult->fetch();
+
+            // Provide a link back to edit the associated record
+            if (isActionAccessible($guid, $connection2, '/modules/Finance/invoicees_manage_edit.php') == true && !empty($oldValues['gibbonFinanceInvoiceeID'])) {
+                echo "<div class='linkTop'>";
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoicees_manage_edit.php&gibbonFinanceInvoiceeID=".$oldValues['gibbonFinanceInvoiceeID']."&search=&allUsers='>".__('Edit Invoicee')."<img style='margin: 0 0 -4px 5px' title='".__('Edit Invoicee')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
+                echo '</div>';
+            }
             
             // An array of common fields to compare in each data set, and the field label
             $compare = array(

--- a/modules/Data Updater/data_medicalProcess.php
+++ b/modules/Data Updater/data_medicalProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\DataUpdater\Domain\DataUpdaterGateway;
 
 include '../../gibbon.php';
 
@@ -271,6 +272,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
                 $event->setActionLink('/index.php?q=/modules/Data Updater/data_medical_manage.php');
 
                 $event->sendNotifications($pdo, $gibbon->session);
+
+                // Redirect this user to the My Data Updates page if there are any required updates pending
+                $requiredUpdates = getSettingByScope($connection2, 'Data Updater', 'requiredUpdates');
+                if ($requiredUpdates == 'Y') {
+                    $gateway = new DataUpdaterGateway($pdo);
+                    $updatesRequiredCount = $gateway->countAllRequiredUpdatesByPerson($_SESSION[$guid]['gibbonPersonID']);
+                    if ($updatesRequiredCount > 0) {
+                        $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Data Updater/data_updates.php';
+                    }
+                }
 
                 if ($partialFail == true) {
                     $URL .= '&return=warning1';

--- a/modules/Data Updater/data_medical_manage_edit.php
+++ b/modules/Data Updater/data_medical_manage_edit.php
@@ -70,6 +70,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
             $oldValues = $result->fetch();
             $newValues = $newResult->fetch();
 
+            // Provide a link back to edit the associated record
+            if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage_edit.php') == true && !empty($oldValues['gibbonPersonMedicalID'])) {
+                echo "<div class='linkTop'>";
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Students/medicalForm_manage_edit.php&gibbonPersonMedicalID=".$oldValues['gibbonPersonMedicalID']."&search='>".__('Edit Medical Form')."<img style='margin: 0 0 -4px 5px' title='".__('Edit Medical Form')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
+                echo '</div>';
+            }
+
             $compare = array(
                 'bloodType'                 => __('Blood Type'),
                 'longTermMedication'        => __('Long-Term Medication?'),

--- a/modules/Data Updater/data_personalProcess.php
+++ b/modules/Data Updater/data_personalProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\DataUpdater\Domain\DataUpdaterGateway;
 
 include '../../gibbon.php';
 
@@ -354,6 +355,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                         $event->setActionLink('/index.php?q=/modules/Data Updater/data_personal_manage.php');
 
                         $event->sendNotifications($pdo, $gibbon->session);
+
+                        // Redirect this user to the My Data Updates page if there are any required updates pending
+                        $requiredUpdates = getSettingByScope($connection2, 'Data Updater', 'requiredUpdates');
+                        if ($requiredUpdates == 'Y') {
+                            $gateway = new DataUpdaterGateway($pdo);
+                            $updatesRequiredCount = $gateway->countAllRequiredUpdatesByPerson($_SESSION[$guid]['gibbonPersonID']);
+                            if ($updatesRequiredCount > 0) {
+                                $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Data Updater/data_updates.php';
+                            }
+                        }
 
                         if ($partialFail == true) {
                             $URL .= '&return=warning1';

--- a/modules/Data Updater/data_personal_manage_edit.php
+++ b/modules/Data Updater/data_personal_manage_edit.php
@@ -66,6 +66,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
             $oldValues = $result->fetch();
             $newValues = $newResult->fetch();
 
+            // Provide a link back to edit the associated record
+            echo "<div class='linkTop'>";
+            if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edit.php') == true) {
+                echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/User Admin/user_manage_edit.php&gibbonPersonID=".$oldValues['gibbonPersonID']."'>".__('Edit User')."<img style='margin: 0 0 -4px 5px' title='".__('Edit User')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
+            }
+            if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_details.php') == true && getRoleCategory($oldValues['gibbonRoleIDPrimary'], $connection2) == 'Student') {
+                echo "&nbsp;&nbsp;&nbsp;<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID=".$oldValues['gibbonPersonID']."'>".__('View Student')."<img style='margin: 0 0 -4px 5px' title='".__('View Student')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/plus.png'/></a> ";
+            }
+            echo '</div>';
+
             //Get categories
             $staff = false;
             $student = false;

--- a/modules/Data Updater/data_updates.php
+++ b/modules/Data Updater/data_updates.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_updates.
 
                 if (!empty($dataUpdatesByType[$type])) {
                     foreach ($dataUpdatesByType[$type] as $dataUpdate) {
-                        $output .= '<a href="'.$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Data Updater/data_'.strtolower($type).'.php&'.$dataUpdate['idType'].'='.$dataUpdate['id'].'">';
+                        $output .= '<a href="'.$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Data Updater/data_'.strtolower($type).'.php&'.$dataUpdate['idType'].'='.$dataUpdate['id'].'" style="display:block;">';
 
                         $lastUpdate = !empty($dataUpdate['lastUpdated'])? __('Last Updated').': '.date('F j, Y', strtotime($dataUpdate['lastUpdated'])) : '';
                         


### PR DESCRIPTION
This PR adds two small features:
- If required data updates are enabled, it will redirect the user back to the My Data Updates page after submitting a form if they still have pending updates. This helps the workflow of users to easily find their way back to the visual view of any updates they still have to make.
- Adds helper links to the top of the Manage Update pages to easily find and edit the associated records (if the user has permission to). This helps staff members who review and accept the updates, if there's a change they need to make manually either before or after accepting the data update.