### PR TITLE
System Admin: handle i18n files during Install and Update

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -753,4 +753,6 @@ ALTER TABLE `gibbonPersonField` ADD `activePublicRegistration` TINYINT(1) NOT NU
 ALTER TABLE `gibbonMessengerReceipt` CHANGE `targetType` `targetType` ENUM('Class','Course','Roll Group','Year Group','Activity','Role','Applicants','Individuals','Houses','Role Category','Transport','Attendance','Group') CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL;end
 UPDATE `gibbonAction` SET `category` = 'Extend & Update', `name` = 'Manage Languages' WHERE `name` = 'Language Settings' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='System Admin');end
 UPDATE gibbonCountry SET printable_name='Russia', iddCountryCode='7' WHERE printable_name='Russian Federation';end
+ALTER TABLE `gibboni18n` ADD `installed` ENUM('Y','N') NOT NULL DEFAULT 'N' AFTER `active`;end
+ALTER TABLE `gibboni18n` ADD `version` VARCHAR(10) NULL AFTER `name`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ CHANGELOG
 v17.0.00
 --------
     Headlines
+        Languages can now be installed and updated through Manage Languages in System Admin
 
     Changes With Important Notices
 

--- a/functions.php
+++ b/functions.php
@@ -2760,8 +2760,7 @@ function sidebar($gibbon, $pdo)
 
             $row = $form->addRow()->setClass('loginOptions');
                 $row->addContent(sprintf($loginIcon, 'language', __('Language')));
-                $row->addSelect('gibboni18nID')
-                    ->fromQuery($pdo, "SELECT gibboni18nID as value, name FROM gibboni18n WHERE active='Y' ORDER BY name")
+                $row->addSelectI18n('gibboni18nID')
                     ->setClass('fullWidth')
                     ->placeholder(null)
                     ->selected($_SESSION[$guid]['i18n']['gibboni18nID']);

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -102,8 +102,7 @@ if (isset($authUrl)){
 
         $row = $form->addRow()->setClass('loginOptionsGoogle');
             $row->addContent(sprintf($loginIcon, 'language', __('Language')));
-            $row->addSelect('gibboni18nIDGoogle')
-                ->fromQuery($pdo, "SELECT gibboni18nID as value, name FROM gibboni18n WHERE active='Y' ORDER BY name")
+            $row->addSelectI18n('gibboni18nIDGoogle')
                 ->setClass('fullWidth')
                 ->placeholder(null)
                 ->selected($_SESSION[$guid]['i18n']['gibboni18nID']);

--- a/modules/System Admin/i18n_manage.php
+++ b/modules/System Admin/i18n_manage.php
@@ -22,6 +22,9 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\System\I18nGateway;
 
+//Module includes
+require_once __DIR__ . '/moduleFunctions.php';
+
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.php') == false) {
     //Acess denied
     echo "<div class='error'>";
@@ -39,6 +42,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.p
             )
         );
     }
+
+    // Update any existing languages that may have been installed manually
+    i18nCheckAndUpdateVersion($container, $version);
 
     echo '<h2>';
     echo __('Installed');

--- a/modules/System Admin/i18n_manage_install.php
+++ b/modules/System Admin/i18n_manage_install.php
@@ -32,7 +32,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.p
     }
 
     //Check if school year specified
