### PR TITLE
Timetable: redirect back to facility timetable from Add Facility Booking

### DIFF
--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -2094,14 +2094,14 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
                     $output .= $rowPeriods['name'].'<br/>';
                     $output .= '<i>'.substr($effectiveStart, 0, 5).'-'.substr($effectiveEnd, 0, 5).'</i><br/>';
 
-                    if ($_SESSION[$guid]['viewCalendarSpaceBooking'] == 'Y' && isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_manage_add.php')) {
+                    if ($_SESSION[$guid]['viewCalendarSpaceBooking'] == 'Y' && isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_manage_add.php') && $date >= date('Y-m-d')) {
                         $overlappingBookings = array_filter(is_array($eventsSpaceBooking)? $eventsSpaceBooking : [], 
                             function ($event) use ($date, $effectiveStart, $effectiveEnd) {
                                 return ($event[3] == $date) && ( ($event[4] >= $effectiveStart && $event[4] < $effectiveEnd) || ($effectiveStart >= $event[4] && $effectiveStart < $event[5]) );
                             }); 
 
                         if (empty($overlappingBookings)) {
-                            $output .= "<a style='pointer-events: auto; position: absolute; right: 5px; bottom: 5px;' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Timetable/spaceBooking_manage_add.php&gibbonSpaceID='.$gibbonSpaceID.'&date='.$date.'&timeStart='.$effectiveStart.'&timeEnd='.$effectiveEnd."'><img style='' title='".__('Add Facility Booking')."' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
+                            $output .= "<a style='pointer-events: auto; position: absolute; right: 5px; bottom: 5px;' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Timetable/spaceBooking_manage_add.php&gibbonSpaceID='.$gibbonSpaceID.'&date='.$date.'&timeStart='.$effectiveStart.'&timeEnd='.$effectiveEnd."&source=tt'><img style='' title='".__('Add Facility Booking')."' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
                         }
                     }
                 }

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -2101,7 +2101,7 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
                             }); 
 
                         if (empty($overlappingBookings)) {
-                            $output .= "<a target='_blank' style='pointer-events: auto; position: absolute; right: 5px; bottom: 5px;' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Timetable/spaceBooking_manage_add.php&gibbonSpaceID='.$gibbonSpaceID.'&date='.$date.'&timeStart='.$effectiveStart.'&timeEnd='.$effectiveEnd."'><img style='' title='".__('Add Facility Booking')."' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
+                            $output .= "<a style='pointer-events: auto; position: absolute; right: 5px; bottom: 5px;' href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Timetable/spaceBooking_manage_add.php&gibbonSpaceID='.$gibbonSpaceID.'&date='.$date.'&timeStart='.$effectiveStart.'&timeEnd='.$effectiveEnd."'><img style='' title='".__('Add Facility Booking')."' src='".$_SESSION[$guid]['absoluteURL'].'/themes/'.$_SESSION[$guid]['gibbonThemeName']."/img/page_new.png'/></a>";
                         }
                     }
                 }

--- a/modules/Timetable/spaceBooking_manage.php
+++ b/modules/Timetable/spaceBooking_manage.php
@@ -71,8 +71,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
         $table->addColumn('date', __('Date'))
             ->format(Format::using('date', 'date'));
         $table->addColumn('name', __('Facility'))
