### PR TITLE
Students: update how the Privacy section is displayed in forms

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -68,6 +68,7 @@ v17.0.00
         Staff: added a Mark as Left bulk action to Manage Staff
         Students: adjusted Student Enrolment/course enrolment sync logic to mark students as left instead of deleting them
         Students: removed non-students from New Students report, when Ignore Status in use
+        Students: updated how the Privacy section is displayed in application and data updater forms
         Timetable Admin: fixed course sync for courses with multiple year groups
         User Admin: added an option in Manage Roles to toggle login access for all users of a particular role
         User Admin: fixed name display bug in Enrol New Students (Status Full) section of Rollover

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -565,15 +565,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
 					if ($student) {
 						$privacySetting = getSettingByScope($connection2, 'User Admin', 'privacy');
-							$privacyBlurb = getSettingByScope($connection2, 'User Admin', 'privacyBlurb');
-							$privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
+						$privacyBlurb = getSettingByScope($connection2, 'User Admin', 'privacyBlurb');
+						$privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
 
 						if ($privacySetting == 'Y' && !empty($privacyBlurb) && !empty($privacyOptions)) {
+
+                            $form->addRow()->addSubheading(__('Privacy'))->append($privacyBlurb);
+
 							$options = array_map(function($item) { return trim($item); }, explode(',', $privacyOptions));
 							$values['privacyOptions'] = $values['privacy'];
 
 							$row = $form->addRow();
-								$row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
+								$row->addLabel('privacyOptions[]', __('Privacy Options'));
 								$row->addCheckbox('privacyOptions[]')->fromArray($options)->loadFromCSV($values);
 						}
 					}

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -945,10 +945,13 @@ if ($proceed == false) {
     $privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
 
     if ($privacySetting == 'Y' && !empty($privacyBlurb) && !empty($privacyOptions)) {
+
+        $form->addRow()->addSubheading(__('Privacy'))->append($privacyBlurb);
+
         $options = array_map(function($item) { return trim($item); }, explode(',', $privacyOptions));
 
         $row = $form->addRow();
-            $row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
+            $row->addLabel('privacyOptions[]', __('Privacy Options'));
             $row->addCheckbox('privacyOptions[]')->fromArray($options);
     }
 

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -924,11 +924,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     $privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
 
     if ($privacySetting == 'Y' && !empty($privacyBlurb) && !empty($privacyOptions)) {
+
+        $form->addRow()->addSubheading(__('Privacy'))->append($privacyBlurb);
+
         $options = array_map('trim', explode(',', $privacyOptions));
         $checked = array_map('trim', explode(',', $application['privacy']));
 
         $row = $form->addRow();
-            $row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
+            $row->addLabel('privacyOptions[]', __('Privacy'));
             $row->addCheckbox('privacyOptions[]')->fromArray($options)->checked($checked);
     }
 

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -452,14 +452,13 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addTextField('vehicleRegistration')->maxLength(20);
 
     $privacySetting = getSettingByScope($connection2, 'User Admin', 'privacy');
-        $privacyBlurb = getSettingByScope($connection2, 'User Admin', 'privacyBlurb');
-        $privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
+    $privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
 
-    if ($privacySetting == 'Y' && !empty($privacyBlurb) && !empty($privacyOptions)) {
+    if ($privacySetting == 'Y' && !empty($privacyOptions)) {
         $options = array_map(function($item) { return trim($item); }, explode(',', $privacyOptions));
 
         $row = $form->addRow();
-            $row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
+            $row->addLabel('privacyOptions[]', __('Privacy'))->description(__('Check to indicate which privacy options are required.'));
             $row->addCheckbox('privacyOptions[]')->fromArray($options);
     }
 

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -591,15 +591,14 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			if ($student) {
 				$privacySetting = getSettingByScope($connection2, 'User Admin', 'privacy');
-					$privacyBlurb = getSettingByScope($connection2, 'User Admin', 'privacyBlurb');
-					$privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
+				$privacyOptions = getSettingByScope($connection2, 'User Admin', 'privacyOptions');
 
-				if ($privacySetting == 'Y' && !empty($privacyBlurb) && !empty($privacyOptions)) {
+				if ($privacySetting == 'Y' && !empty($privacyOptions)) {
                     $options = array_map('trim', explode(',', $privacyOptions));
                     $values['privacyOptions'] = array_map('trim', explode(',', $values['privacy']));
 
 					$row = $form->addRow();
-						$row->addLabel('privacyOptions[]', __('Privacy'))->description($privacyBlurb);
+						$row->addLabel('privacyOptions[]', __('Privacy'))->description(__('Check to indicate which privacy options are required.'));
 						$row->addCheckbox('privacyOptions[]')->fromArray($options)->checked($values['privacyOptions']);
 				}
 


### PR DESCRIPTION
This is a small tweak to how Privacy settings are displayed. Visually, it's in line with other similar sections: SEN, Agreement, Required Documents, etc.
- In Applications and Data Updater, it adds a heading to that section and some more room for longer descriptive text. 
- In User Admin, it reduces the section to a smaller description text. 

Here's an example (the text might be longer than the average school, but helps illustrate the change).

Application:
<img width="761" alt="screen shot 2018-09-18 at 9 20 05 am" src="https://user-images.githubusercontent.com/897700/45661440-2053fe80-bb30-11e8-88d7-08bbeefd6b0b.png">

User Admin:
<img width="756" alt="screen shot 2018-09-18 at 10 51 40 am" src="https://user-images.githubusercontent.com/897700/45661614-dddef180-bb30-11e8-92b6-c79785b37dfd.png">
