### PR TITLE
Modules: rewrite include path

### DIFF
--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_attendance.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_attendance_sheet.php
+++ b/modules/Activities/activities_attendance_sheet.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_attendance_sheet.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_attendance_sheetPrint.php
+++ b/modules/Activities/activities_attendance_sheetPrint.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_attendance_sheet.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_manage.php
+++ b/modules/Activities/activities_manage.php
@@ -24,7 +24,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_manage_add.php
+++ b/modules/Activities/activities_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_add.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_manage_delete.php
+++ b/modules/Activities/activities_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_manage_edit.php
+++ b/modules/Activities/activities_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_manage_enrolment.php
+++ b/modules/Activities/activities_manage_enrolment.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_enrolment.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_manage_enrolment_add.php
+++ b/modules/Activities/activities_manage_enrolment_add.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_enrolment_add.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_manage_enrolment_addProcess.php
+++ b/modules/Activities/activities_manage_enrolment_addProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/Activities/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $gibbonActivityID = $_GET['gibbonActivityID'];
 

--- a/modules/Activities/activities_manage_enrolment_deleteProcess.php
+++ b/modules/Activities/activities_manage_enrolment_deleteProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/Activities/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $gibbonActivityID = $_GET['gibbonActivityID'];
 $gibbonPersonID = $_GET['gibbonPersonID'];

--- a/modules/Activities/activities_manage_enrolment_edit.php
+++ b/modules/Activities/activities_manage_enrolment_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_enrolment_edit.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_my.php
+++ b/modules/Activities/activities_my.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_my.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_my_full.php
+++ b/modules/Activities/activities_my_full.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_my_full.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_payment.php
+++ b/modules/Activities/activities_payment.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_payment.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_view.php
+++ b/modules/Activities/activities_view.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_view_full.php
+++ b/modules/Activities/activities_view_full.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view_full.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_view_register.php
+++ b/modules/Activities/activities_view_register.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view_register.php') == false) {
     //Acess denied

--- a/modules/Activities/activities_view_registerProcess.php
+++ b/modules/Activities/activities_view_registerProcess.php
@@ -22,7 +22,7 @@ use Gibbon\Comms\NotificationEvent;
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/Activities/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $mode = $_POST['mode'];
 $gibbonActivityID = $_POST['gibbonActivityID'];

--- a/modules/Activities/report_activityChoices_byRollGroup.php
+++ b/modules/Activities/report_activityChoices_byRollGroup.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activityChoices_byRollGroup.php') == false) {
     //Acess denied

--- a/modules/Activities/report_activityChoices_byStudent.php
+++ b/modules/Activities/report_activityChoices_byStudent.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activityChoices_byStudent.php') == false) {
     //Acess denied

--- a/modules/Activities/report_activityEnrollmentSummary.php
+++ b/modules/Activities/report_activityEnrollmentSummary.php
@@ -23,7 +23,7 @@ use Gibbon\Tables\Prefab\ReportTable;
 use Gibbon\Domain\Activities\ActivityReportGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activityEnrollmentSummary.php') == false) {
     //Acess denied

--- a/modules/Activities/report_activitySpread_rollGroup.php
+++ b/modules/Activities/report_activitySpread_rollGroup.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activitySpread_rollGroup.php') == false) {
     //Acess denied

--- a/modules/Activities/report_activityType_rollGroup.php
+++ b/modules/Activities/report_activityType_rollGroup.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activityType_rollGroup.php') == false) {
     //Acess denied

--- a/modules/Activities/report_attendance.php
+++ b/modules/Activities/report_attendance.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendance.php') == false) {
     //Acess denied

--- a/modules/Activities/report_attendance_byDate.php
+++ b/modules/Activities/report_attendance_byDate.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendance_byDate.php') == false) {
     //Acess denied

--- a/modules/Activities/report_attendance_print.php
+++ b/modules/Activities/report_attendance_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendance.php') == false) {
     //Acess denied

--- a/modules/Activities/report_participants.php
+++ b/modules/Activities/report_participants.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_participants.php') == false) {
     //Acess denied

--- a/modules/Activities/report_participants_print.php
+++ b/modules/Activities/report_participants_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/report_participants_print.php') == false) {
     //Acess denied

--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -20,7 +20,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include "./modules/" . $_SESSION[$guid]["module"] . "/moduleFunctions.php" ;
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance.php")==FALSE) {
 	//Acess denied

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 

--- a/modules/Attendance/attendance_studentSelfRegister.php
+++ b/modules/Attendance/attendance_studentSelfRegister.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_studentSelfRegister.php') == false) {
     //Acess denied

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include "./modules/" . $_SESSION[$guid]["module"] . "/moduleFunctions.php";
+require_once __DIR__ . '/moduleFunctions.php';
 
 require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 

--- a/modules/Attendance/attendance_take_byPerson_delete.php
+++ b/modules/Attendance/attendance_take_byPerson_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_delete.php') == false) {
     //Acess denied

--- a/modules/Attendance/attendance_take_byPerson_edit.php
+++ b/modules/Attendance/attendance_take_byPerson_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 require_once $_SESSION[$guid]['absolutePath'].'/modules/Attendance/src/attendanceView.php';
 

