### PR TITLE
Table API: visual tweaks, adjust filter logic, add more unit tests

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -328,6 +328,7 @@ DataTable = (function(element, basePath, filters, totalCount) {
     _.totalCount = totalCount;
     
     if (_.filters.sortBy.length == 0) _.filters.sortBy = {};
+    if (_.filters.filterBy.length == 0) _.filters.filterBy = {};
 
     _.init();
 });
@@ -359,20 +360,17 @@ DataTable.prototype.init = function() {
 
     // Remove Filter
     $(_.table).on('click', '.filter', function() {
-        var index = _.filters.filterBy.indexOf($(this).data('filter'));
+        var filter = $(this).data('filter');
         if ($(this).hasClass('clear')) {
             _.filters.filterBy = [''];
             _.filters.searchBy.columns = [''];
-        } else if (index !== -1) {
-            _.filters.filterBy.splice(index, 1);
-
-            // Remove columns from search criteria if using an in: filter
-            if ($(this).data('filter').startsWith('in:')) {
-                var columnName = $(this).data('filter').substr(3);
-                _.filters.searchBy.columns = _.filters.searchBy.columns.filter(function(item) {
-                    return item != columnName;
-                });
+        } else if (filter in _.filters.filterBy) {
+            // Remove columns from search criteria if removing an in: filter
+            if (filter == 'in') {
+                _.filters.searchBy.columns = [''];
             }
+
+            delete _.filters.filterBy[filter];
         }
         _.filters.page = 1;
         _.refresh();
@@ -380,10 +378,11 @@ DataTable.prototype.init = function() {
 
     // Add Filter
     $(_.table).on('change', '.filters', function() {
-        if (!_.filters.filterBy.includes($(this).val())) {
-            _.filters.filterBy.push( $(this).val() );
-            _.filters.page = 1;
-        }
+        var [filter, value] = $(this).val().split(':');
+
+        _.filters.filterBy[filter] = value;
+        _.filters.page = 1;
+
         _.refresh();
     });
 

--- a/gibbon.php
+++ b/gibbon.php
@@ -32,7 +32,7 @@ $container->add('session', new Gibbon\Session($container));
 $container->add('locale', new Gibbon\Locale($container));
 $container->add('autoloader', $autoloader);
 
-\Gibbon\Services\Format::setup($container->get('session'));
+\Gibbon\Services\Format::setupFromSession($container->get('session'));
 
 // Globals for backwards compatibility
 $gibbon = $container->get('config');

--- a/src/Domain/QueryableGateway.php
+++ b/src/Domain/QueryableGateway.php
@@ -93,10 +93,8 @@ abstract class QueryableGateway extends Gateway
 
         // Filter By
         if ($criteria->hasFilter()) {
-            foreach ($criteria->getFilterBy() as $name) {
-                list($name, $value) = array_pad(explode(':', $name, 2), 2, '');
+            foreach ($criteria->getFilterBy() as $name => $value) {
                 if ($callback = $criteria->getFilterRule($name)) {
-                    $value = str_replace('"', '', $value);
                     $query = $callback($query, $value);
                 }
             }
@@ -107,13 +105,13 @@ abstract class QueryableGateway extends Gateway
             $searchable = $this->getSearchableColumns();
 
             $query->where(function($query) use ($criteria, $searchable) {
-                $search = $criteria->getSearchBy();
-                foreach ($search['columns'] as $count => $column) {
+                $searchText = $criteria->getSearchText();
+                foreach ($criteria->getSearchColumns() as $count => $column) {
                     if (!in_array($column, $searchable)) continue;
 
                     $column = $this->escapeIdentifier($column);
                     $query->orWhere("{$column} LIKE :search{$count}");
-                    $query->bindValue(":search{$count}", "%{$search['text']}%");
+                    $query->bindValue(":search{$count}", "%{$searchText}%");
                 }
             });
         }

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -172,8 +172,6 @@ class PaginatedRenderer implements RendererInterface
             }
         }
 
-        
-
         $output .= '</div></div><br/>';
 
         // Initialize the jQuery Data Table functionality
@@ -195,14 +193,14 @@ class PaginatedRenderer implements RendererInterface
      */
     protected function renderPageCount(DataSet $dataSet)
     {
-        $output = '<span class="small" style="line-height: 32px;margin-right: 10px;">';
+        $output = '<small style="margin-right: 10px;">';
 
         $output .= $this->criteria->hasSearchText()? __('Search').' ' : '';
         $output .= $dataSet->isSubset()? __('Results') : __('Records');
         $output .= $dataSet->count() > 0? ' '.$dataSet->getPageFrom().'-'.$dataSet->getPageTo().' '.__('of').' ' : ': ';
         $output .= $dataSet->isSubset()? $dataSet->getResultCount() : $dataSet->getTotalCount();
 
-        $output .= '</span>';
+        $output .= '</small>';
 
         return $output;
     }
@@ -216,7 +214,7 @@ class PaginatedRenderer implements RendererInterface
      */
     protected function renderPageFilters(DataSet $dataSet, array $filters)
     {
-        $output = '<span class="small" style="line-height: 32px;">';
+        $output = '<small>';
 
         if ($this->criteria->hasFilter()) {
             $output .= __('Filtered by').' ';
@@ -232,6 +230,8 @@ class PaginatedRenderer implements RendererInterface
 
             $output .= '<input type="button" class="filter clear buttonLink" value="'.__('Clear').'">';
         }
+
+        $output = '</small>';
 
         return $output;
     }

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -219,19 +219,20 @@ class PaginatedRenderer implements RendererInterface
         if ($this->criteria->hasFilter()) {
             $output .= __('Filtered by').' ';
 
-            $criteriaUsed = array_reduce($this->criteria->getFilterBy(), function($group, $item) use ($filters) {
-                $group[$item] = isset($filters[$item])? $filters[$item] : ucwords(str_replace(':', ': ', $item));
-                return $group; 
-            }, array());
+            $criteriaUsed = array();
+            foreach ($this->criteria->getFilterBy() as $name => $value) {
+                $key = $name.':'.$value;
+                $criteriaUsed[$name] = isset($filters[$key]) ? $filters[$key] : __(ucfirst($name)).': '.__(ucfirst($value));
+            }
 
-            foreach ($criteriaUsed as $value => $label) {
-                $output .= '<input type="button" class="filter" value="'.$label.'" data-filter="'.$value.'"> ';
+            foreach ($criteriaUsed as $name => $label) {
+                $output .= '<input type="button" class="filter" value="'.$label.'" data-filter="'.$name.'"> ';
             }
 
             $output .= '<input type="button" class="filter clear buttonLink" value="'.__('Clear').'">';
         }
 
-        $output = '</small>';
+        $output .= '</small>';
 
         return $output;
     }

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -156,8 +156,10 @@ class PaginatedRenderer implements RendererInterface
             $output .= '</tbody>';
             $output .= '</table>';
 
-            $output .= $this->renderPageCount($dataSet);
-            $output .= $this->renderPagination($dataSet);
+            if ($dataSet->getPageCount() > 1) {
+                $output .= $this->renderPageCount($dataSet);
+                $output .= $this->renderPagination($dataSet);
+            }
         } else {
             if ($dataSet->isSubset()) {
                 $output .= '<div class="warning">';

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -1,0 +1,208 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+*/
+
+namespace Gibbon\Services;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Format
+ */
+class FormatTest extends TestCase
+{
+    public function setUp()
+    {
+        $settings = [
+            'code'                           => 'en_GB',
+            'name'                           => 'English - United Kingdom',
+            'dateFormat'                     => 'dd/mm/yyyy',
+            'dateFormatRegEx'                => '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/i',
+            'dateFormatPHP'                  => 'd/m/Y',
+            'rtl'                            => 'N',
+            'currency'                       => 'HKD $',
+            'currencySymbol'                 => '$',
+            'currencyName'                   => 'HKD',
+        ];
+
+        Format::setup($settings);
+    }
+
+    public function testFormatsDates()
+    {
+        $this->assertEquals('18/05/2018', Format::date('2018-05-18'));
+    }
+
+    public function testFormatsDatesWithOptionalFormat()
+    {
+        $this->assertEquals('Sunday April 1st 2018', Format::date('2018-04-01', 'l F jS Y'));
+    }
+
+    public function testFormatsAmericanDates()
+    {
+        Format::setup(['dateFormatPHP' => 'm/d/Y']);
+        $this->assertEquals('05/18/2018', Format::date('2018-05-18'));
+    }
+
+    public function testFormatsDateTime()
+    {
+        $this->assertEquals('May 18, 2018 5:16 pm', Format::dateTime('2018-05-18 17:16:18'));
+    }
+
+    public function testFormatsReadableDates()
+    {
+        $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
+    }
+
+    public function testFormatsDateRanges()
+    {
+        $this->assertEquals('18/05/2018 - 18/06/2018', Format::dateRange('2018-05-18', '2018-06-18'));
+    }
+
+    public function testFormatsDateFromTimestamps()
+    {
+        $this->assertEquals('18/05/2018', Format::dateFromTimestamp('1526615872'));
+    }
+
+    public function testFormatsNumbers()
+    {
+        $this->assertEquals('123.00', Format::number(123));
+    }
+
+    public function testFormatsCurrency()
+    {
+        $this->assertEquals('$321.00', Format::currency(321));
+    }
+
+    public function testFormatsCurrencyWithName()
+    {
+        $this->assertEquals('$321.00 (HKD)', Format::currency(321, true));
+    }
+
+    public function testFormatsAlternateCurrency()
+    {
+        Format::setup(['currencySymbol' => '£']);
+        $this->assertEquals('£321.00', Format::currency(321));
+    }
+
+    public function testFormatsYesNo()
+    {
+        $this->assertEquals('Yes', Format::yesNo('Y'));
+        $this->assertEquals('No', Format::yesNo('N'));
+        $this->assertEquals('No', Format::yesNo('Invalid'));
+    }
+
+    public function testFormatsAge()
+    {
+        $date = date('Y-m-d', strtotime('-12 years -6 months'));
+        $this->assertEquals('12 years, 6 months', Format::age($date));
+    }
+
+    public function testFormatsShortAge()
+    {
+        $date = date('Y-m-d', strtotime('-24 years -0 months'));
+        $this->assertEquals('24y, 0m', Format::age($date, true));
+    }
+
+    public function testFormatsUnknownAge()
+    {
+        $this->assertEquals('Unknown', Format::age('foo bar'));
+    }
+
+    public function testFormatsPhoneNumbers()
+    {
+        $this->assertEquals('Work: +852 1234 5678', Format::phone('12345678', '852', 'Work'));
+    }
+
+    public function testFormatsSevenDigitPhoneNumbers()
+    {
+        $this->assertEquals('123 4567', Format::phone('1234567'));
+    }
+
+    public function testFormatsEightDigitPhoneNumbers()
+    {
+        $this->assertEquals('1234 5678', Format::phone('12345678'));
+    }
+
+    public function testFormatsNineDigitPhoneNumbers()
+    {
+        $this->assertEquals('123 - 45 67 89', Format::phone('123456789'));
+    }
+
+    public function testFormatsTenDigitPhoneNumbers()
+    {
+        $this->assertEquals('123 - 45 67 890', Format::phone('1234567890'));
+    }
+
+    public function testFormatsPhoneNumbersNumerically()
+    {
+        $this->assertEquals('1234 5678', Format::phone('+1 (234) 5678 Foo Bar'));
+    }
+
+    public function testFormatsCourseClassNames()
+    {
+        $this->assertEquals('Foo.1-2', Format::courseClassName('Foo', '1-2'));
+    }
+
+    public function testFormatsStudentNames()
+    {
+        $this->assertEquals('Test McTest', Format::name('', 'Test', 'McTest', 'Student'));
+    }
+
+    public function testFormatsStudentNamesReversed()
+    {
+        $this->assertEquals('McTest, Test', Format::name('', 'Test', 'McTest', 'Student', true));
+    }
+
+    public function testFormatsParentNames()
+    {
+        $this->assertEquals('Ms. Test McTest', Format::name('Ms.', 'Test', 'McTest', 'Parent'));
+    }
+
+    public function testFormatsParentNamesReversed()
+    {
+        $this->assertEquals('Ms. McTest, Test', Format::name('Ms.', 'Test', 'McTest', 'Parent', true));
+    }
+
+    public function testFormatsParentNamesInformal()
+    {
+        $this->assertEquals('Test McTest', Format::name('Ms.', 'Test', 'McTest', 'Parent', false, true));
+    }
+
+    public function testFormatsParentNamesReversedInformal()
+    {
+        $this->assertEquals('McTest, Test', Format::name('Ms.', 'Test', 'McTest', 'Parent', true, true));
+    }
+
+    public function testFormatsStaffNamesBySetting()
+    {
+        Format::setup(['nameFormatStaffFormal' => '[title] [preferredName:1]. [surname]']);
+        $this->assertEquals('Mr. T. McTest', Format::name('Mr.', 'Test', 'McTest', 'Staff'));
+
+        Format::setup(['nameFormatStaffFormal' => '[title] [surname]']);
+        $this->assertEquals('Mr. McTest', Format::name('Mr.', 'Test', 'McTest', 'Staff'));
+    }
+
+    public function testFormatsStaffNamesReversedBySetting()
+    {
+        Format::setup(['nameFormatStaffFormalReversed' => '[title] [surname], [preferredName:1].']);
+        $this->assertEquals('Mr. McTest, T.', Format::name('Mr.', 'Test', 'McTest', 'Staff', true));
+
+        Format::setup(['nameFormatStaffFormalReversed' => '[title] [surname], [preferredName]']);
+        $this->assertEquals('Ms. McTest, Test', Format::name('Ms.', 'Test', 'McTest', 'Staff', true));
+    }
+
+    public function testFormatsStaffNamesInformalBySetting()
+    {
+        Format::setup(['nameFormatStaffInformal' => '[preferredName] [surname]']);
+        $this->assertEquals('Test McTest', Format::name('Mr.', 'Test', 'McTest', 'Staff', false, true));
+
+        Format::setup(['nameFormatStaffInformalReversed' => '[surname], [preferredName]']);
+        $this->assertEquals('McTest, Test', Format::name('Mr.', 'Test', 'McTest', 'Staff', true, true));
+    }
+}

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1623,7 +1623,8 @@ table.smallIntBorder td.noPadding {
 /* Gibbon Data Table CSS - Will be moved to core.css */
 .dataTable .sortable {
 	cursor: pointer;
-	position: relative;
+    position: relative;
+    padding-right: 20px;
 }
 
 .dataTable .sortable:not(.sorting):hover:after,
@@ -1634,8 +1635,8 @@ table.smallIntBorder td.noPadding {
 	height: 0px; 
 	border: 5px solid transparent;
 	position: absolute;
-	top: 20px;
-	right: 10px;
+	top: 18px;
+	right: 6px;
 }
 
 .dataTable .sortable:not(.sorting):hover:after {

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1673,6 +1673,11 @@ table.smallIntBorder td.noPadding {
     margin: 0;
 }
 
+.dataTable small {
+    font-size: 12px;
+    line-height: 32px;
+}
+
 button, input[type="submit"], input[type="button"] {
 	cursor: pointer;
 }


### PR DESCRIPTION
- Reduces the size of the record count to match the regular table styles, for consistency. 
- Adjusts the criteria so that filters of the same type are always mutually exclusive. This makes selecting a new filter of the same type replace the current one, rather than allowing conflicting filters.
- Some more visual tweaks to fix the sort arrow placement, table footer, etc.
- Adds unit tests for the Format class (and adjusts the class internally to make it more testable)