### PR TITLE
System: fix html IDs of search forms

### DIFF
--- a/modules/Activities/activities_manage.php
+++ b/modules/Activities/activities_manage.php
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
     $paymentOn = getSettingByScope($connection2, 'Activities', 'payment') != 'None' and getSettingByScope($connection2, 'Activities', 'payment') != 'Single';
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth');
 
     $form->addHiddenValue('q', "/modules/".$_SESSION[$guid]['module']."/activities_manage.php");

--- a/modules/Activities/activities_view.php
+++ b/modules/Activities/activities_view.php
@@ -133,7 +133,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
 
             $search = isset($_GET['search'])? $_GET['search'] : null;
 
-            $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php','get');
+            $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php','get');
             $form->setClass('noIntBorder fullWidth');
 
             $form->addHiddenValue('q', "/modules/".$_SESSION[$guid]['module']."/activities_view.php");

--- a/modules/Finance/expenses_manage.php
+++ b/modules/Finance/expenses_manage.php
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage.ph
                         echo __($guid, 'Filters');
                         echo '</h3>';
 
-                        $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+                        $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
                         $form->setClass('noIntBorder fullWidth');
 
                         $form->addHiddenValue('q', '/modules/Finance/expenses_manage.php');

--- a/modules/Formal Assessment/externalAssessment.php
+++ b/modules/Formal Assessment/externalAssessment.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
     $search = isset($_GET['search'])? $_GET['search'] : '';
     $allStudents = isset($_GET['allStudents'])? $_GET['allStudents'] : '';
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth standardForm');
     
     $form->addHiddenValue('q', '/modules/Formal Assessment/externalAssessment.php');

--- a/modules/Individual Needs/iep_view_myChildren.php
+++ b/modules/Individual Needs/iep_view_myChildren.php
@@ -80,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/iep_view_
             echo 'Choose Student';
             echo '</h2>';
 
-            $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+            $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
             $form->setClass('noIntBorder fullWidth');
 
             $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/iep_view_myChildren.php');

--- a/modules/Individual Needs/in_view.php
+++ b/modules/Individual Needs/in_view.php
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_view.p
         echo __('Search');
         echo '</h2>';
 
-        $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+        $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
         $form->setClass('noIntBorder fullWidth');
 
         $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/in_view.php');

--- a/modules/Library/library_browse.php
+++ b/modules/Library/library_browse.php
@@ -164,7 +164,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
     }, array());
 
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth borderGrey');
 
     $form->addHiddenValue('q', '/modules/Library/library_browse.php');

--- a/modules/Library/library_manage_catalog.php
+++ b/modules/Library/library_manage_catalog.php
@@ -95,7 +95,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
         }
     }
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->setClass('noIntBorder fullWidth');
 

--- a/modules/Markbook/markbook_edit.php
+++ b/modules/Markbook/markbook_edit.php
@@ -257,7 +257,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
                     echo __($guid, 'Copy Markbook Columns');
                     echo '</h1>';
 
-                    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Markbook/markbook_edit_copy.php&gibbonCourseClassID='.$gibbonCourseClassID);
+                    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Markbook/markbook_edit_copy.php&gibbonCourseClassID='.$gibbonCourseClassID);
                     $form->setFactory(DatabaseFormFactory::create($pdo));
                     $form->setClass('noIntBorder fullWidth');
 