--- a/modules/Attendance/report_courseClassesNotRegistered_byDate.php
+++ b/modules/Attendance/report_courseClassesNotRegistered_byDate.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_courseClassesNotRegistered_byDate.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+++ b/modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_courseClassesNotRegistered_byDate_print.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 function getDateRange($guid, $connection2, $first, $last, $step = '+1 day', $output_format = 'Y-m-d' ) {
 

--- a/modules/Attendance/report_rollGroupsNotRegistered_byDate.php
+++ b/modules/Attendance/report_rollGroupsNotRegistered_byDate.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_rollGroupsNotRegistered_byDate.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_rollGroupsNotRegistered_byDate_print.php
+++ b/modules/Attendance/report_rollGroupsNotRegistered_byDate_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_rollGroupsNotRegistered_byDate_print.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_studentHistory.php
+++ b/modules/Attendance/report_studentHistory.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentHistory.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_studentHistory_print.php
+++ b/modules/Attendance/report_studentHistory_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentHistory_print.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_studentsNotOnsite_byDate.php
+++ b/modules/Attendance/report_studentsNotOnsite_byDate.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentsNotOnsite_byDate.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_studentsNotOnsite_byDate_print.php
+++ b/modules/Attendance/report_studentsNotOnsite_byDate_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentsNotOnsite_byDate_print.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_studentsNotPresent_byDate.php
+++ b/modules/Attendance/report_studentsNotPresent_byDate.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentsNotPresent_byDate.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_studentsNotPresent_byDate_print.php
+++ b/modules/Attendance/report_studentsNotPresent_byDate_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentsNotPresent_byDate_print.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_summary_byDate.php
+++ b/modules/Attendance/report_summary_byDate.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_summary_byDate.php') == false) {
     //Acess denied

--- a/modules/Attendance/report_summary_byDate_print.php
+++ b/modules/Attendance/report_summary_byDate_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_summary_byDate.php') == false) {
     //Acess denied

--- a/modules/Behaviour/behaviour_letters.php
+++ b/modules/Behaviour/behaviour_letters.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_letters.php') == false) {
     //Access denied

--- a/modules/Behaviour/behaviour_manage.php
+++ b/modules/Behaviour/behaviour_manage.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $enableDescriptors = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors');
 $enableLevels = getSettingByScope($connection2, 'Behaviour', 'enableLevels');

--- a/modules/Behaviour/behaviour_manage_add.php
+++ b/modules/Behaviour/behaviour_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $enableDescriptors = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors');
 $enableLevels = getSettingByScope($connection2, 'Behaviour', 'enableLevels');

--- a/modules/Behaviour/behaviour_manage_addMulti.php
+++ b/modules/Behaviour/behaviour_manage_addMulti.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $enableDescriptors = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors');
 $enableLevels = getSettingByScope($connection2, 'Behaviour', 'enableLevels');

--- a/modules/Behaviour/behaviour_manage_delete.php
+++ b/modules/Behaviour/behaviour_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $enableDescriptors = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors');
 $enableLevels = getSettingByScope($connection2, 'Behaviour', 'enableLevels');

--- a/modules/Behaviour/behaviour_pattern.php
+++ b/modules/Behaviour/behaviour_pattern.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $enableDescriptors = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors');
 $enableLevels = getSettingByScope($connection2, 'Behaviour', 'enableLevels');

--- a/modules/Behaviour/behaviour_view_details.php
+++ b/modules/Behaviour/behaviour_view_details.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $enableDescriptors = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors');
 $enableLevels = getSettingByScope($connection2, 'Behaviour', 'enableLevels');

--- a/modules/Crowd Assessment/crowdAssess.php
+++ b/modules/Crowd Assessment/crowdAssess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Crowd Assessment/crowdAssess.php') == false) {
     //Acess denied

--- a/modules/Crowd Assessment/crowdAssess_view.php
+++ b/modules/Crowd Assessment/crowdAssess_view.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Crowd Assessment/crowdAssess_view.php') == false) {
     //Acess denied

--- a/modules/Crowd Assessment/crowdAssess_view_discuss.php
+++ b/modules/Crowd Assessment/crowdAssess_view_discuss.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Crowd Assessment/crowdAssess_view_discuss.php') == false) {
     //Acess denied

--- a/modules/Crowd Assessment/crowdAssess_view_discuss_post.php
+++ b/modules/Crowd Assessment/crowdAssess_view_discuss_post.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Crowd Assessment/crowdAssess_view_discuss_post.php') == false) {
     //Acess denied

--- a/modules/Crowd Assessment/crowdAssess_view_discuss_postProcess.php
+++ b/modules/Crowd Assessment/crowdAssess_view_discuss_postProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/'.getModuleName($_GET['address']).'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $gibbonPlannerEntryID = $_GET['gibbonPlannerEntryID'];
 $gibbonPlannerEntryHomeworkID = $_GET['gibbonPlannerEntryHomeworkID'];

--- a/modules/Data Updater/data_family.php
+++ b/modules/Data Updater/data_family.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.php') == false) {
     //Acess denied

--- a/modules/Data Updater/data_family_manage_delete.php
+++ b/modules/Data Updater/data_family_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_manage_delete.php') == false) {
     //Acess denied
@@ -65,4 +65,3 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_m
         }
     }
 }
-?>

--- a/modules/Data Updater/data_family_manage_edit.php
+++ b/modules/Data Updater/data_family_manage_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Data Updater/data_finance.php
+++ b/modules/Data Updater/data_finance.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.php') == false) {
     //Acess denied
@@ -286,4 +286,3 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
         }
     }
 }
-?>

--- a/modules/Data Updater/data_finance_manage_delete.php
+++ b/modules/Data Updater/data_finance_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_manage_delete.php') == false) {
     //Acess denied
@@ -65,4 +65,3 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
         }
     }
 }
-?>

--- a/modules/Data Updater/data_finance_manage_edit.php
+++ b/modules/Data Updater/data_finance_manage_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_manage_edit.php') == false) {
     //Acess denied
@@ -123,4 +123,3 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
         }
     }
 }
-?>

--- a/modules/Data Updater/data_medical.php
+++ b/modules/Data Updater/data_medical.php
@@ -23,7 +23,7 @@ use Gibbon\Domain\Students\MedicalGateway;
 use Gibbon\Domain\DataUpdater\MedicalUpdateGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.php') == false) {
     //Acess denied

--- a/modules/Data Updater/data_medical_manage_delete.php
+++ b/modules/Data Updater/data_medical_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Data Updater/data_medical_manage_edit.php
+++ b/modules/Data Updater/data_medical_manage_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 include './modules/User Admin/moduleFunctions.php'; //for User Admin (for custom fields)
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal.php') == false) {
@@ -611,4 +611,3 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
         }
     }
 }
-?>

--- a/modules/Data Updater/data_personal_manage_delete.php
+++ b/modules/Data Updater/data_personal_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal_manage_delete.php') == false) {
     //Acess denied
@@ -65,4 +65,3 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
         }
     }
 }
-?>

