### PR TITLE
User Admin: add a Can Login option for roles in Manage Roles 

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -738,5 +738,5 @@ $sql[$count][1] = "";
 ++$count;
 $sql[$count][0] = '17.0.00';
 $sql[$count][1] = "
-ALTER TABLE `gibbonRole` ADD `canLogin` ENUM('Y','N') NOT NULL DEFAULT 'Y' AFTER `type`;end
+ALTER TABLE `gibbonRole` ADD `canLoginRole` ENUM('Y','N') NOT NULL DEFAULT 'Y' AFTER `type`;end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -737,4 +737,6 @@ $sql[$count][1] = "";
 //v17.0.00
 ++$count;
 $sql[$count][0] = '17.0.00';
-$sql[$count][1] = "";
+$sql[$count][1] = "
+ALTER TABLE `gibbonRole` ADD `canLogin` ENUM('Y','N') NOT NULL DEFAULT 'Y' AFTER `type`;end
+";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ v17.0.00
     Tweaks & Bug Fixes
         Planner: added SMTP persistence to weekly summary CLI script
         System: fixed IE incompatibility with javascript and select inputs
+        User Admin: added an option in Manage Roles to toggle login access for all users of a particular role
 
 v16.0.01
 --------

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -198,7 +198,7 @@ if (isset($authUrl)){
         $role = $pdo->selectOne($sql, $data);
 
         // Insufficient privileges to login
-        if ($row['canLogin'] != 'Y' || (!empty($role['canLogin']) && $role['canLogin'] != 'Y')) {
+        if ($row['canLogin'] != 'Y' || (!empty($role['canLoginRole']) && $role['canLoginRole'] != 'Y')) {
             unset($_SESSION[$guid]['googleAPIAccessToken'] );
             unset($_SESSION[$guid]['gplusuer']);
             @session_destroy();

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -173,7 +173,7 @@ if (isset($authUrl)){
 	//Start to collect User Info and test
 	try {
 		$data = array("email"=>$email);
-		$sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE email=:email AND status='Full'";
+		$sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, gibbonRole.canLogin AS canLoginRole FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE email=:email AND status='Full'";
 		$result = $connection2->prepare($sql);
 		$result->execute($data);
 	}
@@ -193,7 +193,7 @@ if (isset($authUrl)){
 		$row = $result->fetch();
 
         // Insufficient privileges to login
-        if ($row['canLogin'] != 'Y') {
+        if ($row['canLogin'] != 'Y' || $row['canLoginRole'] != 'Y') {
             unset($_SESSION[$guid]['googleAPIAccessToken'] );
             unset($_SESSION[$guid]['gplusuer']);
             @session_destroy();

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -173,7 +173,7 @@ if (isset($authUrl)){
 	//Start to collect User Info and test
 	try {
 		$data = array("email"=>$email);
-		$sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, gibbonRole.canLogin AS canLoginRole FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE email=:email AND status='Full'";
+		$sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE email=:email AND status='Full'";
 		$result = $connection2->prepare($sql);
 		$result->execute($data);
 	}
@@ -190,10 +190,15 @@ if (isset($authUrl)){
         exit;
 	}
 	else {
-		$row = $result->fetch();
+        $row = $result->fetch();
+        
+        // Get primary role info
+        $data = array('gibbonRoleIDPrimary' => $row['gibbonRoleIDPrimary']);
+        $sql = "SELECT * FROM gibbonRole WHERE gibbonRoleID=:gibbonRoleIDPrimary";
+        $role = $pdo->selectOne($sql, $data);
 
         // Insufficient privileges to login
-        if ($row['canLogin'] != 'Y' || $row['canLoginRole'] != 'Y') {
+        if ($row['canLogin'] != 'Y' || (!empty($role['canLogin']) && $role['canLogin'] != 'Y')) {
             unset($_SESSION[$guid]['googleAPIAccessToken'] );
             unset($_SESSION[$guid]['gplusuer']);
             @session_destroy();

--- a/login.php
+++ b/login.php
@@ -71,7 +71,7 @@ else {
         $role = $pdo->selectOne($sql, $data);
 
         // Insufficient privileges to login
-        if ($row['canLogin'] != 'Y' || (!empty($role['canLogin']) && $role['canLogin'] != 'Y')) {
+        if ($row['canLogin'] != 'Y' || (!empty($role['canLoginRole']) && $role['canLoginRole'] != 'Y')) {
             $URL .= '?loginReturn=fail2';
             header("Location: {$URL}");
             exit;

--- a/login.php
+++ b/login.php
@@ -50,7 +50,7 @@ if (empty($username) or empty($password)) {
 else {
     try {
         $data = array('username' => $username);
-        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, canLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full'))";
+        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, gibbonPerson.canLogin, gibbonRole.canLogin AS canLoginRole FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full'))";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
@@ -66,7 +66,7 @@ else {
         $row = $result->fetch();
 
         // Insufficient privledges to login
-        if ($row['canLogin'] != 'Y') {
+        if ($row['canLogin'] != 'Y' || $row['canLoginRole'] != 'Y') {
             $URL .= '?loginReturn=fail2';
             header("Location: {$URL}");
             exit;

--- a/login.php
+++ b/login.php
@@ -50,7 +50,7 @@ if (empty($username) or empty($password)) {
 else {
     try {
         $data = array('username' => $username);
-        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, gibbonPerson.canLogin, gibbonRole.canLogin AS canLoginRole FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full'))";
+        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, gibbonRole.canLogin AS canLoginRole FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full'))";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {

--- a/login.php
+++ b/login.php
@@ -50,7 +50,7 @@ if (empty($username) or empty($password)) {
 else {
     try {
         $data = array('username' => $username);
-        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin, gibbonRole.canLogin AS canLoginRole FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full'))";
+        $sql = "SELECT gibbonPerson.*, futureYearsLogin, pastYearsLogin FROM gibbonPerson LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE ((username=:username OR (LOCATE('@', :username)>0 AND email=:username) ) AND (status='Full'))";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
@@ -65,8 +65,13 @@ else {
     } else {
         $row = $result->fetch();
 
-        // Insufficient privledges to login
-        if ($row['canLogin'] != 'Y' || $row['canLoginRole'] != 'Y') {
+        // Get primary role info
+        $data = array('gibbonRoleIDPrimary' => $row['gibbonRoleIDPrimary']);
+        $sql = "SELECT * FROM gibbonRole WHERE gibbonRoleID=:gibbonRoleIDPrimary";
+        $role = $pdo->selectOne($sql, $data);
+
+        // Insufficient privileges to login
+        if ($row['canLogin'] != 'Y' || (!empty($role['canLogin']) && $role['canLogin'] != 'Y')) {
             $URL .= '?loginReturn=fail2';
             header("Location: {$URL}");
             exit;

--- a/modules/User Admin/role_manage.php
+++ b/modules/User Admin/role_manage.php
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage.php
     $table->addColumn('loginYear', __('Login Years'))
         ->notSortable()
         ->format(function ($row) {
-            if ($row['canLogin'] == 'N') {
+            if ($row['canLoginRole'] == 'N') {
                 return __('None');
             } else if ($row['futureYearsLogin'] == 'Y' and $row['pastYearsLogin'] == 'Y') {
                 return __('All years');

--- a/modules/User Admin/role_manage.php
+++ b/modules/User Admin/role_manage.php
@@ -59,7 +59,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage.php
     $table->addColumn('loginYear', __('Login Years'))
         ->notSortable()
         ->format(function ($row) {
-            if ($row['futureYearsLogin'] == 'Y' and $row['pastYearsLogin'] == 'Y') {
+            if ($row['canLogin'] == 'N') {
+                return __('None');
+            } else if ($row['futureYearsLogin'] == 'Y' and $row['pastYearsLogin'] == 'Y') {
                 return __('All years');
             } elseif ($row['futureYearsLogin'] == 'N' and $row['pastYearsLogin'] == 'N') {
                 return __('Current year only');

--- a/modules/User Admin/role_manage_add.php
+++ b/modules/User Admin/role_manage_add.php
@@ -76,10 +76,10 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_add
         $row->addTextField('type')->isRequired()->readonly()->setValue('Additional');
 
     $row = $form->addRow();
-        $row->addLabel('canLogin', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
-        $row->addYesNo('canLogin')->isRequired()->selected('Y');
+        $row->addLabel('canLoginRole', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
+        $row->addYesNo('canLoginRole')->isRequired()->selected('Y');
 
-    $form->toggleVisibilityByClass('loginOptions')->onSelect('canLogin')->when('Y');
+    $form->toggleVisibilityByClass('loginOptions')->onSelect('canLoginRole')->when('Y');
     $row = $form->addRow()->addClass('loginOptions');
         $row->addLabel('pastYearsLogin', __('Login To Past Years'));
         $row->addYesNo('pastYearsLogin')->isRequired();

--- a/modules/User Admin/role_manage_add.php
+++ b/modules/User Admin/role_manage_add.php
@@ -76,10 +76,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_add
         $row->addTextField('type')->isRequired()->readonly()->setValue('Additional');
 
     $row = $form->addRow();
+        $row->addLabel('canLogin', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
+        $row->addYesNo('canLogin')->isRequired()->selected('Y');
+
+    $form->toggleVisibilityByClass('loginOptions')->onSelect('canLogin')->when('Y');
+    $row = $form->addRow()->addClass('loginOptions');
         $row->addLabel('pastYearsLogin', __('Login To Past Years'));
         $row->addYesNo('pastYearsLogin')->isRequired();
 
-    $row = $form->addRow();
+    $row = $form->addRow()->addClass('loginOptions');
         $row->addLabel('futureYearsLogin', __('Login To Future Years'));
         $row->addYesNo('futureYearsLogin')->isRequired();
 

--- a/modules/User Admin/role_manage_addProcess.php
+++ b/modules/User Admin/role_manage_addProcess.php
@@ -31,8 +31,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_add
     $name = $_POST['name'];
     $nameShort = $_POST['nameShort'];
     $description = $_POST['description'];
-    $futureYearsLogin = $_POST['futureYearsLogin'];
-    $pastYearsLogin = $_POST['pastYearsLogin'];
+    $canLogin = isset($_POST['canLogin'])? $_POST['canLogin'] : 'Y';
+    $futureYearsLogin = isset($_POST['futureYearsLogin'])? $_POST['futureYearsLogin'] : 'N';
+    $pastYearsLogin = isset($_POST['pastYearsLogin'])? $_POST['pastYearsLogin'] : 'N';
     $restriction = $_POST['restriction'];
 
     if (empty($category) or empty($name) or empty($nameShort) or empty($description) or empty($futureYearsLogin) or empty($pastYearsLogin) or empty($restriction) ) {
@@ -57,8 +58,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_add
         } else {
             //Write to database
             try {
-                $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction);
-                $sql = "INSERT INTO gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, type='Additional', futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction";
+                $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'canLogin' => $canLogin, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction);
+                $sql = "INSERT INTO gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, type='Additional', canLogin=:canLogin, futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/User Admin/role_manage_addProcess.php
+++ b/modules/User Admin/role_manage_addProcess.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_add
     $name = $_POST['name'];
     $nameShort = $_POST['nameShort'];
     $description = $_POST['description'];
-    $canLogin = isset($_POST['canLogin'])? $_POST['canLogin'] : 'Y';
+    $canLoginRole = isset($_POST['canLoginRole'])? $_POST['canLoginRole'] : 'Y';
     $futureYearsLogin = isset($_POST['futureYearsLogin'])? $_POST['futureYearsLogin'] : 'N';
     $pastYearsLogin = isset($_POST['pastYearsLogin'])? $_POST['pastYearsLogin'] : 'N';
     $restriction = $_POST['restriction'];
@@ -58,8 +58,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_add
         } else {
             //Write to database
             try {
-                $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'canLogin' => $canLogin, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction);
-                $sql = "INSERT INTO gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, type='Additional', canLogin=:canLogin, futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction";
+                $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'canLoginRole' => $canLoginRole, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction);
+                $sql = "INSERT INTO gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, type='Additional', canLoginRole=:canLoginRole, futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/User Admin/role_manage_duplicateProcess.php
+++ b/modules/User Admin/role_manage_duplicateProcess.php
@@ -84,8 +84,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_dup
             } else {
                 $row = $result->fetch();
                 try {
-                    $data = array('gibbonRoleID' => $AI, 'category' => $row['category'], 'name' => $name, 'nameShort' => $nameShort, 'description' => $row['description'], 'restriction' => $row['restriction']);
-                    $sql = "INSERT INTO gibbonRole SET gibbonRoleID=:gibbonRoleID, category=:category, name=:name, nameShort=:nameShort, description=:description, type='Additional', restriction=:restriction";
+                    $data = array('gibbonRoleID' => $AI, 'category' => $row['category'], 'name' => $name, 'nameShort' => $nameShort, 'description' => $row['description'], 'canLoginRole' => $row['canLoginRole'], 'restriction' => $row['restriction']);
+                    $sql = "INSERT INTO gibbonRole SET gibbonRoleID=:gibbonRoleID, category=:category, name=:name, nameShort=:nameShort, description=:description, type='Additional', canLoginRole=:canLoginRole, restriction=:restriction";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/modules/User Admin/role_manage_edit.php
+++ b/modules/User Admin/role_manage_edit.php
@@ -101,10 +101,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
                 $row->addTextField('type')->isRequired()->readonly()->setValue($role['type']);
 
             $row = $form->addRow();
+                $row->addLabel('canLogin', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
+                if ($role['name'] == 'Administrator') {
+                    $row->addTextField('canLogin')->isRequired()->readonly()->setValue(__('Yes'));
+                } else {
+                    $row->addYesNo('canLogin')->isRequired()->selected($role['canLogin']);
+                    $form->toggleVisibilityByClass('loginOptions')->onSelect('canLogin')->when('Y');
+                }
+
+            $row = $form->addRow()->addClass('loginOptions');
                 $row->addLabel('pastYearsLogin', __('Login To Past Years'));
                 $row->addYesNo('pastYearsLogin')->isRequired()->selected($role['pastYearsLogin']);
 
-            $row = $form->addRow();
+            $row = $form->addRow()->addClass('loginOptions');
                 $row->addLabel('futureYearsLogin', __('Login To Future Years'));
                 $row->addYesNo('futureYearsLogin')->isRequired()->selected($role['futureYearsLogin']);
 

--- a/modules/User Admin/role_manage_edit.php
+++ b/modules/User Admin/role_manage_edit.php
@@ -101,12 +101,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
                 $row->addTextField('type')->isRequired()->readonly()->setValue($role['type']);
 
             $row = $form->addRow();
-                $row->addLabel('canLogin', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
+                $row->addLabel('canLoginRole', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
                 if ($role['name'] == 'Administrator') {
-                    $row->addTextField('canLogin')->isRequired()->readonly()->setValue(__('Yes'));
+                    $row->addTextField('canLoginRole')->isRequired()->readonly()->setValue(__('Yes'));
                 } else {
-                    $row->addYesNo('canLogin')->isRequired()->selected($role['canLogin']);
-                    $form->toggleVisibilityByClass('loginOptions')->onSelect('canLogin')->when('Y');
+                    $row->addYesNo('canLoginRole')->isRequired()->selected($role['canLoginRole']);
+                    $form->toggleVisibilityByClass('loginOptions')->onSelect('canLoginRole')->when('Y');
                 }
 
             $row = $form->addRow()->addClass('loginOptions');

--- a/modules/User Admin/role_manage_editProcess.php
+++ b/modules/User Admin/role_manage_editProcess.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
             $name = $_POST['name'];
             $nameShort = $_POST['nameShort'];
             $description = $_POST['description'];
-            $canLogin = isset($_POST['canLogin'])? $_POST['canLogin'] : 'Y';
+            $canLoginRole = isset($_POST['canLoginRole'])? $_POST['canLoginRole'] : 'Y';
             $futureYearsLogin = isset($_POST['futureYearsLogin'])? $_POST['futureYearsLogin'] : $values['futureYearsLogin'];
             $pastYearsLogin = isset($_POST['pastYearsLogin'])? $_POST['pastYearsLogin'] : $values['pastYearsLogin'];
             $restriction = $_POST['restriction'];
@@ -81,8 +81,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
                 } else {
                     //Write to database
                     try {
-                        $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'canLogin' => $canLogin, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction, 'gibbonRoleID' => $gibbonRoleID);
-                        $sql = 'UPDATE gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, canLogin=:canLogin, futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction WHERE gibbonRoleID=:gibbonRoleID';
+                        $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'canLoginRole' => $canLoginRole, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction, 'gibbonRoleID' => $gibbonRoleID);
+                        $sql = 'UPDATE gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, canLoginRole=:canLoginRole, futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction WHERE gibbonRoleID=:gibbonRoleID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/User Admin/role_manage_editProcess.php
+++ b/modules/User Admin/role_manage_editProcess.php
@@ -47,13 +47,16 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
             $URL .= '&return=error2';
             header("Location: {$URL}");
         } else {
+            $values = $result->fetch();
+
             //Validate Inputs
             $category = $_POST['category'];
             $name = $_POST['name'];
             $nameShort = $_POST['nameShort'];
             $description = $_POST['description'];
-            $futureYearsLogin = $_POST['futureYearsLogin'];
-            $pastYearsLogin = $_POST['pastYearsLogin'];
+            $canLogin = isset($_POST['canLogin'])? $_POST['canLogin'] : 'Y';
+            $futureYearsLogin = isset($_POST['futureYearsLogin'])? $_POST['futureYearsLogin'] : $values['futureYearsLogin'];
+            $pastYearsLogin = isset($_POST['pastYearsLogin'])? $_POST['pastYearsLogin'] : $values['pastYearsLogin'];
             $restriction = $_POST['restriction'];
 
             if (empty($category) or empty($name) or empty($nameShort) or empty($description) or empty($futureYearsLogin) or empty($pastYearsLogin) or empty($restriction) ) {
@@ -78,8 +81,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
                 } else {
                     //Write to database
                     try {
-                        $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction, 'gibbonRoleID' => $gibbonRoleID);
-                        $sql = 'UPDATE gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction WHERE gibbonRoleID=:gibbonRoleID';
+                        $data = array('category' => $category, 'name' => $name, 'nameShort' => $nameShort, 'description' => $description, 'canLogin' => $canLogin, 'futureYearsLogin' => $futureYearsLogin, 'pastYearsLogin' => $pastYearsLogin, 'restriction' => $restriction, 'gibbonRoleID' => $gibbonRoleID);
+                        $sql = 'UPDATE gibbonRole SET category=:category, name=:name, nameShort=:nameShort, description=:description, canLogin=:canLogin, futureYearsLogin=:futureYearsLogin, pastYearsLogin=:pastYearsLogin, restriction=:restriction WHERE gibbonRoleID=:gibbonRoleID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/src/Domain/User/RoleGateway.php
+++ b/src/Domain/User/RoleGateway.php
@@ -45,7 +45,7 @@ class RoleGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonRoleID', 'name', 'nameShort', 'category', 'description', 'type', 'canLogin', 'futureYearsLogin', 'pastYearsLogin'
+                'gibbonRoleID', 'name', 'nameShort', 'category', 'description', 'type', 'canLoginRole', 'futureYearsLogin', 'pastYearsLogin'
             ]);
 
         return $this->runQuery($query, $criteria);

--- a/src/Domain/User/RoleGateway.php
+++ b/src/Domain/User/RoleGateway.php
@@ -45,7 +45,7 @@ class RoleGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonRoleID', 'name', 'nameShort', 'category', 'description', 'type', 'futureYearsLogin', 'pastYearsLogin'
+                'gibbonRoleID', 'name', 'nameShort', 'category', 'description', 'type', 'canLogin', 'futureYearsLogin', 'pastYearsLogin'
             ]);
 
         return $this->runQuery($query, $criteria);


### PR DESCRIPTION
**New Feature**

## Description
This feature gives school admin access to toggle a Can Login option for an entire role. Similar to the Can Login option per-user, if the role-level access is set to No then any primary user of that role will not be able to login.

## Motivation and Context
There are a number of use-cases where it can be handy to prevent login access for an entire role:
- When first setting up a system, so that newly imported users cannot use Forgot Password to reset and login to their account before the system is ready.
- To disable login access by role for a period of time, eg: during a holiday or school break.
- Assigning different access by roles, eg: younger students cannot login and older students can.

## How Has This Been Tested?
Locally and in production at one school.