--- a/modules/Markbook/moduleFunctions.php
+++ b/modules/Markbook/moduleFunctions.php
@@ -31,7 +31,7 @@ function sidebarExtra($guid, $pdo, $gibbonPersonID, $gibbonCourseClassID = '', $
     $output .= __($guid, 'Choose A Class');
     $output .= '</h2>';
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->addHiddenValue('q', '/modules/Markbook/'.$basePage);
     
@@ -59,7 +59,7 @@ function classChooser($guid, $pdo, $gibbonCourseClassID)
     $output .= __($guid, 'Choose Class');
     $output .= '</h3>';
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->setClass('noIntBorder fullWidth');
 

--- a/modules/Markbook/weighting_manage.php
+++ b/modules/Markbook/weighting_manage.php
@@ -273,7 +273,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.
                 echo __($guid, 'Copy Weightings');
                 echo '</h3>';
 
-                $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/weighting_manage_copyProcess.php?gibbonCourseClassID='.$gibbonCourseClassID);
+                $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/weighting_manage_copyProcess.php?gibbonCourseClassID='.$gibbonCourseClassID);
                 $form->setFactory(DatabaseFormFactory::create($pdo));
                 $form->setClass('noIntBorder fullWidth');
 

--- a/modules/Messenger/messenger_manage.php
+++ b/modules/Messenger/messenger_manage.php
@@ -58,7 +58,7 @@ else {
 
 		$search = isset($_GET['search'])? $_GET['search'] : '';
 
-		$form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+		$form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
 		$form->setClass('noIntBorder fullWidth');
 
 		$form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/messenger_manage.php');

--- a/modules/Planner/curriculumMapping_outcomesByCourse.php
+++ b/modules/Planner/curriculumMapping_outcomesByCourse.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/curriculumMapping_
 
     $gibbonCourseID = isset($_GET['gibbonCourseID'])? $_GET['gibbonCourseID'] : null;
 
-	$form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+	$form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
 
 	$form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/curriculumMapping_outcomesByCourse.php');
 

--- a/modules/Planner/report_parentWeeklyEmailSummaryConfirmation.php
+++ b/modules/Planner/report_parentWeeklyEmailSummaryConfirmation.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/report_parentWeekl
     $gibbonRollGroupID = isset($_GET['gibbonRollGroupID'])? $_GET['gibbonRollGroupID'] : null;
     $weekOfYear = isset($_GET['weekOfYear'])? $_GET['weekOfYear'] : null;
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setFactory(DatabaseFormFactory::create($pdo));
 
     $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/report_parentWeeklyEmailSummaryConfirmation.php');

--- a/modules/Planner/report_workSummary_byRollGroup.php
+++ b/modules/Planner/report_workSummary_byRollGroup.php
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/report_workSummary
 
     $gibbonRollGroupID = isset($_GET['gibbonRollGroupID'])? $_GET['gibbonRollGroupID'] : null;
 
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setFactory(DatabaseFormFactory::create($pdo));
 
     $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/report_workSummary_byRollGroup.php');

--- a/modules/Students/applicationForm_manage.php
+++ b/modules/Students/applicationForm_manage.php
@@ -101,7 +101,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         echo __($guid, 'Search');
         echo '</h2>';
 
-        $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+        $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
 
         $form->setClass('noIntBorder fullWidth');
         $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/applicationForm_manage.php');

--- a/modules/Students/studentEnrolment_manage.php
+++ b/modules/Students/studentEnrolment_manage.php
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
         echo __('Search');
         echo '</h3>';
 
-        $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php','get');
+        $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php','get');
         $form->setClass('noIntBorder fullWidth');
 
         $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/studentEnrolment_manage.php');

--- a/modules/System Admin/stringReplacement_manage.php
+++ b/modules/System Admin/stringReplacement_manage.php
@@ -51,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     echo __('Search');
     echo '</h2>';
     
-    $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
     $form->setClass('noIntBorder fullWidth');
     
     $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/stringReplacement_manage.php');

--- a/modules/Timetable Admin/courseEnrolment_manage.php
+++ b/modules/Timetable Admin/courseEnrolment_manage.php
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         echo __('Filters');
         echo '</h3>'; 
         
-        $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+        $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
         $form->setFactory(DatabaseFormFactory::create($pdo));
 
         $form->setClass('noIntBorder fullWidth');

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         echo __('Filters');
         echo '</h3>'; 
         
-        $form = Form::create('search', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+        $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
         $form->setClass('noIntBorder fullWidth');
 
         $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/courseEnrolment_manage_byPerson.php');


### PR DESCRIPTION
Fixes a minor issue where the HTML id attribute for search `<form>`s were the same ID as the search `<input>`s, causing LiveValidation to silently fail for that form.