--- a/modules/Data Updater/data_updates.php
+++ b/modules/Data Updater/data_updates.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Domain\DataUpdater\DataUpdaterGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_updates.php') == false) {
     //Acess denied

--- a/modules/Data Updater/report_family_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_family_dataUpdaterHistory.php
@@ -24,7 +24,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Domain\DataUpdater\FamilyUpdateGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family_dataUpdaterHistory.php') == false) {
     //Acess denied

--- a/modules/Data Updater/report_student_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_student_dataUpdaterHistory.php
@@ -24,7 +24,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\DataUpdater\PersonUpdateGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_student_dataUpdaterHistory.php') == false) {
     //Acess denied

--- a/modules/Departments/department.php
+++ b/modules/Departments/department.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $makeDepartmentsPublic = getSettingByScope($connection2, 'Departments', 'makeDepartmentsPublic');
 if (isActionAccessible($guid, $connection2, '/modules/Departments/department.php') == false and $makeDepartmentsPublic != 'Y') {

--- a/modules/Departments/department_course.php
+++ b/modules/Departments/department_course.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $makeDepartmentsPublic = getSettingByScope($connection2, 'Departments', 'makeDepartmentsPublic');
 if (isActionAccessible($guid, $connection2, '/modules/Departments/department_course.php') == false and $makeDepartmentsPublic != 'Y') {

--- a/modules/Departments/department_course_class.php
+++ b/modules/Departments/department_course_class.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $makeDepartmentsPublic = getSettingByScope($connection2, 'Departments', 'makeDepartmentsPublic');
 if (isActionAccessible($guid, $connection2, '/modules/Departments/department_course_class.php') == false) {

--- a/modules/Departments/department_course_edit.php
+++ b/modules/Departments/department_course_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Departments/department_course_edit.php') == false) {
     //Acess denied

--- a/modules/Departments/department_edit.php
+++ b/modules/Departments/department_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Departments/department_edit.php') == false) {
     //Acess denied

--- a/modules/Departments/departments.php
+++ b/modules/Departments/departments.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $makeDepartmentsPublic = getSettingByScope($connection2, 'Departments', 'makeDepartmentsPublic');
 if (isActionAccessible($guid, $connection2, '/modules/Departments/departments.php') == false and $makeDepartmentsPublic != 'Y') {

--- a/modules/Finance/budgets_manage_add.php
+++ b/modules/Finance/budgets_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_add.php') == false) {
     //Acess denied

--- a/modules/Finance/budgets_manage_delete.php
+++ b/modules/Finance/budgets_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Finance/budgets_manage_edit.php
+++ b/modules/Finance/budgets_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Finance/expenseRequest_manage.php
+++ b/modules/Finance/expenseRequest_manage.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/Finance/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_manage.php') == false) {
     //Acess denied

--- a/modules/Finance/expenseRequest_manage_add.php
+++ b/modules/Finance/expenseRequest_manage_add.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_manage_add.php') == false) {
     //Acess denied

--- a/modules/Finance/expenseRequest_manage_reimburse.php
+++ b/modules/Finance/expenseRequest_manage_reimburse.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_manage_reimburse.php') == false) {
     //Acess denied

--- a/modules/Finance/expenseRequest_manage_view.php
+++ b/modules/Finance/expenseRequest_manage_view.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_manage_view.php') == false) {
     //Acess denied

--- a/modules/Finance/expenses_manage.php
+++ b/modules/Finance/expenses_manage.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\Prefab\BulkActionForm;
 
 //Module includes
-include './modules/Finance/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage.php') == false) {
     //Acess denied

--- a/modules/Finance/expenses_manage_add.php
+++ b/modules/Finance/expenses_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_add.php', 'Manage Expenses_all') == false) {
     //Acess denied

--- a/modules/Finance/expenses_manage_approve.php
+++ b/modules/Finance/expenses_manage_approve.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_approve.php') == false) {
     //Acess denied

--- a/modules/Finance/expenses_manage_edit.php
+++ b/modules/Finance/expenses_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Finance/expenses_manage_print.php
+++ b/modules/Finance/expenses_manage_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_print.php') == false) {
     //Acess denied

--- a/modules/Finance/expenses_manage_print_print.php
+++ b/modules/Finance/expenses_manage_print_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_print.php') == false) {
     //Acess denied

--- a/modules/Finance/expenses_manage_view.php
+++ b/modules/Finance/expenses_manage_view.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_view.php') == false) {
     //Acess denied

--- a/modules/Finance/feeCategories_manage_add.php
+++ b/modules/Finance/feeCategories_manage_add.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_manage_add.php') == false) {
     //Acess denied

--- a/modules/Finance/feeCategories_manage_delete.php
+++ b/modules/Finance/feeCategories_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Finance/feeCategories_manage_edit.php
+++ b/modules/Finance/feeCategories_manage_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Finance/invoicees_manage_edit.php
+++ b/modules/Finance/invoicees_manage_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoicees_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -25,7 +25,7 @@ use Gibbon\Domain\Finance\InvoiceGateway;
 use Gibbon\Finance\Forms\FinanceFormFactory;
 
 //Module includes
-include './modules/Finance/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Finance\Forms\FinanceFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_add.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_manage_delete.php
+++ b/modules/Finance/invoices_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_manage_edit.php
+++ b/modules/Finance/invoices_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Finance\Forms\FinanceFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_manage_issue.php
+++ b/modules/Finance/invoices_manage_issue.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Finance\Forms\FinanceFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_issue.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_manage_print.php
+++ b/modules/Finance/invoices_manage_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_print.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_manage_print_print.php
+++ b/modules/Finance/invoices_manage_print_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_print.php') == false) {
     //Acess denied

--- a/modules/Finance/invoices_view_print.php
+++ b/modules/Finance/invoices_view_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_view_print.php') == false) {
     //Acess denied

--- a/modules/Formal Assessment/externalAssessment.php
+++ b/modules/Formal Assessment/externalAssessment.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/externalAssessment.php') == false) {
     //Acess denied

--- a/modules/Formal Assessment/externalAssessment_details.php
+++ b/modules/Formal Assessment/externalAssessment_details.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/externalAssessment_details.php') == false) {
     //Acess denied

--- a/modules/Formal Assessment/externalAssessment_view.php
+++ b/modules/Formal Assessment/externalAssessment_view.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/externalAssessment_view.php') == false) {
     //Acess denied

--- a/modules/Formal Assessment/internalAssessment_manage.php
+++ b/modules/Formal Assessment/internalAssessment_manage.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internalAssessment_manage.php') == false) {
     //Acess denied

--- a/modules/Formal Assessment/internalAssessment_manage_add.php
+++ b/modules/Formal Assessment/internalAssessment_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get alternative header names
 $attainmentAlternativeName = getSettingByScope($connection2, 'Markbook', 'attainmentAlternativeName');

--- a/modules/Formal Assessment/internalAssessment_manage_delete.php
+++ b/modules/Formal Assessment/internalAssessment_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internalAssessment_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Formal Assessment/internalAssessment_manage_edit.php
+++ b/modules/Formal Assessment/internalAssessment_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get alternative header names
 $attainmentAlternativeName = getSettingByScope($connection2, 'Markbook', 'attainmentAlternativeName');

--- a/modules/Formal Assessment/internalAssessment_view.php
+++ b/modules/Formal Assessment/internalAssessment_view.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internalAssessment_view.php') == false) {
     //Acess denied

--- a/modules/Formal Assessment/internalAssessment_write.php
+++ b/modules/Formal Assessment/internalAssessment_write.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get alternative header names
 $attainmentAlternativeName = getSettingByScope($connection2, 'Markbook', 'attainmentAlternativeName');

--- a/modules/Formal Assessment/internalAssessment_write_data.php
+++ b/modules/Formal Assessment/internalAssessment_write_data.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get alternative header names
 $attainmentAlternativeName = getSettingByScope($connection2, 'Markbook', 'attainmentAlternativeName');

--- a/modules/Individual Needs/in_archive.php
+++ b/modules/Individual Needs/in_archive.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_archive.php') == false) {
     //Acess denied

--- a/modules/Individual Needs/in_edit.php
+++ b/modules/Individual Needs/in_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_edit.php') == false) {
     //Acess denied

--- a/modules/Individual Needs/in_summary.php
+++ b/modules/Individual Needs/in_summary.php
@@ -24,7 +24,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\IndividualNeeds\INGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_summary.php') == false) {
     //Acess denied

--- a/modules/Library/library_browse.php
+++ b/modules/Library/library_browse.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php') == false) {
     //Acess denied

--- a/modules/Library/library_lending_item.php
+++ b/modules/Library/library_lending_item.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_item.php') == false) {
     //Acess denied

--- a/modules/Library/library_manage_catalog_add.php
+++ b/modules/Library/library_manage_catalog_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_catalog_add.php') == false) {
     //Acess denied

--- a/modules/Library/library_manage_catalog_delete.php
+++ b/modules/Library/library_manage_catalog_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_catalog_delete.php') == false) {
     //Acess denied

--- a/modules/Library/library_manage_catalog_duplicate.php
+++ b/modules/Library/library_manage_catalog_duplicate.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_catalog_duplicate.php') == false) {
     //Acess denied

--- a/modules/Library/library_manage_catalog_edit.php
+++ b/modules/Library/library_manage_catalog_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_catalog_edit.php') == false) {
     //Acess denied

--- a/modules/Library/report_catalogSummary.php
+++ b/modules/Library/report_catalogSummary.php
@@ -23,7 +23,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 $_SESSION[$guid]['report_student_emergencySummary.php_choices'] = '';
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/report_catalogSummary.php') == false) {
     //Acess denied

--- a/modules/Library/report_studentBorrowingRecord.php
+++ b/modules/Library/report_studentBorrowingRecord.php
@@ -23,7 +23,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 $_SESSION[$guid]['report_student_emergencySummary.php_choices'] = '';
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/report_studentBorrowingRecord.php') == false) {
     //Acess denied

--- a/modules/Library/report_viewOverdueItems.php
+++ b/modules/Library/report_viewOverdueItems.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Library/report_viewOverdueItems.php') == false) {
     //Acess denied

--- a/modules/Markbook/markbook_edit.php
+++ b/modules/Markbook/markbook_edit.php
@@ -22,7 +22,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php') == false) {
     //Acess denied

--- a/modules/Markbook/markbook_edit_add.php
+++ b/modules/Markbook/markbook_edit_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get settings
 $enableEffort = getSettingByScope($connection2, 'Markbook', 'enableEffort');

--- a/modules/Markbook/markbook_edit_addMulti.php
+++ b/modules/Markbook/markbook_edit_addMulti.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get settings
 $enableEffort = getSettingByScope($connection2, 'Markbook', 'enableEffort');

--- a/modules/Markbook/markbook_edit_copy.php
+++ b/modules/Markbook/markbook_edit_copy.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_copy.php') == false) {
     //Acess denied

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get settings
 $enableEffort = getSettingByScope($connection2, 'Markbook', 'enableEffort');

--- a/modules/Markbook/markbook_edit_delete.php
+++ b/modules/Markbook/markbook_edit_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_delete.php') == false) {
     //Acess denied

--- a/modules/Markbook/markbook_edit_edit.php
+++ b/modules/Markbook/markbook_edit_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Get settings
 $enableEffort = getSettingByScope($connection2, 'Markbook', 'enableEffort');

--- a/modules/Markbook/markbook_edit_targets.php
+++ b/modules/Markbook/markbook_edit_targets.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_targets.php') == false) {
     //Acess denied

--- a/modules/Markbook/markbook_view.php
+++ b/modules/Markbook/markbook_view.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php') == false) {
     //Acess denied
@@ -43,15 +43,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
 
         //VIEW ACCESS TO ALL MARKBOOK DATA
         if ($highestAction == 'View Markbook_allClassesAllData' || $highestAction == 'View Markbook_myClasses') {
-            require_once './modules/'.$_SESSION[$guid]['module'].'/markbook_view_allClassesAllData.php';
+            require __DIR__ . '/markbook_view_allClassesAllData.php';
         }
         //VIEW ACCESS TO MY OWN MARKBOOK DATA
         elseif ($highestAction == 'View Markbook_myMarks') {
-            require_once './modules/'.$_SESSION[$guid]['module'].'/markbook_view_myMarks.php';
+            require __DIR__ . '/markbook_view_myMarks.php';
         }
         //VIEW ACCESS TO MY CHILDREN'S MARKBOOK DATA
         elseif ($highestAction == 'View Markbook_viewMyChildrensClasses') {
-            require_once './modules/'.$_SESSION[$guid]['module'].'/markbook_view_viewMyChildrensClasses.php';
+            require __DIR__ . '/markbook_view_viewMyChildrensClasses.php';
         }
     }
 }

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -2,8 +2,8 @@
 	// Lock the file so other scripts cannot call it
 	if (MARKBOOK_VIEW_LOCK !== sha1( $highestAction . $_SESSION[$guid]['gibbonPersonID'] ) . date('zWy') ) return;
 
-	require_once './modules/'.$_SESSION[$guid]['module'].'/src/markbookView.php';
-	require_once './modules/'.$_SESSION[$guid]['module'].'/src/markbookColumn.php';
+	require_once __DIR__ . '/src/markbookView.php';
+	require_once __DIR__ . '/src/markbookColumn.php';
 
     //Check for access to multiple column add
     $multiAdd = false;

--- a/modules/Markbook/markbook_view_rubric.php
+++ b/modules/Markbook/markbook_view_rubric.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Rubric includes
-include './modules/Rubrics/moduleFunctions.php';
+require_once __DIR__ . '/../Rubrics/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php') == false) {
     //Acess denied

--- a/modules/Markbook/weighting_manage.php
+++ b/modules/Markbook/weighting_manage.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.php') == false) {
     //Acess denied

--- a/modules/Markbook/weighting_manage_add.php
+++ b/modules/Markbook/weighting_manage_add.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_add.php') == false) {
     //Acess denied

--- a/modules/Markbook/weighting_manage_delete.php
+++ b/modules/Markbook/weighting_manage_delete.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Prefab\DeleteForm;
 
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Markbook/weighting_manage_edit.php
+++ b/modules/Markbook/weighting_manage_edit.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Messenger/groups_manage_deleteProcess.php
+++ b/modules/Messenger/groups_manage_deleteProcess.php
@@ -22,7 +22,7 @@ use Gibbon\Domain\Messenger\GroupGateway;
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/Messenger/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $gibbonGroupID = isset($_GET['gibbonGroupID'])? $_GET['gibbonGroupID'] : '';
 

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -19,17 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 
-//Only include module include if it is not already included (which it may be been on the index page)
-$included=FALSE ;
-$includes=get_included_files() ;
-foreach ($includes AS $include) {
-	if (str_replace("\\","/",$include)==str_replace("\\","/",$_SESSION[$guid]["absolutePath"] . "/modules/" . $_SESSION[$guid]["module"] . "/moduleFunctions.php")) {
-		$included=TRUE ;
-	}
-}
-if ($included==FALSE) {
-	include_once "./modules/" . $_SESSION[$guid]["module"] . "/moduleFunctions.php" ;
-}
+require_once __DIR__ . '/moduleFunctions.php';
+
 if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php")==FALSE) {
 	//Acess denied
 	print "<div class='error'>" ;

--- a/modules/Messenger/messenger_postQuickWall.php
+++ b/modules/Messenger/messenger_postQuickWall.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 
-require_once './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_postQuickWall.php') == false) {
     //Acess denied

--- a/modules/Planner/conceptExplorer.php
+++ b/modules/Planner/conceptExplorer.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/conceptExplorer.php') == false) {
     //Acess denied

--- a/modules/Planner/curriculumMapping_outcomesByCourse.php
+++ b/modules/Planner/curriculumMapping_outcomesByCourse.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/curriculumMapping_outcomesByCourse.php') == false) {
     //Acess denied

--- a/modules/Planner/outcomes_add.php
+++ b/modules/Planner/outcomes_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_add.php') == false) {
     //Acess denied

--- a/modules/Planner/outcomes_delete.php
+++ b/modules/Planner/outcomes_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_delete.php') == false) {
     //Acess denied

--- a/modules/Planner/outcomes_edit.php
+++ b/modules/Planner/outcomes_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_edit.php') == false) {
     //Acess denied

--- a/modules/Planner/planner.php
+++ b/modules/Planner/planner.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == false) {
     //Acess denied

--- a/modules/Planner/plannerProcess.php
+++ b/modules/Planner/plannerProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/'.getModuleName($_GET['address']).'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $gibbonPlannerEntryID = $_GET['gibbonPlannerEntryID'];
 $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];

