### PR TITLE
System: add a Format class for locale-aware data formatting

### DIFF
--- a/gibbon.php
+++ b/gibbon.php
@@ -32,6 +32,8 @@ $container->add('session', new Gibbon\Session($container));
 $container->add('locale', new Gibbon\Locale($container));
 $container->add('autoloader', $autoloader);
 
+\Gibbon\Services\Format::setup($container->get('session'));
+
 // Globals for backwards compatibility
 $gibbon = $container->get('config');
 $gibbon->session = $container->get('session');

--- a/modules/User Admin/user_manage.php
+++ b/modules/User Admin/user_manage.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Services\Format;
+
 use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Domain\User\UserGateway;
@@ -97,16 +99,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
     // COLUMNS
     $table->addColumn('image_240', __('Photo'))
         ->width('10%')
-        ->format(function($person) use ($guid) {
-            return getUserPhoto($guid, $person['image_240'], 75);
-        });
+        ->format(Format::using('userPhoto', 'image_240'));
 
     $table->addColumn('fullName', __('Name'))
         ->width('30%')
         ->sortable(['surname', 'preferredName'])
-        ->format(function($person) {
-            return formatName('', $person['preferredName'], $person['surname'], 'Student', true);
-        });
+        ->format(Format::using('name', ['title', 'preferredName', 'surname', 'Student', true]));
 
     $table->addColumn('status', __('Status'))
         ->width('10%')

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -1,0 +1,165 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Gibbon\Services;
+
+use DateTime;
+
+/**
+ * Format values based on locale and system settings.
+ *
+ * @version v16
+ * @since   v16
+ */
+class Format
+{
+    use FormatResolver;
+
+    protected static $session;
+    protected static $i18n;
+
+    public static function setup($session)
+    {
+        static::$session = $session;
+        static::$i18n = $session->get('i18n');
+    }
+
+    public static function date($dateString, $format = false)
+    {
+        $date = DateTime::createFromFormat('Y-m-d', $dateString);
+        return $date ? $date->format($format ? $format : static::$i18n['dateFormatPHP']) : '';
+    }
+
+    public static function dateTime($dateString)
+    {
+        return static::date($dateString, 'F j, Y g:i a');
+    }
+
+    public static function dateReadable($dateString)
+    {
+        return static::date($dateString, 'F j, Y');
+    }
+
+    public static function dateRange($dateFrom, $dateTo, $format = false)
+    {
+        return static::date($dateFrom, $format) . ' - ' . static::date($dateTo, $format);
+    }
+
+    public static function dateFromTimestamp($timestamp, $format = false)
+    {
+        $date = DateTime::createFromFormat('U', $timestamp);
+        return $date ? $date->format($format ? $format : static::$i18n['dateFormatPHP']) : '';
+    }
+
+    public static function dateConvert($dateString)
+    {
+        $date = DateTime::createFromFormat(static::$i18n['dateFormatPHP'], $dateString);
+        return $date ? $date->format('Y-m-d') : '';
+    }
+
+    public static function timestamp($dateString)
+    {
+        $date = DateTime::createFromFormat('Y-m-d', $dateString);
+        return $date ? $date->getTimestamp() : '';
+    }
+
+    public static function number($value, $decimals = 0)
+    {
+        return number_format($value, $decimals);
+    }
+
+    public static function currency($value, $decimals = 2)
+    {
+        return number_format($value, $decimals).' ('.static::$session->get('currency').')';
+    }
+
+    public static function yesNo($value)
+    {
+        return ($value == 'Y' || $value == 'Yes') ? __('Yes') : __('No');
+    }
+
+    public static function age($dateString, $short = false)
+    {
+        $date = DateTime::createFromFormat('Y-m-d', $dateString);
+        if (!$date) return __('Unknown');
+
+        $date = $date->diff(new DateTime());
+        
+        return $short 
+            ? $date->y . __('y') .', '. $date->m . __('m')
+            : $date->y .' '. __('years') .', '. $date->m .' '. __('months');
+    }
+
+    public static function phone($number, $countryCode = false, $type = false)
+    {
+        $number = preg_replace('/[^0-9]/', '', $number);
+        switch (strlen($number)) {
+            case 7:     $number = preg_replace('/([0-9]{3})([0-9]{4})/', '$1 $2', $number); break;
+            case 8:     $number = preg_replace('/([0-9]{4})([0-9]{4})/', '$1 $2', $number); break;
+            case 9:     $number = preg_replace('/([0-9]{3})([0-9]{2})([0-9]{2})([0-9]{2})/', '$1 - $2 $3 $4', $number); break;
+            case 10:    $number = preg_replace('/([0-9]{3})([0-9]{2})([0-9]{2})([0-9]{3})/', '$1 - $2 $3 $4', $number); break;
+        }
+
+        return ($type? $type.': ' : '') . ($countryCode? '+'.$countryCode.' ' : '') . $number;
+    }
+
+    public static function name($title, $preferredName, $surname, $roleCategory = 'Staff', $reverse = false, $informal = false)
+    {
+        $output = '';
+
+        if ($roleCategory == 'Staff' or $roleCategory == 'Other') {
+            $setting = 'nameFormatStaff' . ($informal? 'Informal' : 'Formal') . ($reverse? 'Reversed' : '');
+            $format = static::$session->get($setting, '[title] [preferredName:1]. [surname]');
+
+            $output = preg_replace_callback('/\[+([^\]]*)\]+/u',
+                function ($matches) use ($title, $preferredName, $surname) {
+                    list($token, $length) = array_pad(explode(':', $matches[1], 2), 2, false);
+                    return isset($$token)
+                        ? (!empty($length)? mb_substr($$token, 0, intval($length)) : $$token)
+                        : $matches[0];
+                },
+            $format);
+
+        } elseif ($roleCategory == 'Parent') {
+            $format = ($informal? '%1$s ' : '') . ($reverse? '%3$s, %2$s' : '%2$s %3$s');
+            $output = sprintf($format, $title, $preferredName, $surname);
+        } elseif ($roleCategory == 'Student') {
+            $format = $reverse ? '%2$s, %1$s' : '%1$s %2$s';
+            $output = sprintf($format, $preferredName, $surname);
+        }
+
+        return trim($output);
+    }
+
+    public static function userPhoto($path, $size = 75)
+    {   
+        $sizeStyle = $size == 240 ? "width: 240px; height: 320px" : "width: 75px; height: 100px";
+
+        if (empty($path) or file_exists(static::$session->get('absolutePath').'/'.$path) == false) {
+            $path = '/themes/'.static::$session->get('gibbonThemeName').'/img/anonymous_'.$size.'.jpg';
+        }
+
+        return sprintf('<img class="user" style="%1$s" src="%2$s"><br/>', $sizeStyle, static::$session->get('absoluteURL').'/'.$path);
+    }
+
+    public static function courseClassName($courseName, $className)
+    {
+        return $courseName .'.'. $className;
+    }
+}

