### PR TITLE
Tables: add ability to create nested columns, Activity Spread by Roll Group ooification

### DIFF
--- a/modules/Activities/report_activitySpread_rollGroup.php
+++ b/modules/Activities/report_activitySpread_rollGroup.php
@@ -20,8 +20,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Services\Format;
-use Gibbon\Tables\DataTable;
+use Gibbon\Tables\Prefab\ReportTable;
 use Gibbon\Domain\Activities\ActivityReportGateway;
+use Gibbon\Domain\Students\StudentGateway;
 
 //Module includes
 include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
@@ -33,9 +34,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
     echo '</div>';
 } else {
     //Proceed!
-
     $gibbonRollGroupID = isset($_GET['gibbonRollGroupID'])? $_GET['gibbonRollGroupID'] : null;
     $status = isset($_GET['status'])? $_GET['status'] : null;
+    $dateType = getSettingByScope($connection2, 'Activities', 'dateType');
 
     $viewMode = isset($_REQUEST['format']) ? $_REQUEST['format'] : '';
 
@@ -70,204 +71,74 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
         echo $form->getOutput();
     }
 
-    if ($gibbonRollGroupID != '') {
+    if (empty($gibbonRollGroupID)) return;
 
-        $activityGateway = $container->get(ActivityReportGateway::class);
+    $activityGateway = $container->get(ActivityReportGateway::class);
+    $studentGateway = $container->get(StudentGateway::class);
 
-        // CRITERIA
-        $criteria = $activityGateway->newQueryCriteria()
-            ->searchBy($activityGateway->getSearchableColumns(), isset($_GET['search'])? $_GET['search'] : '')
-            // ->sortBy('gibbonActivity.name')
-            ->pageSize(!empty($viewMode) ? 0 : 50)
-            ->fromArray($_POST);
+    // CRITERIA
+    $criteria = $activityGateway->newQueryCriteria()
+        ->searchBy($activityGateway->getSearchableColumns(), isset($_GET['search'])? $_GET['search'] : '')
+        ->sortBy(['surname', 'preferredName'])
+        ->pageSize(!empty($viewMode) ? 0 : 50)
+        ->fromArray($_POST);
 
-        $activities = $activityGateway->queryActivitySpreadByRollGroup($criteria, $gibbonRollGroupID);
+    $rollGroups = $studentGateway->queryStudentEnrolmentByRollGroup($criteria, $gibbonRollGroupID);
 
-        // DATA TABLE
-        $table = DataTable::createReport('activities', $criteria, $viewMode, $guid);
+    // Join a set of activity counts per student
+    $rollGroups->transform(function(&$student) use ($activityGateway, $dateType, $status) {
+        $activityCounts = $activityGateway->selectActivitySpreadByStudent($student['gibbonSchoolYearID'], $student['gibbonPersonID'], $dateType, $status);
+        $student['activities'] = $activityCounts->fetchGroupedUnique();
+    });
 
-        $table->addColumn('rollGroup', __('Roll Group'));
-        $group = $table->addColumn('thing', __('Thing'));
-            $group->addColumn('A1', __('A1'));
-            $group->addColumn('A2', __('A2'));
-            $group->addColumn('A3', __('A3'));
+    // DATA TABLE
+    $table = ReportTable::createPaginated('activitySpread_rollGroup', $criteria)->setViewMode($viewMode, $gibbon->session);
 
-            $group2 = $group->addColumn('A4', __('A4'));
-                $group2->addColumn('B1', __('B1'));
-                $group2->addColumn('B2', __('B2'));
+    $table->setTitle(__('Activity Spread by Roll Group'));
 
-                $group2B = $group2->addColumn('B3', __('B3'));
-                $group2B->addColumn('X1', __('X1'));
-                $group2B->addColumn('X2', __('X2'));
+    $table->addColumn('rollGroup', __('Roll Group'))->width('10%');
+    $table->addColumn('student', __('Student'))
+        ->sortable(['surname', 'preferredName'])
+        ->format(function ($student) use ($guid) {
+            $name = Format::name('', $student['preferredName'], $student['surname'], 'Student', true);
+            return Format::link($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$student['gibbonPersonID'].'&subpage=Activities', $name);
+        });
 
-        $table->addColumn('thing2', __('Thing2'));
+    // Build a reusable formatter for activity counts
+    $displayActivityCount = function($student, $key) {
+        $count = isset($student['activities'][$key])? $student['activities'][$key]['count'] : 0;
+        $title = ($count > 0) ? $student['activities'][$key]['activityNames'] : __('There are no records to display.');
+        $extra = ($count > 0 && $student['activities'][$key]['notAccepted'] > 0) ? "<span style='color: #cc0000' title='".__('Some activities not accepted.')."'> *</span>" : '';
 
-        $group3 = $table->addColumn('thing3', __('Thing3'));
-            $group3->addColumn('C1', __('C1'));
-            $group3->addColumn('C2', __('C2'));
+        return '<span title="'.$title.'">'.$count.$extra.'</span>';
+    };
 
-            $group3B = $group3->addColumn('C3', __('C3'));
-                $group3B->addColumn('E1', __('E1'));
-                $group3B->addColumn('E2', __('E2'));
-
-        $group4 = $table->addColumn('thing4', __('Thing4'));
-            $group4->addColumn('D1', __('D1'));
-            $group4->addColumn('D2', __('D2'));
-            $group4->addColumn('D3', __('D3'));
-
-        echo $table->render($activities);
-
-        $output = ''; 
-
-        echo '<h2>';
-        echo __('Report Data');
-        echo '</h2>';
-
-        try {
-            $data = array('gibbonRollGroupID' => $gibbonRollGroupID);
-            $sql = "SELECT gibbonPerson.gibbonPersonID, surname, preferredName, name FROM gibbonPerson JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) WHERE status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') AND gibbonStudentEnrolment.gibbonRollGroupID=:gibbonRollGroupID ORDER BY surname, preferredName";
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
+    if ($dateType == 'Term') {
+        // Group the activity spread by term & weekday
+        $terms = $activityGateway->selectActivityWeekdaysPerTerm($_SESSION[$guid]['gibbonSchoolYearID'])->fetchGrouped();
+        foreach ($terms as $termName => $days) {
+            $termColumn = $table->addColumn($termName, $termName);
+            foreach ($days as $day) {
+                $termColumn->addColumn($day['nameShort'], $day['nameShort'])
+                    ->notSortable()
+                    ->format(function($student) use ($displayActivityCount, $day) {
+                        $key = $day['gibbonSchoolYearTermID'].'-'.$day['gibbonDaysOfWeekID'];
+                        return $displayActivityCount($student, $key);
+                    });
+            }
         }
-
-        if ($result->rowCount() < 1) {
-            echo "<div class='error'>";
-            echo __($guid, 'There are no records to display.');
-            echo '</div>';
-        } else {
-            echo "<table class='mini' cellspacing='0' style='width: 100%'>";
-            echo "<tr class='head'>";
-            echo '<th rowspan=2>';
-            echo __($guid, 'Roll Group');
-            echo '</th>';
-            echo '<th rowspan=2>';
-            echo __($guid, 'Student');
-            echo '</th>';
-                    //Get terms and days of week
-                    $terms = getTerms($connection2, $_SESSION[$guid]['gibbonSchoolYearID']);
-            $days = false;
-
-            try {
-                $dataDays = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-                $sqlDays = "SELECT DISTINCT gibbonDaysOfWeek.* FROM gibbonDaysOfWeek JOIN gibbonActivitySlot ON (gibbonActivitySlot.gibbonDaysOfWeekID=gibbonDaysOfWeek.gibbonDaysOfWeekID) JOIN gibbonActivity ON (gibbonActivitySlot.gibbonActivityID=gibbonActivity.gibbonActivityID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND schoolDay='Y' ORDER BY sequenceNumber";
-                $resultDays = $connection2->prepare($sqlDays);
-                $resultDays->execute($dataDays);
-            } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
-            }
-
-            while ($rowDays = $resultDays->fetch()) {
-                $days = $days.$rowDays['gibbonDaysOfWeekID'].',';
-                $days = $days.$rowDays['nameShort'].',';
-            }
-            if ($days != false) {
-                $days = substr($days, 0, (strlen($days) - 1));
-                $days = explode(',', $days);
-            }
-
-			//Create columns
-			$columns = array();
-            $columnCount = 0;
-            for ($i = 0; $i < count($terms); $i = $i + 2) {
-                echo '<th colspan='.count($days) / 2 .'>';
-                echo $terms[($i + 1)];
-                echo '</th>';
-            }
-            echo '</tr>';
-            echo "<tr class='head'>";
-            for ($i = 0; $i < count($terms); $i = $i + 2) {
-                for ($j = 0; $j < count($days); $j = $j + 2) {
-                    echo '<th>';
-                    echo __($guid, $days[($j + 1)]);
-                    $columns[$columnCount][0] = $terms[$i];
-                    $columns[$columnCount][1] = $days[$j];
-                    ++$columnCount;
-                    echo '</th>';
-                }
-            }
-            echo '</tr>';
-
-            $count = 0;
-            $rowNum = 'odd';
-            while ($row = $result->fetch()) {
-                if ($count % 2 == 0) {
-                    $rowNum = 'even';
-                } else {
-                    $rowNum = 'odd';
-                }
-                ++$count;
-
-				//COLOR ROW BY STATUS!
-				echo "<tr class=$rowNum>";
-                echo '<td>';
-                echo $row['name'];
-                echo '</td>';
-                echo '<td>';
-				//List activities seleted in title of student name
-				try {
-					$dataActivities = array('gibbonPersonID' => $row['gibbonPersonID'], 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-					$sqlActivities = "SELECT gibbonActivity.* FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivity.gibbonActivityID=gibbonActivityStudent.gibbonActivityID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND NOT status='Not Accepted' ORDER BY name";
-					$resultActivities = $connection2->prepare($sqlActivities);
-					$resultActivities->execute($dataActivities);
-				} catch (PDOException $e) {
-					echo "<div class='error'>".$e->getMessage().'</div>';
-				}
-
-                $title = '';
-                while ($rowActivities = $resultActivities->fetch()) {
-                    $title = $title.$rowActivities['name'].' | ';
-                }
-                $title = substr($title, 0, -3);
-                echo "<span title='$title'>".formatName('', $row['preferredName'], $row['surname'], 'Student', true).'</span>';
-                echo '</td>';
-                for ($i = 0; $i < $columnCount; ++$i) {
-                    echo '<td>';
-                    try {
-                        $dataReg = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $row['gibbonPersonID'], 'gibbonDaysOfWeekID' => $columns[$i][1], 'gibbonSchoolYearTermIDList' => '%'.$columns[$i][0].'%');
-                        if ($_GET['status'] == 'Accepted') {
-                            $sqlReg = "SELECT DISTINCT gibbonActivity.name, gibbonActivityStudent.status FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivityStudent.gibbonActivityID=gibbonActivity.gibbonActivityID) JOIN gibbonActivitySlot ON (gibbonActivitySlot.gibbonActivityID=gibbonActivity.gibbonActivityID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID AND gibbonDaysOfWeekID=:gibbonDaysOfWeekID AND gibbonSchoolYearTermIDList LIKE :gibbonSchoolYearTermIDList AND status='Accepted'";
-                        } else {
-                            $sqlReg = "SELECT DISTINCT gibbonActivity.name, gibbonActivityStudent.status FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivityStudent.gibbonActivityID=gibbonActivity.gibbonActivityID) JOIN gibbonActivitySlot ON (gibbonActivitySlot.gibbonActivityID=gibbonActivity.gibbonActivityID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonID=:gibbonPersonID AND gibbonDaysOfWeekID=:gibbonDaysOfWeekID AND gibbonSchoolYearTermIDList LIKE :gibbonSchoolYearTermIDList AND NOT status='Not Accepted'";
-                        }
-                        $resultReg = $connection2->prepare($sqlReg);
-                        $resultReg->execute($dataReg);
-                    } catch (PDOException $e) {
-                        echo "<div class='error'>".$e->getMessage().'</div>';
-                    }
-
-                    $title = '';
-                    $notAccepted = false;
-                    while ($rowReg = $resultReg->fetch()) {
-                        $title .= $rowReg['name'].', ';
-                        if ($rowReg['status'] != 'Accepted') {
-                            $notAccepted = true;
-                        }
-                    }
-                    if ($title == '') {
-                        $title = __($guid, 'There are no records to display.');
-                    } else {
-                        $title = substr($title, 0, -2);
-                    }
-                    echo "<span title='".htmlPrep($title)."'>".$resultReg->rowCount().'<span>';
-                    if ($notAccepted == true and $_GET['status'] == 'Registered') {
-                        echo "<span style='color: #cc0000' title='".__($guid, 'Some activities not accepted.')."'> *</span>";
-                    }
-                    echo '</td>';
-                }
-
-                echo '</tr>';
-            }
-            if ($count == 0) {
-                echo "<tr class=$rowNum>";
-                echo '<td colspan=2>';
-                echo __($guid, 'There are no records to display.');
-                echo '</td>';
-                echo '</tr>';
-            }
-            echo '</table>';
+    } else {
+        // Group the activity spread by weekday only
+        $days = $activityGateway->selectActivityWeekdays($_SESSION[$guid]['gibbonSchoolYearID'])->fetchAll();
+        foreach ($days as $day) {
+            $table->addColumn($day['nameShort'], $day['nameShort'])
+                ->notSortable()
+                ->format(function($student) use ($displayActivityCount, $day) {
+                    $key = $day['gibbonDaysOfWeekID'];
+                    return $displayActivityCount($student, $key);
+                });
         }
     }
+
+    echo $table->render($rollGroups);
 }
-?>

--- a/src/Domain/Activities/ActivityReportGateway.php
+++ b/src/Domain/Activities/ActivityReportGateway.php
@@ -83,4 +83,20 @@ class ActivityReportGateway extends QueryableGateway
 
         return $this->runQuery($query, $criteria);
     }
