### PR TITLE
Tables: fix hidden fields in bulk action forms after AJAX reload

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ v17.0.00
         Planner: added SMTP persistence to weekly summary CLI script
         System: fixed IE incompatibility with javascript and select inputs
         System: added the option to display all records in a paginated table
+        System: fixed an issue with hidden fields in bulk action forms after pagination
         User Admin: added an option in Manage Roles to toggle login access for all users of a particular role
         User Admin: fixed name display bug in Enrol New Students (Status Full) section of Rollover
         User Admin: fixed bug preventing correct display of existing Privacy and Student Agreement options in user edit

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -27,8 +27,8 @@ jQuery(function($){
     /**
      * Bluk Actions: show/hide the bulk action panel, highlight selected
      */
-    $(document).on('click, change', '.dataTable .bulkCheckbox :checkbox', function () {
-        var checkboxes = $(this).parents('.dataTable').find('.bulkCheckbox :checkbox');
+    $(document).on('click, change', '.bulkActionForm .bulkCheckbox :checkbox', function () {
+        var checkboxes = $(this).parents('.bulkActionForm').find('.bulkCheckbox :checkbox');
         var checkedCount = checkboxes.filter(':checked').length;
 
         if (checkedCount > 0) {
@@ -436,6 +436,7 @@ DataTable.prototype.refresh = function() {
     }, 500);
 
     $(_.table).load(_.path, _.filters, function(responseText, textStatus, jqXHR) { 
+        $('.bulkActionPanel').hide();
         tb_init('a.thickbox'); 
         clearTimeout(submitted);
     });

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -34,6 +34,9 @@ jQuery(function($){
         if (checkedCount > 0) {
             $('.bulkActionCount span').html(checkedCount);
             $('.bulkActionPanel').fadeIn(150);
+
+            // Trigger a showhide event on any nested inputs to update their visibility & validation state
+            $('.bulkActionPanel :input').trigger('showhide');
         } else {
             $('.bulkActionPanel').fadeOut(75);
         }

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -148,6 +148,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
         echo __($guid, 'View');
         echo '</h3>';
 
+        echo '<p class="bulkPaid">';
+        echo __('This bluk action can be used to update the status for more than one invoice to Paid (in full). It does NOT email receipts or work with payments requiring a Transaction ID. If you need to include email receipts, add a Transaction ID or process a partial payment use the Edit action for each individual invoice.');
+        echo '</p>';
+
         // QUERY
         $invoiceGateway = $container->get(InvoiceGateway::class);
 
@@ -182,17 +186,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
 
         $form->toggleVisibilityByClass('bulkPaid')->onSelect('action')->when('paid');
 
-        $row = $form->addRow()->addClass('bulkPaid');
-            $row->addContent(__('This bluk action can be used to update the status for more than one invoice to Paid (in full). It does NOT email receipts or work with payments requiring a Transaction ID. If you need to include email receipts, add a Transaction ID or process a partial payment use the Edit action for each individual invoice.'))->wrap('<p>', '</p>');
-
         $col = $form->createBulkActionColumn($bulkActions);
             $col->addSelectPaymentMethod('paymentType')
                 ->setClass('bulkPaid shortWidth displayNone')
                 ->isRequired()
+                ->addValidationOption('onlyOnSubmit: true')
                 ->placeholder(__('Payment Type').'...');
             $col->addDate('paidDate')
                 ->setClass('bulkPaid shortWidth displayNone')
                 ->isRequired()
+                ->addValidationOption('onlyOnSubmit: true')
                 ->placeholder(__('Date Paid'));
             $col->addSubmit(__('Go'));
 

--- a/src/Forms/Layout/Trigger.php
+++ b/src/Forms/Layout/Trigger.php
@@ -136,7 +136,7 @@ class Trigger implements OutputableInterface
         // Change target visibility if source value equals trigger value
         // Handles LiveValidation by also disabling/enabling inputs
         // The change() call activates any nested triggers
-        $output .= "$(document).on('change', '{$this->sourceSelector}', function(){ \n";
+        $output .= "$(document).on('change showhide', '{$this->sourceSelector}', function(event){ \n";
             $output .= "if ($('{$this->sourceSelector}').prop('disabled') == false && {$comparisons}) { \n";
                 $output .= "$('{$this->targetSelector}').slideDown('fast'); \n";
                 $output .= "$('{$this->targetSelector} :input').prop('disabled', false).change(); \n";

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -70,6 +70,9 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
 
         $output .= '</div></div><br/>';
 
+        // Persist the bulk actions outside the AJAX-reloaded data table div
+        $output .= $this->renderBulkActions($table);
+
         $postData = $table->getMetaData('post');
         $jsonData = !empty($postData) 
             ? json_encode(array_replace($postData, $this->criteria->toArray()))
@@ -109,7 +112,6 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
         $output .= $this->renderFilterOptions($dataSet, $filterOptions);
         $output .= $this->renderPageSize($dataSet);
         $output .= $this->renderPagination($dataSet);
-        $output .= $this->renderBulkActions($table);
 
         return $output;
     }

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1742,19 +1742,29 @@ tr.selected, tr.selected td, div.selected, td.selected {
     -webkit-transform: rotate(45deg);
 }
 
-.dataTable .bulkActionPanel {
+.bulkActionForm {
+    position: relative;
+}
+
+.bulkActionForm .bulkActionPanel {
     position:absolute;
     z-index:1;
-    bottom: -8px;
+    top: 44px;
     right: 0;
-    width: 100%;background: #9d7cc6;
+    width: 100%;
+    background: #9d7cc6;
     padding: 5px;
     box-sizing: border-box;
     border-top-right-radius: 3px;
     border-top-left-radius: 3px;
 }
 
-.dataTable .bulkActionCount {
+.bulkActionForm .bulkActionPanel .LV_validation_message {
+    position: absolute;
+    bottom: -14px;
+}
+
+.bulkActionForm .bulkActionCount {
     position: relative; 
     right: 10px;
     font-size:13px;
@@ -1762,12 +1772,12 @@ tr.selected, tr.selected td, div.selected, td.selected {
     color:#fff
 }
 
-.dataTable .bulkCheckbox {
+.bulkActionForm .bulkCheckbox {
     position: relative;
     text-align: center;
 }
 
-.dataTable .bulkCheckbox label {
+.bulkActionForm .bulkCheckbox label {
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
Fixed an issue where the hidden fields in a bulk action form were not properly showing/hiding after pagination.

Also fixed an issue with LiveValidation after pagination. The paginated data tables work by re-loading the table with an AJAX call. When this happened it was disconnecting the LV fields from the script that controls them, causing the LV to believe the form had been filled incorrectly. Fixed this by moving the bulk action form elements outside the data table, so they persist separate from the AJAX-reloaded part of the table.