### PR TITLE
System: prevent password reset if canLogin is disabled, update error messages

### DIFF
--- a/login.php
+++ b/login.php
@@ -65,14 +65,21 @@ else {
     } else {
         $row = $result->fetch();
 
+        // Insufficient privileges to login
+        if ($row['canLogin'] != 'Y') {
+            $URL .= '?loginReturn=fail2';
+            header("Location: {$URL}");
+            exit;
+        }
+
         // Get primary role info
         $data = array('gibbonRoleIDPrimary' => $row['gibbonRoleIDPrimary']);
         $sql = "SELECT * FROM gibbonRole WHERE gibbonRoleID=:gibbonRoleIDPrimary";
         $role = $pdo->selectOne($sql, $data);
 
-        // Insufficient privileges to login
-        if ($row['canLogin'] != 'Y' || (!empty($role['canLoginRole']) && $role['canLoginRole'] != 'Y')) {
-            $URL .= '?loginReturn=fail2';
+        // Login not allowed for this role
+        if (!empty($role['canLoginRole']) && $role['canLoginRole'] != 'Y') {
+            $URL .= '?loginReturn=fail9';
             header("Location: {$URL}");
             exit;
         }

--- a/passwordReset.php
+++ b/passwordReset.php
@@ -43,6 +43,7 @@ if ($step == 1) {
     $returns['error4'] = __($guid, 'Your request failed due to non-matching passwords.');
     $returns['error6'] = __($guid, 'Your request failed because your password to not meet the minimum requirements for strength.');
     $returns['error7'] = __($guid, 'Your request failed because your new password is the same as your current password.');
+    $returns['error8'] = __($guid, 'Your request failed because you do not have sufficient privileges to login.');
     $returns['success0'] = __($guid, 'Password reset request successfully initiated, please check your email.');
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, $returns);

--- a/passwordReset.php
+++ b/passwordReset.php
@@ -33,18 +33,19 @@ if (isset($_GET['step'])) {
 if ($step == 1) {
     ?>
     <p>
-        <?php echo sprintf(__($guid, 'Enter your %1$s username, or the email address you have listed in the system, and press submit: a unique password reset link will be emailed to you.'), $_SESSION[$guid]['systemName']); ?>
+        <?php echo sprintf(__('Enter your %1$s username, or the email address you have listed in the system, and press submit: a unique password reset link will be emailed to you.'), $_SESSION[$guid]['systemName']); ?>
     </p>
     <?php
     $returns = array();
-    $returns['error0'] = __($guid, 'Email address not set.');
-    $returns['error4'] = __($guid, 'Your request failed due to incorrect or non-existent or non-unique email address.');
-    $returns['error3'] = __($guid, 'Failed to send update email.');
-    $returns['error4'] = __($guid, 'Your request failed due to non-matching passwords.');
-    $returns['error6'] = __($guid, 'Your request failed because your password to not meet the minimum requirements for strength.');
-    $returns['error7'] = __($guid, 'Your request failed because your new password is the same as your current password.');
-    $returns['error8'] = __($guid, 'Your request failed because you do not have sufficient privileges to login.');
-    $returns['success0'] = __($guid, 'Password reset request successfully initiated, please check your email.');
+    $returns['error0'] = __('Email address not set.');
+    $returns['error4'] = __('Your request failed due to incorrect or non-existent or non-unique email address.');
+    $returns['error3'] = __('Failed to send update email.');
+    $returns['error4'] = __('Your request failed due to non-matching passwords.');
+    $returns['error6'] = __('Your request failed because your password to not meet the minimum requirements for strength.');
+    $returns['error7'] = __('Your request failed because your new password is the same as your current password.');
+    $returns['fail2'] = __('You do not have sufficient privileges to login.');
+    $returns['fail9'] = __('Your primary role does not support the ability to log into the specified year.');
+    $returns['success0'] = __('Password reset request successfully initiated, please check your email.');
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, $returns);
     }

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -42,7 +42,7 @@ if ($input == '' or ($step != 1 and $step != 2)) {
 else {
     try {
         $data = array('email' => $input, 'username' => $input);
-        $sql = "SELECT gibbonPersonID, email, username FROM gibbonPerson WHERE (email=:email OR username=:username) AND gibbonPerson.status='Full' AND NOT email=''";
+        $sql = "SELECT gibbonPersonID, email, username, canLogin FROM gibbonPerson WHERE (email=:email OR username=:username) AND gibbonPerson.status='Full' AND NOT email=''";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
@@ -56,6 +56,14 @@ else {
         header("Location: {$URL}");
     } else {
         $row = $result->fetch();
+
+        // Insufficient privledges message if login not enabled
+        if ($row['canLogin'] != 'Y') {
+            $URL .= '&return=error8';
+            header("Location: {$URL}");
+            exit;
+        }
+
         $gibbonPersonID = $row['gibbonPersonID'];
         $email = $row['email'];
         $username = $row['username'];

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -42,7 +42,7 @@ if ($input == '' or ($step != 1 and $step != 2)) {
 else {
     try {
         $data = array('email' => $input, 'username' => $input);
-        $sql = "SELECT gibbonPersonID, email, username, canLogin FROM gibbonPerson WHERE (email=:email OR username=:username) AND gibbonPerson.status='Full' AND NOT email=''";
+        $sql = "SELECT gibbonPersonID, email, username, canLogin, gibbonRoleIDPrimary FROM gibbonPerson WHERE (email=:email OR username=:username) AND gibbonPerson.status='Full' AND NOT email=''";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
@@ -57,9 +57,21 @@ else {
     } else {
         $row = $result->fetch();
 
-        // Insufficient privledges message if login not enabled
+        // Insufficient privileges to login
         if ($row['canLogin'] != 'Y') {
-            $URL .= '&return=error8';
+            $URL .= '&return=fail2';
+            header("Location: {$URL}");
+            exit;
+        }
+
+        // Get primary role info
+        $data = array('gibbonRoleIDPrimary' => $row['gibbonRoleIDPrimary']);
+        $sql = "SELECT * FROM gibbonRole WHERE gibbonRoleID=:gibbonRoleIDPrimary";
+        $role = $pdo->selectOne($sql, $data);
+
+        // Login not allowed for this role
+        if (!empty($role['canLoginRole']) && $role['canLoginRole'] != 'Y') {
+            $URL .= '&return=fail9';
             header("Location: {$URL}");
             exit;
         }


### PR DESCRIPTION
This PR makes two changes to how the canLogin field is handled:

- On login, if the canLogin failure is based on the users role rather than the user account, it uses the more verbose fail9 message: `Your primary role does not support the ability to log into the specified year.` which is less jarring, in the case that access is temporarily turned off.

- Check for canLogin on password reset and fail (with the same messages as login) if the user does not have privileges to login to the system. The logic here is that a user should not be able to go through the whole password reset process if they cannot actually login to the system.