### PR TITLE
Tables: don't display filters in search field after Back to Search Results

### DIFF
--- a/modules/Individual Needs/in_view.php
+++ b/modules/Individual Needs/in_view.php
@@ -39,13 +39,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_view.p
         echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > </div><div class='trailEnd'>".__($guid, 'View Student Records').'</div>';
         echo '</div>';
 
-        echo '<h2>';
-        echo __($guid, 'Search');
-        echo '</h2>';
+        $studentGateway = $container->get(StudentGateway::class);
 
         $gibbonPersonID = isset($_GET['gibbonPersonID'])? $_GET['gibbonPersonID'] : '';
         $search = isset($_GET['search'])? $_GET['search'] : '';
         $allStudents = (isset($_GET['allStudents']) ? $_GET['allStudents'] : '');
+
+        // CRITERIA
+        $criteria = $studentGateway->newQueryCriteria()
+            ->searchBy($studentGateway->getSearchableColumns(), $search)
+            ->sortBy(['surname', 'preferredName'])
+            ->filterBy('all', $allStudents)
+            ->fromArray($_POST);
+
+        echo '<h2>';
+        echo __('Search');
+        echo '</h2>';
 
         $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
         $form->setClass('noIntBorder fullWidth');
@@ -54,7 +63,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_view.p
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username.'));
-            $row->addTextField('search')->setValue($search);
+            $row->addTextField('search')->setValue($criteria->getSearchText());
 
         $row = $form->addRow();
             $row->addLabel('allStudents', __('All Students'))->description(__('Include all students, regardless of status and current enrolment. Some data may not display.'));
@@ -66,19 +75,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_view.p
         echo $form->getOutput();
 
         echo '<h2>';
-        echo __($guid, 'Choose A Student');
+        echo __('Choose A Student');
         echo '</h2>';
         echo '<p>';
-        echo __($guid, 'This page displays all students enroled in the school, including those who have not yet met their start date. With the right permissions, you can set Individual Needs status and Individual Education Plan details for any student.');
+        echo __('This page displays all students enroled in the school, including those who have not yet met their start date. With the right permissions, you can set Individual Needs status and Individual Education Plan details for any student.');
         echo '</p>';
-
-        $studentGateway = $container->get(StudentGateway::class);
-
-        $criteria = $studentGateway->newQueryCriteria()
-            ->searchBy($studentGateway->getSearchableColumns(), $search)
-            ->sortBy(['surname', 'preferredName'])
-            ->filterBy('all', $allStudents)
-            ->fromArray($_POST);
 
         $students = $studentGateway->queryStudentsBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 

--- a/modules/School Admin/space_manage.php
+++ b/modules/School Admin/space_manage.php
@@ -37,11 +37,19 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage.
         returnProcess($guid, $_GET['return'], null, null);
     }
 
-    echo '<h3>';
-    echo __('search');
-    echo '</h3>';
-
     $search = isset($_GET['search'])? $_GET['search'] : '';
+
+    $facilityGateway = $container->get(FacilityGateway::class);
+
+    // QUERY
+    $criteria = $facilityGateway->newQueryCriteria()
+        ->searchBy($facilityGateway->getSearchableColumns(), $search)
+        ->sortBy(['name'])
+        ->fromArray($_POST);
+
+    echo '<h3>';
+    echo __('Search');
+    echo '</h3>';
 
     $form = Form::create('filter', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth');
@@ -50,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage.
 
     $row = $form->addRow();
         $row->addLabel('search', __('Search For'));
-        $row->addTextField('search')->setValue($search);
+        $row->addTextField('search')->setValue($criteria->getSearchText());
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session, __('Clear Search'));
@@ -60,14 +68,6 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage.
     echo '<h3>';
     echo __('View');
     echo '</h3>';
-
-    $facilityGateway = $container->get(FacilityGateway::class);
-
-    // QUERY
-    $criteria = $facilityGateway->newQueryCriteria()
-        ->searchBy($facilityGateway->getSearchableColumns(), $search)
-        ->sortBy(['name'])
-        ->fromArray($_POST);
 
     $facilities = $facilityGateway->queryFacilities($criteria);
 

