### PR TITLE
Tables: add an All option to the pagination size selector

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ v17.0.00
         Markbook: fixed bug in handling personalised attainment targets when using scales other than class scale
         Planner: added SMTP persistence to weekly summary CLI script
         System: fixed IE incompatibility with javascript and select inputs
+        System: added the option to display all records in a paginated table
         User Admin: added an option in Manage Roles to toggle login access for all users of a particular role
         User Admin: fixed name display bug in Enrol New Students (Status Full) section of Rollover
         User Admin: fixed bug preventing correct display of existing Privacy and Student Agreement options in user edit

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -241,6 +241,7 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
 
         return $this->factory->createSelect('limit')
             ->fromArray(array(10, 25, 50, 100))
+            ->fromArray(array($dataSet->getResultCount() => __('All')))
             ->setClass('limit floatNone')
             ->selected($dataSet->getPageSize())
             ->append('<small style="line-height: 30px;margin-left:5px;">'.__('Per Page').'</small>')


### PR DESCRIPTION
Adds an option for pagination to select "All" as the page size, displaying all results for the table.

If used too frequently on large tables it could add strain to the system 🤔 Perhaps we can keep an eye on it, and it may be worth changing this to an optional parameter for specific data tables (invoices, etc.), off by default.