### PR TITLE
Data Updater: add a Family Data Updater History report

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -737,4 +737,7 @@ $sql[$count][1] = "";
 //v17.0.00
 ++$count;
 $sql[$count][0] = '17.0.00';
-$sql[$count][1] = "";
+$sql[$count][1] = "
+INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, `description`, `URLList`, `entryURL`, `defaultPermissionAdmin`, `defaultPermissionTeacher`, `defaultPermissionStudent`, `defaultPermissionParent`, `defaultPermissionSupport`, `categoryPermissionStaff`, `categoryPermissionStudent`, `categoryPermissionParent`, `categoryPermissionOther`) VALUES ((SELECT gibbonModuleID FROM gibbonModule WHERE name='Data Updater'), 'Family Data Updater History', 0, 'Reports', 'Allows users to check, for active families, how recently they have been updated.', 'report_family_dataUpdaterHistory.php', 'report_family_dataUpdaterHistory.php', 'Y', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'Y');end
+INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Data Updater' AND gibbonAction.name='Family Data Updater History'));end
+";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ v17.0.00
     Security
 
     Tweaks & Bug Fixes
+        Data Updater: added a Family Data Updater History report
         Planner: added SMTP persistence to weekly summary CLI script
         System: fixed IE incompatibility with javascript and select inputs
 

--- a/modules/Data Updater/report_family_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_family_dataUpdaterHistory.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
     echo '</div>';
 
     echo '<p>';
-    echo __('This report allows a user to select a range of families—with at least one child enroled in the target year group—and check whether or not they have had their family and personal data updated after a specified date.');
+    echo __('This report allows a user to select a range of families, with at least one child enroled in the target year group, and check whether or not they have had their family and personal data updated after a specified date.');
     echo '</p>';
 
     echo '<h2>';