--- a/modules/Staff/applicationForm_manage.php
+++ b/modules/Staff/applicationForm_manage.php
@@ -39,8 +39,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
     $search = isset($_GET['search'])? $_GET['search'] : '';
 
+    $applicationGateway = $container->get(StaffApplicationFormGateway::class);
+
+    // CRITERIA
+    $criteria = $applicationGateway->newQueryCriteria()
+        ->searchBy($applicationGateway->getSearchableColumns(), $search)
+        ->sortBy('gibbonStaffApplicationForm.status')
+        ->sortBy(['priority', 'timestamp'], 'DESC')
+        ->fromArray($_POST);
+
     echo '<h4>';
-    echo __($guid, 'Search');
+    echo __('Search');
     echo '</h2>';
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
@@ -52,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
     $row = $form->addRow();
         $row->addLabel('search', __('Search For'))->description(__('Application ID, preferred, surname'));
-        $row->addTextField('search')->setValue($search)->maxLength(20);
+        $row->addTextField('search')->setValue($criteria->getSearchText())->maxLength(20);
 
     $row = $form->addRow();
         $row->addFooter();
@@ -61,17 +70,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
     echo $form->getOutput();
 
     echo '<h4>';
-    echo __($guid, 'View');
+    echo __('View');
     echo '</h2>';
-
-    $applicationGateway = $container->get(StaffApplicationFormGateway::class);
-
-    // QUERY
-    $criteria = $applicationGateway->newQueryCriteria()
-        ->searchBy($applicationGateway->getSearchableColumns(), $search)
-        ->sortBy('gibbonStaffApplicationForm.status')
-        ->sortBy(['priority', 'timestamp'], 'DESC')
-        ->fromArray($_POST);
 
     $applications = $applicationGateway->queryApplications($criteria);
 

--- a/modules/Staff/staff_manage.php
+++ b/modules/Staff/staff_manage.php
@@ -40,8 +40,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
     $search = (isset($_GET['search']) ? $_GET['search'] : '');
     $allStaff = (isset($_GET['allStaff']) ? $_GET['allStaff'] : '');
 
+    $staffGateway = $container->get(StaffGateway::class);
+
+    // CRITERIA
+    $criteria = $staffGateway->newQueryCriteria()
+        ->searchBy($staffGateway->getSearchableColumns(), $search)
+        ->filterBy('all', $allStaff)
+        ->sortBy(['surname', 'preferredName'])
+        ->fromArray($_POST);
+
     echo '<h2>';
-    echo __($guid, 'Search & Filter');
+    echo __('Search & Filter');
     echo '</h2>';
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL']."/index.php", 'get');
@@ -53,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
 
     $row = $form->addRow();
         $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username.'));
-        $row->addTextField('search')->setValue($search)->maxLength(20);
+        $row->addTextField('search')->setValue($criteria->getSearchText())->maxLength(20);
 
     $row = $form->addRow();
         $row->addLabel('allStaff', __('All Staff'))->description('Include Expected and Left.');
@@ -66,17 +75,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
     echo $form->getOutput();
 
     echo '<h2>';
-    echo __($guid, 'View');
+    echo __('View');
     echo '</h2>';
-
-    $staffGateway = $container->get(StaffGateway::class);
-
-    // QUERY
-    $criteria = $staffGateway->newQueryCriteria()
-        ->searchBy($staffGateway->getSearchableColumns(), $search)
-        ->filterBy('all', $allStaff)
-        ->sortBy(['surname', 'preferredName'])
-        ->fromArray($_POST);
 
     $staff = $staffGateway->queryAllStaff($criteria);
 

--- a/modules/Staff/staff_view.php
+++ b/modules/Staff/staff_view.php
@@ -43,6 +43,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view.php') == 
         $search = (isset($_GET['search']) ? $_GET['search'] : '');
         $allStaff = (isset($_GET['allStaff']) ? $_GET['allStaff'] : '');
 
