### PR TITLE
System: fix IE incompatibility with javascript and select inputs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ v17.0.00
 
     Tweaks & Bug Fixes
         Planner: added SMTP persistence to weekly summary CLI script
+        System: fixed IE incompatibility with javascript and select inputs
 
 v16.0.01
 --------

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -212,7 +212,7 @@ CustomBlocks.prototype.init = function() {
     _.refresh();
 };
 
-CustomBlocks.prototype.addBlock = function(data = {}) {
+CustomBlocks.prototype.addBlock = function(data) {
     var _ = this;
 
     _.blockCount++;
@@ -237,7 +237,7 @@ CustomBlocks.prototype.removeBlock = function(block) {
     });
 };
 
-CustomBlocks.prototype.initBlock = function(block, data = {}) {
+CustomBlocks.prototype.initBlock = function(block, data) {
     var _ = this;
 
     block.blockNumber = _.blockCount;
@@ -248,7 +248,7 @@ CustomBlocks.prototype.initBlock = function(block, data = {}) {
     _.addBlockEvents(block);
 };
 
-CustomBlocks.prototype.loadBlockInputData = function(block, data = {}) {
+CustomBlocks.prototype.loadBlockInputData = function(block, data) {
     var _ = this;
 
     for (key in data) {
@@ -399,7 +399,9 @@ DataTable.prototype.init = function() {
 
     // Add Filter
     $(_.table).on('change', '.filters', function() {
-        var [filter, value] = $(this).val().split(':');
+        var filterData = $(this).val().split(':');
+        var filter = filterData[0];
+        var value = filterData[1];
 
         _.filters.filterBy[filter] = value;
         _.filters.page = 1;

--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -175,7 +175,7 @@ class Select extends Input
 
         if (!empty($this->getAttribute('multiple'))) {
             if (empty($this->getAttribute('size'))) {
-                $this->setAttribute('size', $this->getOptionCount());
+                $this->setAttribute('size', 8);
             }
 
             if (stripos($this->getName(), '[]') === false) {

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1299,7 +1299,6 @@ table.standardForm td.standardWidth:last-child:nth-child(2) {
 
 select[multiple] {
 	height: auto;
-	max-height: 130px;
 }
 
 .shortWidth {


### PR DESCRIPTION
I'd love to one day forget that IE ever existed 😏 ...until that day, here's a couple backwards compatibility fixes for IE10-11. The changes are only a couple lines and work just as well with modern browsers, so worth the effort... maybe.

- Changes some default argument assignment and array destructuring to use javascript that's compatible with older browsers.
- Fixes an IE rendering issue with max-height and multiple selects where the select area was not scrollable.