### PR TITLE
Messenger: update logic for Staff selected via the Year Group target

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ v17.0.00
         Messenger: added row colouring to By Roll Group report, and made it default view
         Messenger: amended default confirmLink text in New Message
         Messenger: added missing Group target information into Manage Messages view
+        Messenger: updated the Year Group target for Staff to only include tutors and teachers of courses in the same year group
         Planner: added SMTP persistence to weekly summary CLI script
         Planner: improved accessibility of link from Scope & Sequence to Dump Unit
         Planner: fixed school year name on Edit Unit page

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -291,7 +291,7 @@ else {
 		//Year group
 		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_yearGroups_any")) {
 			$row = $form->addRow();
-				$row->addLabel('yearGroup', __('Year Group'))->description(__('Students in year; all staff.'));
+				$row->addLabel('yearGroup', __('Year Group'))->description(__('Students in year; staff by tutors and courses taught.'));
 				$row->addYesNoRadio('yearGroup')->checked('N')->isRequired();
 
 			$form->toggleVisibilityByClass('yearGroup')->onRadio('yearGroup')->when('Y');

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -376,8 +376,27 @@ else {
 							if ($email=="Y") {
 								if ($staff=="Y") {
 									try {
-										$dataEmail=array();
-										$sqlEmail="SELECT DISTINCT email, gibbonPerson.gibbonPersonID FROM gibbonPerson JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE NOT email='' AND status='Full'" ;
+										$dataEmail=array('gibbonSchoolYearID'=>$_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonYearGroupID'=>$t);
+										$sqlEmail="(SELECT DISTINCT email, gibbonPerson.gibbonPersonID 
+                                            FROM gibbonPerson 
+                                            JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) 
+                                            JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonStaff.gibbonPersonID)
+                                            JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID)
+                                            JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
+                                            WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID
+                                            AND FIND_IN_SET(:gibbonYearGroupID, gibbonCourse.gibbonYearGroupIDList)
+                                            AND NOT gibbonPerson.email='' 
+                                            AND gibbonPerson.status='Full')
+                                        UNION ALL (
+                                            SELECT DISTINCT email, gibbonPerson.gibbonPersonID 
+                                            FROM gibbonPerson 
+                                            JOIN gibbonRollGroup ON (gibbonRollGroup.gibbonPersonIDTutor=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor2=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor3=gibbonPerson.gibbonPersonID) 
+                                            JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                                            WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID
+                                            AND NOT email='' AND status='Full' 
+                                            AND gibbonStudentEnrolment.gibbonYearGroupID=:gibbonYearGroupID
+                                            GROUP BY gibbonPerson.gibbonPersonID
+                                        )" ;
 										$resultEmail=$connection2->prepare($sqlEmail);
 										$resultEmail->execute($dataEmail);
 									}


### PR DESCRIPTION
In Messenger, the Year Group target for Staff was including all staff in the system. This updates the logic to look for year group associations by two criteria: teaching a course for that year group, or a form group tutor of any student in that year group.

This tweak doesn't remove any capabilities, as the Role Category target for Staff can still be used if someone wishes to target all staff in the system.