+
+    public function queryActivitySpreadByRollGroup(QueryCriteria $criteria, $gibbonRollGroupID)
+    {
+        $query = $this
+            ->newQuery()
+            ->from('gibbonPerson')
+            ->cols([
+                'gibbonPerson.gibbonPersonID', 'surname', 'preferredName', 'gibbonRollGroup.name as rollGroup'
+            ])
+            ->leftJoin('gibbonStudentEnrolment', 'gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
+            ->leftJoin('gibbonRollGroup', 'gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID')
+            ->where('gibbonStudentEnrolment.gibbonRollGroupID=:gibbonRollGroupID')
+            ->bindValue('gibbonRollGroupID', $gibbonRollGroupID);
+
+        return $this->runQuery($query, $criteria);
+    }
 }

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -104,6 +104,25 @@ class StudentGateway extends QueryableGateway
         return $this->runQuery($query, $criteria);
     }
 
+    public function queryStudentEnrolmentByRollGroup(QueryCriteria $criteria, $gibbonRollGroupID)
+    {
+        $query = $this
+            ->newQuery()
+            ->from('gibbonPerson')
+            ->cols([
+                'gibbonPerson.gibbonPersonID', 'gibbonStudentEnrolmentID', 'gibbonStudentEnrolment.gibbonSchoolYearID', 'gibbonPerson.title', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'gibbonPerson.image_240', 'gibbonYearGroup.nameShort AS yearGroup', 'gibbonRollGroup.nameShort AS rollGroup', 'gibbonStudentEnrolment.rollOrder', 'gibbonPerson.dateStart', 'gibbonPerson.dateEnd', 'gibbonPerson.status', "'Student' as roleCategory"
+            ])
+            ->innerJoin('gibbonStudentEnrolment', 'gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
+            ->innerJoin('gibbonYearGroup', 'gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID')
+            ->innerJoin('gibbonRollGroup', 'gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID')
+            ->where('gibbonStudentEnrolment.gibbonRollGroupID = :gibbonRollGroupID')
+            ->bindValue('gibbonRollGroupID', $gibbonRollGroupID);
+
+        $criteria->addFilterRules($this->getSharedUserFilterRules());
+
+        return $this->runQuery($query, $criteria);
+    }
+
     public function queryStudentsAndTeachersBySchoolYear(QueryCriteria $criteria, $gibbonSchoolYearID) 
     {
         $query = $this

--- a/src/Tables/Columns/Column.php
+++ b/src/Tables/Columns/Column.php
@@ -240,11 +240,11 @@ class Column
     {
         if (!$this->hasNestedColumns()) return 1;
 
-        $depth = $this->getDepth();
+        $depth = 1;
         foreach ($this->getColumns() as $column) {
             $depth = max($depth, $column->getTotalDepth());
         }
-
+        
         return $depth + 1;
     }
 

--- a/src/Tables/Columns/Column.php
+++ b/src/Tables/Columns/Column.php
@@ -34,16 +34,19 @@ class Column
     protected $label;
     protected $description;
     protected $width = 'auto';
+    protected $depth = 0;
     protected $sortable = false;
     protected $formatter;
 
+    protected $columns = array();
     protected $cellModifiers = [];
 
-    public function __construct($id, $label = '')
+    public function __construct($id, $label = '', $depth = 0)
     {
         $this->setID($id);
         $this->label = $label;
         $this->sortable = [$id];
+        $this->depth = $depth;
     }
 
     /**
@@ -77,6 +80,16 @@ class Column
     public function getWidth()
     {
         return $this->width;
+    }
+
+    /**
+     * Get the nested depth of the current column, counting from 0.
+     *
+     * @return int
+     */
+    public function getDepth()
+    {
+        return $this->depth;
     }
 
     /**
@@ -181,6 +194,75 @@ class Column
     public function getCellModifiers()
     {
         return $this->cellModifiers;
+    }
+
+    /**
+     * Add a nested column, by name and optional label. Returns the created column.
+     *
+     * @param string $name
+     * @param string $label
+     * @return Column
+     */
+    public function addColumn($id, $label = '')
+    {
+        $this->columns[$id] = new Column($id, $label, $this->depth + 1);
+        $this->sortable = false;
+
+        return $this->columns[$id];
+    }
+
+    /**
+     * Get all nested columns under this column.
+     *
+     * @return array
+     */
+    public function getColumns()
+    {
+        return $this->columns;
+    }
+
+    /**
+     * Returns true if this column has other columns nested under it.
+     *
+     * @return bool
+     */
+    public function hasNestedColumns()
+    {
+        return count($this->columns) > 0;
+    }
+
+    /**
+     * Gets the total column depth of all nested columns.
+     *
+     * @return int
+     */
+    public function getTotalDepth()
+    {
+        if (!$this->hasNestedColumns()) return 1;
+
+        $depth = $this->getDepth();
+        foreach ($this->getColumns() as $column) {
+            $depth = max($depth, $column->getTotalDepth());
+        }
+
+        return $depth + 1;
+    }
+
+    /**
+     * Gets the total column span of all nested columns.
+     *
+     * @return int
+     */
+    public function getTotalSpan()
+    {
+        if (!$this->hasNestedColumns()) return 1;
+
+        $count = 0;
+        foreach ($this->getColumns() as $column) {
+            $count += $column->getTotalSpan();
+        }
+
+        return $count;
     }
 
     /**

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -111,7 +111,7 @@ class DataTable implements OutputableInterface
 
         $table->addHeaderAction('print', __('Print'))
             ->setURL('/report.php')
-            ->addParam('q', $_GET['q'])
+            ->addParams($_GET)
             ->addParam('format', 'print')
             ->addParam('search', $criteria->getSearchText(true))
             ->isDirect()
@@ -119,7 +119,7 @@ class DataTable implements OutputableInterface
 
         $table->addHeaderAction('export', __('Export'))
             ->setURL('/export.php')
-            ->addParam('q', $_GET['q'])
+            ->addParams($_GET)
             ->addParam('format', 'export')
             ->addParam('search', $criteria->getSearchText(true))
             ->isDirect();

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -89,45 +89,6 @@ class DataTable implements OutputableInterface
     }
 
     /**
-     * Helper method to create a report data table, which can display as a table, printable page or export.
-     *
-     * @param string $id
-     * @param QueryCriteria $criteria
-     * @param string $viewMode
-     * @param string $guid
-     * @return self
-     */
-    public static function createReport($id, QueryCriteria $criteria, $viewMode, $guid)
-    {
-        if ($viewMode == 'print') {
-            $table = new self($id, new PrintableRenderer());
-        } else if ($viewMode == 'export') {
-            $table = new self($id, new SpreadsheetRenderer($_SESSION[$guid]['absolutePath']));
-        } else {
-            $table = new self($id, new PaginatedRenderer($criteria, '/fullscreen.php?'.http_build_query($_GET)));
-        }
-
-        $table->addMetaData('creator', formatName('', $_SESSION[$guid]['preferredName'], $_SESSION[$guid]['surname'], 'Staff'));
-
-        $table->addHeaderAction('print', __('Print'))
-            ->setURL('/report.php')
-            ->addParams($_GET)
-            ->addParam('format', 'print')
-            ->addParam('search', $criteria->getSearchText(true))
-            ->isDirect()
-            ->append('&nbsp;');
-
-        $table->addHeaderAction('export', __('Export'))
-            ->setURL('/export.php')
-            ->addParams($_GET)
-            ->addParam('format', 'export')
-            ->addParam('search', $criteria->getSearchText(true))
-            ->isDirect();
-
-        return $table;
-    }
-
-    /**
      * Set the table ID.
      *
      * @param string $id

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -292,7 +292,7 @@ class DataTable implements OutputableInterface
             $depth = max($depth, $column->getTotalDepth());
         }
 
-        return $depth + 1;
+        return $depth;
     }
 
     /**

--- a/src/Tables/Prefab/ReportTable.php
+++ b/src/Tables/Prefab/ReportTable.php
@@ -48,7 +48,7 @@ class ReportTable extends DataTable
 
         $table->addHeaderAction('print', __('Print'))
             ->setURL('/report.php')
-            ->addParam('q', $_GET['q'])
+            ->addParams($_GET)
             ->addParam('format', 'print')
             ->addParam('search', $criteria->getSearchText(true))
             ->isDirect()
@@ -56,7 +56,7 @@ class ReportTable extends DataTable
 
         $table->addHeaderAction('export', __('Export'))
             ->setURL('/export.php')
-            ->addParam('q', $_GET['q'])
+            ->addParams($_GET)
             ->addParam('format', 'export')
             ->addParam('search', $criteria->getSearchText(true))
             ->isDirect();

--- a/src/Tables/Renderer/SimpleRenderer.php
+++ b/src/Tables/Renderer/SimpleRenderer.php
@@ -92,7 +92,7 @@ class SimpleRenderer implements RendererInterface
 
                     // Calculate colspan and rowspan to handle nested column headers
                     $colspan = $column->getTotalSpan();
-                    $rowspan = ($column->getTotalDepth() > 1) ? 1 : ($totalColumnDepth - $column->getDepth()) + 1;
+                    $rowspan = ($column->getTotalDepth() > 1) ? 1 : ($totalColumnDepth - $column->getDepth()) ;
 
                     if ($column->getDepth() < $i) continue;
 

--- a/src/Tables/Renderer/SimpleRenderer.php
+++ b/src/Tables/Renderer/SimpleRenderer.php
@@ -79,17 +79,31 @@ class SimpleRenderer implements RendererInterface
 
             // HEADER
             $output .= '<thead>';
-            $output .= '<tr class="head">';
-            foreach ($table->getColumns() as $columnName => $column) {
-                $th = $this->createTableHeader($column);
+            
+            $totalColumnDepth = $table->getTotalColumnDepth();
 
-                if (!$th) continue; // Can be removed by tableHeader logic
+            for ($i = 0; $i < $totalColumnDepth; $i++) {
+                $output .= '<tr class="head">';
 
-                $output .= '<th '.$th->getAttributeString().' style="width:'.$column->getWidth().'">';
-                $output .= $th->getOutput();
-                $output .= '</th>';
+                foreach ($table->getColumns($i) as $columnName => $column) {
+                    $th = $this->createTableHeader($column);
+
+                    if (!$th) continue; // Can be removed by tableHeader logic
+
+                    // Calculate colspan and rowspan to handle nested column headers
+                    $colspan = $column->getTotalSpan();
+                    $rowspan = ($column->getTotalDepth() > 1) ? 1 : ($totalColumnDepth - $column->getDepth()) + 1;
+
+                    if ($column->getDepth() < $i) continue;
+
+                    $output .= '<th '.$th->getAttributeString().' style="width:'.$column->getWidth().'" colspan="'.$colspan.'" rowspan="'.$rowspan.'">';
+                    $output .= $th->getOutput();
+                    $output .= '</th>';
+                }
+
+                $output .= '</tr>';
             }
-            $output .= '</tr>';
+            
             $output .= '</thead>';
 
             // ROWS

--- a/src/Tables/Renderer/SpreadsheetRenderer.php
+++ b/src/Tables/Renderer/SpreadsheetRenderer.php
@@ -80,6 +80,7 @@ class SpreadsheetRenderer implements RendererInterface
         $currentStyle = ['fill' => [ 'type' => \PHPExcel_Style_Fill::FILL_SOLID, 'color' => ['rgb' => 'B3EFC2'],]];
         $errorStyle = ['fill' => [ 'type' => \PHPExcel_Style_Fill::FILL_SOLID, 'color' => ['rgb' => 'F6CECB'],]];
         $warningStyle = ['fill' => [ 'type' => \PHPExcel_Style_Fill::FILL_SOLID, 'color' => ['rgb' => 'FFD2A9'],]];
+        $rowStripeStyle = ['fill' => [ 'type' => \PHPExcel_Style_Fill::FILL_SOLID, 'color' => ['rgb' => 'FAFAFA'],]];
 
         // Set document properties
         $excel->getProperties()->setCreator($table->getMetaData('creator'))
@@ -159,9 +160,11 @@ class SpreadsheetRenderer implements RendererInterface
                     $sheet->getStyle($alpha.$rowCount)->applyFromArray($rowStyle);
 
                     $cellStyle = null;
-                    if (stripos($row->getClass(), 'current') !== false) $cellStyle = $currentStyle;
                     if (stripos($row->getClass(), 'error') !== false) $cellStyle = $errorStyle;
-                    if (stripos($row->getClass(), 'warning') !== false) $cellStyle = $warningStyle;
+                    else if (stripos($row->getClass(), 'warning') !== false) $cellStyle = $warningStyle;
+                    else if (stripos($row->getClass(), 'current') !== false) $cellStyle = $currentStyle;
+                    else if ($rowCount % 2 != 0) $cellStyle = $rowStripeStyle;
+
                     if (!empty($cellStyle)) $sheet->getStyle($alpha.$rowCount)->applyFromArray($cellStyle);
                     
 

--- a/src/Tables/Renderer/SpreadsheetRenderer.php
+++ b/src/Tables/Renderer/SpreadsheetRenderer.php
@@ -112,13 +112,7 @@ class SpreadsheetRenderer implements RendererInterface
                     $alpha = $this->num2alpha($cellCount);
                     $range = $alpha.$rowCount;
 
-                    $sheet->setCellValue($alpha.$rowCount, $column->getLabel());
-                    
-                    if ($column->getWidth() == 'auto') {
-                        $sheet->getColumnDimension($alpha)->setAutoSize(true);
-                    } else {
-                        $sheet->getColumnDimension($alpha)->setWidth(intval($column->getWidth()));
-                    }
+                    $sheet->setCellValue($alpha.$rowCount, $column->getLabel());  
 
                     $colSpan = $column->getTotalSpan();
                     if ($colSpan > 1) {
@@ -133,6 +127,12 @@ class SpreadsheetRenderer implements RendererInterface
 
                         $range = $alpha.$rowCount.':'.$alpha.($rowCount+$rowspan-1);
                         $sheet->mergeCells($range);
+                    }
+
+                    if ($column->getWidth() == 'auto') {
+                        $sheet->getColumnDimension($alpha)->setAutoSize(true);
+                    } else {
+                        $sheet->getColumnDimension($alpha)->setWidth(intval($column->getWidth()));
                     }
 
                     $sheet->getStyle($range)->applyFromArray($headerStyle);


### PR DESCRIPTION
Many of the reports in Gibbon group the column headings together for context. This PR adds the ability to nest columns when adding them to DataTables, which enables the renderers to display them as grouped headings. 

OOifies the Activity Spread by Roll Group report as an example, which now handles the dateType for terms and dates separately.

SimpleRenderer: (handles nested columns with colspan and rowspan)
<img width="762" alt="screen shot 2018-09-10 at 9 59 10 am" src="https://user-images.githubusercontent.com/897700/45398196-ceb1fc80-b675-11e8-893f-f16bc0633f4f.png">

SpreadsheetRenderer: (handles nested columns by merging cells)
![screen shot 2018-09-10 at 9 59 04 am](https://user-images.githubusercontent.com/897700/45398209-d70a3780-b675-11e8-863f-912068d40f88.png)

The nesting can handle a fair bit of complexity too:
<img width="765" alt="screen shot 2018-09-06 at 4 07 02 pm" src="https://user-images.githubusercontent.com/897700/45398243-0751d600-b676-11e8-908f-24c9f644893a.png">