-    $gibboni18nID = $_GET['gibboni18nID'];
+    $gibboni18nID = isset($_GET['gibboni18nID'])? $_GET['gibboni18nID'] : '';
+    $mode = isset($_GET['mode'])? $_GET['mode'] : 'install';
+
     if (empty($gibboni18nID)) {
         echo "<div class='error'>";
         echo __('You have not specified one or more required parameters.');
@@ -55,8 +57,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.p
 
             $row = $form->addRow();
                 $col = $row->addColumn();
-                $col->addContent(__('Install').' '.$i18n['name'])->wrap('<strong style="font-size: 18px;">', '</strong><br/><br/>');
-                $col->addContent(sprintf(__('Installing a new language will download the required files and place them in the %1$s folder on your server.'), '<b>'.$_SESSION[$guid]['absolutePath'].'/i18n/'.'</b>').' '.__('Are you sure you want to continue?'));
+                $col->addContent( ($mode == 'update'? __('Update') : __('Install')).' '.$i18n['name'])->wrap('<strong style="font-size: 18px;">', '</strong><br/><br/>');
+                $col->addContent(sprintf(__('This action will download the required files and place them in the %1$s folder on your server.'), '<b>'.$_SESSION[$guid]['absolutePath'].'/i18n/'.'</b>').' '.__('Are you sure you want to continue?'));
 
             $form->addRow()->addConfirmSubmit();
 

--- a/modules/System Admin/moduleFunctions.php
+++ b/modules/System Admin/moduleFunctions.php
@@ -17,6 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\System\I18nGateway;
+use Psr\Container\ContainerInterface;
+
 //Sets the sequence numbers appropriately for a given first day of the week (either Sunday or Monday)
 function setFirstDayOfTheWeek($connection2, $fdotw, $databaseName)
 {
@@ -216,4 +219,67 @@ function getCurrentVersion($guid, $connection2, $version)
     }
 
     return $output;
+}
+
+/**
+ * Checks to see if a gibbon.mo language file exists for the given i18n code.
+ *
+ * @param string $absolutePath
+ * @param string $code
+ * @return bool
+ */
+function i18nFileExists($absolutePath, $code)
+{
+    return file_exists($absolutePath.'/i18n/'.$code.'/LC_MESSAGES/gibbon.mo');
+}
+
+/**
+ * Downloads and installs the gibbon.mo file for a given i18n code.
+ *
+ * @param string $absolutePath
+ * @param string $code
+ * @return bool
+ */
+function i18nFileInstall($absolutePath, $code)
+{
+    // Grab the file contents from the GibbonEdu i18n repository
+    $gitHubURL = 'https://github.com/GibbonEdu/i18n/blob/master/'.$code.'/LC_MESSAGES/gibbon.mo?raw=true';
+    $gitHubContents = file_get_contents($gitHubURL);
+
+    if (empty($gitHubContents)) return false;
+
+    // Locate where the i18n files will be copied to on the server
+    $localPath = $absolutePath.'/i18n/'.$code.'/LC_MESSAGES/gibbon.mo';
+    $localDir = dirname($localPath);
+    if (!is_dir($localDir)) {
+        mkdir($localDir, 0755, true);
+    }
+
+    // Copy files
+    return file_put_contents($localPath, $gitHubContents) !== false;
+}
+
+/**
+ * Finds and sets any languages to installed='Y' if the file already exists.
+ * Sets langueges to  installed='N' if the file no longer exits.
+ *
+ * @param ContainerInterface $container
+ */
+function i18nCheckAndUpdateVersion($container, $version = null)
+{
+    $absolutePath = $container->get('session')->get('absolutePath');
+
+    $i18nGateway = $container->get(I18nGateway::class);
+    $i18nList = $i18nGateway->selectActiveI18n()->fetchAll();
+
+    foreach ($i18nList as $i18n) {
+        $fileExists = i18nFileExists($absolutePath, $i18n['code']);
+
+        if ($i18n['installed'] == 'N' && $fileExists) {
+            $versionUpdate = version_compare($version, $i18n['version'], '>') ? $version : $i18n['version'];
+            $i18nGateway->updateI18nVersion($i18n['gibboni18nID'], 'Y', $versionUpdate);
+        } else if ($i18n['installed'] == 'Y' && !$fileExists) {
+            $i18nGateway->updateI18nVersion($i18n['gibboni18nID'], 'N', null);
+        }
+    }
 }

--- a/modules/System Admin/updateProcess.php
+++ b/modules/System Admin/updateProcess.php
@@ -19,6 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 include '../../gibbon.php';
 
