### PR TITLE
Tables: moved the header actions to SimpleRenderer, misc tweaks

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -319,14 +319,12 @@ $.prototype.gibbonCustomBlocks = function(settings) {
  */
 var DataTable = window.DataTable || {};
 
-DataTable = (function(element, basePath, filters, totalCount) {
+DataTable = (function(element, basePath, filters) {
     var _ = this;
 
     _.table = $(element);
     _.path = basePath + " #" + $(element).attr('id') + " .dataTable";
     _.filters = filters;
-    _.totalCount = totalCount;
-    
     if (_.filters.sortBy.length == 0) _.filters.sortBy = {};
     if (_.filters.filterBy.length == 0) _.filters.filterBy = {};
 
@@ -338,7 +336,8 @@ DataTable.prototype.init = function() {
 
     // Pagination
     $(_.table).on('click', '.paginate', function() {
-        _.filters.pageMax = Math.ceil(_.totalCount / _.filters.pageSize);
+        var resultCount = $('.dataTable', _.table).data('results');
+        _.filters.pageMax = Math.ceil(resultCount / _.filters.pageSize);
         _.filters.page = Math.min($(this).data('page'), _.filters.pageMax);
         _.refresh();
     });
@@ -367,10 +366,7 @@ DataTable.prototype.init = function() {
             _.filters.searchBy.columns = [''];
         } else if (filter in _.filters.filterBy) {
             // Remove columns from search criteria if removing an in: filter
-            if (filter == 'in') {
-                _.filters.searchBy.columns = [''];
-            }
-            
+            if (filter == 'in') _.filters.searchBy.columns = [''];
             delete _.filters.filterBy[filter];
         }
 
@@ -392,8 +388,9 @@ DataTable.prototype.init = function() {
 
     // Page Size
     $(_.table).on('change', '.limit', function() {
+        var resultCount = $('.dataTable', _.table).data('results');
         _.filters.pageSize = parseInt($(this).val());
-        _.filters.pageMax = Math.ceil(_.totalCount / _.filters.pageSize);
+        _.filters.pageMax = Math.ceil(resultCount / _.filters.pageSize);
         _.filters.page = Math.min(_.filters.page, _.filters.pageMax);
         _.refresh();
     });
@@ -413,6 +410,6 @@ DataTable.prototype.refresh = function() {
     });
 };
 
-$.prototype.gibbonDataTable = function(basePath, filters, totalCount) {
-    this.gibbonDataTable = new DataTable(this, basePath, filters, totalCount);
+$.prototype.gibbonDataTable = function(basePath, filters) {
+    this.gibbonDataTable = new DataTable(this, basePath, filters);
 };

--- a/src/Domain/QueryableGateway.php
+++ b/src/Domain/QueryableGateway.php
@@ -56,7 +56,7 @@ abstract class QueryableGateway extends Gateway
      */
     protected function newQuery()
     {
-        return $this->getQueryFactory()->newSelect();
+        return $this->getQueryFactory()->newSelect()->calcFoundRows();
     }
 
     /**
@@ -87,8 +87,6 @@ abstract class QueryableGateway extends Gateway
      */
     private function applyCriteria(SelectInterface $query, QueryCriteria $criteria)
     {
-        $query->calcFoundRows();
-
         $criteria->addFilterRules($this->getDefaultFilterRules($criteria));
 
         // Filter By

--- a/src/Domain/QueryableGateway.php
+++ b/src/Domain/QueryableGateway.php
@@ -95,7 +95,7 @@ abstract class QueryableGateway extends Gateway
         if ($criteria->hasFilter()) {
             foreach ($criteria->getFilterBy() as $name => $value) {
                 if ($callback = $criteria->getFilterRule($name)) {
-                    $query = $callback($query, $value);
+                    $callback($query, $value);
                 }
             }
         }

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -32,7 +32,11 @@ class Format
 {
     use FormatResolver;
 
-    protected static $settings = [];
+    protected static $settings = [
+        'dateFormatPHP'     => 'd/m/Y',
+        'dateTimeFormatPHP' => 'd/m/Y H:i',
+        'timeFormatPHP'     => 'H:i',
+    ];
 
     /**
      * Sets the internal formatting options from an array.
@@ -76,7 +80,7 @@ class Format
      */
     public static function date($dateString, $format = false)
     {
-        $date = DateTime::createFromFormat('Y-m-d', $dateString);
+        $date = DateTime::createFromFormat('Y-m-d', substr($dateString, 0, 10));
         return $date ? $date->format($format ? $format : static::$settings['dateFormatPHP']) : '';
     }
 
@@ -93,7 +97,7 @@ class Format
     }
 
     /**
-     * Formats a YYY-MM-DD H:I:S MySQL timestamp as a readable string. Optionally provide a format string to use.
+     * Formats a YYYY-MM-DD H:I:S MySQL timestamp as a readable string. Optionally provide a format string to use.
      *
      * @param string $dateString
      * @param string $format
@@ -102,7 +106,7 @@ class Format
     public static function dateTime($dateString, $format = false)
     {
         $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateString);
-        return $date ? $date->format($format ? $format : 'F j, Y g:i a') : '';
+        return $date ? $date->format($format ? $format : static::$settings['dateTimeFormatPHP']) : '';
     }
     
     /**
@@ -142,14 +146,42 @@ class Format
     }
 
     /**
-     * Converts a YYYY-MM-DD date to a Unix timestamp;
+     * Converts a YYYY-MM-DD date to a Unix timestamp.
      *
      * @return string
      */
     public static function timestamp($dateString)
     {
-        $date = DateTime::createFromFormat('Y-m-d', $dateString);
+        if (strlen($dateString) == 10) $dateString .= ' 00:00:00';
+        $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateString);
         return $date ? $date->getTimestamp() : 0;
+    }
+
+    /**
+     * Formats a time from a given MySQL time or timestamp value.
+     * 
+     * @param string $timeString
+     * @param string|bool $format
+     * @return string
+     */
+    public static function time($timeString, $format = false)
+    {
+        $convertFormat = strlen($timeString) == 8? 'H:i:s' : 'Y-m-d H:i:s';
+        $date = DateTime::createFromFormat($convertFormat, $timeString);
+        return $date ? $date->format($format ? $format : static::$settings['timeFormatPHP']) : '';
+    }
+
+    /**
+     * Formats a range of times from two given MySQL time or timestamp values.
+     * 
+     * @param string $timeFrom
+     * @param string $timeTo
+     * @param string|bool $format
+     * @return string
+     */
+    public static function timeRange($timeFrom, $timeTo, $format = false)
+    {
+        return static::time($timeFrom, $format) . ' - ' . static::time($timeTo, $format);
     }
 
     /**

--- a/src/Tables/Action.php
+++ b/src/Tables/Action.php
@@ -178,10 +178,8 @@ class Action extends WebLink
 
         $queryParams = !$this->direct ? array('q' => $this->url) : array();
 
-        if (!empty($data)) {
-            foreach (array_merge($params, $this->params) as $key => $value) {
-                $queryParams[$key] = (empty($value) && !empty($data[$key]))? $data[$key] : $value;
-            }
+        foreach (array_merge($params, $this->params) as $key => $value) {
+            $queryParams[$key] = (empty($value) && !empty($data[$key]))? $data[$key] : $value;
         }
 
         if ($this->direct) {

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -35,6 +35,7 @@ use Gibbon\Forms\FormFactory;
 class PaginatedRenderer extends SimpleRenderer implements RendererInterface
 {
     protected $path;
+    protected $post = [];
     protected $criteria;
     protected $factory;
     
@@ -50,6 +51,19 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
         $this->path = $path;
         $this->criteria = $criteria;
         $this->factory = FormFactory::create();
+    }
+
+    /**
+     * Add an array of $_POST data to be passed between the paginated renderer and AJAX.
+     * 
+     * @param array $values
+     * @return self
+     */
+    public function addPostData(array $values)
+    {
+        $this->post = array_replace($this->post, $values);
+        
+        return $this;
     }
 
     /**
@@ -70,7 +84,7 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
         $output .= '</div>';
 
         $output .= '<div id="'.$table->getID().'">';
-        $output .= '<div class="dataTable">';
+        $output .= '<div class="dataTable" data-results="'.$dataSet->getResultCount().'">';
 
         $filterOptions = $table->getMetaData('filterOptions', []);
 
@@ -95,11 +109,17 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
 
         $output .= '</div></div><br/>';
 
+        if (!empty($this->post)) {
+            $postData = json_encode(array_replace($this->post, $this->criteria->toArray()));
+        } else {
+            $postData = $this->criteria->toJson();
+        }
+        
         // Initialize the jQuery Data Table functionality
         $output .="
         <script>
         $(function(){
-            $('#".$table->getID()."').gibbonDataTable('.".str_replace(' ', '%20', $this->path)."', ".$this->criteria->toJson().", ".$dataSet->getResultCount().");
+            $('#".$table->getID()."').gibbonDataTable('.".str_replace(' ', '%20', $this->path)."', ".$postData.");
         });
         </script>";
 

--- a/src/Tables/Renderer/SimpleRenderer.php
+++ b/src/Tables/Renderer/SimpleRenderer.php
@@ -51,6 +51,10 @@ class SimpleRenderer implements RendererInterface
     {
         $output = '';
 
+        $output .= '<header>';
+        $output .= $this->renderHeader($table, $dataSet);
+        $output .= '</header>';
+
         if ($dataSet->count() == 0) {
             if ($dataSet->isSubset()) {
                 $output .= '<div class="warning">';
@@ -110,7 +114,31 @@ class SimpleRenderer implements RendererInterface
             $output .= '</table>';
         }
 
+        $output .= '<footer>';
+        $output .= $this->renderFooter($table, $dataSet);
+        $output .= '</footer>';
+
         return $output;
+    }
+
+    protected function renderHeader(DataTable $table, DataSet $dataSet)
+    {
+        $output = '';
+
+        if ($headerActions = $table->getHeader()) {
+            $output .= '<div class="linkTop">';
+            foreach ($headerActions as $header) {
+                $output .= $header->getOutput();
+            }
+            $output .= '</div>';
+        }
+
+        return $output;
+    }
+
+    protected function renderFooter(DataTable $table, DataSet $dataSet)
+    {
+        return '';
     }
 
     /**

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -38,6 +38,11 @@ class FormatTest extends TestCase
         $this->assertEquals('18/05/2018', Format::date('2018-05-18'));
     }
 
+    public function testFormatsDatesFromTimestamp()
+    {
+        $this->assertEquals('18/05/2018', Format::date('2018-05-18 09:00:15'));
+    }
+
     public function testFormatsDatesWithOptionalFormat()
     {
         $this->assertEquals('Sunday April 1st 2018', Format::date('2018-04-01', 'l F jS Y'));
@@ -51,7 +56,12 @@ class FormatTest extends TestCase
 
     public function testFormatsDateTime()
     {
-        $this->assertEquals('May 18, 2018 5:16 pm', Format::dateTime('2018-05-18 17:16:18'));
+        $this->assertEquals('18/05/2018 17:16', Format::dateTime('2018-05-18 17:16:18'));
+    }
+
+    public function testFormatsDateTimeWithFormat()
+    {
+        $this->assertEquals('May 18, 2018 5:16 pm', Format::dateTime('2018-05-18 17:16:18', 'F j, Y g:i a'));
     }
 
     public function testFormatsReadableDates()
@@ -67,6 +77,36 @@ class FormatTest extends TestCase
     public function testFormatsDateFromTimestamps()
     {
         $this->assertEquals('18/05/2018', Format::dateFromTimestamp('1526615872'));
+    }
+
+    public function testFormatsUnixTimestamps()
+    {
+        $this->assertEquals('1526572800', Format::timestamp('2018-05-18'));
+    }
+
+    public function testFormatsUnixTimestampsFromMysqlTimestamps()
+    {
+        $this->assertEquals('1526607015', Format::timestamp('2018-05-18 09:30:15'));
+    }
+
+    public function testFormatsTimes()
+    {
+        $this->assertEquals('09:30', Format::time('09:30:15'));
+    }
+
+    public function testFormatsTimesFromTimestamp()
+    {
+        $this->assertEquals('09:30', Format::time('2018-05-18 09:30:15'));
+    }
+
+    public function testFormatsTimesWithFormat()
+    {
+        $this->assertEquals('9:30 am', Format::time('09:30:15', 'g:i a'));
+    }
+
+    public function testFormatsTimeRanges()
+    {
+        $this->assertEquals('9:30 am - 1:45 pm', Format::timeRange('09:30:15', '13:45:42', 'g:i a'));
     }
 
     public function testFormatsNumbers()


### PR DESCRIPTION
- The header actions are now available to simple tables, and in a paginated table will now bring the search/sort/filter params with them (for the Return to search results functionally).
- Fixed a fun and elusive pagination issue, which now passes accurate result counts to JS as part of the table data
- Added time and timeRange methods to Format