--- a/src/Services/FormatResolver.php
+++ b/src/Services/FormatResolver.php
@@ -1,0 +1,70 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Gibbon\Services;
+
+/**
+ * The resolver allows modules to add their own formatters, which can be accessed with Format::newMethod
+ * I can also return a formatter as a closure with the using() method, which can be provided to classes
+ * such as the DataTable that loop over and format array data.
+ * 
+ * @version v16
+ * @since   v16
+ */
+trait FormatResolver
+{
+    protected static $formatters;
+
+    public static function addFormatter($method, callable $callable)
+    {
+        static::$formatters[$method] = $callable;
+    }
+
+    public static function getFormatter($method)
+    {
+        if (method_exists(static::class, $method)) {
+            return [static::class, $method];
+        }
+
+        if (isset(static::$formatters[$method])) {
+            return static::$formatters[$method];
+        }
+        
+        throw new \InvalidArgumentException(sprintf('Unknown formatter "%s"', $method));
+    }
+
+    public static function using($method, $param)
+    {
+        $callable = static::getFormatter($method);
+        $params = is_array($param)? $param : array($param);
+
+        return function ($data) use ($callable, $params) {
+            $args = array_map(function($key) use (&$data) {
+                return isset($data[$key])? $data[$key] : $key;
+            }, $params);
+
+            return $callable(...$args);
+        };
+    }
+
+    public static function __callStatic($method, $arguments = array())
+    {
+        return call_user_func_array(static::getFormatter($method), $arguments);
+    }
+}


### PR DESCRIPTION
This PR adds a Format class, which helps clean up and replace a lot of the global formatting functions, and remove the need to pass in session and $guid data to them each time.

The specific formats and settings can be loaded in from the session and locale data, giving us a flexible way to internationalize and customize data that's output throughout the codebase.

The Format class can also pass a formatter to a DataTable as a closure with the `using()` method, which allows a specific format to be applied to a non-uniform array of row data when looped over. Eg: loop over an array of users, and pass each row of user data into different formatters that can extract the fields they need and display a string.

Modules can also use addFormatter to supply their own formats without needing to edit the core, providing some extra flexibility for developers.

Some examples of the format methods so-far:

```php
echo Format::date('2018-05-18');
// 18/05/2018

echo Format::dateConvert('18/05/2018');
// 2018-05-18

echo Format::dateReadable('2018-05-18');
// May 18, 2018

echo Format::dateTime('2018-05-18');
// May 18, 2018 11:57 am

echo Format::dateRange('2018-05-18', '2018-06-18');
// 18/05/2018 - 18/06/2018

echo Format::timestamp('2018-05-18');
// 1526615872

echo Format::currency('123');
// 123.00 (MOP)

echo Format::age('1984-07-17');
// 33 years, 10 months

echo Format::phone('12345678', '853', 'Mobile');
// Mobile: +853 1234 5678

echo Format::name('Mr.', 'Test', 'McTest');
// Mr. T. McTest

echo Format::name('Mr.', 'Test', 'McTest', 'Staff', true, true);
// McTest, Test

echo Format::yesNo('N');
// No
```