### PR TITLE
User Admin: change all address fields to a short two-line text area

### DIFF
--- a/modules/Data Updater/data_family.php
+++ b/modules/Data Updater/data_family.php
@@ -186,7 +186,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
 
                     $row = $form->addRow();
                         $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-                        $row->addTextField('homeAddress')->maxLength(255)->setRequired($required);
+                        $row->addTextArea('homeAddress')->maxLength(255)->setRequired($required)->setRows(2);
 
                     $row = $form->addRow();
                         $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -381,7 +381,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
 					$row = $form->addRow()->addClass('address');
 						$row->addLabel('address1', __('Address 1'))->description(__('Unit, Building, Street'));
-						$row->addTextField('address1')->maxLength(255);
+                        $row->addTextArea('address1')->maxLength(255)->setRows(2);
 
 					$row = $form->addRow()->addClass('address');
 						$row->addLabel('address1District', __('Address 1 District'))->description(__('County, State, District'));
@@ -432,7 +432,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
 					$row = $form->addRow()->addClass('address');
 						$row->addLabel('address2', __('Address 2'))->description(__('Unit, Building, Street'));
-						$row->addTextField('address2')->maxLength(255);
+                        $row->addTextArea('address2')->maxLength(255)->setRows(2);
 
 					$row = $form->addRow()->addClass('address');
 						$row->addLabel('address2District', __('Address 2 District'))->description(__('County, State, District'));

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -440,7 +440,7 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-                $row->addTextField('homeAddress')->isRequired()->maxLength(255);
+                $row->addTextArea('homeAddress')->isRequired()->maxLength(255)->setRows(2);
 
             $row = $form->addRow();
                 $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -476,7 +476,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
         $row = $form->addRow();
             $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-            $row->addTextField('homeAddress')->isRequired()->maxLength(255);
+            $row->addTextArea('homeAddress')->isRequired()->maxLength(255)->setRows(2);
 
         $row = $form->addRow();
             $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));

--- a/modules/User Admin/family_manage_edit.php
+++ b/modules/User Admin/family_manage_edit.php
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-                $row->addTextField('homeAddress')->maxLength(255);
+                $row->addTextArea('homeAddress')->maxLength(255)->setRows(2);
 
             $row = $form->addRow();
                 $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -259,7 +259,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$row = $form->addRow()->addClass('address');
 				$row->addLabel('address1', __('Address 1'))->description(__('Unit, Building, Street'));
-				$row->addTextField('address1')->maxLength(255);
+				$row->addTextArea('address1')->maxLength(255)->setRows(2);
 
 			$row = $form->addRow()->addClass('address');
 				$row->addLabel('address1District', __('Address 1 District'))->description(__('County, State, District'));
@@ -302,7 +302,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$row = $form->addRow()->addClass('address');
 				$row->addLabel('address2', __('Address 2'))->description(__('Unit, Building, Street'));
-				$row->addTextField('address2')->maxLength(255);
+                $row->addTextArea('address2')->maxLength(255)->setRows(2);
 
 			$row = $form->addRow()->addClass('address');
 				$row->addLabel('address2District', __('Address 2 District'))->description(__('County, State, District'));


### PR DESCRIPTION
Currently addresses are edited in a text field, which is often too short to read the whole address (which requires using your cursor inside the field to scroll right). This PR makes a small visual tweak by changing the Address 1/Address 2/Home Address fields to a short two-row text area.