### PR TITLE
System: update old sqlConnection class to implement Connection contract

### DIFF
--- a/src/Gibbon/sqlConnection.php
+++ b/src/Gibbon/sqlConnection.php
@@ -19,6 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon ;
 
+use Gibbon\Contracts\Database\Connection as ConnectionInterface;
+
 /**
  * @deprecated v16
  * Database Connection Class
@@ -26,7 +28,7 @@ namespace Gibbon ;
  * @version	v13
  * @since	v12
  */
-class sqlConnection
+class sqlConnection implements ConnectionInterface
 {
     /**
      * PDO Object
@@ -173,6 +175,41 @@ class sqlConnection
         }
 
         return $this->result ;
+    }
+
+    public function selectOne($query, $bindings = [])
+    {
+        return $this->executeQuery($bindings, $query);
+    }
+
+    public function select($query, $bindings = [])
+    {
+        return $this->executeQuery($bindings, $query);
+    }
+
+    public function insert($query, $bindings = [])
+    {
+        return $this->executeQuery($bindings, $query);
+    }
+
+    public function update($query, $bindings = [])
+    {
+        return $this->executeQuery($bindings, $query);
+    }
+
+    public function delete($query, $bindings = [])
+    {
+        return $this->executeQuery($bindings, $query);
+    }
+
+    public function statement($query, $bindings = [])
+    {
+        return $this->executeQuery($bindings, $query);
+    }
+
+    public function affectingStatement($query, $bindings = [])
+    {
+        return $this->executeQuery($bindings, $query);
     }
 
     /**


### PR DESCRIPTION
This is a small change, but it will likely help reduce the friction for the v16 update process by implementing the new database Connection contract in the old sqlConnection class. This will prevent type-hinting related errors for additional modules that haven't been updated and may still contain duplicate $connection2 instances.