### PR TITLE
Students: Manage Medical Forms table ooification

### DIFF
--- a/modules/Students/medicalForm_manage.php
+++ b/modules/Students/medicalForm_manage.php
@@ -19,6 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Tables\DataTable;
+use Gibbon\Services\Format;
+use Gibbon\Domain\Students\MedicalGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage.php') == false) {
     //Acess denied
@@ -35,17 +38,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
         returnProcess($guid, $_GET['return'], null, null);
     }
 
-    //Set pagination variable
-    $page = 1;
-    if (isset($_GET['page'])) {
-        $page = $_GET['page'];
-    }
-    if ((!is_numeric($page)) or $page < 1) {
-        $page = 1;
-    }
-
     echo '<h2>';
-    echo __($guid, 'Search');
+    echo __('Search');
     echo '</h2>';
 
     $search = isset($_GET['search'])? $_GET['search'] : '';
@@ -65,145 +59,60 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     echo $form->getOutput();
 
     echo '<h2>';
-    echo __($guid, 'View');
+    echo __('View');
     echo '</h2>';
 
-    $search = null;
-    if (isset($_GET['search'])) {
-        $search = $_GET['search'];
-    }
-    try {
-        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-        $sql = "SELECT * FROM gibbonPerson JOIN gibbonPersonMedical ON (gibbonPerson.gibbonPersonID=gibbonPersonMedical.gibbonPersonID) JOIN gibbonStudentEnrolment ON (gibbonPersonMedical.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonRollGroup ON (gibbonRollGroup.gibbonRollGroupID=gibbonStudentEnrolment.gibbonRollGroupID) WHERE (gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID) AND (status='FULL') ORDER BY surname, preferredName";
-        if ($search != '') {
-            $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'search1' => "%$search%", 'search2' => "%$search%", 'search3' => "%$search%");
-            $sql = "SELECT * FROM gibbonPerson JOIN gibbonPersonMedical ON (gibbonPerson.gibbonPersonID=gibbonPersonMedical.gibbonPersonID) JOIN gibbonStudentEnrolment ON (gibbonPersonMedical.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonRollGroup ON (gibbonRollGroup.gibbonRollGroupID=gibbonStudentEnrolment.gibbonRollGroupID) WHERE (gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID) AND (status='FULL') AND ((preferredName LIKE :search1) OR (surname LIKE :search2) OR (username LIKE :search3)) ORDER BY surname, preferredName";
-        }
-        $sqlPage = $sql.' LIMIT '.$_SESSION[$guid]['pagination'].' OFFSET '.(($page - 1) * $_SESSION[$guid]['pagination']);
-        $result = $connection2->prepare($sql);
-        $result->execute($data);
-    } catch (PDOException $e) {
-        echo "<div class='error'>".$e->getMessage().'</div>';
-    }
+    $medicalGateway = $container->get(MedicalGateway::class);
 
-    echo "<div class='linkTop'>";
-    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_add.php&search=$search'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
-    echo '</div>';
+    $criteria = $medicalGateway->newQueryCriteria()
+        ->searchBy($medicalGateway->getSearchableColumns(), $search)
+        ->sortBy(['surname', 'preferredName'])
+        ->fromArray($_POST);
 
-    if ($result->rowCount() < 1) {
-        echo "<div class='error'>";
-        echo __($guid, 'There are no records to display.');
-        echo '</div>';
-    } else {
-        if ($result->rowCount() > $_SESSION[$guid]['pagination']) {
-            printPagination($guid, $result->rowCount(), $page, $_SESSION[$guid]['pagination'], 'top', "search=$search");
-        }
+    $medicalForms = $medicalGateway->queryMedicalFormsBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 
-        echo "<table cellspacing='0' style='width: 100%'>";
-        echo "<tr class='head'>";
-        echo "<th style='width: 150px'>";
-        echo __($guid, 'Name');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Roll Group');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Blood Type');
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Medication').'<br/>';
-        echo "<span style='font-size: 80%'><i>".__($guid, 'Long Term').'</span>';
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Tetanus').'<br/>';
-        echo "<span style='font-size: 80%'><i>".__($guid, '10 Years').'</span>';
-        echo '</th>';
-        echo '<th>';
-        echo __($guid, 'Conditions');
-        echo '</th>';
-        echo "<th style='width: 110px'>";
-        echo __($guid, 'Actions');
-        echo '</th>';
-        echo '</tr>';
+    // DATA TABLE
+    $table = DataTable::createPaginated('medicalForms', $criteria);
 