-            ->format(function($row) {
-                return $row['name'].'<br/><small><i>'
+            ->format(function($row) use ($guid) {
+                if ($row['foreignKey']=='gibbonSpaceID') {
+                    $output = Format::link($_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Timetable/tt_space_view.php&gibbonSpaceID='.str_pad($row['foreignKeyID'], 10, '0', STR_PAD_LEFT).'&ttDate='.dateConvertBack($guid, $row['date']), $row['name']);
+                } else {
+                    $output = $row['name'];
+                }
+
+                return $output.'<br/><small><i>'
                      .($row['foreignKey'] == 'gibbonLibraryItemID'? __('Library') :'').'</i></small>';
             });
         $table->addColumn('time', __('Time'))

--- a/modules/Timetable/spaceBooking_manage_add.php
+++ b/modules/Timetable/spaceBooking_manage_add.php
@@ -63,6 +63,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
             $form->setFactory(DatabaseFormFactory::create($pdo));
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+            $form->addHiddenValue('source', isset($_REQUEST['source'])? $_REQUEST['source'] : '');
 
             $facilities = array();
 
@@ -183,6 +184,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                     $form = Form::create('spaceBookingStep1', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/spaceBooking_manage_addProcess.php');
 
                     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+                    $form->addHiddenValue('source', isset($_REQUEST['source'])? $_REQUEST['source'] : '');
 
                     $form->addHiddenValue('foreignKey', $foreignKey);
                     $form->addHiddenValue('foreignKeyID', $foreignKeyID);

--- a/modules/Timetable/spaceBooking_manage_addProcess.php
+++ b/modules/Timetable/spaceBooking_manage_addProcess.php
@@ -100,6 +100,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                 $URL .= '&return=warning1';
                 header("Location: {$URL}");
             } else {
+                // Redirect back to View Timetable by Facility if we started there
+                if (isset($_POST['source']) && $_POST['source'] == 'tt') {
+                    $ttDate = dateConvertBack($guid, $dates[0]);
+                    $URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Timetable/tt_space_view.php&gibbonSpaceID='.$foreignKeyID.'&ttDate='.$ttDate;
+                }
+
                 $URL .= '&return=success0';
                 header("Location: {$URL}");
             }

--- a/modules/Timetable/tt_space.php
+++ b/modules/Timetable/tt_space.php
@@ -84,6 +84,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space.php') =
 
         $table->addActionColumn()
             ->addParam('gibbonSpaceID')
+            ->addParam('search', $criteria->getSearchText(true))
             ->format(function ($row, $actions) {
                 $actions->addAction('view', __('View'))
                         ->setURL('/modules/Timetable/tt_space_view.php');

--- a/modules/Timetable/tt_space_view.php
+++ b/modules/Timetable/tt_space_view.php
@@ -33,17 +33,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space_view.ph
         echo __($guid, 'The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        $gibbonSpaceID = $_GET['gibbonSpaceID'];
-
-        $search = null;
-        if (isset($_GET['search'])) {
-            $search = $_GET['search'];
-        }
-
-        $gibbonTTID = null;
-        if (isset($_GET['gibbonTTID'])) {
-            $gibbonTTID = $_GET['gibbonTTID'];
-        }
+        $gibbonSpaceID = isset($_REQUEST['gibbonSpaceID']) ? $_REQUEST['gibbonSpaceID'] : '';
+        $search = isset($_REQUEST['search']) ? $_REQUEST['search'] : null;
+        $gibbonTTID = isset($_REQUEST['gibbonTTID']) ? $_REQUEST['gibbonTTID'] : null;
 
         try {
             $data = array('gibbonSpaceID' => $gibbonSpaceID);
@@ -72,8 +64,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space_view.ph
             }
 
             $ttDate = null;
-            if (isset($_POST['ttDate'])) {
-                $ttDate = dateConvertToTimestamp(dateConvert($guid, $_POST['ttDate']));
+            if (isset($_REQUEST['ttDate'])) {
+                $ttDate = dateConvertToTimestamp(dateConvert($guid, $_REQUEST['ttDate']));
             }
 
             if (isset($_POST['fromTT'])) {

--- a/modules/Timetable/tt_space_view.php
+++ b/modules/Timetable/tt_space_view.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space_view.ph
 
         if ($result->rowCount() != 1) {
             echo "<div class='error'>";
-            echo 'The specified room does not seem to exist.';
+            echo __('The specified room does not seem to exist.');
             echo '</div>';
         } else {
             $row = $result->fetch();
@@ -56,6 +56,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space_view.ph
             echo "<div class='trail'>";
             echo "<div class='trailHead'><a href='".$_SESSION[$guid]['absoluteURL']."'>".__($guid, 'Home')."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q']).'/'.getModuleEntry($_GET['q'], $connection2, $guid)."'>".__($guid, getModuleName($_GET['q']))."</a> > <a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_GET['q'])."/tt_space.php'>View Timetable by Facility</a> > </div><div class='trailEnd'>".$row['name'].'</div>';
             echo '</div>';
+
+            if (isset($_GET['return'])) {
+                returnProcess($guid, $_GET['return'], null, null);
+            }
 
             if ($search != '') {
                 echo "<div class='linkTop'>";
@@ -65,7 +69,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space_view.ph
 
             $ttDate = null;
             if (isset($_REQUEST['ttDate'])) {
-                $ttDate = dateConvertToTimestamp(dateConvert($guid, $_REQUEST['ttDate']));
+                $date = dateConvert($guid, $_REQUEST['ttDate']);
+                $ttDate = strtotime('last Sunday +1 day', strtotime($date));
             }
 
             if (isset($_POST['fromTT'])) {

--- a/src/Domain/Timetable/FacilityBookingGateway.php
+++ b/src/Domain/Timetable/FacilityBookingGateway.php
@@ -45,7 +45,7 @@ class FacilityBookingGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonTTSpaceBookingID', 'date', 'timeStart', 'timeEnd', 'gibbonSpace.name', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'foreignKey'
+                'gibbonTTSpaceBookingID', 'date', 'timeStart', 'timeEnd', 'gibbonSpace.name', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'foreignKey', 'foreignKeyID'
             ])
             ->innerJoin('gibbonSpace', 'gibbonTTSpaceBooking.foreignKeyID=gibbonSpace.gibbonSpaceID')
             ->innerJoin('gibbonPerson', 'gibbonTTSpaceBooking.gibbonPersonID=gibbonPerson.gibbonPersonID')
@@ -61,7 +61,7 @@ class FacilityBookingGateway extends QueryableGateway
         $query->unionAll()
             ->from($this->getTableName())
             ->cols([
-                'gibbonTTSpaceBookingID', 'date', 'timeStart', 'timeEnd', 'gibbonLibraryItem.name', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'foreignKey'
+                'gibbonTTSpaceBookingID', 'date', 'timeStart', 'timeEnd', 'gibbonLibraryItem.name', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'foreignKey', 'foreignKeyID'
             ])
             ->innerJoin('gibbonLibraryItem', 'gibbonTTSpaceBooking.foreignKeyID=gibbonLibraryItem.gibbonLibraryItemID')
             ->innerJoin('gibbonPerson', 'gibbonTTSpaceBooking.gibbonPersonID=gibbonPerson.gibbonPersonID')


### PR DESCRIPTION
Replaced the target='_blank' with a selective redirect based on the starting point of the booking.

A few other tweaks:
- Only show the + bookings button for future dates & times
- Link back to the facility's timetable from Manage Bookings
- Fix a bug where bookings were not showing up when navigating week by week