+//Module includes
+require_once __DIR__ . '/moduleFunctions.php';
+
 $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/update.php';
 $partialFail = false;
 $_SESSION[$guid]['systemUpdateError'] = '';
@@ -74,6 +77,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
                     header("Location: {$URL}");
                     exit();
                 }
+
+                // Update DB version for existing languages
+                i18nCheckAndUpdateVersion($container, $versionDB);
 
                 $URL .= '&return=success0';
                 header("Location: {$URL}");
@@ -185,6 +191,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
                     header("Location: {$URL}");
                     exit();
                 }
+
+                // Update DB version for existing languages
+                i18nCheckAndUpdateVersion($container, $versionDB);
 
                 //Reset cache to force top-menu reload
                 $_SESSION[$guid]['pageLoads'] = null;

--- a/preferences.php
+++ b/preferences.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
 
 if (!isset($_SESSION[$guid]["username"])) {
     //Acess denied
@@ -115,6 +116,7 @@ if (!isset($_SESSION[$guid]["username"])) {
         }
 
         $form = Form::create('preferences', $_SESSION[$guid]['absoluteURL'].'/preferencesProcess.php');
+        $form->setFactory(DatabaseFormFactory::create($pdo));
 
         $form->addRow()->addHeading(__('Settings'));
 
@@ -129,18 +131,14 @@ if (!isset($_SESSION[$guid]["username"])) {
                 $password = $row->addURL('personalBackground');
         }
 
-        $data = array();
-        $sql = "SELECT gibbonThemeID as value, (CASE WHEN active='Y' THEN CONCAT(name, ' (', '".__('System Default')."', ')') ELSE name END) AS name FROM gibbonTheme ORDER BY name";
         $row = $form->addRow();
             $row->addLabel('gibbonThemeIDPersonal', __('Personal Theme'))->description(__('Override the system theme.'));
-            $row->addSelect('gibbonThemeIDPersonal')->fromQuery($pdo, $sql, $data)->placeholder();
+            $row->addSelectTheme('gibbonThemeIDPersonal');
 
 
-        $data = array();
-        $sql = "SELECT gibboni18nID as value, (CASE WHEN systemDefault='Y' THEN CONCAT(name, ' (', '".__('System Default')."', ')') ELSE name END) AS name FROM gibboni18n WHERE active='Y' ORDER BY name";
         $row = $form->addRow();
             $row->addLabel('gibboni18nIDPersonal', __('Personal Language'))->description(__('Override the system default language.'));
-            $row->addSelect('gibboni18nIDPersonal')->fromQuery($pdo, $sql, $data)->placeholder();
+            $row->addSelectI18n('gibboni18nIDPersonal');
 
         $row = $form->addRow();
             $row->addLabel('receiveNotificationEmails', __('Receive Email Notifications?'))->description(__('Notifications can always be viewed on screen.'));

--- a/src/Domain/System/I18nGateway.php
+++ b/src/Domain/System/I18nGateway.php
@@ -39,16 +39,25 @@ class I18nGateway extends QueryableGateway
      * @param QueryCriteria $criteria
      * @return DataSet
      */
-    public function queryI18n(QueryCriteria $criteria)
+    public function queryI18n(QueryCriteria $criteria, $installed = 'Y')
     {
         $query = $this
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibboni18nID', 'name', 'code', 'active', 'systemDefault'
-            ]);
+                'gibboni18nID', 'name', 'code', 'active', 'version', 'systemDefault'
+            ])
+            ->where('installed = :installed')
+            ->bindValue('installed', $installed);
 
         return $this->runQuery($query, $criteria);
+    }
+
+    public function selectActiveI18n()
+    {
+        $sql = "SELECT * FROM gibboni18n WHERE active='Y'";
+
+        return $this->db()->select($sql);
     }
 
     public function getI18nByID($gibboni18nID)