+        $staffGateway = $container->get(StaffGateway::class);
+
+        // QUERY
+        $criteria = $staffGateway->newQueryCriteria()
+            ->searchBy($staffGateway->getSearchableColumns(), $search)
+            ->filterBy('all', $allStaff)
+            ->sortBy(['surname', 'preferredName'])
+            ->fromArray($_POST);
+
         echo '<h2>';
         echo __($guid, 'Search');
         echo '</h2>';
@@ -56,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view.php') == 
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username.'));
-            $row->addTextField('search')->setValue($search)->maxLength(20);
+            $row->addTextField('search')->setValue($criteria->getSearchText())->maxLength(20);
 
         if ($highestAction == 'View Staff Profile_full') {
             $row = $form->addRow();
@@ -73,15 +82,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view.php') == 
         echo '<h2>';
         echo __($guid, 'Choose A Staff Member');
         echo '</h2>';
-
-        $staffGateway = $container->get(StaffGateway::class);
-
-        // QUERY
-        $criteria = $staffGateway->newQueryCriteria()
-            ->searchBy($staffGateway->getSearchableColumns(), $search)
-            ->filterBy('all', $allStaff)
-            ->sortBy(['surname', 'preferredName'])
-            ->fromArray($_POST);
 
         $staff = $staffGateway->queryAllStaff($criteria);
 

--- a/modules/Students/medicalForm_manage.php
+++ b/modules/Students/medicalForm_manage.php
@@ -38,11 +38,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
         returnProcess($guid, $_GET['return'], null, null);
     }
 
+    $search = isset($_GET['search'])? $_GET['search'] : '';
+
+    $medicalGateway = $container->get(MedicalGateway::class);
+
+    // CRITERIA
+    $criteria = $medicalGateway->newQueryCriteria()
+        ->searchBy($medicalGateway->getSearchableColumns(), $search)
+        ->sortBy(['surname', 'preferredName'])
+        ->fromArray($_POST);
+
     echo '<h2>';
     echo __('Search');
     echo '</h2>';
-
-    $search = isset($_GET['search'])? $_GET['search'] : '';
 
     $form = Form::create('filter', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth');
@@ -51,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
     $row = $form->addRow();
         $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username.'));
-        $row->addTextField('search')->setValue($search);
+        $row->addTextField('search')->setValue($criteria->getSearchText());
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session, __('Clear Search'));
@@ -61,13 +69,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     echo '<h2>';
     echo __('View');
     echo '</h2>';
-
-    $medicalGateway = $container->get(MedicalGateway::class);
-
-    $criteria = $medicalGateway->newQueryCriteria()
-        ->searchBy($medicalGateway->getSearchableColumns(), $search)
-        ->sortBy(['surname', 'preferredName'])
-        ->fromArray($_POST);
 
     $medicalForms = $medicalGateway->queryMedicalFormsBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 

--- a/modules/Students/studentEnrolment_manage.php
+++ b/modules/Students/studentEnrolment_manage.php
@@ -86,11 +86,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
         }
         echo '</div>';
 
+        $search = isset($_GET['search'])? $_GET['search'] : '';
+
+        $studentGateway = $container->get(StudentGateway::class);
+
+        $criteria = $studentGateway->newQueryCriteria()
+            ->searchBy($studentGateway->getSearchableColumns(), $search)
+            ->sortBy(['surname', 'preferredName'])
+            ->fromArray($_POST);
+
         echo '<h3>';
         echo __('Search');
         echo '</h3>';
-
-        $search = isset($_GET['search'])? $_GET['search'] : '';
 
         $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php','get');
         $form->setClass('noIntBorder fullWidth');
@@ -100,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username.'));
-            $row->addTextField('search')->setValue($search);
+            $row->addTextField('search')->setValue($criteria->getSearchText());
 
         $row = $form->addRow();
             $row->addSearchSubmit($gibbon->session, __('Clear Search'), array('gibbonSchoolYearID'));
