### PR TITLE
System: fix update process for cuttingEdge code

### DIFF
--- a/modules/System Admin/updateProcess.php
+++ b/modules/System Admin/updateProcess.php
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
                         $sqlTokens = explode(';end', $version[1]);
                         if ($version[0] == $versionDB) { //Finish current version
                             foreach ($sqlTokens as $sqlToken) {
-                                if (version_compare($tokenCount[0], $cuttingEdgeCodeLine, '>=')) {
+                                if (version_compare($tokenCount, $cuttingEdgeCodeLine, '>=')) {
                                     if (trim($sqlToken) != '') { //Decide whether this has been run or not
                                         try {
                                             $result = $connection2->query($sqlToken);


### PR DESCRIPTION
This error manifests in cutting edge installs on update, they'll see an 'Update success' message, but upon further inspection none of the SQL updates had been run. 

It happens only when a cutting edge install is one full version behind, which likely hasn't happened much before, but in this case v16.0.01 has been added in-between v16 and v17.

In the code, the error arises when `$tokenCount` was being accessed as an array `$tokenCount[0]` and incremented as a plain integer. Oddly, no errors were thrown by this syntax.