### PR TITLE
System: fixes for PHP notices + other minor testing-relates fixes

### DIFF
--- a/fullscreen.php
+++ b/fullscreen.php
@@ -61,7 +61,7 @@ if (empty($_SESSION[$guid]['systemSettingsSet'])) {
         }
         $resultTheme = $connection2->prepare($sqlTheme);
         $resultTheme->execute($dataTheme);
-        if (count($resultTheme) == 1) {
+        if ($resultTheme->rowCount() == 1) {
             $rowTheme = $resultTheme->fetch();
             $themeCSS = "<link rel='stylesheet' type='text/css' href='./themes/".$rowTheme['name']."/css/main.css' />";
             if ($_SESSION[$guid]['i18n']['rtl'] == 'Y') {

--- a/modules/Data Updater/report_student_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_student_dataUpdaterHistory.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_studen
     echo __($guid, 'Choose Students');
     echo '</h2>';
 
-    $choices = isset($_POST['members'])? $_POST['members'] : null;
+    $choices = isset($_POST['members'])? $_POST['members'] : array();
     $nonCompliant = isset($_POST['nonCompliant'])? $_POST['nonCompliant'] : '';
     $date = isset($_POST['date'])? $_POST['date'] : date($_SESSION[$guid]['i18n']['dateFormatPHP'], (time() - (604800 * 26)));
 

--- a/modules/Markbook/css/module.css
+++ b/modules/Markbook/css/module.css
@@ -78,17 +78,23 @@ th.dataColumn {
 }
 
 .marksColumn {
-	padding: 0px !important;
+	padding: 0px 0px 30px 0px !important;
 	text-align: center;
-	min-width: 140px;
+    min-width: 140px;
+    position: relative;
+    vertical-align: top;
 }
 
 .marksColumn .columnActions {
-	margin-top: 6px;
+    margin-top: 6px;
 }
 
 .marksColumn .columnLabels {
-	margin-top: 2px;
+    margin-top: 2px;
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    width: 100%;
 }
 
 

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -365,8 +365,8 @@
 
             $info .= '</ul>';
 
-            echo "<th class='marksColumn notdraggable' data-header='".$column->gibbonMarkbookColumnID."' style='text-align: center; padding: 0px !important'>";
-            echo "<div class='dragtable-drag-handle'></div>";
+            echo "<th class='marksColumn notdraggable' data-header='".$column->gibbonMarkbookColumnID."' style='padding: 0px 0px 30px 0px !important; text-align: center;vertical-align: top;'>";
+
             echo ($canEditThisClass) ? "<div class='dragtable-drag-handle'></div>" :  "<br/>";
 
             echo "<span title='".htmlPrep( $info )."'>".$column->getData('name').'</span><br/>';
@@ -385,8 +385,8 @@
 
 
             echo '</span>';
-            echo '<div class="columnActions">';
             if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php') and $canEditThisClass) {
+                echo '<div class="columnActions">';
                 echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/markbook_edit_edit.php&gibbonCourseClassID=$gibbonCourseClassID&gibbonMarkbookColumnID=".$column->gibbonMarkbookColumnID."'><img title='".__($guid, 'Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
 
                 echo "<a class='miniIcon' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/markbook_edit_data.php&gibbonCourseClassID=$gibbonCourseClassID&gibbonMarkbookColumnID=".$column->gibbonMarkbookColumnID."'><img title='".__($guid, 'Enter Data')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/markbook.png'/> ";

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -367,6 +367,7 @@
 
             echo "<th class='marksColumn notdraggable' data-header='".$column->gibbonMarkbookColumnID."' style='text-align: center; padding: 0px !important'>";
             echo "<div class='dragtable-drag-handle'></div>";
+            echo ($canEditThisClass) ? "<div class='dragtable-drag-handle'></div>" :  "<br/>";
 
             echo "<span title='".htmlPrep( $info )."'>".$column->getData('name').'</span><br/>';
             echo "<span class='details'>";

--- a/modules/Students/report_student_emergencySummary.php
+++ b/modules/Students/report_student_emergencySummary.php
@@ -43,10 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_em
     echo __($guid, 'Choose Students');
     echo '</h2>';
 
-    $choices = null;
-    if (isset($_POST['gibbonPersonID'])) {
-        $choices = $_POST['gibbonPersonID'];
-    }
+    $choices = isset($_POST['gibbonPersonID'])? $_POST['gibbonPersonID'] : array();
 
     $form = Form::create('action',  $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Students/report_student_emergencySummary.php");
 

--- a/modules/Students/report_student_medicalSummary.php
+++ b/modules/Students/report_student_medicalSummary.php
@@ -43,10 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_me
     echo __($guid, 'Choose Students');
     echo '</h2>';
 
-    $choices = null;
-    if (isset($_POST['gibbonPersonID'])) {
-        $choices = $_POST['gibbonPersonID'];
-    }
+    $choices = isset($_POST['gibbonPersonID'])? $_POST['gibbonPersonID'] : array();
 
     $form = Form::create('action',  $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Students/report_student_medicalSummary.php");
 

--- a/modules/Students/report_students_byHouse.php
+++ b/modules/Students/report_students_byHouse.php
@@ -115,6 +115,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_b
 
                     // Append the current totals to the running totals for each house
                     $totals[$data['house']] = array_reduce(array_keys($data), function ($carry, $key) use ($data) {
+                        if (stripos($key, 'total') === false) return $carry;
                         $carry[$key] = (isset($carry[$key]))? $carry[$key] + $data[$key] : $data[$key];
                         return $carry;
                     }, $totals[$data['house']]);

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -360,6 +360,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         $action = $_GET['action'];
                     }
 
+                    // When viewing left students, they won't have a year group ID
+                    if (empty($row['gibbonYearGroupID'])) $row['gibbonYearGroupID'] = '';
+
                     if ($subpage == '' and ($hook == '' or $module == '' or $action == '')) {
                         $subpage = 'Overview';
                     }

--- a/modules/Timetable/tt.php
+++ b/modules/Timetable/tt.php
@@ -127,7 +127,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == fals
             }
         }
 
-        if (count($users) == 0) {
+        if (!$canViewAllTimetables && count($users) == 0) {
             echo '<div class="error">';
             echo __('The selected record does not exist, or you do not have access to it.');
             echo '</div>';


### PR DESCRIPTION
- Fixes a visual alignment issue with long titles and unit names in View Markbook Columns; adds some css to keep the column actions and sub-headings aligned better.
- Removes the drag-handle when a markbook column should not be editable.
- Fixes an issue in View Timetable by Person where the generic 'no results found' message was superseding the built-in data tables one, causing the table to disappear when certain filters were applied.
- The rest are PHP notice fixes.