### PR TITLE
Tables: add a JsonRenderer class for outputting JSON object data

### DIFF
--- a/src/Tables/Renderer/JsonRenderer.php
+++ b/src/Tables/Renderer/JsonRenderer.php
@@ -1,0 +1,86 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Tables\Renderer;
+
+use Gibbon\Domain\DataSet;
+use Gibbon\Tables\DataTable;
+use Gibbon\Tables\Columns\Column;
+use Gibbon\Tables\Renderer\RendererInterface;
+
+/**
+ * JSON Renderer
+ *
+ * @version v17
+ * @since   v17
+ */
+class JsonRenderer implements RendererInterface
+{
+    protected $jsonOptions;
+
+    /**
+     * @param int json_encode options (optional)
+     */
+    public function __construct($jsonOptions = JSON_PRETTY_PRINT)
+    {
+        $this->jsonOptions = $jsonOptions;
+    }
+
+    /**
+     * Render the table to JSON.
+     *
+     * @param DataTable $table
+     * @param DataSet $dataSet
+     * @return string
+     */
+    public function renderTable(DataTable $table, DataSet $dataSet)
+    {
+        $jsonData = array();
+
+        foreach ($dataSet as $index => $data) {
+            $jsonData[$index] = $this->jsonifyColumns($table->getColumns(0), $data);
+        }
+
+        return json_encode($jsonData, $this->jsonOptions);
+    }
+
+    /**
+     * Recursively build a set of column data, handling nested columns as nested JSON objects.
+     *
+     * @param array $columns
+     * @param array $data
+     * @return array
+     */
+    protected function jsonifyColumns(array $columns, array &$data)
+    {
+        $columnData = array();
+        foreach ($columns as $column) {
+            $columnData[$column->getID()] = ($column->getTotalDepth() > 1)
+                ? $this->jsonifyColumns($column->getColumns(), $data)
+                : $this->stripTags($column->getOutput($data));
+        }
+        return $columnData;
+    }
+
+    protected function stripTags($content)
+    {
+        $content = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, $content);
+        return strip_tags($content);
+    }
+}


### PR DESCRIPTION
The goal for DataTables is to keep them abstracted enough that we can render them out in many different forms: paginated tables, printable, spreadsheets, etc. This PR adds a renderer class for JSON data, which also handles grouped column headings as nested object data.

This isn't used anywhere _just yet_ but it's part of some unit tests I'm working on for the DataTables, and in the future it will give us more export options, and tie into API functionality.