### PR TITLE
Data Updater: do not require updates for new students after the cutoff

### DIFF
--- a/modules/Data Updater/data_updates.php
+++ b/modules/Data Updater/data_updates.php
@@ -118,6 +118,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_updates.
             echo '</td>';
 
             $dataUpdatesByType = $gateway->selectDataUpdatesByPerson($person['gibbonPersonID'], $gibbonPersonID)->fetchGrouped();
+            $recentlyStarted = !empty($person['dateStart']) && $person['dateStart'] >= $cutoffDate;
 
             foreach ($updatableDataTypes as $type) {
                 $updateRequired = false;
@@ -129,7 +130,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_updates.
 
                         $lastUpdate = !empty($dataUpdate['lastUpdated'])? __('Last Updated').': '.date('F j, Y', strtotime($dataUpdate['lastUpdated'])) : '';
                         
-                        if (!in_array($type, $requiredUpdatesByType) || empty($cutoffDate)) {
+                        if (!in_array($type, $requiredUpdatesByType) || empty($cutoffDate) || $recentlyStarted) {
                             // Display an edit link if updates aren't required or no cutoff date is set
                             $output .= "<img title='".__('Edit').'<br/>'.$lastUpdate."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/><br/>";
                             $output .= $dataUpdate['name'];


### PR DESCRIPTION
A small tweak that will not count required updates for users whose start date is after the cutoff date. A brand new student shouldn't need to update their info right away.