### PR TITLE
Staff: add a Mark as Left bulk action to Manage Staff 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ v17.0.00
         Markbook: fixed bug in handling personalised attainment targets when using scales other than class scale
         Markbook: removed WordPress Comment Push functionality
         Planner: added SMTP persistence to weekly summary CLI script
+        Staff: added a Mark as Left bulk action to Manage Staff
         System: fixed IE incompatibility with javascript and select inputs
         System: added the option to display all records in a paginated table
         System: fixed an issue with hidden fields in bulk action forms after pagination

--- a/modules/Staff/staff_manage.php
+++ b/modules/Staff/staff_manage.php
@@ -88,6 +88,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
         ->addParam('search', $search)
         ->displayLabel();
 
+    $table->modifyRows(function($person, $row) {
+        if (!empty($person['status']) && $person['status'] != 'Full') $row->addClass('error');
+        return $row;
+    });
+
     $table->addMetaData('filterOptions', [
         'all:on'          => __('All Staff'),
         'type:teaching'   => __('Staff Type').': '.__('Teaching'),

--- a/modules/Staff/staff_manage.php
+++ b/modules/Staff/staff_manage.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
+use Gibbon\Forms\Prefab\BulkActionForm;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Staff\StaffGateway;
 
@@ -80,8 +81,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
 
     $staff = $staffGateway->queryAllStaff($criteria);
 
+    // FORM
+    $form = BulkActionForm::create('bulkAction', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/staff_manageProcessBulk.php?search='.$search.'&allStaff='.$allStaff);
+    $form->addHiddenValue('search', $search);
+
+    $bulkActions = array(
+        'Left' => __('Mark as Left'),
+    );
+
+    $col = $form->createBulkActionColumn($bulkActions);
+        $col->addDate('dateEnd')
+            ->placeholder(__('Date End'))
+            ->setClass('shortWidth dateEnd');
+        $col->addSubmit(__('Go'));
+
+    $form->toggleVisibilityByClass('dateEnd')->onSelect('action')->when('Left');
+
+
     // DATA TABLE
-    $table = DataTable::createPaginated('staffManage', $criteria);
+    $table = $form->addRow()->addDataTable('staffManage', $criteria)->withData($staff);
 
     $table->addHeaderAction('add', __('Add'))
         ->setURL('/modules/Staff/staff_manage_add.php')
@@ -102,6 +120,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
         'status:left'     => __('Status').': '.__('Left'),
         'status:expected' => __('Status').': '.__('Expected'),
     ]);
+
+    $table->addMetaData('bulkActions', $col);
 
     // COLUMNS
     $table->addColumn('fullName', __('Name'))
@@ -129,5 +149,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
                     ->setURL('/modules/Staff/staff_manage_delete.php');
         });
 
-    echo $table->render($staff);
+    $table->addCheckboxColumn('gibbonStaffID');
+
+    echo $form->getOutput();
 }

--- a/modules/Staff/staff_manageProcessBulk.php
+++ b/modules/Staff/staff_manageProcessBulk.php
@@ -1,0 +1,62 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+include '../../gibbon.php';
+
+$action = isset($_POST['action']) ? $_POST['action'] : '';
+$gibbonStaffID = isset($_POST['gibbonStaffID']) ? $_POST['gibbonStaffID'] : array();
+$dateEnd = isset($_POST['dateEnd']) ? dateConvert($guid, $_POST['dateEnd']) : '';
+
+$allStaff = isset($_GET['allStaff']) ? $_GET['allStaff'] : '';
+$search = isset($_GET['search']) ? $_GET['search'] : '';
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address'])."/staff_manage.php&search=$search&allStaff=$allStaff";
+
+if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    //Proceed!
+    if (empty($action) || empty($gibbonStaffID)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+    } else {
+        $gibbonStaffIDList = is_array($gibbonStaffID)? implode(',', $gibbonStaffID) : $gibbonStaffID;
+
+        if ($action == 'Left') {
+            $data = array('gibbonStaffIDList' => $gibbonStaffIDList, 'dateEnd' => $dateEnd);
+            $sql = "UPDATE gibbonStaff 
+                    JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonStaff.gibbonPersonID) 
+                    SET gibbonPerson.status='Left', gibbonPerson.dateEnd=:dateEnd
+                    WHERE FIND_IN_SET(gibbonStaffID, :gibbonStaffIDList)";
+
+            $updated = $pdo->update($sql, $data);
+
+            if ($pdo->getQuerySuccess() == false){
+                $URL .= '&return=error2';
+                header("Location: {$URL}");
+                exit();
+            }
+        }
+
+        $URL .= '&return=success0';
+        header("Location: {$URL}");
+        exit();
+    }
+}


### PR DESCRIPTION
**New Feature**

## Description
Adds a bulk action form to the Manage Staff page, with a Mark as Left action. This will set any selected staff members status to Left and update their End Date with the date provided.

## Motivation and Context
Any time there's a changeover in staff, such as the end of year, it's helpful to be able to see the full list of staff members and check off any that have left in one action.

Also adds a row highlight based on user status to make checking the list of active staff easier.