--- a/modules/Data Updater/report_family_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_family_dataUpdaterHistory.php
@@ -1,0 +1,170 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Domain\DataUpdater\FamilyUpdateGateway;
+
+//Module includes
+include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family_dataUpdaterHistory.php') == false) {
+    //Acess denied
+    echo "<div class='error'>";
+    echo __($guid, 'You do not have access to this action.');
+    echo '</div>';
+} else {
+    //Proceed!
+    echo "<div class='trail'>";
+    echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__('Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__(getModuleName($_GET['q']))."</a> > </div><div class='trailEnd'>".__('Family Data Updater History').'</div>';
+    echo '</div>';
+
+    echo '<p>';
+    echo __('This report allows a user to select a range of families—with at least one child enroled in the target year group—and check whether or not they have had their family and personal data updated after a specified date.');
+    echo '</p>';
+
+    echo '<h2>';
+    echo __('Choose Options');
+    echo '</h2>';
+
+    $cutoffDate = getSettingByScope($connection2, 'Data Updater', 'cutoffDate');
+    $cutoffDate = !empty($cutoffDate)? Format::date($cutoffDate) : Format::dateFromTimestamp(time() - (604800 * 26)); 
+
+    $gibbonYearGroupIDList = isset($_POST['gibbonYearGroupIDList'])? $_POST['gibbonYearGroupIDList'] : array();
+    $nonCompliant = isset($_POST['nonCompliant'])? $_POST['nonCompliant'] : '';
+    $date = isset($_POST['date'])? $_POST['date'] : $cutoffDate;
+
+    $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/report_family_dataUpdaterHistory.php');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+    $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+
+    $row = $form->addRow();
+        $row->addLabel('gibbonYearGroupIDList',__('Year Groups'));
+        $row->addSelectYearGroup('gibbonYearGroupIDList')->selectMultiple()->selected($gibbonYearGroupIDList)->selectAll(true);
+
+    $row = $form->addRow();
+        $row->addLabel('date', __('Date'))->description(__('Earliest acceptable update'));
+        $row->addDate('date')->setValue($date)->isRequired();
+
+    $row = $form->addRow();
+        $row->addLabel('nonCompliant', __('Show Only Non-Compliant?'))->description(__('If not checked, show all. If checked, show only non-compliant students.'));
+        $row->addCheckbox('nonCompliant')->setValue('Y')->checked($nonCompliant);
+    
+    $row = $form->addRow();
+        $row->addSubmit();
+    
+    echo $form->getOutput();
+
+    if (!empty($gibbonYearGroupIDList)) {
+        echo '<h2>';
+        echo __('Report Data');
+        echo '</h2>';
+
+        $gateway = $container->get(FamilyUpdateGateway::class);
+
+        // QUERY
+        $criteria = $gateway->newQueryCriteria()
+            ->sortBy(['gibbonFamily.name'])
+            ->filterBy('cutoff', $nonCompliant == 'Y'? Format::dateConvert($date) : '')
+            ->fromArray($_POST);
+
+        $dataUpdates = $gateway->queryFamilyUpdaterHistory($criteria, $_SESSION[$guid]['gibbonSchoolYearID'], $gibbonYearGroupIDList);
+        $families = $dataUpdates->getColumn('gibbonFamilyID');
+
+        // Join a set of family adults & updater info
+        $familyAdults = $gateway->selectFamilyAdultUpdatesByFamily($families)->fetchGrouped();
+        $dataUpdates->joinColumn('gibbonFamilyID', 'familyAdults', $familyAdults);
+
+        // Join a set of family children & updater info
+        $familyChildren = $gateway->selectFamilyChildUpdatesByFamily($families, $_SESSION[$guid]['gibbonSchoolYearID'])->fetchGrouped();
+        $dataUpdates->joinColumn('gibbonFamilyID', 'familyChildren', $familyChildren);
+
+        // Function to display the updater info based on the cutoff date
+        $dateCutoff = DateTime::createFromFormat('Y-m-d H:i:s', Format::dateConvert($date).' 00:00:00');
+        $dataChecker = function($dateUpdated, $dateStart) use ($dateCutoff, $guid) {
+            $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateUpdated);
+            $dateDisplay = !empty($dateUpdated)? Format::dateTime($dateUpdated) : __('No data');
+
+            if (DateTime::createFromFormat('Y-m-d', $dateStart) > $dateCutoff) {
+                return "<img title='".__('Start Date').': '.Format::date($dateStart)."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/iconTick_light.png' width='18' />";
+            }
+
+            return empty($dateUpdated) || $dateCutoff > $date
+                ? "<img title='".__('Update Required').': '.$dateDisplay."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/iconCross.png' width='18' />"
+                : "<img title='".__('Up to date').': '.$dateDisplay."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/iconTick.png' width='18' />";
+        };
+
+        // DATA TABLE
+        $table = DataTable::createPaginated('studentUpdaterHistory', $criteria);
+        $table->addMetaData('post', ['gibbonYearGroupIDList' => $gibbonYearGroupIDList]);
+
+        $count = $dataUpdates->getPageFrom();
+        $table->addColumn('count', '')
+            ->notSortable()
+            ->width('5%')
+            ->format(function ($row) use (&$count) {
+                return $count++;
+            });
+
+        $table->addColumn('familyName', __('Family'))
+              ->width('20%')
+              ->format(function($row) use ($guid) {
+                  return '<a href="'.$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/User Admin/family_manage_edit.php&gibbonFamilyID='.$row['gibbonFamilyID'].'">'.$row['familyName'].'</a>';
+              });
+
+        $table->addColumn('familyUpdate', __('Family Data'))
+            ->width('5%')
+            ->format(function($row) use ($dataChecker) {
+                return $dataChecker($row['familyUpdate'], $row['earliestDateStart']);
+            });
+
+        $table->addColumn('familyAdults', __('Adults'))
+            ->notSortable()
+            ->format(function($row) use ($dataChecker) {
+                $output = '<table class="smallIntBorder fullWidth colorOddEven" cellspacing=0>';
+                foreach ($row['familyAdults'] as $adult) {
+                    $output .= '<tr>';
+                    $output .= '<td style="width:90%">'.Format::name($adult['title'], $adult['preferredName'], $adult['surname'], 'Parent').'</td>';
+                    $output .= '<td style="width:10%">'.$dataChecker($adult['personalUpdate'], $row['earliestDateStart']).'</td>';
+                    $output .= '</tr>';
+                }
+                $output .= '</table>';
+                return $output;
+            });
+
+        $table->addColumn('familyChildren', __('Children'))
+            ->notSortable()
+            ->format(function($row) use ($dataChecker) {
+                $output = '<table class="smallIntBorder fullWidth colorOddEven" cellspacing=0>';
+                foreach ($row['familyChildren'] as $child) {
+                    $output .= '<tr>';
+                    $output .= '<td style="width:80%">'.Format::name('', $child['preferredName'], $child['surname'], 'Student').'</td>';
+                    $output .= '<td style="width:10%">'.$child['rollGroup'].'</td>';
+                    $output .= '<td style="width:10%">'.$dataChecker($child['personalUpdate'], $child['dateStart']).'</td>';
+                    $output .= '</tr>';
+                }
+                $output .= '</table>';
+                return $output;
+            });
+
+        echo $table->render($dataUpdates);
+    }
+}

