### PR TITLE
Timetable: add a bookings button to TT in View Timetable by Facility

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -70,6 +70,7 @@ v17.0.00
         Students: adjusted Student Enrolment/course enrolment sync logic to mark students as left instead of deleting them
         Students: removed non-students from New Students report, when Ignore Status in use
         Students: updated how the Privacy section is displayed in application and data updater forms
+        Timetable: added a facility booking button to the timetable in View Timetable by Facility
         Timetable Admin: fixed course sync for courses with multiple year groups
         User Admin: added an option in Manage Roles to toggle login access for all users of a particular role
         User Admin: fixed name display bug in Enrol New Students (Status Full) section of Rollover

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -1969,10 +1969,6 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
     $schoolCalendarAlpha = 0.85;
     $ttAlpha = 1.0;
 
-    if ($_SESSION[$guid]['viewCalendarSpaceBooking'] != 'N') {
-        $ttAlpha = 0.75;
-    }
-
     $date = date('Y-m-d', ($startDayStamp + (86400 * $count)));
 
     $output = '';
@@ -2097,6 +2093,17 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
                 } elseif ($height >= 30) {
                     $output .= $rowPeriods['name'].'<br/>';
                     $output .= '<i>'.substr($effectiveStart, 0, 5).'-'.substr($effectiveEnd, 0, 5).'</i><br/>';
+
+                    if ($_SESSION[$guid]['viewCalendarSpaceBooking'] == 'Y' && isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_manage_add.php')) {
+                        $overlappingBookings = array_filter(is_array($eventsSpaceBooking)? $eventsSpaceBooking : [], 
+                            function ($event) use ($date, $effectiveStart, $effectiveEnd) {
+                                return ($event[3] == $date) && ( ($event[4] >= $effectiveStart && $event[4] < $effectiveEnd) || ($effectiveStart >= $event[4] && $effectiveStart < $event[5]) );
+                            }); 
+
+                        if (empty($overlappingBookings)) {
+                            $output .= "<a target='_blank' style='pointer-events: auto; position: absolute; right: 5px; bottom: 5px;' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Timetable/spaceBooking_manage_add.php&gibbonSpaceID='.$gibbonSpaceID.'&date='.$date.'&timeStart='.$effectiveStart.'&timeEnd='.$effectiveEnd."'><img style='' title='".__('Add Facility Booking')."' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
+                        }
+                    }
                 }
                 $output .= '</div>';
                 ++$zCount;

--- a/modules/Timetable/spaceBooking_manage_add.php
+++ b/modules/Timetable/spaceBooking_manage_add.php
@@ -66,6 +66,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
 
             $facilities = array();
 
+            $foreignKeyID = isset($_GET['gibbonSpaceID'])? 'gibbonSpaceID-'.$_GET['gibbonSpaceID'] : '';
+            $date = isset($_GET['date'])? dateConvertBack($guid, $_GET['date']) : '';
+            $timeStart = isset($_GET['timeStart'])? $_GET['timeStart'] : '';
+            $timeEnd = isset($_GET['timeEnd'])? $_GET['timeEnd'] : '';
+
             // Collect facilities
             $sql = "SELECT CONCAT('gibbonSpaceID-', gibbonSpaceID) as value, name FROM gibbonSpace ORDER BY name";
             $results = $pdo->executeQuery(array(), $sql);
@@ -82,19 +87,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
 
             $row = $form->addRow();
                 $row->addLabel('foreignKeyID', __('Facility'));
-                $row->addSelect('foreignKeyID')->fromArray($facilities)->isRequired()->placeholder();
+                $row->addSelect('foreignKeyID')->fromArray($facilities)->isRequired()->placeholder()->selected($foreignKeyID);
 
             $row = $form->addRow();
                 $row->addLabel('date', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                $row->addDate('date')->isRequired();
+                $row->addDate('date')->isRequired()->setValue($date);
 
             $row = $form->addRow();
                 $row->addLabel('timeStart', __('Start Time'));
-                $row->addTime('timeStart')->isRequired();
+                $row->addTime('timeStart')->isRequired()->setValue($timeStart);
 
             $row = $form->addRow();
                 $row->addLabel('timeEnd', __('End Time'));
-                $row->addTime('timeEnd')->isRequired()->chainedTo('timeStart');
+                $row->addTime('timeEnd')->isRequired()->chainedTo('timeStart')->setValue($timeEnd);
 
             $repeatOptions = array('No' => __('No'), 'Daily' => __('Daily'), 'Weekly' => __('Weekly'));
             $row = $form->addRow();


### PR DESCRIPTION
This is a usability tweak for schools using the facility booking options. It adds a quick way to book a period of time relative to the school's timetable, by looking up a room in View Timetable by Facility and clicking a + button to create a booking. This pre-fills the Add Facility Booking page with the details of the selected space & times.

<img width="774" alt="screen shot 2018-09-26 at 3 22 08 pm" src="https://user-images.githubusercontent.com/897700/46064986-7c0f2f00-c1a3-11e8-966d-df42f1dad24a.png">