-        $count = 0;
-        $rowNum = 'odd';
-        try {
-            $resultPage = $connection2->prepare($sqlPage);
-            $resultPage->execute($data);
-        } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
-        }
-        while ($row = $resultPage->fetch()) {
-            if ($count % 2 == 0) {
-                $rowNum = 'even';
-            } else {
-                $rowNum = 'odd';
-            }
-            ++$count;
+    $table->addHeaderAction('add', __('Add'))
+        ->setURL('/modules/Students/medicalForm_manage_add.php')
+        ->addParam('search', $criteria->getSearchText(true))
+        ->displayLabel();
 
-            //COLOR ROW BY STATUS!
-            echo "<tr class=$rowNum>";
-            echo '<td>';
-            echo formatName('', $row['preferredName'], $row['surname'], 'Student', true);
-            echo '</td>';
-            echo '<td>';
-            echo $row['name'];
-            echo '</td>';
-            echo '<td>';
-            echo $row['bloodType'];
-            echo '</td>';
-            echo '<td>';
-            if ($row['longTermMedicationDetails'] != '') {
-                echo $row['longTermMedicationDetails'];
-            } else {
-                echo $row['longTermMedication'];
-            }
-            echo '</td>';
-            echo '<td>';
-            echo $row['tetanusWithin10Years'];
-            echo '</td>';
-            echo '<td>';
-            try {
-                $dataCondition = array('gibbonPersonMedicalID' => $row['gibbonPersonMedicalID']);
-                $sqlCondition = 'SELECT * FROM gibbonPersonMedical JOIN gibbonPersonMedicalCondition ON (gibbonPersonMedical.gibbonPersonMedicalID=gibbonPersonMedicalCondition.gibbonPersonMedicalID) WHERE gibbonPersonMedical.gibbonPersonMedicalID=:gibbonPersonMedicalID';
-                $resultCondition = $connection2->prepare($sqlCondition);
-                $resultCondition->execute($dataCondition);
-            } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
-            }
-            echo $resultCondition->rowCount();
-            echo '</td>';
-            echo '<td>';
-            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/medicalForm_manage_edit.php&gibbonPersonMedicalID='.$row['gibbonPersonMedicalID']."&search=$search'><img title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
-            echo "<a class='thickbox' href='".$_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/medicalForm_manage_delete.php&gibbonPersonMedicalID='.$row['gibbonPersonMedicalID']."&search=$search&width=650&height=135'><img title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a>";
-            echo "<script type='text/javascript'>";
-            echo '$(document).ready(function(){';
-            echo "\$(\".comment-$count\").hide();";
-            echo "\$(\".show_hide-$count\").fadeIn(1000);";
-            echo "\$(\".show_hide-$count\").click(function(){";
-            echo "\$(\".comment-$count\").fadeToggle(1000);";
-            echo '});';
-            echo '});';
-            echo '</script>';
-            if ($row['comment'] != '') {
-                echo "<a title='".__($guid, 'View Description')."' class='show_hide-$count' onclick='false' href='#'><img style='padding-right: 5px' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/page_down.png' alt='".__($guid, 'Show Comment')."' onclick='return false;' /></a>";
-            }
-            echo '</td>';
-            echo '</tr>';
-            if ($row['comment'] != '') {
-                echo "<tr class='comment-$count' id='comment-$count'>";
-                echo "<td colspan=7>";
-                    echo nl2brr($row['comment']).'<br/><br/>';
-                echo '</td>';
-                echo '</tr>';
-            }
-        }
-        echo '</table>';
+    // COLUMNS
+    $table->addExpandableColumn('comment')->format(function($person) {
+        return !empty($person['comment'])? '<b>'.__('Comment').'</b><br/>'.nl2brr($person['comment']) : '';
+    });
 