--- a/src/Domain/DataUpdater/FamilyUpdateGateway.php
+++ b/src/Domain/DataUpdater/FamilyUpdateGateway.php
@@ -54,4 +54,80 @@ class FamilyUpdateGateway extends QueryableGateway
 
         return $this->runQuery($query, $criteria);
     }
+
+    /**
+     * @param QueryCriteria $criteria
+     * @return DataSet
+     */
+    public function queryFamilyUpdaterHistory(QueryCriteria $criteria, $gibbonSchoolYearID, $gibbonYearGroupIDList)
+    {
+        $gibbonYearGroupIDList = is_array($gibbonYearGroupIDList)? implode(',', $gibbonYearGroupIDList) : $gibbonYearGroupIDList;
+
+        $query = $this
+            ->newQuery()
+            ->from('gibbonFamily')
+            ->cols([
+                'gibbonFamily.gibbonFamilyID', 'gibbonFamily.name as familyName', 'gibbonFamilyUpdate.timestamp as familyUpdate', 
+                "MIN(IFNULL(gibbonPerson.dateStart, '0000-00-00')) as earliestDateStart",
+                "MAX(IFNULL(gibbonPerson.dateEnd, NOW())) as latestEndDate",
+            ])
+            ->innerJoin('gibbonFamilyChild', 'gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID')
+            ->innerJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonFamilyChild.gibbonPersonID')
+            ->innerJoin('gibbonStudentEnrolment', 'gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID')
+            ->leftJoin('gibbonFamilyUpdate', 'gibbonFamilyUpdate.gibbonFamilyID=gibbonFamily.gibbonFamilyID')
+            ->where("gibbonPerson.status='Full'")
+            ->where('gibbonStudentEnrolment.gibbonSchoolYearID = :gibbonSchoolYearID')
+            ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID)
+            ->where('FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, :gibbonYearGroupIDList)')
+            ->bindValue('gibbonYearGroupIDList', $gibbonYearGroupIDList)
+            ->groupBy(['gibbonFamily.gibbonFamilyID'])
+            ->having('latestEndDate >= NOW()');
+
+        $criteria->addFilterRules([
+            'cutoff' => function ($query, $cutoffDate) {
+                $query->where('(gibbonFamilyUpdateID IS NULL OR gibbonFamilyUpdate.timestamp < :cutoffDate)');
+                $query->bindValue('cutoffDate', $cutoffDate);
+                $query->having('earliestDateStart < :cutoffDate');
+            },
+        ]);
+
+        return $this->runQuery($query, $criteria);
+    }
+
+    public function selectFamilyAdultUpdatesByFamily($gibbonFamilyIDList)
+    {
+        $gibbonFamilyIDList = is_array($gibbonFamilyIDList) ? implode(',', $gibbonFamilyIDList) : $gibbonFamilyIDList;
+        $data = array('gibbonFamilyIDList' => $gibbonFamilyIDList);
+        $sql = "SELECT gibbonFamilyAdult.gibbonFamilyID, gibbonPerson.title, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.status, MAX(gibbonPersonUpdate.timestamp) as personalUpdate
+            FROM gibbonFamilyAdult
+            JOIN gibbonPerson ON (gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            LEFT JOIN gibbonPersonUpdate ON (gibbonPersonUpdate.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            WHERE FIND_IN_SET(gibbonFamilyAdult.gibbonFamilyID, :gibbonFamilyIDList) 
+            AND gibbonPerson.status='Full'
+            GROUP BY gibbonFamilyAdult.gibbonPersonID 
+            ORDER BY gibbonPerson.surname, gibbonPerson.preferredName";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectFamilyChildUpdatesByFamily($gibbonFamilyIDList, $gibbonSchoolYearID)
+    {
+        $gibbonFamilyIDList = is_array($gibbonFamilyIDList) ? implode(',', $gibbonFamilyIDList) : $gibbonFamilyIDList;
+        $data = array('gibbonFamilyIDList' => $gibbonFamilyIDList, 'gibbonSchoolYearID' => $gibbonSchoolYearID);
+        $sql = "SELECT gibbonFamilyChild.gibbonFamilyID, '' as title, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.status, gibbonRollGroup.nameShort as rollGroup, MAX(gibbonPersonUpdate.timestamp) as personalUpdate, MAX(gibbonPersonMedicalUpdate.timestamp) as medicalUpdate, gibbonPerson.dateStart AS dateStart
+            FROM gibbonFamilyChild
+            JOIN gibbonPerson ON (gibbonFamilyChild.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            JOIN gibbonRollGroup ON (gibbonRollGroup.gibbonRollGroupID=gibbonStudentEnrolment.gibbonRollGroupID)
+            JOIN gibbonYearGroup ON (gibbonYearGroup.gibbonYearGroupID=gibbonStudentEnrolment.gibbonYearGroupID)
+            LEFT JOIN gibbonPersonUpdate ON (gibbonPersonUpdate.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            LEFT JOIN gibbonPersonMedicalUpdate ON (gibbonPersonMedicalUpdate.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            WHERE FIND_IN_SET(gibbonFamilyChild.gibbonFamilyID, :gibbonFamilyIDList) 
+            AND gibbonPerson.status='Full'
+            AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID
+            GROUP BY gibbonFamilyChild.gibbonPersonID 
+            ORDER BY gibbonYearGroup.sequenceNumber, gibbonRollGroup.nameShort, gibbonPerson.surname, gibbonPerson.preferredName";
+
+        return $this->db()->select($sql, $data);
+    }
 }

--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -65,13 +65,15 @@ class Select extends Input
 
     /**
      * Set the selected element(s) to include all available options.
-     * @param   bool    $value
+     * @param   bool    $onlyIfEmpty
      * @return  self
      */
-    public function selectAll()
+    public function selectAll($onlyIfEmpty = false)
     {
         if ($this->getAttribute('multiple') == true) {
-            $this->selected = array_keys($this->options);
+            if (!$onlyIfEmpty || ($onlyIfEmpty && empty($this->selected))) {
+                $this->selected = array_keys($this->options);
+            }
         }
 
         return $this;

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -562,7 +562,7 @@ table td {
 	background: -webkit-gradient(linear, left top, left bottom, from(#fbfbfb), to(#fafafa));
 	background: -moz-linear-gradient(top,  #fbfbfb,  #fafafa);
 }
-table tr.even td {
+table tr.even > td {
 	background: #f0f0f0;
 	background: -webkit-gradient(linear, left top, left bottom, from(#f2f2f2), to(#f0f0f0));
 	background: -moz-linear-gradient(top,  #f2f2f2,  #f0f0f0);


### PR DESCRIPTION
**New Feature**

## Description
Similar to the student updater history, the family updater history gives an overview of families in the school and whether the family data & personal data of family members has been updated recently. This view helps school admin when undertaking an effort to update data school-wide.

## Screenshots:
![screen shot 2018-06-26 at 11 48 05 am](https://user-images.githubusercontent.com/897700/41888210-d7ce7aae-7936-11e8-8abd-5d9003d42047.png)