@@ -57,5 +66,13 @@ class I18nGateway extends QueryableGateway
         $sql = "SELECT * FROM gibboni18n WHERE gibboni18nID=:gibboni18nID";
 
         return $this->db()->selectOne($sql, $data);
+    }
+
+    public function updateI18nVersion($gibboni18nID, $installed, $version)
+    {
+        $data = array('gibboni18nID' => $gibboni18nID, 'installed' => $installed, 'version' => $version);
+        $sql = "UPDATE gibboni18n SET installed=:installed, version=:version WHERE gibboni18nID=:gibboni18nID";
+
+        return $this->db()->update($sql, $data);
     }
 }

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -199,6 +199,22 @@ class DatabaseFormFactory extends FormFactory
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
 
+    public function createSelectTheme($name)
+    {
+        $sql = "SELECT gibbonThemeID as value, (CASE WHEN active='Y' THEN CONCAT(name, ' (', '".__('System Default')."', ')') ELSE name END) AS name FROM gibbonTheme ORDER BY name";
+        $results = $this->pdo->executeQuery(array(), $sql);
+
+        return $this->createSelect($name)->fromResults($results)->placeholder();
+    }
+
+    public function createSelectI18n($name)
+    {
+        $sql = "SELECT gibboni18nID as value, (CASE WHEN systemDefault='Y' THEN CONCAT(name, ' (', '".__('System Default')."', ')') ELSE name END) AS name FROM gibboni18n WHERE installed='Y' AND active='Y' ORDER BY code";
+        $results = $this->pdo->executeQuery(array(), $sql);
+
+        return $this->createSelect($name)->fromResults($results)->placeholder();
+    }
+
     public function createSelectLanguage($name)
     {
         $sql = "SELECT name as value, name FROM gibbonLanguage ORDER BY name";

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -343,6 +343,29 @@ class FormFactory implements FormFactoryInterface
         ))->placeholder();
     }
 
+    public function createSelectSystemLanguage($name)
+    {
+        $languages = array(
+            'nl_NL' => 'Dutch - Nederland',
+            'en_GB' => 'English - United Kingdom',
+            'en_US' => 'English - United States',
+            'es_ES' => 'Español',
+            'fr_FR' => 'Français - France',
+            'it_IT' => 'Italiano - Italia',
+            'pl_PL' => 'Język polski - Polska',
+            'pt_BR' => 'Português - Brasil',
+            'ro_RO' => 'Română',
+            'sq_AL' => 'Shqip - Shqipëri',
+            'vi_VN' => 'Tiếng Việt - Việt Nam',
+            'ar_SA' => 'العربية - المملكة العربية السعودية',
+            'th_TH' => 'ภาษาไทย - ราชอาณาจักรไทย',
+            'zh_CN' => '汉语 - 中国',
+            'zh_HK' => '體字 - 香港',
+        );
+        
+        return $this->createSelect($name)->fromArray($languages);
+    }
+
     public function createSelectCurrency($name)
     {
         // I hate doing this ... was there a YAML file at one point?


### PR DESCRIPTION
This PR builds on the i18n features added in #628 to address the issue of installing and updating language files.

Database:
- Adds two fields to the gibboni18n table: `installed` & `version`

Installation:
- Step 2 will download & install the language file for the System Default language, ensuring each new system has at least one language installed.
- Step 2 displays a message if the download failed, so the user can install language files manually.
- The final install step will also check for & set installed to Y any languages that may have been manually installed by adding them to the `i18n/` folder.

Update:
- The update process will find & set installed to Y any languages where the files already exist (populating the Manage Languages list). It will also set installed to N for any files that no longer exist.
- The Manage Languages page now has an Update action, available for any language where the version installed is less than the current Gibbon version. 
- The Manage Languages page also detects manually installed language files, same as the Update/Install process.

Forms:
- OOified the SelectSystemLanguage options, which appear in the installer step 1 before the database has been setup.
- OOified the SelectI18n options, which appear in login forms and on the preferences page: only installed & active languages will appear in the list.