### PR TITLE
School Admin: fix the Assign Houses tool to handle unspecified genders

### DIFF
--- a/modules/School Admin/house_manage_assignProcess.php
+++ b/modules/School Admin/house_manage_assignProcess.php
@@ -124,6 +124,9 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
             if (!empty($houses) && $result->rowCount() > 0) {
 
                 while ($student = $result->fetch()) {
+                    if ($student['gender'] == 'Other' || $student['gender'] == 'Unspecified') {
+                        $student['gender'] = random_int(0, 1) == 1? 'M' : 'F';
+                    }
 
                     // Use the closure to grab the next house to fill
                     $group = ($balanceGender == 'Y')? 'total'.$student['gender'] : 'total';


### PR DESCRIPTION
The assign houses tool has a Balance by Gender option that currently does not properly handle users with Other or Unspecified genders. This fix randomly selects M or F _only_ for the purposes of numerical distribution, so it can continue to balance the house totals by gender and/or year group.