### PR TITLE
User Admin: fix display of student name and status in Rollover

### DIFF
--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -172,11 +172,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                     $header->addContent(__('New Class'));
 
                 foreach ($currentCourses as $gibbonCourseClassID => $course) {
+                    $gibbonCourseClassIDNext = isset($course['gibbonCourseClassIDNext'])? $course['gibbonCourseClassIDNext'] : '';
+
                     $row = $table->addRow();
                         $row->addContent($course['course'].'.'.$course['class']);
                         $row->addSelect('gibbonCourseClassIDNext['.$gibbonCourseClassID.']')
                             ->fromArray($nextCourses)
-                            ->selected($course['gibbonCourseClassIDNext'])
+                            ->selected($gibbonCourseClassIDNext)
                             ->placeholder()
                             ->setClass('mediumWidth');
                 }

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -346,7 +346,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                                 $form->addHiddenValue($count."-enrolFull-gibbonPersonID", $student[0]);
                                 $row = $form->addRow();
-                                    $row->addColumn()->addContent(formatName('', $student[1], $student[2], 'Student', true));
+                                    $row->addColumn()->addContent(formatName('', $student[2], $student[1], 'Student', true));
                                     $row->addColumn()->addContent(__($student[3]));
                                     $column = $row->addColumn();
                                         $column->addCheckbox($count."-enrolFull-enrol")->setValue('Y')->checked('Y');
@@ -461,7 +461,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                         $row = $form->addRow();
                             $row->addColumn()->addContent(formatName('', $rowFinal['preferredName'], $rowFinal['surname'], 'Student', true));
                             $row->addColumn()->addContent(__($rowFinal['name']));
-                            $row->addColumn()->addContent(__('Expected'));
+                            $row->addColumn()->addContent(__('Full'));
                             $column = $row->addColumn();
                                 $column->addSelect($count."-final-status")->fromArray($statuses)->isRequired()->setClass('shortWidth floatNone')->selected('Left');
                     }


### PR DESCRIPTION
**Bug Fix**

- The surname & preferred name in 'Enrol New Students (Status Full)' were reversed
- The current status in 'Set Final Year Students To Left' was listed as Expected rather than Full