### PR TITLE
Data Updater: fix an SQL aggregation related issue in updater history

### DIFF
--- a/src/Domain/DataUpdater/FamilyUpdateGateway.php
+++ b/src/Domain/DataUpdater/FamilyUpdateGateway.php
@@ -67,9 +67,12 @@ class FamilyUpdateGateway extends QueryableGateway
             ->newQuery()
             ->from('gibbonFamily')
             ->cols([
-                'gibbonFamily.gibbonFamilyID', 'gibbonFamily.name as familyName', 'gibbonFamilyUpdate.timestamp as familyUpdate', 
+                'gibbonFamily.gibbonFamilyID', 
+                'gibbonFamily.name as familyName', 
+                'MAX(gibbonFamilyUpdate.timestamp) as familyUpdate', 
                 "MIN(IFNULL(gibbonPerson.dateStart, '0000-00-00')) as earliestDateStart",
                 "MAX(IFNULL(gibbonPerson.dateEnd, NOW())) as latestEndDate",
+                'gibbonFamilyUpdate.gibbonFamilyUpdateID'
             ])
             ->innerJoin('gibbonFamilyChild', 'gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID')
             ->innerJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonFamilyChild.gibbonPersonID')
@@ -85,9 +88,8 @@ class FamilyUpdateGateway extends QueryableGateway
 
         $criteria->addFilterRules([
             'cutoff' => function ($query, $cutoffDate) {
-                $query->where('(gibbonFamilyUpdateID IS NULL OR gibbonFamilyUpdate.timestamp < :cutoffDate)');
+                $query->having("(gibbonFamilyUpdateID IS NULL OR familyUpdate < :cutoffDate) AND (earliestDateStart < :cutoffDate)");
                 $query->bindValue('cutoffDate', $cutoffDate);
-                $query->having('earliestDateStart < :cutoffDate');
             },
         ]);
 

--- a/src/Domain/DataUpdater/PersonUpdateGateway.php
+++ b/src/Domain/DataUpdater/PersonUpdateGateway.php
@@ -65,9 +65,15 @@ class PersonUpdateGateway extends QueryableGateway
             ->newQuery()
             ->from('gibbonPerson')
             ->cols([
-                'gibbonPerson.gibbonPersonID', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonPerson.gibbonPersonID', 'gibbonRollGroup.name as rollGroupName', 
-                'MAX(gibbonPersonUpdate.timestamp) as personalUpdate', 
-                'MAX(gibbonPersonMedicalUpdate.timestamp) as medicalUpdate'
+                'gibbonPerson.gibbonPersonID', 
+                'gibbonPerson.surname', 
+                'gibbonPerson.preferredName', 
+                'gibbonPerson.gibbonPersonID', 
+                'gibbonRollGroup.name as rollGroupName', 
+                'gibbonPersonUpdate.gibbonPersonUpdateID', 
+                'gibbonPersonMedicalUpdate.gibbonPersonMedicalUpdateID', 
+                "MAX(gibbonPersonUpdate.timestamp) as personalUpdate", 
+                "MAX(gibbonPersonMedicalUpdate.timestamp) as medicalUpdate"
             ])
             ->innerJoin('gibbonStudentEnrolment', 'gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
             ->innerJoin('gibbonRollGroup', 'gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID')
@@ -83,11 +89,8 @@ class PersonUpdateGateway extends QueryableGateway
 
         $criteria->addFilterRules([
             'cutoff' => function ($query, $cutoffDate) {
-                $query->where(function($query) {
-                    $query->where('(gibbonPersonUpdateID IS NULL OR gibbonPersonUpdate.timestamp < :cutoffDate)')
-                          ->orWhere('(gibbonPersonMedicalUpdateID IS NULL OR gibbonPersonMedicalUpdate.timestamp < :cutoffDate)');
-                });
-
+                $query->having("((gibbonPersonUpdateID IS NULL OR personalUpdate < :cutoffDate)
+                    OR (gibbonPersonMedicalUpdateID IS NULL OR medicalUpdate < :cutoffDate))");
                 $query->bindValue('cutoffDate', $cutoffDate);
             },
         ]);


### PR DESCRIPTION
I'm not sure I was 100% able to reproduce the issue, but I did take a close look at the query and made some changes. Previously it was comparing the timestamp in a GROUP BY query, so the field being compared needed wrapped in a group aggregate function (eg: MAX()). This then changed the conditional for the cutoff from a WHERE to a HAVING.