-        if ($result->rowCount() > $_SESSION[$guid]['pagination']) {
-            printPagination($guid, $result->rowCount(), $page, $_SESSION[$guid]['pagination'], 'bottom', "search=$search");
-        }
-    }
+    $table->addColumn('student', __('Student'))
+        ->sortable(['surname', 'preferredName'])
+        ->format(Format::using('name', ['', 'preferredName', 'surname', 'Student', true]));
+
+    $table->addColumn('rollGroup', __('Roll Group'));
+
+    $table->addColumn('bloodType', __('Blood Type'));
+
+    $table->addColumn('longTermMedication', __('Medication'))
+        ->format(function($person) {
+            return !empty($person['longTermMedicationDetails'])? $person['longTermMedicationDetails'] : Format::yesNo($person['longTermMedication']);
+        });
+
+    $table->addColumn('tetanusWithin10Years', __('Tetanus'))
+        ->format(Format::using('yesNo', 'tetanusWithin10Years'));
+
+    $table->addColumn('conditionCount', __('Conditions'));
+
+    // ACTIONS
+    $table->addActionColumn()
+        ->addParam('gibbonPersonMedicalID')
+        ->addParam('search', $criteria->getSearchText(true))
+        ->format(function ($person, $actions) {
+            $actions->addAction('edit', __('Edit'))
+                ->setURL('/modules/Students/medicalForm_manage_edit.php');
+
+            $actions->addAction('delete', __('Delete'))
+                ->setURL('/modules/Students/medicalForm_manage_delete.php');
+        });
+
+    echo $table->render($medicalForms);
 }
-?>

--- a/modules/Students/medicalForm_manage_condition_add.php
+++ b/modules/Students/medicalForm_manage_condition_add.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Domain\Students\MedicalGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage_condition_add.php') == false) {
     //Acess denied
