### PR TITLE
Tables: add a spinner icon to Data Tables for reloads longer than 0.5s

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -426,8 +426,13 @@ DataTable.prototype.init = function() {
 DataTable.prototype.refresh = function() {
     var _ = this;
 
+    var submitted = setTimeout(function() {
+        $('.pagination', _.table).prepend('<span class="submitted"></span>');
+    }, 500);
+
     $(_.table).load(_.path, _.filters, function(responseText, textStatus, jqXHR) { 
         tb_init('a.thickbox'); 
+        clearTimeout(submitted);
     });
 };
 

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -259,7 +259,7 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
 
         $pageNumber = $dataSet->getPage();
 
-        $output = '<div class="floatRight">';
+        $output = '<div class="pagination floatRight">';
             $output .= '<input type="button" class="paginate" data-page="'.$dataSet->getPrevPageNumber().'" '.($dataSet->isFirstPage()? 'disabled' : '').' value="'.__('Prev').'">';
 
             foreach ($dataSet->getPaginatedRange() as $page) {


### PR DESCRIPTION
Adds a spinner icon, identical to the submit button, that shows up on data table refreshes that take longer than 0.5s. 

![screen shot 2018-06-21 at 2 15 03 pm](https://user-images.githubusercontent.com/897700/41701123-ca1403d4-755d-11e8-9385-f8aee8806dee.png)

This helps as a visual clue to the user that the AJAX process is still working, but on a delay so it doesn't flash on & off for quick page loads.