### PR TITLE
Tables: fix conflicting POST data in multiple DataTable instances

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -343,12 +343,13 @@ $.prototype.gibbonCustomBlocks = function(settings) {
  */
 var DataTable = window.DataTable || {};
 
-DataTable = (function(element, basePath, filters) {
+DataTable = (function(element, basePath, filters, identifier) {
     var _ = this;
 
     _.table = $(element);
     _.path = basePath + " #" + $(element).attr('id') + " .dataTable";
     _.filters = filters;
+    _.identifier = identifier;
     if (_.filters.sortBy.length == 0) _.filters.sortBy = {};
     if (_.filters.filterBy.length == 0) _.filters.filterBy = {};
 
@@ -434,16 +435,24 @@ DataTable.prototype.refresh = function() {
     var submitted = setTimeout(function() {
         $('.pagination', _.table).prepend('<span class="submitted"></span>');
     }, 500);
+    
+    var postData = {};
 
-    $(_.table).load(_.path, _.filters, function(responseText, textStatus, jqXHR) { 
+    if (_.identifier != '') {
+        postData[_.identifier] = _.filters;
+    } else {
+        postData = _.filters;
+    }
+
+    $(_.table).load(_.path, postData, function(responseText, textStatus, jqXHR) { 
         $('.bulkActionPanel').hide();
         tb_init('a.thickbox'); 
         clearTimeout(submitted);
     });
 };
 
-$.prototype.gibbonDataTable = function(basePath, filters) {
-    this.gibbonDataTable = new DataTable(this, basePath, filters);
+$.prototype.gibbonDataTable = function(basePath, filters, identifier) {
+    this.gibbonDataTable = new DataTable(this, basePath, filters, identifier);
 };
 
 /**

--- a/modules/Activities/activities_manage.php
+++ b/modules/Activities/activities_manage.php
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         ->sortBy($dateType != 'Date' ? 'gibbonSchoolYearTermIDList' : 'programStart', $dateType != 'Date' ? 'ASC' : 'DESC')
         ->sortBy('name');
 
-    $criteria->fromArray($_POST);
+    $criteria->fromPOST();
 
     echo '<h2>';
     echo __('Search & Filter');

--- a/modules/Activities/report_activityEnrollmentSummary.php
+++ b/modules/Activities/report_activityEnrollmentSummary.php
@@ -47,7 +47,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
         ->searchBy($activityGateway->getSearchableColumns(), isset($_GET['search'])? $_GET['search'] : '')
         ->sortBy('gibbonActivity.name')
         ->pageSize(!empty($viewMode) ? 0 : 50)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $activities = $activityGateway->queryActivityEnrollmentSummary($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 

--- a/modules/Activities/report_activitySpread_rollGroup.php
+++ b/modules/Activities/report_activitySpread_rollGroup.php
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
         ->searchBy($activityGateway->getSearchableColumns(), isset($_GET['search'])? $_GET['search'] : '')
         ->sortBy(['surname', 'preferredName'])
         ->pageSize(!empty($viewMode) ? 0 : 50)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $rollGroups = $studentGateway->queryStudentEnrolmentByRollGroup($criteria, $gibbonRollGroupID);
 

--- a/modules/Activities/report_activityType_rollGroup.php
+++ b/modules/Activities/report_activityType_rollGroup.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
         ->searchBy($activityGateway->getSearchableColumns(), isset($_GET['search'])? $_GET['search'] : '')
         ->sortBy(['surname', 'preferredName'])
         ->pageSize(!empty($viewMode) ? 0 : 50)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $rollGroups = $studentGateway->queryStudentEnrolmentByRollGroup($criteria, $gibbonRollGroupID);
 

--- a/modules/Activities/report_attendance_byDate.php
+++ b/modules/Activities/report_attendance_byDate.php
@@ -105,7 +105,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
         ->searchBy($activityGateway->getSearchableColumns(), isset($_GET['search'])? $_GET['search'] : '')
         ->sortBy($defaultSort)
         ->pageSize(!empty($viewMode) ? 0 : 50)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $activityAttendance = $activityGateway->queryActivityAttendanceByDate($criteria, $_SESSION[$guid]['gibbonSchoolYearID'], $dateType, $date);
 

--- a/modules/Activities/report_participants.php
+++ b/modules/Activities/report_participants.php
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_particip
         ->searchBy($activityGateway->getSearchableColumns(), isset($_GET['search'])? $_GET['search'] : '')
         ->sortBy(['surname', 'preferredName'])
         ->pageSize(!empty($viewMode) ? 0 : 50)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $participants = $activityGateway->queryParticipantsByActivity($criteria, $gibbonActivityID);
 

--- a/modules/Behaviour/behaviour_letters.php
+++ b/modules/Behaviour/behaviour_letters.php
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_letter
     $criteria = $behaviourGateway->newQueryCriteria()
         ->sortBy('timestamp', 'DESC')
         ->filterBy('student', $gibbonPersonID)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $letters = $behaviourGateway->queryBehaviourLettersBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 

--- a/modules/Behaviour/behaviour_manage.php
+++ b/modules/Behaviour/behaviour_manage.php
@@ -93,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             ->filterBy('rollGroup', $gibbonRollGroupID)
             ->filterBy('yearGroup', $gibbonYearGroupID)
             ->filterBy('type', $type)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         
         if ($highestAction == 'Manage Behaviour Records_all') {

--- a/modules/Behaviour/behaviour_pattern.php
+++ b/modules/Behaviour/behaviour_pattern.php
@@ -120,7 +120,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
         ->filterBy('rollGroup', $gibbonRollGroupID)
         ->filterBy('yearGroup', $gibbonYearGroupID)
         ->filterBy('minimumCount', $minimumCount)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $records = $behaviourGateway->queryBehaviourPatternsBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 

--- a/modules/Behaviour/behaviour_view.php
+++ b/modules/Behaviour/behaviour_view.php
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_view.p
             $criteria = $studentGateway->newQueryCriteria()
                 ->searchBy($studentGateway->getSearchableColumns(), $search)
                 ->sortBy(['surname', 'preferredName'])
-                ->fromArray($_POST);
+                ->fromPOST();
 
             $students = $studentGateway->queryStudentsBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID'], false);
 

--- a/modules/Data Updater/data_family_manage.php
+++ b/modules/Data Updater/data_family_manage.php
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_m
     $criteria = $gateway->newQueryCriteria()
         ->sortBy('status')
         ->sortBy('timestamp', 'DESC')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $dataUpdates = $gateway->queryDataUpdates($criteria, $gibbonSchoolYearID);
 

--- a/modules/Data Updater/data_finance_manage.php
+++ b/modules/Data Updater/data_finance_manage.php
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
     $criteria = $gateway->newQueryCriteria()
         ->sortBy('status')
         ->sortBy('timestamp', 'DESC')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $dataUpdates = $gateway->queryDataUpdates($criteria, $gibbonSchoolYearID);
 

--- a/modules/Data Updater/data_medical_manage.php
+++ b/modules/Data Updater/data_medical_manage.php
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
     $criteria = $gateway->newQueryCriteria()
         ->sortBy('status')
         ->sortBy('timestamp', 'DESC')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $dataUpdates = $gateway->queryDataUpdates($criteria, $gibbonSchoolYearID);
 

--- a/modules/Data Updater/data_personal_manage.php
+++ b/modules/Data Updater/data_personal_manage.php
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
     $criteria = $gateway->newQueryCriteria()
         ->sortBy('status')
         ->sortBy('timestamp', 'DESC')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $dataUpdates = $gateway->queryDataUpdates($criteria, $gibbonSchoolYearID);
 

--- a/modules/Data Updater/report_family_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_family_dataUpdaterHistory.php
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
         $criteria = $gateway->newQueryCriteria()
             ->sortBy(['gibbonFamily.name'])
             ->filterBy('cutoff', $nonCompliant == 'Y'? Format::dateConvert($date) : '')
-            ->fromArray($_POST);
+            ->fromPOST();
 
         $dataUpdates = $gateway->queryFamilyUpdaterHistory($criteria, $_SESSION[$guid]['gibbonSchoolYearID'], $gibbonYearGroupIDList);
         $families = $dataUpdates->getColumn('gibbonFamilyID');

--- a/modules/Data Updater/report_student_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_student_dataUpdaterHistory.php
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_studen
         $criteria = $gateway->newQueryCriteria()
             ->sortBy(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
             ->filterBy('cutoff', $nonCompliant == 'Y'? Format::dateConvert($date) : '')
-            ->fromArray($_POST);
+            ->fromPOST();
 
         $dataUpdates = $gateway->queryStudentUpdaterHistory($criteria, $_SESSION[$guid]['gibbonSchoolYearID'], $choices);
         

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -163,7 +163,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
             ->filterBy('month', $request['monthOfIssue'])
             ->filterBy('billingSchedule', $request['gibbonFinanceBillingScheduleID'])
             ->filterBy('feeCategory', $request['gibbonFinanceFeeCategoryID'])
-            ->fromArray($_POST);
+            ->fromPOST();
         $invoices = $invoiceGateway->queryInvoicesByYear($criteria, $gibbonSchoolYearID);
 
         // FORM

--- a/modules/Individual Needs/in_summary.php
+++ b/modules/Individual Needs/in_summary.php
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_summar
         ->filterBy('alert', $gibbonAlertLevelID)
         ->filterBy('rollGroup', $gibbonRollGroupID)
         ->filterBy('yearGroup', $gibbonYearGroupID)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $individualNeeds = $individualNeedsGateway->queryINBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 

--- a/modules/Individual Needs/in_view.php
+++ b/modules/Individual Needs/in_view.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_view.p
             ->searchBy($studentGateway->getSearchableColumns(), $search)
             ->sortBy(['surname', 'preferredName'])
             ->filterBy('all', $allStudents)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h2>';
         echo __('Search');

--- a/modules/Messenger/groups_manage.php
+++ b/modules/Messenger/groups_manage.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage.ph
 
     $criteria = $groupGateway->newQueryCriteria()
         ->sortBy(['schoolYear', 'name'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $highestAction = getHighestGroupedAction($guid, '/modules/Messenger/groups_manage.php', $connection2);
     if ($highestAction == 'Manage Groups_all') {

--- a/modules/Messenger/groups_manage_edit.php
+++ b/modules/Messenger/groups_manage_edit.php
@@ -91,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_ed
 
             $criteria = $groupGateway->newQueryCriteria()
                 ->sortBy(['surname', 'preferredName'])
-                ->fromArray($_POST);
+                ->fromPOST();
 
             $members = $groupGateway->queryGroupMembers($criteria, $gibbonGroupID);
 

--- a/modules/Rubrics/rubrics.php
+++ b/modules/Rubrics/rubrics.php
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics.php') == f
             ->searchBy($rubricGateway->getSearchableColumns(), $search)
             ->sortBy(['scope', 'category', 'name'])
             ->filterBy('department', $department)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         // SEARCH
         $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/rubrics.php');

--- a/modules/Rubrics/rubrics_view.php
+++ b/modules/Rubrics/rubrics_view.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_view.php')
         ->searchBy($rubricGateway->getSearchableColumns(), $search)
         ->sortBy(['scope', 'category', 'name'])
         ->filterBy('department', $department)
-        ->fromArray($_POST);
+        ->fromPOST();
 
     // SEARCH
     $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/rubrics_view.php');

--- a/modules/School Admin/department_manage.php
+++ b/modules/School Admin/department_manage.php
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
     // QUERY
     $criteria = $departmentGateway->newQueryCriteria()
         ->sortBy('name')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $departments = $departmentGateway->queryDepartments($criteria);
 

--- a/modules/School Admin/externalAssessments_manage.php
+++ b/modules/School Admin/externalAssessments_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
     // QUERY
     $criteria = $externalAssessmentGateway->newQueryCriteria()
         ->sortBy('name')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $externalAssessments = $externalAssessmentGateway->queryExternalAssessments($criteria);
 

--- a/modules/School Admin/externalAssessments_manage_edit.php
+++ b/modules/School Admin/externalAssessments_manage_edit.php
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
             // QUERY
             $criteria = $externalAssessmentGateway->newQueryCriteria()
                 ->sortBy(['category', 'order'])
-                ->fromArray($_POST);
+                ->fromPOST();
 
             $externalAssessments = $externalAssessmentGateway->queryExternalAssessmentFields($criteria, $gibbonExternalAssessmentID);
 

--- a/modules/School Admin/fileExtensions_manage.php
+++ b/modules/School Admin/fileExtensions_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
     // QUERY
     $criteria = $fileExtensionGateway->newQueryCriteria()
         ->sortBy('extension')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $fileExtensions = $fileExtensionGateway->queryFileExtensions($criteria);
 

--- a/modules/School Admin/gradeScales_manage.php
+++ b/modules/School Admin/gradeScales_manage.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
     // QUERY
     $criteria = $gradeScaleGateway->newQueryCriteria()
         ->sortBy('name')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $gradeScales = $gradeScaleGateway->queryGradeScales($criteria);
 

--- a/modules/School Admin/gradeScales_manage_edit.php
+++ b/modules/School Admin/gradeScales_manage_edit.php
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
             // QUERY
             $criteria = $gradeScaleGateway->newQueryCriteria()
                 ->sortBy('sequenceNumber')
-                ->fromArray($_POST);
+                ->fromPOST();
 
             $grades = $gradeScaleGateway->queryGradeScaleGrades($criteria, $gibbonScaleID);
 

--- a/modules/School Admin/house_manage.php
+++ b/modules/School Admin/house_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage.
     // QUERY
     $criteria = $houseGateway->newQueryCriteria()
         ->sortBy(['name'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $houses = $houseGateway->queryHouses($criteria);
 

--- a/modules/School Admin/rollGroup_manage.php
+++ b/modules/School Admin/rollGroup_manage.php
@@ -68,7 +68,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/rollGroup_man
     // QUERY
     $criteria = $rollGroupGateway->newQueryCriteria()
         ->sortBy(['sequenceNumber', 'gibbonRollGroup.name'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $rollGroups = $rollGroupGateway->queryRollGroups($criteria, $gibbonSchoolYearID);
 

--- a/modules/School Admin/schoolYearTerm_manage.php
+++ b/modules/School Admin/schoolYearTerm_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
     // QUERY
     $criteria = $termGateway->newQueryCriteria()
         ->sortBy(['schoolYearSequence', 'sequenceNumber'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $terms = $termGateway->querySchoolYearTerms($criteria);
 

--- a/modules/School Admin/schoolYear_manage.php
+++ b/modules/School Admin/schoolYear_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
     // QUERY
     $criteria = $schoolYearGateway->newQueryCriteria()
         ->sortBy(['sequenceNumber'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $schoolYears = $schoolYearGateway->querySchoolYears($criteria);
 

--- a/modules/School Admin/space_manage.php
+++ b/modules/School Admin/space_manage.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage.
     $criteria = $facilityGateway->newQueryCriteria()
         ->searchBy($facilityGateway->getSearchableColumns(), $search)
         ->sortBy(['name'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     echo '<h3>';
     echo __('Search');

--- a/modules/School Admin/yearGroup_manage.php
+++ b/modules/School Admin/yearGroup_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
     // QUERY
     $criteria = $yearGroupGateway->newQueryCriteria()
         ->sortBy(['sequenceNumber'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $yearGroups = $yearGroupGateway->queryYearGroups($criteria);
 

--- a/modules/Staff/applicationForm_manage.php
+++ b/modules/Staff/applicationForm_manage.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
         ->searchBy($applicationGateway->getSearchableColumns(), $search)
         ->sortBy('gibbonStaffApplicationForm.status')
         ->sortBy(['priority', 'timestamp'], 'DESC')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     echo '<h4>';
     echo __('Search');

--- a/modules/Staff/jobOpenings_manage.php
+++ b/modules/Staff/jobOpenings_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage.p
     // QUERY
     $criteria = $jobGateway->newQueryCriteria()
         ->sortBy(['dateOpen', 'jobTitle'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $jobs = $jobGateway->queryJobOpenings($criteria);
 

--- a/modules/Staff/staff_manage.php
+++ b/modules/Staff/staff_manage.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
         ->searchBy($staffGateway->getSearchableColumns(), $search)
         ->filterBy('all', $allStaff)
         ->sortBy(['surname', 'preferredName'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     echo '<h2>';
     echo __('Search & Filter');

--- a/modules/Staff/staff_view.php
+++ b/modules/Staff/staff_view.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view.php') == 
             ->searchBy($staffGateway->getSearchableColumns(), $search)
             ->filterBy('all', $allStaff)
             ->sortBy(['surname', 'preferredName'])
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h2>';
         echo __($guid, 'Search');

--- a/modules/Students/applicationForm_manage.php
+++ b/modules/Students/applicationForm_manage.php
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
             ->sortBy('gibbonApplicationForm.priority', 'DESC')
             ->sortBy('gibbonApplicationForm.timestamp', 'DESC')
             ->filterBy('yearGroup', $gibbonYearGroupID)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h4>';
         echo __('Search');

--- a/modules/Students/firstAidRecord.php
+++ b/modules/Students/firstAidRecord.php
@@ -91,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.ph
             ->filterBy('student', $gibbonPersonID)
             ->filterBy('rollGroup', $gibbonRollGroupID)
             ->filterBy('yearGroup', $gibbonYearGroupID)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         $firstAidRecords = $firstAidGateway->queryFirstAidBySchoolYear($criteria, $_SESSION[$guid]['gibbonSchoolYearID']);
 

--- a/modules/Students/medicalForm_manage.php
+++ b/modules/Students/medicalForm_manage.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     $criteria = $medicalGateway->newQueryCriteria()
         ->searchBy($medicalGateway->getSearchableColumns(), $search)
         ->sortBy(['surname', 'preferredName'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     echo '<h2>';
     echo __('Search');

--- a/modules/Students/studentEnrolment_manage.php
+++ b/modules/Students/studentEnrolment_manage.php
@@ -93,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
         $criteria = $studentGateway->newQueryCriteria()
             ->searchBy($studentGateway->getSearchableColumns(), $search)
             ->sortBy(['surname', 'preferredName'])
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h3>';
         echo __('Search');

--- a/modules/Students/student_view.php
+++ b/modules/Students/student_view.php
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view.php'
                 ->searchBy($studentGateway->getSearchableColumns(), $search)
                 ->sortBy(array_filter(explode(',', $sort)))
                 ->filterBy('all', $canViewFullProfile ? $allStudents : '')
-                ->fromArray($_POST);
+                ->fromPOST();
 
             echo '<h2>';
             echo __('Filter');

--- a/modules/System Admin/module_manage.php
+++ b/modules/System Admin/module_manage.php
@@ -68,7 +68,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
     $moduleGateway = $container->get(ModuleGateway::class);
     $criteria = $moduleGateway->newQueryCriteria()
         ->sortBy('name')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $modules = $moduleGateway->queryModules($criteria);
     $moduleNames = $moduleGateway->getAllModuleNames();

--- a/modules/System Admin/stringReplacement_manage.php
+++ b/modules/System Admin/stringReplacement_manage.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     $criteria = $stringGateway->newQueryCriteria()
         ->searchBy($stringGateway->getSearchableColumns(), $search)
         ->sortBy('priority', 'DESC')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     echo '<h2>';
     echo __('Search');

--- a/modules/Timetable Admin/courseEnrolment_manage.php
+++ b/modules/Timetable Admin/courseEnrolment_manage.php
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             ->sortBy(['gibbonCourse.nameShort', 'gibbonCourse.name'])
             ->filterBy('yearGroup', $gibbonYearGroupID)
             ->pageSize(0)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h3>';
         echo __('Filters');

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
@@ -80,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             ->searchBy($studentGateway->getSearchableColumns(), $search)
             ->sortBy(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
             ->filterBy('all', $allUsers)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h3>';
         echo __('Filters');

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             $criteria = $courseEnrolmentGateway->newQueryCriteria()
                 ->sortBy('roleSortOrder')
                 ->sortBy(['course', 'class'])
-                ->fromArray($_POST);
+                ->fromPOST();
 
             $enrolment = $courseEnrolmentGateway->queryCourseEnrolmentByPerson($criteria, $gibbonSchoolYearID, $gibbonPersonID);
 

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
@@ -125,7 +125,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             $criteria = $courseEnrolmentGateway->newQueryCriteria()
                 ->sortBy('roleSortOrder')
                 ->sortBy(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
-                ->fromArray($_POST);
+                ->fromPOST();
 
             $enrolment = $courseEnrolmentGateway->queryCourseEnrolmentByClass($criteria, $gibbonSchoolYearID, $gibbonCourseClassID);
 

--- a/modules/Timetable Admin/course_manage.php
+++ b/modules/Timetable Admin/course_manage.php
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             ->searchBy($courseGateway->getSearchableColumns(), $search)
             ->sortBy(['gibbonCourse.nameShort', 'gibbonCourse.name'])
             ->filterBy('yearGroup', $gibbonYearGroupID)
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h3>';
         echo __('Filters');

--- a/modules/Timetable/spaceBooking_manage.php
+++ b/modules/Timetable/spaceBooking_manage.php
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
 
         $criteria = $facilityBookingGateway->newQueryCriteria()
             ->sortBy(['date', 'name'])
-            ->fromArray($_POST);
+            ->fromPOST();
 
         if ($highestAction == 'Manage Facility Bookings_allBookings') {
             $facilityBookings = $facilityBookingGateway->queryFacilityBookings($criteria);

--- a/modules/Timetable/spaceChange_manage.php
+++ b/modules/Timetable/spaceChange_manage.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
 
         $criteria = $facilityChangeGateway->newQueryCriteria()
             ->sortBy(['date', 'courseName', 'className'])
-            ->fromArray($_POST);
+            ->fromPOST();
 
         if ($highestAction == 'Manage Facility Changes_allClasses') {
             $facilityChanges = $facilityChangeGateway->queryFacilityChanges($criteria);

--- a/modules/Timetable/tt.php
+++ b/modules/Timetable/tt.php
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == fals
                 ->searchBy($studentGateway->getSearchableColumns(), $search)
                 ->sortBy(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
                 ->filterBy('all', $allUsers)
-                ->fromArray($_POST);
+                ->fromPOST();
 
             echo '<h2>';
             echo __('Filters');

--- a/modules/Timetable/tt_space.php
+++ b/modules/Timetable/tt_space.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space.php') =
         $criteria = $facilityGateway->newQueryCriteria()
             ->searchBy($facilityGateway->getSearchableColumns(), $search)
             ->sortBy('name')
-            ->fromArray($_POST);
+            ->fromPOST();
 
         echo '<h2>';
         echo __('Search');

--- a/modules/User Admin/district_manage.php
+++ b/modules/User Admin/district_manage.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
     // QUERY
     $criteria = $districtGateway->newQueryCriteria()
         ->sortBy('name')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $districts = $districtGateway->queryDistricts($criteria);
 

--- a/modules/User Admin/family_manage.php
+++ b/modules/User Admin/family_manage.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage.p
     $criteria = $familyGateway->newQueryCriteria()
         ->searchBy($familyGateway->getSearchableColumns(), $search)
         ->sortBy(['name'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     echo '<h2>';
     echo __($guid, 'Search');

--- a/modules/User Admin/role_manage.php
+++ b/modules/User Admin/role_manage.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage.php
     // QUERY
     $criteria = $roleGateway->newQueryCriteria()
         ->sortBy(['type', 'name'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $roles = $roleGateway->queryRoles($criteria);
 

--- a/modules/User Admin/userFields.php
+++ b/modules/User Admin/userFields.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields.php'
     // QUERY
     $criteria = $userFieldGateway->newQueryCriteria()
         ->sortBy('name')
-        ->fromArray($_POST);
+        ->fromPOST();
 
     $userFields = $userFieldGateway->queryUserFields($criteria);
 

--- a/modules/User Admin/user_manage.php
+++ b/modules/User Admin/user_manage.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
     $criteria = $userGateway->newQueryCriteria()
         ->searchBy($userGateway->getSearchableColumns(), $search)
         ->sortBy(['surname', 'preferredName'])
-        ->fromArray($_POST);
+        ->fromPOST();
 
     echo '<h2>';
     echo __($guid, 'Search');

--- a/src/Domain/QueryCriteria.php
+++ b/src/Domain/QueryCriteria.php
@@ -26,6 +26,8 @@ use Closure;
  */
 class QueryCriteria
 {
+    protected $identifier = '';
+
     protected $criteria = array(
         'page' => 1,
         'pageSize' => 25,
@@ -35,6 +37,21 @@ class QueryCriteria
     );
 
     protected $rules = array();
+
+    /**
+     * Loads a set of criteria from POST data, using an identifier (if available) to separate unique table instances.
+     *
+     * @param string $key
+     * @return self
+     */
+    public function fromPOST($identifier = '')
+    {
+        $this->setIdentifier($identifier);
+
+        return !empty($identifier) && isset($_POST[$identifier]) 
+            ? $this->fromArray($_POST[$identifier]) 
+            : $this->fromArray($_POST);
+    }
 
     /**
      * Loads and sanitizes a set of criteria from array.
@@ -104,6 +121,29 @@ class QueryCriteria
     public function toJson()
     {
         return json_encode($this->criteria);
+    }
+
+    /**
+     * Sets a unique identifier for this criteria, used for multiple table instances.
+     *
+     * @param string $identifier
+     * @return self
+     */
+    public function setIdentifier($identifier)
+    {
+        $this->identifier = $identifier;
+
+        return $this;
+    }
+
+    /**
+     * Gets the unique identifier for this criteria.
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
     }
 
     /**

--- a/src/Tables/Renderer/PaginatedRenderer.php
+++ b/src/Tables/Renderer/PaginatedRenderer.php
@@ -82,7 +82,7 @@ class PaginatedRenderer extends SimpleRenderer implements RendererInterface
         $output .="
         <script>
         $(function(){
-            $('#".$table->getID()."').gibbonDataTable('.".str_replace(' ', '%20', $this->path)."', ".$jsonData.");
+            $('#".$table->getID()."').gibbonDataTable('.".str_replace(' ', '%20', $this->path)."', ".$jsonData.", '".$this->criteria->getIdentifier()."');
         });
         </script>";
 


### PR DESCRIPTION
I discovered a small issue with multiple DataTables on the same page: currently, the PaginatedRenderer and accompanying javascript use POST to communicate the result of user interactions for re-drawing the table. Two or more tables both sending POST data were conflicting.

This PR adds an optional array key to separate out the data, allowing more than one data table instance per page.

- Adds a `fromPOST` method, which accepts an optional `$identifier` that is used as an array key on the $_POST global, and used in the renderer to pass into the js DataTable object.
- Updates all the `fromArray($_POST)` instances to `fromPOST()`, a small but important distinction. This will become `fromRequest()` when we have PSR-7 implemented.