### PR TITLE
Test: Ignore additional test environment file

### DIFF
--- a/tests/config/envs/.gitignore
+++ b/tests/config/envs/.gitignore
@@ -1,0 +1,2 @@
+*.yml
+!travis_ci.yml


### PR DESCRIPTION
## Description
To ignore `*.yml` in `tests/config/envs/` except `travis_ci.yml`.

## Motivation and Context
Codeception test framework allow setting up multiple testing environment. It is helpful if a developer can define his own environment file for testing on local machine. But the local test files would contain local database information, which are not supposed to be commit and push anywhere.

Adding the `.gitignore` file would prevent accidentally adding such file and submit to the internet.

## How Has This Been Tested?
1. Unit test pass.
2. But seriously, it is only a `.gitignore` file.