### PR TITLE
Students: fix read-only student field in Edit Student Enrolment

### DIFF
--- a/modules/Students/studentEnrolment_manage_edit.php
+++ b/modules/Students/studentEnrolment_manage_edit.php
@@ -72,6 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonStudentEnrolmentID', $gibbonStudentEnrolmentID);
+            $form->addHiddenValue('gibbonPersonID', $values['gibbonPersonID']);
             $form->addHiddenValue('gibbonRollGroupIDOriginal', $values['gibbonRollGroupID']);
 
             $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
@@ -85,8 +86,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
                 $row->addTextField('yearName')->readOnly()->maxLength(20)->setValue($schoolYearName);
 
             $row = $form->addRow();
-                $row->addLabel('gibbonPersonID', __('Student'));
-                $row->addSelectStudent('gibbonPersonID', $gibbonSchoolYearID, array('allStudents' => true))->isRequired()->placeholder();
+                $row->addLabel('studentName', __('Student'));
+                $row->addTextField('studentName')->readOnly()->setValue(formatName('', $values['preferredName'], $values['surname'], 'Student', true));
 
             $row = $form->addRow();
                 $row->addLabel('gibbonYearGroupID', __('Year Group'));


### PR DESCRIPTION
**:bug: Post-oofication Bug Fix**

When editing enrolments the selected student should be read-only, and was in the past.