@@ -113,13 +120,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
         echo '<p>';
         echo __("Students highlighted in red are marked as 'Full' but have either not reached their start date, or have exceeded their end date.");
         echo '<p>';
-
-        $studentGateway = $container->get(StudentGateway::class);
-
-        $criteria = $studentGateway->newQueryCriteria()
-            ->searchBy($studentGateway->getSearchableColumns(), $search)
-            ->sortBy(['surname', 'preferredName'])
-            ->fromArray($_POST);
 
         $students = $studentGateway->queryStudentEnrolmentBySchoolYear($criteria, $gibbonSchoolYearID);
 

--- a/modules/Students/student_view.php
+++ b/modules/Students/student_view.php
@@ -88,14 +88,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view.php'
         }
         
         if ($canViewBriefProfile || $canViewFullProfile) {
-            
             //Proceed!
+            $search = isset($_GET['search'])? $_GET['search'] : '';
+            $sort = isset($_GET['sort'])? $_GET['sort'] : 'surname,preferredName';
+            $allStudents = isset($_GET['allStudents'])? $_GET['allStudents'] : '';
+            
+            $studentGateway = $container->get(StudentGateway::class);
+
+            $criteria = $studentGateway->newQueryCriteria()
+                ->searchBy($studentGateway->getSearchableColumns(), $search)
+                ->sortBy(array_filter(explode(',', $sort)))
+                ->filterBy('all', $canViewFullProfile ? $allStudents : '')
+                ->fromArray($_POST);
+
             echo '<h2>';
             echo __('Filter');
             echo '</h2>';
-            
-            $search = isset($_GET['search'])? $_GET['search'] : '';
-            $sort = isset($_GET['sort'])? $_GET['sort'] : 'surname,preferredName';
 
             $sortOptions = array(
                 'surname,preferredName' => __('Surname'),
@@ -117,14 +125,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view.php'
                 $row->addLabel('search', __('Search For'))
                     ->setClass('mediumWidth')
                     ->description($searchDescription);
-                $row->addTextField('search')->setValue($search);
+                $row->addTextField('search')->setValue($criteria->getSearchText());
 
             $row = $form->addRow();
                 $row->addLabel('sort', __('Sort By'));
                 $row->addSelect('sort')->fromArray($sortOptions)->selected($sort);
 
             if ($canViewFullProfile) {
-                $allStudents = isset($_GET['allStudents'])? $_GET['allStudents'] : '';
                 $row = $form->addRow();
                     $row->addLabel('allStudents', __('All Students'))->description(__('Include all students, regardless of status and current enrolment. Some data may not display.'));
                     $row->addCheckbox('allStudents')->setValue('on')->checked($allStudents);
@@ -138,14 +145,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view.php'
             echo '<h2>';
             echo __('Choose A Student');
             echo '</h2>';
-
-            $studentGateway = $container->get(StudentGateway::class);
-
-            $criteria = $studentGateway->newQueryCriteria()
-                ->searchBy($studentGateway->getSearchableColumns(), $search)
-                ->sortBy(array_filter(explode(',', $sort)))
-                ->filterBy('all', $canViewFullProfile ? $allStudents : '')
-                ->fromArray($_POST);
 
             $students = $studentGateway->queryStudentsBySchoolYear($criteria, $gibbonSchoolYearID, $canViewFullProfile);
 

--- a/modules/System Admin/stringReplacement_manage.php
+++ b/modules/System Admin/stringReplacement_manage.php
@@ -39,8 +39,16 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
 
     $search = isset($_GET['search'])? $_GET['search'] : '';
 
+    $stringGateway = $container->get(StringGateway::class);
+
+    // CRITERIA
+    $criteria = $stringGateway->newQueryCriteria()
+        ->searchBy($stringGateway->getSearchableColumns(), $search)
+        ->sortBy('priority', 'DESC')
+        ->fromArray($_POST);
+
     echo '<h2>';
-    echo __($guid, 'Search');
+    echo __('Search');
     echo '</h2>';
     
     $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
@@ -50,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     
     $row = $form->addRow();
         $row->addLabel('search', __('Search For'))->description(__('Original string, replacement string.'));
-        $row->addTextField('search')->setValue($search);
+        $row->addTextField('search')->setValue($criteria->getSearchText());
     
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session, __('Clear Search'));
@@ -58,15 +66,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     echo $form->getOutput();
 
     echo '<h2>';
-    echo __($guid, 'View');
+    echo __('View');
     echo '</h2>';
-
-    $stringGateway = $container->get(StringGateway::class);
-
-    $criteria = $stringGateway->newQueryCriteria()
-        ->searchBy($stringGateway->getSearchableColumns(), $search)
-        ->sortBy('priority', 'DESC')
-        ->fromArray($_POST);
 
     $strings = $stringGateway->queryStrings($criteria);
 

--- a/modules/Timetable Admin/courseEnrolment_manage.php
+++ b/modules/Timetable Admin/courseEnrolment_manage.php
@@ -73,8 +73,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         $search = (isset($_GET['search']))? $_GET['search'] : '';
         $gibbonYearGroupID = (isset($_GET['gibbonYearGroupID']))? $_GET['gibbonYearGroupID'] : '';
 
+        $courseGateway = $container->get(CourseGateway::class);
+        
+        // CRITERIA
+        $criteria = $courseGateway->newQueryCriteria()
+            ->searchBy($courseGateway->getSearchableColumns(), $search)
+            ->sortBy(['gibbonCourse.nameShort', 'gibbonCourse.name'])
+            ->filterBy('yearGroup', $gibbonYearGroupID)
+            ->pageSize(0)
+            ->fromArray($_POST);
+
         echo '<h3>';
-        echo __($guid, 'Filters');
+        echo __('Filters');
         echo '</h3>'; 
         
         $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
@@ -87,7 +97,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'));
-            $row->addTextField('search')->setValue($search);
+            $row->addTextField('search')->setValue($criteria->getSearchText());
 
         $row = $form->addRow();
             $row->addLabel('gibbonYearGroupID', __('Year Group'));
@@ -99,16 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
         echo $form->getOutput();
 
-        $courseGateway = $container->get(CourseGateway::class);
-
         // QUERY
-        $criteria = $courseGateway->newQueryCriteria()
-            ->searchBy($courseGateway->getSearchableColumns(), $search)
-            ->sortBy(['gibbonCourse.nameShort', 'gibbonCourse.name'])
-            ->filterBy('yearGroup', $gibbonYearGroupID)
-            ->pageSize(0)
-            ->fromArray($_POST);
-
         $courses = $courseGateway->queryCoursesBySchoolYear($criteria, $gibbonSchoolYearID);
 
         if (count($courses) == 0) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             ->fromArray($_POST);
 
         echo '<h3>';
-        echo __($guid, 'Filters');
+        echo __('Filters');
         echo '</h3>'; 
         
         $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         echo $form->getOutput();
 
         echo '<h3>';
-        echo __($guid, 'View');
+        echo __('View');
         echo '</h3>';
             
         $users = $studentGateway->queryStudentsAndTeachersBySchoolYear($criteria, $gibbonSchoolYearID);

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
@@ -73,6 +73,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         $allUsers = isset($_GET['allUsers'])? $_GET['allUsers'] : '';
         $search = isset($_GET['search'])? $_GET['search'] : '';
 
+        // CRITERIA
+        $studentGateway = $container->get(StudentGateway::class);
+
+        $criteria = $studentGateway->newQueryCriteria()
+            ->searchBy($studentGateway->getSearchableColumns(), $search)
+            ->sortBy(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
+            ->filterBy('all', $allUsers)
+            ->fromArray($_POST);
+
         echo '<h3>';
         echo __($guid, 'Filters');
         echo '</h3>'; 
@@ -85,7 +94,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username.'));
-            $row->addTextField('search')->setValue($search);
+            $row->addTextField('search')->setValue($criteria->getSearchText());
 
         $row = $form->addRow();
             $row->addLabel('allUsers', __('All Users'))->description(__('Include non-staff, non-student users.'));
@@ -99,14 +108,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         echo '<h3>';
         echo __($guid, 'View');
         echo '</h3>';
-
-        $studentGateway = $container->get(StudentGateway::class);
-
-        $criteria = $studentGateway->newQueryCriteria()
-            ->searchBy($studentGateway->getSearchableColumns(), $search)
-            ->sortBy(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
-            ->filterBy('all', $allUsers)
-            ->fromArray($_POST);
             
         $users = $studentGateway->queryStudentsAndTeachersBySchoolYear($criteria, $gibbonSchoolYearID);
 

--- a/modules/Timetable Admin/course_manage.php
+++ b/modules/Timetable Admin/course_manage.php
@@ -93,6 +93,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         $search = (isset($_GET['search']))? $_GET['search'] : '';
         $gibbonYearGroupID = (isset($_GET['gibbonYearGroupID']))? $_GET['gibbonYearGroupID'] : '';
 
+        $courseGateway = $container->get(CourseGateway::class);
+
+        // CRITERIA
+        $criteria = $courseGateway->newQueryCriteria()
+            ->searchBy($courseGateway->getSearchableColumns(), $search)
+            ->sortBy(['gibbonCourse.nameShort', 'gibbonCourse.name'])
+            ->filterBy('yearGroup', $gibbonYearGroupID)
+            ->fromArray($_POST);
+
         echo '<h3>';
         echo __('Filters');
         echo '</h3>';
@@ -107,7 +116,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'));
-            $row->addTextField('search')->setValue($search);
+            $row->addTextField('search')->setValue($criteria->getSearchText());
 
         $row = $form->addRow();
             $row->addLabel('gibbonYearGroupID', __('Year Group'));
@@ -121,15 +130,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         echo '<h3>';
         echo __('View');
         echo '</h3>';
-
-        $courseGateway = $container->get(CourseGateway::class);
-
-        // QUERY
-        $criteria = $courseGateway->newQueryCriteria()
-            ->searchBy($courseGateway->getSearchableColumns(), $search)
-            ->sortBy(['gibbonCourse.nameShort', 'gibbonCourse.name'])
-            ->filterBy('yearGroup', $gibbonYearGroupID)
-            ->fromArray($_POST);
 
         $courses = $courseGateway->queryCoursesBySchoolYear($criteria, $gibbonSchoolYearID);
 

--- a/modules/User Admin/family_manage.php
+++ b/modules/User Admin/family_manage.php
@@ -38,11 +38,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage.p
         returnProcess($guid, $_GET['return'], null, null);
     }
 
+    $search = isset($_GET['search'])? $_GET['search'] : '';
+
+    $familyGateway = $container->get(FamilyGateway::class);
+
+    // QUERY
+    $criteria = $familyGateway->newQueryCriteria()
+        ->searchBy($familyGateway->getSearchableColumns(), $search)
+        ->sortBy(['name'])
+        ->fromArray($_POST);
+
     echo '<h2>';
     echo __($guid, 'Search');
     echo '</h2>';
-
-    $search = isset($_GET['search'])? $_GET['search'] : '';
 
     $form = Form::create('filter', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth');
@@ -51,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage.p
 
     $row = $form->addRow();
         $row->addLabel('search', __('Search For'))->description('Family name.');
-        $row->addTextField('search')->setValue($search);
+        $row->addTextField('search')->setValue($criteria->getSearchText());
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session, __('Clear Search'));
@@ -62,14 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage.p
     echo __($guid, 'View');
     echo '</h2>';
 
-    $familyGateway = $container->get(FamilyGateway::class);
-
     // QUERY
-    $criteria = $familyGateway->newQueryCriteria()
-        ->searchBy($familyGateway->getSearchableColumns(), $search)
-        ->sortBy(['name'])
-        ->fromArray($_POST);
-
     $families = $familyGateway->queryFamilies($criteria);
 
     $familyIDs = $families->getColumn('gibbonFamilyID');

--- a/modules/User Admin/user_manage.php
+++ b/modules/User Admin/user_manage.php
@@ -38,19 +38,20 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
         returnProcess($guid, $_GET['return'], null, null);
     }
 
-    echo '<h2>';
-    echo __($guid, 'Search');
-    echo '</h2>';
-
     $search = isset($_GET['search'])? $_GET['search'] : '';
 
-    // QUERY
+    // CRITERIA
     $userGateway = $container->get(UserGateway::class);
     $criteria = $userGateway->newQueryCriteria()
         ->searchBy($userGateway->getSearchableColumns(), $search)
         ->sortBy(['surname', 'preferredName'])
         ->fromArray($_POST);
 
+
+    echo '<h2>';
+    echo __($guid, 'Search');
+    echo '</h2>';
+    
     $form = Form::create('filter', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth');
 
@@ -69,6 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
     echo __($guid, 'View');
     echo '</h2>';
 
+    // QUERY
     $dataSet = $userGateway->queryAllUsers($criteria);
 
     // Join a set of family data per user

--- a/modules/User Admin/user_manage.php
+++ b/modules/User Admin/user_manage.php
@@ -47,7 +47,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
         ->sortBy(['surname', 'preferredName'])
         ->fromArray($_POST);
 
-
     echo '<h2>';
     echo __($guid, 'Search');
     echo '</h2>';

--- a/modules/User Admin/user_manage.php
+++ b/modules/User Admin/user_manage.php
@@ -44,6 +44,13 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
 
     $search = isset($_GET['search'])? $_GET['search'] : '';
 
+    // QUERY
+    $userGateway = $container->get(UserGateway::class);
+    $criteria = $userGateway->newQueryCriteria()
+        ->searchBy($userGateway->getSearchableColumns(), $search)
+        ->sortBy(['surname', 'preferredName'])
+        ->fromArray($_POST);
+
     $form = Form::create('filter', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth');
 
@@ -51,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
 
     $row = $form->addRow();
         $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username, role, student ID, email, phone number, vehicle registration'));
-        $row->addTextField('search')->setValue($search);
+        $row->addTextField('search')->setValue($criteria->getSearchText());
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session, __('Clear Search'));
@@ -61,14 +68,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
     echo '<h2>';
     echo __($guid, 'View');
     echo '</h2>';
-
-    $userGateway = $container->get(UserGateway::class);
-    
-    // QUERY
-    $criteria = $userGateway->newQueryCriteria()
-        ->searchBy($userGateway->getSearchableColumns(), $search)
-        ->sortBy(['surname', 'preferredName'])
-        ->fromArray($_POST);
 
     $dataSet = $userGateway->queryAllUsers($criteria);
 

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -196,7 +196,7 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
                 $key = $name.':'.$value;
                 $criteriaUsed[$name] = isset($filters[$key]) 
                     ? $filters[$key] 
-                    : __(ucwords(preg_replace('/(?<=[a-z])(?=[A-Z])/', ' $0', $name))); // camelCase => Title Case
+                    : __(ucwords(preg_replace('/(?<=[a-z])(?=[A-Z])/', ' $0', $name))) . ($name == 'in'? ': '.ucfirst($value) : ''); // camelCase => Title Case
             }
 
             foreach ($criteriaUsed as $name => $label) {


### PR DESCRIPTION
This changes a fair number of files, but the change is fairly small and the same each time:
- Moves the creation of $criteria above the search form.
- Changes the search text field to use `$criteria->getSearchText()` rather than the raw `$_GET['search']` value. This is the processed search text that has filters removed.

Usability wise this means the filter text (eg `all:on` `active:Y`) will no longer show up in the search field, including filters typed into the search. This still feels pretty intuitive, since the filters can be seen and managed via the UI, and it separates the function of the clear search and clear filter links. 