--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') == false) {
     //Acess denied

--- a/modules/Planner/planner_bump.php
+++ b/modules/Planner/planner_bump.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_bump.php') == false) {
     //Acess denied

--- a/modules/Planner/planner_deadlines.php
+++ b/modules/Planner/planner_deadlines.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $style = '';
 

--- a/modules/Planner/planner_delete.php
+++ b/modules/Planner/planner_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_delete.php') == false) {
     //Acess denied

--- a/modules/Planner/planner_duplicate.php
+++ b/modules/Planner/planner_duplicate.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.php') == false) {
     //Acess denied

--- a/modules/Planner/planner_edit.php
+++ b/modules/Planner/planner_edit.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php') == false) {
     //Acess denied

--- a/modules/Planner/planner_unitOverview.php
+++ b/modules/Planner/planner_unitOverview.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_unitOverview.php') == false) {
     //Acess denied

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 include './modules/Attendance/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.php') == false) {

--- a/modules/Planner/planner_view_full_post.php
+++ b/modules/Planner/planner_view_full_post.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_post.php') == false) {
     //Acess denied

--- a/modules/Planner/planner_view_full_submit_edit.php
+++ b/modules/Planner/planner_view_full_submit_edit.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_submit_edit.php') == false) {
     //Acess denied

--- a/modules/Planner/report_goldStars_staff.php
+++ b/modules/Planner/report_goldStars_staff.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/report_goldStars_staff.php') == false) {
     //Acess denied

--- a/modules/Planner/report_parentWeeklyEmailSummaryConfirmation.php
+++ b/modules/Planner/report_parentWeeklyEmailSummaryConfirmation.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/report_parentWeeklyEmailSummaryConfirmation.php') == false) {
     //Acess denied

--- a/modules/Planner/report_workSummary_byRollGroup.php
+++ b/modules/Planner/report_workSummary_byRollGroup.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/report_workSummary_byRollGroup.php') == false) {
     //Acess denied

--- a/modules/Planner/resources_addQuick_ajax.php
+++ b/modules/Planner/resources_addQuick_ajax.php
@@ -23,7 +23,7 @@ use Gibbon\Forms\Form;
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Setup variables
 $output = '';

--- a/modules/Planner/resources_add_ajax.php
+++ b/modules/Planner/resources_add_ajax.php
@@ -24,7 +24,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Setup variables
 $output = '';

--- a/modules/Planner/resources_insert_ajax.php
+++ b/modules/Planner/resources_insert_ajax.php
@@ -24,7 +24,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 include '../../gibbon.php';
 
 //Module includes
-include $_SESSION[$guid]['absolutePath'].'/modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Setup variables
 $output = '';

--- a/modules/Planner/resources_manage.php
+++ b/modules/Planner/resources_manage.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage.php') == false) {
     //Acess denied

--- a/modules/Planner/resources_manage_add.php
+++ b/modules/Planner/resources_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_add.php') == false) {
     //Acess denied

--- a/modules/Planner/resources_manage_edit.php
+++ b/modules/Planner/resources_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Planner/resources_view.php
+++ b/modules/Planner/resources_view.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_view.php') == false) {
     //Acess denied

--- a/modules/Planner/resources_view_full.php
+++ b/modules/Planner/resources_view_full.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_view_full.php') == false) {
     //Acess denied

--- a/modules/Planner/scopeAndSequence.php
+++ b/modules/Planner/scopeAndSequence.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/scopeAndSequence.php') == false) {
     //Acess denied

--- a/modules/Planner/units.php
+++ b/modules/Planner/units.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units.php') == false) {
     //Acess denied

--- a/modules/Planner/units_add.php
+++ b/modules/Planner/units_add.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_add.php') == false) {
     //Acess denied

--- a/modules/Planner/units_delete.php
+++ b/modules/Planner/units_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_delete.php') == false) {
     //Acess denied

--- a/modules/Planner/units_dump.php
+++ b/modules/Planner/units_dump.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_dump.php') == false && isActionAccessible($guid, $connection2, '/modules/Planner/scopeAndSequence.php') == false) {
     //Acess denied

--- a/modules/Planner/units_duplicate.php
+++ b/modules/Planner/units_duplicate.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_duplicate.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit.php
+++ b/modules/Planner/units_edit.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit_copyBack.php
+++ b/modules/Planner/units_edit_copyBack.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_copyBack.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit_copyForward.php
+++ b/modules/Planner/units_edit_copyForward.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_copyForward.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit_deploy.php
+++ b/modules/Planner/units_edit_deploy.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit_smartBlockify.php
+++ b/modules/Planner/units_edit_smartBlockify.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_smartBlockify.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit_working.php
+++ b/modules/Planner/units_edit_working.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit_working_add.php
+++ b/modules/Planner/units_edit_working_add.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working_add.php') == false) {
     //Acess denied

--- a/modules/Planner/units_edit_working_copyback.php
+++ b/modules/Planner/units_edit_working_copyback.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working_add.php') == false) {
     //Acess denied

--- a/modules/Planner/units_public.php
+++ b/modules/Planner/units_public.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $makeUnitsPublic = getSettingByScope($connection2, 'Planner', 'makeUnitsPublic');
 if ($makeUnitsPublic != 'Y') {

--- a/modules/Planner/units_public_view.php
+++ b/modules/Planner/units_public_view.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 $makeUnitsPublic = getSettingByScope($connection2, 'Planner', 'makeUnitsPublic');
 if ($makeUnitsPublic != 'Y') {

--- a/modules/Rubrics/rubrics_add.php
+++ b/modules/Rubrics/rubrics_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Search & Filters
 $search = null;

--- a/modules/Rubrics/rubrics_delete.php
+++ b/modules/Rubrics/rubrics_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Search & Filters
 $search = null;

--- a/modules/Rubrics/rubrics_duplicate.php
+++ b/modules/Rubrics/rubrics_duplicate.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Search & Filters
 $search = null;

--- a/modules/Rubrics/rubrics_edit.php
+++ b/modules/Rubrics/rubrics_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Search & Filters
 $search = null;

--- a/modules/Rubrics/rubrics_edit_editRowsColumns.php
+++ b/modules/Rubrics/rubrics_edit_editRowsColumns.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Search & Filters
 $search = null;

--- a/modules/Rubrics/rubrics_view_full.php
+++ b/modules/Rubrics/rubrics_view_full.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Rubric includes
-include './modules/Rubrics/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_view_full.php') == false) {
     //Acess denied

--- a/modules/School Admin/attendanceSettings_manage_add.php
+++ b/modules/School Admin/attendanceSettings_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSettings_manage_add.php') == false) {
     //Acess denied

--- a/modules/School Admin/attendanceSettings_manage_edit.php
+++ b/modules/School Admin/attendanceSettings_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSettings_manage_edit.php') == false) {
     //Acess denied

--- a/modules/School Admin/department_manage.php
+++ b/modules/School Admin/department_manage.php
@@ -23,7 +23,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\School\DepartmentGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_manage.php') == false) {
     //Acess denied

--- a/modules/School Admin/department_manage_add.php
+++ b/modules/School Admin/department_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_manage_add.php') == false) {
     //Acess denied

--- a/modules/School Admin/department_manage_delete.php
+++ b/modules/School Admin/department_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_manage_delete.php') == false) {
     //Acess denied

--- a/modules/School Admin/department_manage_edit.php
+++ b/modules/School Admin/department_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_manage_edit.php') == false) {
     //Acess denied

--- a/modules/School Admin/externalAssessments_manage_add.php
+++ b/modules/School Admin/externalAssessments_manage_add.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAssessments_manage_add.php') == false) {
     //Acess denied

--- a/modules/School Admin/externalAssessments_manage_edit.php
+++ b/modules/School Admin/externalAssessments_manage_edit.php
@@ -23,7 +23,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\School\ExternalAssessmentGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAssessments_manage_edit.php') == false) {
     //Acess denied

--- a/modules/School Admin/gradeScales_manage_add.php
+++ b/modules/School Admin/gradeScales_manage_add.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_manage_add.php') == false) {
     //Acess denied

--- a/modules/School Admin/gradeScales_manage_edit.php
+++ b/modules/School Admin/gradeScales_manage_edit.php
@@ -23,7 +23,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\School\GradeScaleGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Staff/applicationFormProcess.php
+++ b/modules/Staff/applicationFormProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Comms\NotificationEvent;
 
 include '../../gibbon.php';
-require '../../lib/PHPMailer/PHPMailerAutoload.php';
+require_once __DIR__ . '/../../lib/PHPMailer/PHPMailerAutoload.php';
 
 //Check to see if system settings are set from databases
 if (empty($_SESSION[$guid]['systemSettingsSet'])) {

--- a/modules/Staff/applicationForm_manage_accept.php
+++ b/modules/Staff/applicationForm_manage_accept.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Data\UsernameGenerator;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 require $_SESSION[$guid]['absolutePath'].'/lib/PHPMailer/PHPMailerAutoload.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_manage_accept.php') == false) {

--- a/modules/Staff/applicationForm_manage_delete.php
+++ b/modules/Staff/applicationForm_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Module includes from User Admin (for custom fields)
 include './modules/User Admin/moduleFunctions.php';

--- a/modules/Staff/applicationForm_manage_edit_print.php
+++ b/modules/Staff/applicationForm_manage_edit_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Staff/applicationForm_manage_reject.php
+++ b/modules/Staff/applicationForm_manage_reject.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_manage_reject.php') == false) {
     //Acess denied

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -22,7 +22,7 @@ use Gibbon\Comms\NotificationEvent;
 use Gibbon\Data\UsernameGenerator;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 require $_SESSION[$guid]['absolutePath'].'/lib/PHPMailer/PHPMailerAutoload.php';
 
 

--- a/modules/Students/applicationForm_manage_add.php
+++ b/modules/Students/applicationForm_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Module includes from User Admin (for custom fields)
 include './modules/User Admin/moduleFunctions.php';

--- a/modules/Students/applicationForm_manage_delete.php
+++ b/modules/Students/applicationForm_manage_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_manage_delete.php') == false) {
     //Acess denied

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 //Module includes from User Admin (for custom fields)
 include './modules/User Admin/moduleFunctions.php';

--- a/modules/Students/applicationForm_manage_edit_print.php
+++ b/modules/Students/applicationForm_manage_edit_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Students/applicationForm_manage_reject.php
+++ b/modules/Students/applicationForm_manage_reject.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_manage_reject.php') == false) {
     //Acess denied

--- a/modules/Students/firstAidRecord.php
+++ b/modules/Students/firstAidRecord.php
@@ -24,7 +24,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\Students\FirstAidGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.php') == false) {
     //Acess denied

--- a/modules/Students/firstAidRecord_add.php
+++ b/modules/Students/firstAidRecord_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_add.php') == false) {
     //Acess denied

--- a/modules/Students/firstAidRecord_edit.php
+++ b/modules/Students/firstAidRecord_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_edit.php') == false) {
     //Acess denied

--- a/modules/Students/report_emergencySMS_byTransport.php
+++ b/modules/Students/report_emergencySMS_byTransport.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_emergencySMS_byTransport.php') == false) {
     //Acess denied

--- a/modules/Students/report_emergencySMS_byYearGroup.php
+++ b/modules/Students/report_emergencySMS_byYearGroup.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_emergencySMS_byYearGroup.php') == false) {
     //Acess denied

--- a/modules/Students/report_familyAddress_byStudent.php
+++ b/modules/Students/report_familyAddress_byStudent.php
@@ -23,7 +23,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 $_SESSION[$guid]['report_student_emergencySummary.php_choices'] = '';
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_familyAddress_byStudent.php') == false) {
     //Acess denied

--- a/modules/Students/report_graph_studentEnrolment.php
+++ b/modules/Students/report_graph_studentEnrolment.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 include './modules/Attendance/moduleFunctions.php';
 
 function getDateRange($firstDate, $lastDate, $step = '+1 day', $output_format = 'Y-m-d' ) {

--- a/modules/Students/report_lettersHome_byRollGroup.php
+++ b/modules/Students/report_lettersHome_byRollGroup.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_new') == false) {
     //Acess denied

--- a/modules/Students/report_privacy_student.php
+++ b/modules/Students/report_privacy_student.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_privacy_student.php') == false) {
     //Acess denied

--- a/modules/Students/report_rollGroupSummary.php
+++ b/modules/Students/report_rollGroupSummary.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_rollGroupSummary.php') == false) {
     //Acess denied

--- a/modules/Students/report_student_emergencySummary.php
+++ b/modules/Students/report_student_emergencySummary.php
@@ -23,7 +23,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 $_SESSION[$guid]['report_student_emergencySummary.php_choices'] = '';
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_emergencySummary.php') == false) {
     //Acess denied

--- a/modules/Students/report_student_emergencySummary_print.php
+++ b/modules/Students/report_student_emergencySummary_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_emergencySummary_print.php') == false) {
     //Acess denied

--- a/modules/Students/report_student_medicalSummary.php
+++ b/modules/Students/report_student_medicalSummary.php
@@ -23,7 +23,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 $_SESSION[$guid]['report_student_medicalSummary.php_choices'] = '';
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_medicalSummary.php') == false) {
     //Acess denied

--- a/modules/Students/report_student_medicalSummary_print.php
+++ b/modules/Students/report_student_medicalSummary_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_medicalSummary_print.php') == false) {
     //Acess denied

--- a/modules/Students/report_students_IDCards.php
+++ b/modules/Students/report_students_IDCards.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_IDCards.php') == false) {
     //Acess denied

--- a/modules/Students/report_students_ageGenderSummary.php
+++ b/modules/Students/report_students_ageGenderSummary.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_ageGenderSummary.php') == false) {
     //Acess denied

--- a/modules/Students/report_students_byRollGroup.php
+++ b/modules/Students/report_students_byRollGroup.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_byRollGroup.php') == false) {
     //Acess denied

--- a/modules/Students/report_students_byRollGroup_print.php
+++ b/modules/Students/report_students_byRollGroup_print.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_byRollGroup_print.php') == false) {
     //Acess denied

--- a/modules/Students/report_students_left.php
+++ b/modules/Students/report_students_left.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_left.php') == false) {
     //Acess denied

--- a/modules/Students/report_students_new.php
+++ b/modules/Students/report_students_new.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_new') == false) {
     //Acess denied

--- a/modules/Students/report_transport_student.php
+++ b/modules/Students/report_transport_student.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/report_transport_student.php') == false) {
     //Acess denied

--- a/modules/System Admin/alarm.php
+++ b/modules/System Admin/alarm.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\FileUploader;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/alarm.php') == false) {
     //Acess denied

--- a/modules/System Admin/module_manage.php
+++ b/modules/System Admin/module_manage.php
@@ -23,7 +23,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\System\ModuleGateway;
 
-include './modules/System Admin/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage.php') == false) {
     //Acess denied

--- a/modules/System Admin/systemCheck.php
+++ b/modules/System Admin/systemCheck.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.php') == false) {
     //Acess denied

--- a/modules/System Admin/systemSettings.php
+++ b/modules/System Admin/systemSettings.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSettings.php') == false) {
     //Acess denied

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySettings.php') == false) {
     //Acess denied

--- a/modules/System Admin/update.php
+++ b/modules/System Admin/update.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/courseEnrolment_sync.php
+++ b/modules/Timetable Admin/courseEnrolment_sync.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/courseEnrolment_sync_add.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_add.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/courseEnrolment_sync_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_delete.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_delete.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/courseEnrolment_sync_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_edit.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/courseEnrolment_sync_run.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_run.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_run.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/course_manage_add.php
+++ b/modules/Timetable Admin/course_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_add.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/course_manage_edit.php
+++ b/modules/Timetable Admin/course_manage_edit.php
@@ -24,7 +24,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\CourseGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_edit.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rollover.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/report_classEnrolment_byRollGroup.php
+++ b/modules/Timetable Admin/report_classEnrolment_byRollGroup.php
@@ -24,7 +24,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/report_classEnrolment_byRollGroup.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/ttColumn_add.php
+++ b/modules/Timetable Admin/ttColumn_add.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_add.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/ttColumn_edit.php
+++ b/modules/Timetable Admin/ttColumn_edit.php
@@ -23,7 +23,7 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\TimetableColumnGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/ttDates_edit.php
+++ b/modules/Timetable Admin/ttDates_edit.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_edit.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/tt_add.php
+++ b/modules/Timetable Admin/tt_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Domain\Timetable\TimetableGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php') == false) {
     //Acess denied

--- a/modules/Timetable Admin/tt_edit.php
+++ b/modules/Timetable Admin/tt_edit.php
@@ -24,7 +24,7 @@ use Gibbon\Domain\Timetable\TimetableGateway;
 use Gibbon\Domain\Timetable\TimetableDayGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.php') == false) {
     //Acess denied

--- a/modules/Timetable/report_viewAvailableSpaces.php
+++ b/modules/Timetable/report_viewAvailableSpaces.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvailableSpaces.php') == false) {
     //Acess denied

--- a/modules/Timetable/report_viewAvailableTeachers.php
+++ b/modules/Timetable/report_viewAvailableTeachers.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvailableTeachers.php') == false) {
     //Acess denied

--- a/modules/Timetable/spaceBooking_manage_add.php
+++ b/modules/Timetable/spaceBooking_manage_add.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_manage_add.php') == false) {
     //Acess denied

--- a/modules/Timetable/tt.php
+++ b/modules/Timetable/tt.php
@@ -24,7 +24,7 @@ use Gibbon\Domain\Students\StudentGateway;
 use Gibbon\Domain\Staff\StaffGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == false) {
     //Acess denied

--- a/modules/Timetable/tt_master.php
+++ b/modules/Timetable/tt_master.php
@@ -24,7 +24,7 @@ use Gibbon\Domain\Timetable\TimetableGateway;
 use Gibbon\Domain\Timetable\TimetableDayGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_master.php') == false) {
     //Acess denied

--- a/modules/Timetable/tt_space.php
+++ b/modules/Timetable/tt_space.php
@@ -22,7 +22,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Domain\School\FacilityGateway;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space.php') == false) {
     //Acess denied

--- a/modules/Timetable/tt_space_view.php
+++ b/modules/Timetable/tt_space_view.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space_view.php') == false) {
     //Acess denied

--- a/modules/Timetable/tt_view.php
+++ b/modules/Timetable/tt_view.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_view.php') == false) {
     //Acess denied

--- a/modules/Tracking/dataPoints.php
+++ b/modules/Tracking/dataPoints.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Tracking/dataPoints.php') == false) {
     //Acess denied

--- a/modules/Tracking/graphing.php
+++ b/modules/Tracking/graphing.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') == false) {
     //Acess denied

--- a/modules/User Admin/role_manage_duplicate.php
+++ b/modules/User Admin/role_manage_duplicate.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_duplicate.php') == false) {
     //Acess denied

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') == false) {
     //Acess denied

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -21,7 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
-include './modules/'.$_SESSION[$guid]['module'].'/moduleFunctions.php';
+require_once __DIR__ . '/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edit.php') == false) {
     //Acess denied


### PR DESCRIPTION
## Description
Refactor modules to remove unnecessary use of `$_SESSION['$guid]['module']` in include path. And rewrite include with require_once for module function file inclusion.

## Motivation and Context
Fix #620.

## How Has This Been Tested?
1. Unit test pass.
2. Open a few pages in development environment.

