### PR TITLE
Table API: add SimpleRenderer for DataTables, ooified Roll Groups

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -362,7 +362,7 @@ DataTable.prototype.init = function() {
     $(_.table).on('click', '.filter', function() {
         var filter = $(this).data('filter');
         if ($(this).hasClass('clear')) {
-            _.filters.filterBy = [''];
+            _.filters.filterBy = {};
             _.filters.searchBy.columns = [''];
         } else if (filter in _.filters.filterBy) {
             // Remove columns from search criteria if removing an in: filter

--- a/modules/Roll Groups/rollGroups.php
+++ b/modules/Roll Groups/rollGroups.php
@@ -17,114 +17,46 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Tables\DataTable;
+use Gibbon\Services\Format;
+use Gibbon\Domain\School\RollGroupGateway;
+
 if (isActionAccessible($guid, $connection2, '/modules/Roll Groups/rollGroups.php') == false) {
     //Acess denied
     echo "<div class='error'>";
-    echo __($guid, 'You do not have access to this action.');
+    echo __('You do not have access to this action.');
     echo '</div>';
 } else {
     //Proceed!
     echo "<div class='trail'>";
-    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > </div><div class='trailEnd'>".__($guid, 'View Roll Groups').'</div>';
+    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__('Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > </div><div class='trailEnd'>".__('View Roll Groups').'</div>';
     echo '</div>';
 
     echo '<p>';
-    echo __($guid, 'This page shows all roll groups in the current school year.');
+    echo __('This page shows all roll groups in the current school year.');
     echo '</p>';
 
-    try {
-        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-        $sql = 'SELECT gibbonSchoolYear.gibbonSchoolYearID, gibbonRollGroupID, gibbonSchoolYear.name as yearName, gibbonRollGroup.name, gibbonRollGroup.nameShort, gibbonPersonIDTutor, gibbonPersonIDTutor2, gibbonPersonIDTutor3, gibbonSpace.name AS space, website FROM gibbonRollGroup JOIN gibbonSchoolYear ON (gibbonRollGroup.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) LEFT JOIN gibbonSpace ON (gibbonRollGroup.gibbonSpaceID=gibbonSpace.gibbonSpaceID) WHERE gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY sequenceNumber, gibbonRollGroup.name';
-        $result = $connection2->prepare($sql);
-        $result->execute($data);
-    } catch (PDOException $e) {
-        echo "<div class='error'>".$e->getMessage().'</div>';
-    }
+    $gateway = $container->get(RollGroupGateway::class);
+    $rollGroups = $gateway->selectRollGroupsBySchoolYear($_SESSION[$guid]['gibbonSchoolYearID']);
+    
+    $formatTutorsList = function($row) use ($gateway) {
+        $tutors = $gateway->selectTutorsByRollGroup($row['gibbonRollGroupID'])->fetchAll();
+        if (count($tutors) > 1) $tutors[0]['surname'] .= ' ('.__('Main Tutor').')';
 
-    if ($result->rowCount() < 1) {
-        echo "<div class='error'>";
-        echo __($guid, 'There are no records to display.');
-        echo '</div>';
-    } else {
-        echo "<table cellspacing='0' style='width: 100%'>";
-        echo "<tr class='head'>";
-        echo '<th>';
-        echo __($guid, 'Name');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Form Tutors');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Room');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Students');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Website');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Actions');
-        echo '</th>';
-        echo '</tr>';
+        return Format::listNames($tutors, 'Staff', false, true);
+    };
 
-        $count = 0;
-        $rowNum = 'odd';
-        while ($row = $result->fetch()) {
-            if ($count % 2 == 0) {
-                $rowNum = 'even';
-            } else {
-                $rowNum = 'odd';
-            }
+    $table = DataTable::create('rollGroups');
 
-            //COLOR ROW BY STATUS!
-            echo "<tr class=$rowNum>";
-            echo '<td>';
-            echo $row['name'];
-            echo '</td>';
-            echo '<td>';
-            try {
-                $dataTutor = array('gibbonPersonID1' => $row['gibbonPersonIDTutor'], 'gibbonPersonID2' => $row['gibbonPersonIDTutor2'], 'gibbonPersonID3' => $row['gibbonPersonIDTutor3']);
-                $sqlTutor = 'SELECT gibbonPersonID, surname, preferredName FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID1 OR gibbonPersonID=:gibbonPersonID2 OR gibbonPersonID=:gibbonPersonID3';
-                $resultTutor = $connection2->prepare($sqlTutor);
-                $resultTutor->execute($dataTutor);
-            } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
-            }
-            while ($rowTutor = $resultTutor->fetch()) {
-                echo formatName('', $rowTutor['preferredName'], $rowTutor['surname'], 'Staff', false, true);
-                if ($rowTutor['gibbonPersonID'] == $row['gibbonPersonIDTutor'] and $resultTutor->rowCount() > 1) {
-                    echo ' ('.__($guid, 'Main Tutor').')';
-                }
-                echo '<br/>';
-            }
-            echo '</td>';
-            echo '<td>';
-            echo $row['space'];
-            echo '</td>';
-            echo '<td>';
-            try {
-                $dataCount = array('gibbonRollGroupID' => $row['gibbonRollGroupID']);
-                $sqlCount = "SELECT gibbonPerson.gibbonPersonID FROM gibbonStudentEnrolment INNER JOIN gibbonPerson ON gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID WHERE gibbonRollGroupID=:gibbonRollGroupID AND status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') ORDER BY preferredName, surname";
-                $resultCount = $connection2->prepare($sqlCount);
-                $resultCount->execute($dataCount);
-            } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
-            }
-            echo $resultCount->rowCount();
-            echo '</td>';
-            echo '<td>';
-            if ($row['website'] != '') {
-                echo "<a target='_blank' href='".$row['website']."'>".$row['website'].'</a>';
-            }
-            echo '</td>';
-            echo '<td>';
-            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/rollGroups_details.php&gibbonRollGroupID='.$row['gibbonRollGroupID']."'><img title='".__($guid, 'View')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/plus.png'/></a> ";
-            echo '</td>';
-            echo '</tr>';
+    $table->addColumn('name', __('Name'));
+    $table->addColumn('tutors', __('Form Tutors'))->format($formatTutorsList);
+    $table->addColumn('space', __('Room'));
+    $table->addColumn('students', __('Students'));
+    $table->addColumn('website', __('Website'))->format(Format::using('link', 'website'));
 
-            ++$count;
-        }
-        echo '</table>';
-    }
+    $actions = $table->addActionColumn()->addParam('gibbonRollGroupID');
+    $actions->addAction('view', __('View'))
+            ->setURL('/modules/Roll Groups/rollGroups_details.php');
+
+    echo $table->render($rollGroups->toDataSet());
 }

--- a/modules/Roll Groups/rollGroups.php
+++ b/modules/Roll Groups/rollGroups.php
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Roll Groups/rollGroups.php
         $tutors = $gateway->selectTutorsByRollGroup($row['gibbonRollGroupID'])->fetchAll();
         if (count($tutors) > 1) $tutors[0]['surname'] .= ' ('.__('Main Tutor').')';
 
-        return Format::listNames($tutors, 'Staff', false, true);
+        return Format::nameList($tutors, 'Staff', false, true);
     };
 
     $table = DataTable::create('rollGroups');