@@ -47,26 +48,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
         echo __($guid, 'You have not specified one or more required parameters.');
         echo '</div>';
     } else {
-        try {
-            $data = array('gibbonPersonMedicalID' => $gibbonPersonMedicalID);
-            $sql = 'SELECT gibbonPersonMedical.*, surname, preferredName
-                FROM gibbonPersonMedical
-                    JOIN gibbonPerson ON (gibbonPersonMedical.gibbonPersonID=gibbonPerson.gibbonPersonID)
-                WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID';
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
-        }
 
-        if ($result->rowCount() != 1) {
+        $medicalGateway = $container->get(MedicalGateway::class);
+        $values = $medicalGateway->getMedicalFormByID($gibbonPersonMedicalID);
+
+        if (empty($values)) {
             echo "<div class='error'>";
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
             //Let's go!
-            $values = $result->fetch();
-
             if ($search != '') {
                 echo "<div class='linkTop'>";
                 echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Students/medicalForm_manage_edit.php&search=$search&gibbonPersonMedicalID=$gibbonPersonMedicalID'>".__($guid, 'Back').'</a>';
@@ -87,14 +78,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
                 $row->addLabel('personName', __('Student'));
                 $row->addTextField('personName')->setValue(formatName('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->isRequired()->readonly();
 
-            $data = array();
-            $sql = 'SELECT gibbonMedicalConditionID AS value, name FROM gibbonMedicalCondition ORDER BY name';
+            $sql = "SELECT name AS value, name FROM gibbonMedicalCondition ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('name', __('Condition Name'));
-                $row->addSelect('name')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder();
+                $row->addSelect('name')->fromQuery($pdo, $sql)->isRequired()->placeholder();
 
-            $data = array();
-            $sql = 'SELECT gibbonMedicalConditionID AS value, name FROM gibbonMedicalCondition ORDER BY name';
             $row = $form->addRow();
                 $row->addLabel('gibbonAlertLevelID', __('Risk'));
                 $row->addSelectAlert('gibbonAlertLevelID')->isRequired();

--- a/modules/Students/medicalForm_manage_condition_edit.php
+++ b/modules/Students/medicalForm_manage_condition_edit.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Domain\Students\MedicalGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage_condition_edit.php') == false) {
     //Acess denied
@@ -34,36 +35,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);
     }
-    //Check if school year specified
-    $gibbonPersonMedicalID = $_GET['gibbonPersonMedicalID'];
-    $gibbonPersonMedicalConditionID = $_GET['gibbonPersonMedicalConditionID'];
-    $search = $_GET['search'];
+
+    $gibbonPersonMedicalID = isset($_GET['gibbonPersonMedicalID'])? $_GET['gibbonPersonMedicalID'] : '';
+    $gibbonPersonMedicalConditionID = isset($_GET['gibbonPersonMedicalConditionID'])? $_GET['gibbonPersonMedicalConditionID'] : '';
+    $search = isset($_GET['search'])? $_GET['search'] : '';
+
     if ($gibbonPersonMedicalID == '' or $gibbonPersonMedicalConditionID == '') {
         echo "<div class='error'>";
         echo __($guid, 'You have not specified one or more required parameters.');
         echo '</div>';
     } else {
-        try {
-            $data = array('gibbonPersonMedicalConditionID' => $gibbonPersonMedicalConditionID);
-            $sql = 'SELECT gibbonPersonMedicalCondition.*, surname, preferredName
-                FROM gibbonPersonMedicalCondition
-                    JOIN gibbonPersonMedical ON (gibbonPersonMedicalCondition.gibbonPersonMedicalID=gibbonPersonMedical.gibbonPersonMedicalID)
-                    JOIN gibbonPerson ON (gibbonPersonMedical.gibbonPersonID=gibbonPerson.gibbonPersonID)
-                WHERE gibbonPersonMedicalConditionID=:gibbonPersonMedicalConditionID';
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
-        }
+        $medicalGateway = $container->get(MedicalGateway::class);
+        $values = $medicalGateway->getMedicalConditionByID($gibbonPersonMedicalConditionID);
 
-        if ($result->rowCount() != 1) {
+        if (empty($values)) {
             echo "<div class='error'>";
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
             //Let's go!
-            $values = $result->fetch();
-
             if ($search != '') {
                 echo "<div class='linkTop'>";
                 echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Students/medicalForm_manage_edit.php&search=$search&gibbonPersonMedicalID=$gibbonPersonMedicalID'>".__($guid, 'Back').'</a>';
@@ -84,14 +74,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
                 $row->addLabel('personName', __('Student'));
                 $row->addTextField('personName')->setValue(formatName('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->isRequired()->readonly();
 
-            $data = array();
-            $sql = 'SELECT gibbonMedicalConditionID AS value, name FROM gibbonMedicalCondition ORDER BY name';
+            $sql = "SELECT name AS value, name FROM gibbonMedicalCondition ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('name', __('Condition Name'));
-                $row->addSelect('name')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder();
+                $row->addSelect('name')->fromQuery($pdo, $sql)->isRequired()->placeholder();
 
-            $data = array();
-            $sql = 'SELECT gibbonMedicalConditionID AS value, name FROM gibbonMedicalCondition ORDER BY name';
             $row = $form->addRow();
                 $row->addLabel('gibbonAlertLevelID', __('Risk'));
                 $row->addSelectAlert('gibbonAlertLevelID')->isRequired();

--- a/modules/Students/medicalForm_manage_edit.php
+++ b/modules/Students/medicalForm_manage_edit.php
@@ -19,6 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Tables\DataTable;
+use Gibbon\Services\Format;
+use Gibbon\Domain\Students\MedicalGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage_edit.php') == false) {
     //Acess denied
@@ -36,36 +39,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     }
 
     //Check if person medical specified
-    $gibbonPersonMedicalID = $_GET['gibbonPersonMedicalID'];
-    $search = null;
-    if (isset($_GET['search'])) {
-        $search = $_GET['search'];
-    }
+    $gibbonPersonMedicalID = isset($_GET['gibbonPersonMedicalID'])? $_GET['gibbonPersonMedicalID'] : '';
+    $search = isset($_GET['search'])? $_GET['search'] : '';
+
     if ($gibbonPersonMedicalID == '') {
         echo "<div class='error'>";
         echo __($guid, 'You have not specified one or more required parameters.');
         echo '</div>';
     } else {
-        try {
-            $data = array('gibbonPersonMedicalID' => $gibbonPersonMedicalID);
-            $sql = 'SELECT gibbonPersonMedical.*, surname, preferredName
-                FROM gibbonPersonMedical
-                    JOIN gibbonPerson ON (gibbonPersonMedical.gibbonPersonID=gibbonPerson.gibbonPersonID)
-                WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID';
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
-        }
 
-        if ($result->rowCount() != 1) {
+        $medicalGateway = $container->get(MedicalGateway::class);
+        $values = $medicalGateway->getMedicalFormByID($gibbonPersonMedicalID);
+
+        if (empty($values)) {
             echo "<div class='error'>";
             echo __($guid, 'The specified record cannot be found.');
             echo '</div>';
         } else {
             //Let's go!
-            $values = $result->fetch();
-
             if ($search != '') {
                 echo "<div class='linkTop'>";
                 echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Students/medicalForm_manage.php&search=$search'>".__($guid, 'Back to Search Results').'</a>';
@@ -116,99 +107,47 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             echo $form->getOutput();
 
             echo '<h2>';
-            echo __($guid, 'Medical Conditions');
+            echo __('Medical Conditions');
             echo '</h2>';
 
-            try {
-                $data = array('gibbonPersonMedicalID' => $gibbonPersonMedicalID);
-                $sql = 'SELECT gibbonPersonMedicalCondition.*, gibbonAlertLevel.name AS risk FROM gibbonPersonMedicalCondition JOIN gibbonAlertLevel ON (gibbonPersonMedicalCondition.gibbonAlertLevelID=gibbonAlertLevel.gibbonAlertLevelID) WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID ORDER BY gibbonPersonMedicalCondition.name';
-                $result = $connection2->prepare($sql);
-                $result->execute($data);
-            } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
-            }
+            $conditions = $medicalGateway->selectMedicalConditionsByID($gibbonPersonMedicalID);
 
-            echo "<div class='linkTop'>";
-            echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/medicalForm_manage_condition_add.php&gibbonPersonMedicalID='.$values['gibbonPersonMedicalID']."&search=$search'>".__($guid, 'Add')."<img style='margin-left: 5px' title='".__($guid, 'Add')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
-            echo '</div>';
+            $table = DataTable::create('medicalConditions');
 
-            if ($result->rowCount() < 1) {
-                echo "<div class='error'>";
-                echo __($guid, 'There are no records to display.');
-                echo '</div>';
-            } else {
-                echo "<table cellspacing='0' style='width: 100%'>";
-                echo "<tr class='head'>";
-                echo '<th>';
-                echo __($guid, 'Name');
-                echo '</th>';
-                echo '<th>';
-                echo __($guid, 'Risk');
-                echo '</th>';
-                echo '<th>';
-                echo __($guid, 'Details');
-                echo '</th>';
-                echo '<th>';
-                echo __($guid, 'Medication');
-                echo '</th>';
-                echo '<th>';
-                echo __($guid, 'Comment');
-                echo '</th>';
-                echo '<th>';
-                echo __($guid, 'Actions');
-                echo '</th>';
-                echo '</tr>';
+            $table->addHeaderAction('add', __('Add'))
+                ->setURL('/modules/Students/medicalForm_manage_condition_add.php')
+                ->addParam('gibbonPersonMedicalID', $gibbonPersonMedicalID)
+                ->addParam('search', $search)
+                ->displayLabel();
 
-                $count = 0;
-                $rowNum = 'odd';
-                while ($row = $result->fetch()) {
-                    if ($count % 2 == 0) {
-                        $rowNum = 'even';
-                    } else {
-                        $rowNum = 'odd';
-                    }
-                    ++$count;
+            $table->addColumn('name', __('Name'));
+            $table->addColumn('risk', __('Risk'));
+            $table->addColumn('details', __('Details'))->format(function($condition){
+                $output = '';
+                if (!empty($condition['triggers'])) $output .= '<b>'.__('Triggers').':</b> '.$condition['triggers'].'<br/>';
+                if (!empty($condition['reaction'])) $output .= '<b>'.__('Reaction').':</b> '.$condition['reaction'].'<br/>';
+                if (!empty($condition['response'])) $output .= '<b>'.__('Response').':</b> '.$condition['response'].'<br/>';
+                if (!empty($condition['lastEpisode'])) $output .= '<b>'.__('Last Episode').':</b> '.Format::date($condition['lastEpisode']).'<br/>';
+                if (!empty($condition['lastEpisodeTreatment'])) $output .= '<b>'.__('Last Episode Treatment').':</b> '.$condition['lastEpisodeTreatment'].'<br/>';
+                return $output;
+            });
+            $table->addColumn('medication', __('Medication'));
+            $table->addColumn('comment', __('Comment'));
 
-                    //COLOR ROW BY STATUS!
-                    echo "<tr class=$rowNum>";
-                    echo '<td>';
-                    echo __($guid, $row['name']);
-                    echo '</td>';
-                    echo '<td>';
-                    echo __($guid, $row['risk']);
-                    echo '</td>';
-                    echo '<td>';
-                    if ($row['triggers'] != '') {
-                        echo '<b>'.__($guid, 'Triggers').':</b> '.$row['triggers'].'<br/>';
-                    }
-                    if ($row['reaction'] != '') {
-                        echo '<b>'.__($guid, 'Reaction').':</b> '.$row['reaction'].'<br/>';
-                    }
-                    if ($row['response'] != '') {
-                        echo '<b>'.__($guid, 'Response').':</b> '.$row['response'].'<br/>';
-                    }
-                    if ($row['lastEpisode'] != '') {
-                        echo '<b>'.__($guid, 'Last Episode').':</b> '.dateConvertBack($guid, $row['lastEpisode']).'<br/>';
-                    }
-                    if ($row['lastEpisodeTreatment'] != '') {
-                        echo '<b>'.__($guid, 'Last Episode Treatment').':</b> '.$row['lastEpisodeTreatment'].'<br/>';
-                    }
-                    echo '</td>';
-                    echo '<td>';
-                    echo $row['medication'];
-                    echo '</td>';
-                    echo '<td>';
-                    echo $row['comment'];
-                    echo '</td>';
-                    echo '<td>';
-                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/medicalForm_manage_condition_edit.php&gibbonPersonMedicalID='.$row['gibbonPersonMedicalID'].'&gibbonPersonMedicalConditionID='.$row['gibbonPersonMedicalConditionID']."&search=$search'><img title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
-                    echo "<a class='thickbox' href='".$_SESSION[$guid]['absoluteURL'].'/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/medicalForm_manage_condition_delete.php&gibbonPersonMedicalID='.$row['gibbonPersonMedicalID'].'&gibbonPersonMedicalConditionID='.$row['gibbonPersonMedicalConditionID']."&search=$search&width=650&height=135'><img title='".__($guid, 'Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a>";
-                    echo '</td>';
-                    echo '</tr>';
-                }
-                echo '</table>';
-            }
+            // ACTIONS
+            $table->addActionColumn()
+                ->addParam('gibbonPersonMedicalID', $gibbonPersonMedicalID)
+                ->addParam('gibbonPersonMedicalConditionID')
+                ->addParam('search', $search)
+                ->format(function ($person, $actions) {
+                    $actions->addAction('edit', __('Edit'))
+                        ->setURL('/modules/Students/medicalForm_manage_condition_edit.php');
+
+                    $actions->addAction('delete', __('Delete'))
+                        ->setURL('/modules/Students/medicalForm_manage_condition_delete.php');
+                });
+
+            echo $table->render($conditions->toDataSet());
         }
     }
 }
-?>

--- a/src/Domain/Students/MedicalGateway.php
+++ b/src/Domain/Students/MedicalGateway.php
@@ -1,0 +1,97 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Students;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * @version v16
+ * @since   v16
+ */
+class MedicalGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonPersonMedical';
+
+    private static $searchableColumns = ['preferredName', 'surname', 'username'];
+    
+    /**
+     * @param QueryCriteria $criteria
+     * @return DataSet
+     */
+    public function queryMedicalFormsBySchoolYear(QueryCriteria $criteria, $gibbonSchoolYearID)
+    {
+        $query = $this
+            ->newQuery()
+            ->from($this->getTableName())
+            ->cols([
+                'gibbonPersonMedicalID', 'bloodType', 'longTermMedication', 'longTermMedicationDetails', 'tetanusWithin10Years', 'comment', 'gibbonPerson.gibbonPersonID', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'gibbonRollGroup.name as rollGroup', '(SELECT COUNT(*) FROM gibbonPersonMedicalCondition WHERE gibbonPersonMedicalCondition.gibbonPersonMedicalID=gibbonPersonMedical.gibbonPersonMedicalID) as conditionCount'
+            ])
+            ->innerJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonPersonMedical.gibbonPersonID')
+            ->innerJoin('gibbonStudentEnrolment', 'gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
+            ->innerJoin('gibbonYearGroup', 'gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID')
+            ->innerJoin('gibbonRollGroup', 'gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID')
+            ->where("gibbonPerson.status = 'Full'")
+            ->where('gibbonStudentEnrolment.gibbonSchoolYearID = :gibbonSchoolYearID')
+            ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID);
+
+        return $this->runQuery($query, $criteria);
+    }
+
+    public function selectMedicalConditionsByID($gibbonPersonMedicalID)
+    {
+        $data = array('gibbonPersonMedicalID' => $gibbonPersonMedicalID);
+        $sql = "SELECT gibbonPersonMedicalCondition.*, gibbonAlertLevel.name AS risk, (CASE WHEN gibbonMedicalCondition.gibbonMedicalConditionID IS NOT NULL THEN gibbonMedicalCondition.name ELSE gibbonPersonMedicalCondition.name END) as name 
+                FROM gibbonPersonMedicalCondition 
+                JOIN gibbonAlertLevel ON (gibbonPersonMedicalCondition.gibbonAlertLevelID=gibbonAlertLevel.gibbonAlertLevelID) 
+                LEFT JOIN gibbonMedicalCondition ON (gibbonMedicalCondition.gibbonMedicalConditionID=gibbonPersonMedicalCondition.name)
+                WHERE gibbonPersonMedicalCondition.gibbonPersonMedicalID=:gibbonPersonMedicalID 
+                ORDER BY gibbonPersonMedicalCondition.name";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function getMedicalFormByID($gibbonPersonMedicalID)
+    {
+        $data = array('gibbonPersonMedicalID' => $gibbonPersonMedicalID);
+        $sql = "SELECT gibbonPersonMedical.*, surname, preferredName
+                FROM gibbonPersonMedical
+                JOIN gibbonPerson ON (gibbonPersonMedical.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID";
+
+        return $this->db()->selectOne($sql, $data);
+    }
+
+    public function getMedicalConditionByID($gibbonPersonMedicalConditionID)
+    {
+        $data = array('gibbonPersonMedicalConditionID' => $gibbonPersonMedicalConditionID);
+        $sql = "SELECT gibbonPersonMedicalCondition.*, (CASE WHEN gibbonMedicalCondition.gibbonMedicalConditionID IS NOT NULL THEN gibbonMedicalCondition.name ELSE gibbonPersonMedicalCondition.name END) as name, surname, preferredName
+                FROM gibbonPersonMedicalCondition
+                JOIN gibbonPersonMedical ON (gibbonPersonMedicalCondition.gibbonPersonMedicalID=gibbonPersonMedical.gibbonPersonMedicalID)
+                JOIN gibbonPerson ON (gibbonPersonMedical.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                LEFT JOIN gibbonMedicalCondition ON (gibbonMedicalCondition.gibbonMedicalConditionID=gibbonPersonMedicalCondition.name)
+                WHERE gibbonPersonMedicalConditionID=:gibbonPersonMedicalConditionID";
+
+        return $this->db()->selectOne($sql, $data);
+    }
+}


### PR DESCRIPTION
This PR also fixes what appears to be a post-ooification bug that made it into v15. The names for medical conditions have in the past been stored as strings, after ooification they have been coming through as ID numbers, ending up with a table of mixed names and IDs. The drop-downs have been updated to use the names as strings (the original behaviour) and the Edit Condition page will now select the appropriate name from the drop-down if an ID is present in the database.