--- a/modules/User Admin/user_manage.php
+++ b/modules/User Admin/user_manage.php
@@ -99,6 +99,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
     // COLUMNS
     $table->addColumn('image_240', __('Photo'))
         ->width('10%')
+        ->notSortable()
         ->format(Format::using('userPhoto', 'image_240'));
 
     $table->addColumn('fullName', __('Name'))
@@ -106,15 +107,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
         ->sortable(['surname', 'preferredName'])
         ->format(Format::using('name', ['title', 'preferredName', 'surname', 'Student', true]));
 
-    $table->addColumn('status', __('Status'))
-        ->width('10%')
-        ->sortable();
+    $table->addColumn('status', __('Status'))->width('10%');
 
-    $table->addColumn('primaryRole', __('Primary Role'))
-        ->width('16%')
-        ->sortable();
+    $table->addColumn('primaryRole', __('Primary Role'))->width('16%');
 
     $table->addColumn('family', __('Family'))
+        ->notSortable()
         ->format(function($person) use ($guid) {
             $output = '';
             foreach ($person['families'] as $family) {
@@ -123,7 +121,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
             return $output;
         });
 
-    $table->addColumn('username', __('Username'))->sortable();
+    $table->addColumn('username', __('Username'));
 
     // ACTIONS
     $table->addActionColumn()

--- a/src/Domain/School/RollGroupGateway.php
+++ b/src/Domain/School/RollGroupGateway.php
@@ -1,0 +1,67 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\School;
+
+use Gibbon\Domain\Gateway;
+use Gibbon\Domain\Traits\TableAware;
+
+/**
+ * RollGroup Gateway
+ *
+ * @version v16
+ * @since   v16
+ */
+class RollGroupGateway extends Gateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonRollGroup';
+    private static $searchableColumns = [];
+
+    public function selectRollGroupsBySchoolYear($gibbonSchoolYearID)
+    {
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'today' => date('Y-m-d'));
+        $sql = "SELECT gibbonRollGroup.gibbonRollGroupID, gibbonRollGroup.name, gibbonRollGroup.nameShort, gibbonSpace.name AS space, gibbonRollGroup.website, gibbonPersonIDTutor, gibbonPersonIDTutor2, gibbonPersonIDTutor3, COUNT(DISTINCT students.gibbonPersonID) as students
+                FROM gibbonRollGroup 
+                LEFT JOIN (
+                    SELECT gibbonPerson.gibbonPersonID, gibbonStudentEnrolment.gibbonRollGroupID FROM gibbonStudentEnrolment 
+                    JOIN gibbonPerson ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                    WHERE status='Full' AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL OR dateEnd>=:today)
+                ) AS students ON (students.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                LEFT JOIN gibbonSpace ON (gibbonRollGroup.gibbonSpaceID=gibbonSpace.gibbonSpaceID) 
+                WHERE gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID 
+                GROUP BY gibbonRollGroup.gibbonRollGroupID
+                ORDER BY gibbonRollGroup.name";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectTutorsByRollGroup($gibbonRollGroupID)
+    {
+        $data = array('gibbonRollGroupID' => $gibbonRollGroupID);
+        $sql = "SELECT gibbonPersonID, title, surname, preferredName 
+                FROM gibbonRollGroup 
+                LEFT JOIN gibbonPerson ON (gibbonPersonID=gibbonRollGroup.gibbonPersonIDTutor OR gibbonPersonID=gibbonRollGroup.gibbonPersonIDTutor2 OR gibbonPersonID=gibbonRollGroup.gibbonPersonIDTutor3)
+                WHERE gibbonRollGroup.gibbonRollGroupID=:gibbonRollGroupID 
+                ORDER BY gibbonPersonID=gibbonRollGroup.gibbonPersonIDTutor DESC, gibbonPersonID=gibbonRollGroup.gibbonPersonIDTutor2 DESC";
+
+        return $this->db()->select($sql, $data);
+    }
+}

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -178,10 +178,11 @@ class Format
 
     /**
      * Formats a link from a url. Automatically adds target _blank to external links.
+     * 
      * @param string $url
      * @param string $text
      * @param string $title
-     * @return void
+     * @return string
      */
     public static function link($url, $text = '', $title = '')
     {
@@ -250,6 +251,8 @@ class Format
     {
         $output = '';
 
+        if (empty($preferredName) && empty(empty($surname))) return '';
+
         if ($roleCategory == 'Staff' or $roleCategory == 'Other') {
             $setting = 'nameFormatStaff' . ($informal? 'Informal' : 'Formal') . ($reverse? 'Reversed' : '');
             $format = isset(static::$settings[$setting])? static::$settings[$setting] : '[title] [preferredName:1]. [surname]';
@@ -271,7 +274,7 @@ class Format
             $output = sprintf($format, $preferredName, $surname);
         }
 
-        return trim($output, ' .');
+        return trim($output, ' ');
     }
 
     /**

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -283,7 +283,7 @@ class Format
      * @param bool $informal
      * @return string
      */
-    public static function listNames($list, $roleCategory = 'Staff', $reverse = false, $informal = false)
+    public static function nameList($list, $roleCategory = 'Staff', $reverse = false, $informal = false)
     {
         $output = '';
         foreach ($list as $person) {

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -173,6 +173,24 @@ class Format
     }
 
     /**
+     * Formats a link from a url. Automatically adds target _blank to external links.
+     * @param string $url
+     * @param string $text
+     * @param string $title
+     * @return void
+     */
+    public static function link($url, $text = '', $title = '')
+    {
+        if (!$text) $text = $url;
+
+        if (stripos($url, static::$settings['absoluteURL']) === false) {
+            return '<a href="'.$url.'" title="'.$title.'" target="_blank">'.$text.'</a>';
+        } else {
+            return '<a href="'.$url.'" title="'.$title.'">'.$text.'</a>';
+        }
+    }
+
+    /**
      * Formats a YYYY-MM-DD date as a relative age with years and months.
      *
      * @param string $dateString
@@ -237,7 +255,7 @@ class Format
                     list($token, $length) = array_pad(explode(':', $matches[1], 2), 2, false);
                     return isset($$token)
                         ? (!empty($length)? mb_substr($$token, 0, intval($length)) : $$token)
-                        : $matches[0];
+                        : '';
                 },
             $format);
 
@@ -249,7 +267,27 @@ class Format
             $output = sprintf($format, $preferredName, $surname);
         }
 
-        return trim($output);
+        return trim($output, ' .');
+    }
+
+    /**
+     * Formats a list of names from an array containing standard title, preferredName & surname fields.
+     * 
+     * @param array $list
+     * @param string $roleCategory
+     * @param bool $reverse
+     * @param bool $informal
+     * @return string
+     */
+    public static function listNames($list, $roleCategory = 'Staff', $reverse = false, $informal = false)
+    {
+        $output = '';
+        foreach ($list as $person) {
+            $output .= static::name($person['title'], $person['preferredName'], $person['surname'], $roleCategory, $reverse, $informal);
+            $output .= '<br/>';
+        }
+
+        return $output;
     }
 
     /**

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -59,6 +59,10 @@ class Format
         $settings['currency'] = $session->get('currency');
         $settings['currencySymbol'] = !empty(substr($settings['currency'], 4)) ? substr($settings['currency'], 4) : '';
         $settings['currencyName'] = substr($settings['currency'], 0, 3);
+        $settings['nameFormatStaffInformal'] = $session->get('nameFormatStaffInformal');
+        $settings['nameFormatStaffInformalReversed'] = $session->get('nameFormatStaffInformalReversed');
+        $settings['nameFormatStaffFormal'] = $session->get('nameFormatStaffFormal');
+        $settings['nameFormatStaffFormalReversed'] = $session->get('nameFormatStaffFormalReversed');
         
         static::setup($settings);
     }

--- a/src/Tables/Action.php
+++ b/src/Tables/Action.php
@@ -49,12 +49,25 @@ class Action extends WebLink
                             break;
             case 'edit':    $this->setIcon('config');
                             break;
-            case 'delete':  $this->setIcon('garbage')->isModal(true)->addParam('width', '650')->addParam('height', '135');
+            case 'delete':  $this->setIcon('garbage')->isModal(650, 135);
                             break;
             default:
             case 'view':    $this->setIcon('zoom');
                             break;
         }
+    }
+
+    /**
+     * Sets the internal url for this action.
+     * 
+     * @param string $url
+     * @return self
+     */
+    public function setURL($url)
+    {
+        $this->url = $url;
+
+        return $this;
     }
 
     /**
@@ -122,9 +135,13 @@ class Action extends WebLink
      * @param bool $value
      * @return self
      */
-    public function isModal($value = true) 
+    public function isModal($width = 650, $height = 650) 
     {
-        $this->modal = $value;
+        $this->modal = true;
+
+        $this->setClass('thickbox')
+            ->addParam('width', $width)
+            ->addParam('height', $height);
 
         return $this;
     }
@@ -140,7 +157,13 @@ class Action extends WebLink
     {
         global $guid; // :(
 
-        $queryParams = array();
+        $this->setContent(sprintf('%1$s<img title="%2$s" src="'.$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/%3$s.png" style="margin-left: 5px">', 
+            ($this->displayLabel? $this->getLabel() : ''),
+            $this->getLabel(), 
+            $this->getIcon()
+        ));
+
+        $queryParams = array('q' => $this->url);
 
         if (!empty($data)) {
             foreach (array_merge($params, $this->params) as $key => $value) {
@@ -149,22 +172,10 @@ class Action extends WebLink
         }
 
         if ($this->modal) {
-            $url = $_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q='.$this->getURL();
-            $this->addClass('thickbox');
+            $this->setAttribute('href', $_SESSION[$guid]['absoluteURL'].'/fullscreen.php?'.http_build_query($queryParams));
         } else {
-            $url = $_SESSION[$guid]['absoluteURL'].'/index.php?q='.$this->getURL();
+            $this->setAttribute('href', $_SESSION[$guid]['absoluteURL'].'/index.php?'.http_build_query($queryParams));
         }
-
-        if (!empty($queryParams)) {
-            $url .= '&'.http_build_query($queryParams);
-        }
-
-        $this->setURL($url);
-        $this->setContent(sprintf('%1$s<img title="%2$s" src="'.$_SESSION[$guid]['absoluteURL'].'/themes/Default/img/%3$s.png" style="margin-left: 5px">', 
-                ($this->displayLabel? $this->getLabel() : ''),
-                $this->getLabel(), 
-                $this->getIcon()
-            ));
 
         return parent::getOutput();
     }

--- a/src/Tables/Column.php
+++ b/src/Tables/Column.php
@@ -41,6 +41,7 @@ class Column
     {
         $this->setID($id);
         $this->label = $label;
+        $this->sortable = [$id];
     }
 
     /**
@@ -107,7 +108,19 @@ class Column
      */
     public function sortable($value = null) 
     {
-        $this->sortable = is_null($value) ? array($this->getID()) : $value;
+        $this->sortable = is_null($value) ? [$this->getID()] : $value;
+
+        return $this;
+    }
+
+    /**
+     * Disables sorting for this column.
+     * 
+     * @return self
+     */
+    public function notSortable() 
+    {
+        $this->sortable = false;
 
         return $this;
     }

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -24,6 +24,7 @@ use Gibbon\Domain\QueryCriteria;
 use Gibbon\Tables\Action;
 use Gibbon\Tables\Column;
 use Gibbon\Tables\ActionColumn;
+use Gibbon\Tables\Renderer\SimpleRenderer;
 use Gibbon\Tables\Renderer\PaginatedRenderer;
 use Gibbon\Tables\Renderer\RendererInterface;
 use Gibbon\Forms\OutputableInterface;
@@ -60,7 +61,7 @@ class DataTable implements OutputableInterface
     }
 
     /**
-     * Static create method, for ease of method chaining.
+     * Static create method, for ease of method chaining. Defaults to a simple table renderer.
      *
      * @param string $id
      * @param RendererInterface $renderer
@@ -68,7 +69,7 @@ class DataTable implements OutputableInterface
      */
     public static function create($id, RendererInterface $renderer = null)
     {
-        return new self($id, $renderer);
+        return new self($id, $renderer ? $renderer : new SimpleRenderer());
     }
 
     /**

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -19,11 +19,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Tables\Renderer;
 
+use Gibbon\Tables\Column;
+use Gibbon\Tables\DataTable;
 use Gibbon\Domain\DataSet;
 use Gibbon\Domain\QueryCriteria;
 use Gibbon\Forms\FormFactory;
-use Gibbon\Tables\DataTable;
-use Gibbon\Tables\ActionColumn;
 use Gibbon\Tables\Renderer\RendererInterface;
 
 /**
@@ -32,7 +32,7 @@ use Gibbon\Tables\Renderer\RendererInterface;
  * @version v16
  * @since   v16
  */
-class PaginatedRenderer implements RendererInterface
+class PaginatedRenderer extends SimpleRenderer implements RendererInterface
 {
     protected $path;
     protected $criteria;
@@ -92,84 +92,11 @@ class PaginatedRenderer implements RendererInterface
         $output .= $this->renderPageSize($dataSet);
         $output .= $this->renderPagination($dataSet);
 
-        if ($dataSet->count() > 0) {
-            $output .= '<table class="fullWidth colorOddEven" cellspacing="0">';
+        $output .= parent::renderTable($table, $dataSet);
 
-            // HEADING
-            $output .= '<thead>';
-            $output .= '<tr class="head">';
-            foreach ($table->getColumns() as $columnName => $column) {
-                $classes = array('column');
-
-                if ($sortBy = $column->getSortable()) {
-                    $classes[] = 'sortable';
-
-                    foreach ($sortBy as $sortColumn) {
-                        if ($this->criteria->hasSort($sortColumn)) {
-                            $classes[] = 'sorting sort'.$this->criteria->getSortBy($sortColumn);
-                        }
-                    }
-                } else {
-                    $sortBy = array();
-                }
-
-                $output .= '<th title="'.$column->getTitle().'" style="width:'.$column->getWidth().'" class="'.implode(' ', $classes).'" data-sort="'.implode(',', $sortBy).'">';
-                $output .=  $column->getLabel();
-                $output .= '<br/><small><i>'.$column->getDescription().'</i></small>';
-                $output .= '</th>';
-            }
-            $output .= '</tr>';
-            $output .= '</thead>';
-
-            // ROWS
-            $output .= '<tbody>';
-
-            $rowLogic = $table->getRowLogic();
-            $cellLogic = $table->getCellLogic();
-
-            foreach ($dataSet as $data) {
-                $row = $this->factory->createTableCell();
-                if ($rowLogic) {
-                    $row = $rowLogic($row, $data);
-                }
-
-                $output .= '<tr '.$row->getAttributeString().'>';
-                $output .= $row->getPrepended();
-
-                foreach ($table->getColumns() as $columnName => $column) {
-                    $cell = $this->factory->createTableCell();
-                    if ($cellLogic) {
-                        $cell = $cellLogic($cell, $data);
-                    }
-
-                    $output .= '<td '.$row->getAttributeString().'>';
-                    $output .= $cell->getPrepended();
-                    $output .= $column->getOutput($data);
-                    $output .= $cell->getAppended();
-                    $output .= '</td>';
-                }
-
-                $output .= $row->getAppended();
-                $output .= '</tr>';
-            }
-
-            $output .= '</tbody>';
-            $output .= '</table>';
-
-            if ($dataSet->getPageCount() > 1) {
-                $output .= $this->renderPageCount($dataSet);
-                $output .= $this->renderPagination($dataSet);
-            }
-        } else {
-            if ($dataSet->isSubset()) {
-                $output .= '<div class="warning">';
-                $output .= __('No results matched your search.');
-                $output .= '</div>';
-            } else {
-                $output .= '<div class="error">';
-                $output .= __('There are no records to display.');
-                $output .= '</div>';
-            }
+        if ($dataSet->getPageCount() > 1) {
+            $output .= $this->renderPageCount($dataSet);
+            $output .= $this->renderPagination($dataSet);
         }
 
         $output .= '</div></div><br/>';
@@ -183,6 +110,29 @@ class PaginatedRenderer implements RendererInterface
         </script>";
 
         return $output;
+    }
+
+    /**
+     * Overrides the SimpleRenderer header to add sortable column classes & data attribute.
+     * @param Column $column
+     * @return Element
+     */
+    protected function createTableHeader(Column $column)
+    {
+        $th = parent::createTableHeader($column);
+
+        if ($sortBy = $column->getSortable()) {
+            $th->addClass('sortable');
+            $th->addData('sort', implode(',', $sortBy));
+
+            foreach ($sortBy as $sortColumn) {
+                if ($this->criteria->hasSort($sortColumn)) {
+                    $th->addClass('sorting sort'.$this->criteria->getSortBy($sortColumn));
+                }
+            }
+        }
+
+        return $th;
     }
 
     /**

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -72,31 +72,25 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
         $output .= '<div id="'.$table->getID().'">';
         $output .= '<div class="dataTable">';
 
-        // Debug the AJAX $POST => Filters
-        // $output .= '<code>';
-        // $output .= 'POST: '.json_encode($_POST).'<br/>';
-        // $output .= '</code>';
-
-        // Debug the criteria
-        // $output .= '<code>';
-        // $output .= 'Criteria: '.$this->criteria->toJson();
-        // $output .= '</code>';
-
         $filterOptions = $table->getMetaData('filterOptions', []);
 
-        $output .= '<div>';
-        $output .= $this->renderPageCount($dataSet);
-        $output .= $this->renderPageFilters($dataSet, $filterOptions);
-        $output .= '</div>';
-        $output .= $this->renderFilterOptions($dataSet, $filterOptions);
-        $output .= $this->renderPageSize($dataSet);
-        $output .= $this->renderPagination($dataSet);
+        $output .= '<header>';
+            $output .= '<div>';
+            $output .= $this->renderPageCount($dataSet);
+            $output .= $this->renderPageFilters($dataSet, $filterOptions);
+            $output .= '</div>';
+            $output .= $this->renderFilterOptions($dataSet, $filterOptions);
+            $output .= $this->renderPageSize($dataSet);
+            $output .= $this->renderPagination($dataSet);
+        $output .= '</header>';
 
         $output .= parent::renderTable($table, $dataSet);
 
         if ($dataSet->getPageCount() > 1) {
+            $output .= '<footer>';
             $output .= $this->renderPageCount($dataSet);
             $output .= $this->renderPagination($dataSet);
+            $output .= '</footer>';
         }
 
         $output .= '</div></div><br/>';

--- a/src/Tables/Renderer/SimpleRenderer.php
+++ b/src/Tables/Renderer/SimpleRenderer.php
@@ -84,7 +84,7 @@ class SimpleRenderer implements RendererInterface
             $cellLogic = $table->getCellLogic();
 
             foreach ($dataSet as $data) {
-                $row = $this->createTableRow($table);
+                $row = $this->createTableRow($table, $data);
 
                 $output .= '<tr '.$row->getAttributeString().'>';
                 $output .= $row->getPrepended();
@@ -137,7 +137,7 @@ class SimpleRenderer implements RendererInterface
      * @param DataTable $table
      * @return Element
      */
-    protected function createTableRow(DataTable $table)
+    protected function createTableRow(DataTable $table, array $data)
     {
         $row = new Element();
         if ($rowLogic = $table->getRowLogic()) {

--- a/src/Tables/Renderer/SimpleRenderer.php
+++ b/src/Tables/Renderer/SimpleRenderer.php
@@ -1,0 +1,166 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Tables\Renderer;
+
+use Gibbon\Tables\Column;
+use Gibbon\Tables\DataTable;
+use Gibbon\Domain\DataSet;
+use Gibbon\Tables\Renderer\RendererInterface;
+use Gibbon\Forms\Layout\Element;
+
+/**
+ * SimpleRenderer
+ *
+ * @version v16
+ * @since   v16
+ */
+class SimpleRenderer implements RendererInterface
+{
+    /**
+     * So simple ...
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Render the table to HTML. TODO: replace with Twig.
+     *
+     * @param DataTable $table
+     * @param DataSet $dataSet
+     * @return string
+     */
+    public function renderTable(DataTable $table, DataSet $dataSet)
+    {
+        $output = '';
+
+        if ($dataSet->count() == 0) {
+            if ($dataSet->isSubset()) {
+                $output .= '<div class="warning">';
+                $output .= __('No results matched your search.');
+                $output .= '</div>';
+            } else {
+                $output .= '<div class="error">';
+                $output .= __('There are no records to display.');
+                $output .= '</div>';
+            }
+        } else {
+            $output .= '<table class="fullWidth colorOddEven" cellspacing="0">';
+
+            // HEADER
+            $output .= '<thead>';
+            $output .= '<tr class="head">';
+            foreach ($table->getColumns() as $columnName => $column) {
+                $th = $this->createTableHeader($column);
+
+                $output .= '<th '.$th->getAttributeString().' style="width:'.$column->getWidth().'">';
+                $output .= $th->getOutput();
+                $output .= '</th>';
+            }
+            $output .= '</tr>';
+            $output .= '</thead>';
+
+            // ROWS
+            $output .= '<tbody>';
+
+            $rowLogic = $table->getRowLogic();
+            $cellLogic = $table->getCellLogic();
+
+            foreach ($dataSet as $data) {
+                $row = $this->createTableRow($table);
+
+                $output .= '<tr '.$row->getAttributeString().'>';
+                $output .= $row->getPrepended();
+
+                // CELLS
+                foreach ($table->getColumns() as $columnName => $column) {
+                    $cell = $this->createTableCell($table, $data);
+
+                    $output .= '<td '.$row->getAttributeString().'>';
+                    $output .= $cell->getPrepended();
+                    $output .= $column->getOutput($data);
+                    $output .= $cell->getAppended();
+                    $output .= '</td>';
+                }
+
+                $output .= $row->getAppended();
+                $output .= '</tr>';
+            }
+
+            $output .= '</tbody>';
+            $output .= '</table>';
+        }
+
+        return $output;
+    }
+
+    /**
+     * Creates the HTML object for the <th> tag.
+     * 
+     * @param Column $column
+     * @return Element
+     */
+    protected function createTableHeader(Column $column)
+    {
+        $th = new Element($column->getLabel());
+
+        $th->setTitle($column->getTitle())
+           ->setClass('column');
+
+        if ($description = $column->getDescription()) {
+            $th->append('<br/><small><i>'.$column->getDescription().'</i></small>');
+        }
+
+        return $th;
+    }
+
+    /**
+     * Creates the HTML object for the <tr> tag, applies optional rowLogic callable to modify the output.
+     * 
+     * @param DataTable $table
+     * @return Element
+     */
+    protected function createTableRow(DataTable $table)
+    {
+        $row = new Element();
+        if ($rowLogic = $table->getRowLogic()) {
+            $row = $rowLogic($row, $data);
+        }
+
+        return $row;
+    }
+
+    /**
+     * Creates the HTML object for the <tr> tag, applies optional rowLogic callable to modify the output.
+     * 
+     * @param DataTable $table
+     * @param array $data
+     * @return Element
+     */
+    protected function createTableCell(DataTable $table, array $data)
+    {
+        $cell = new Element();
+        if ($cellLogic = $table->getCellLogic()) {
+            $cell = $cellLogic($cell, $data);
+        }
+
+        return $cell;
+    }
+}

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1673,7 +1673,8 @@ table.smallIntBorder td.noPadding {
     margin: 0;
 }
 
-.dataTable small {
+.dataTable header small,
+.dataTable footer small {
     font-size: 12px;
     line-height: 32px;
 }


### PR DESCRIPTION
Sometimes you don't need a fancy paginated table, just a regular one will do. This PR adds a SimpleRenderer, which can take any SQL result set and transform it into a table. I've ooified the Roll Groups table as an example.

Also includes some other minor tweaks:
- Sortable columns are on by default, and easily disabled for a column with `notSortable()`
- Adds formatters for link and nameList
- Tidies up some internal table class logic
- Fixes filters not working after using the clear button
- Name format no longer outputs default values if params are empty