### PR TITLE
Data Updater: remove the start date check from required updates logic

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -764,4 +764,12 @@ ALTER TABLE `gibbonCourseClass` CHANGE `name` `name` VARCHAR(30) CHARACTER SET u
 ALTER TABLE `gibbonPerson` CHANGE `surname` `surname` VARCHAR(60) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '', CHANGE `firstName` `firstName` VARCHAR(60) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '', CHANGE `preferredName` `preferredName` VARCHAR(60) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '', CHANGE `nameInCharacters` `nameInCharacters` VARCHAR(60) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL, CHANGE `profession` `profession` VARCHAR(90) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL, CHANGE `employer` `employer` VARCHAR(90) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL, CHANGE `jobTitle` `jobTitle` VARCHAR(90) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL, CHANGE `emergency1Name` `emergency1Name` VARCHAR(90) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL, CHANGE `emergency2Name` `emergency2Name` VARCHAR(90) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
 ALTER TABLE `gibbonHouse` CHANGE `nameShort` `nameShort` VARCHAR(10) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
 ALTER TABLE `gibbonCourse` CHANGE `name` `name` VARCHAR(60) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL, CHANGE `nameShort` `nameShort` VARCHAR(12) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
+ALTER TABLE `gibbonFamilyUpdate` ADD INDEX `gibbonFamilyIndex` (`gibbonFamilyID`,`gibbonSchoolYearID`);end
+ALTER TABLE `gibbonPersonUpdate` ADD INDEX `gibbonPersonIndex` (`gibbonPersonID`,`gibbonSchoolYearID`);end
+ALTER TABLE `gibbonPersonMedicalUpdate` ADD INDEX `gibbonMedicalIndex` (`gibbonPersonID`, `gibbonPersonMedicalID`,`gibbonSchoolYearID`);end
+ALTER TABLE `gibbonFinanceInvoiceeUpdate` ADD INDEX `gibbonInvoiceeIndex` (`gibbonFinanceInvoiceeID`,`gibbonSchoolYearID`);end
+ALTER TABLE `gibbonFamilyAdult` ADD INDEX `gibbonPersonIndex` (`gibbonPersonID`);end
+ALTER TABLE `gibbonFamilyChild` ADD INDEX `gibbonPersonIndex` (`gibbonPersonID`);end
+ALTER TABLE `gibbonFamilyChild` ADD INDEX `gibbonFamilyIndex` (`gibbonFamilyID`);end
+ALTER TABLE `gibbonStudentEnrolment` ADD KEY `gibbonPersonIndex` (`gibbonPersonID`,`gibbonSchoolYearID`);end
 ";

--- a/modules/Data Updater/data_updates.php
+++ b/modules/Data Updater/data_updates.php
@@ -118,7 +118,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_updates.
             echo '</td>';
 
             $dataUpdatesByType = $gateway->selectDataUpdatesByPerson($person['gibbonPersonID'], $gibbonPersonID)->fetchGrouped();
-            $recentlyStarted = !empty($person['dateStart']) && $person['dateStart'] >= $cutoffDate;
 
             foreach ($updatableDataTypes as $type) {
                 $updateRequired = false;
@@ -130,7 +129,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_updates.
 
                         $lastUpdate = !empty($dataUpdate['lastUpdated'])? __('Last Updated').': '.date('F j, Y', strtotime($dataUpdate['lastUpdated'])) : '';
                         
-                        if (!in_array($type, $requiredUpdatesByType) || empty($cutoffDate) || $recentlyStarted) {
+                        if (!in_array($type, $requiredUpdatesByType) || empty($cutoffDate)) {
                             // Display an edit link if updates aren't required or no cutoff date is set
                             $output .= "<img title='".__('Edit').'<br/>'.$lastUpdate."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/><br/>";
                             $output .= $dataUpdate['name'];

--- a/modules/Data Updater/report_family_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_family_dataUpdaterHistory.php
@@ -106,13 +106,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
 
         // Function to display the updater info based on the cutoff date
         $dateCutoff = DateTime::createFromFormat('Y-m-d H:i:s', Format::dateConvert($date).' 00:00:00');
-        $dataChecker = function($dateUpdated, $dateStart, $title = '') use ($dateCutoff, $guid) {
+        $dataChecker = function($dateUpdated, $title = '') use ($dateCutoff, $guid) {
             $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateUpdated);
             $dateDisplay = !empty($dateUpdated)? Format::dateTime($dateUpdated) : __('No data');
-
-            if (DateTime::createFromFormat('Y-m-d', $dateStart) > $dateCutoff) {
-                return "<img title='".__('Start Date').': '.Format::date($dateStart)."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/iconTick_light.png' width='18' />";
-            }
 
             return empty($dateUpdated) || $dateCutoff > $date
                 ? "<img title='".$title.' '.__('Update Required').': '.$dateDisplay."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/iconCross.png' width='18' />"
@@ -141,7 +137,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
             $table->addColumn('familyUpdate', __('Family Data'))
                 ->width('5%')
                 ->format(function($row) use ($dataChecker) {
-                    return $dataChecker($row['familyUpdate'], $row['earliestDateStart'],  __('Family'));
+                    return $dataChecker($row['familyUpdate'],  __('Family'));
                 });
 
             $table->addColumn('familyAdults', __('Adults'))
@@ -152,7 +148,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
                         $output .= '<tr>';
                         $output .= '<td style="width:90%">'.Format::name($adult['title'], $adult['preferredName'], $adult['surname'], 'Parent').'</td>';
                         if (in_array('Personal', $requiredUpdatesByType)) {
-                            $output .= '<td style="width:10%">'.$dataChecker($adult['personalUpdate'], $row['earliestDateStart'],  __('Personal')).'</td>';
+                            $output .= '<td style="width:10%">'.$dataChecker($adult['personalUpdate'],  __('Personal')).'</td>';
                         }
                         $output .= '</tr>';
                     }
@@ -169,10 +165,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
                         $output .= '<td style="width:80%">'.Format::name('', $child['preferredName'], $child['surname'], 'Student').'</td>';
                         $output .= '<td style="width:10%">'.$child['rollGroup'].'</td>';
                         if (in_array('Personal', $requiredUpdatesByType)) {
-                            $output .= '<td style="width:10%">'.$dataChecker($child['personalUpdate'], $child['dateStart'], __('Personal')).'</td>';
+                            $output .= '<td style="width:10%">'.$dataChecker($child['personalUpdate'], __('Personal')).'</td>';
                         }
                         if (in_array('Medical', $requiredUpdatesByType)) {
-                            $output .= '<td style="width:10%">'.$dataChecker($child['medicalUpdate'], $child['dateStart'], __('Medical')).'</td>';
+                            $output .= '<td style="width:10%">'.$dataChecker($child['medicalUpdate'], __('Medical')).'</td>';
                         }
                         $output .= '</tr>';
                     }
@@ -182,14 +178,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
         }
         
         $table->addColumn('familyAdultsEmail', __('Parent Email'))
-        ->notSortable()
-        ->format(function($row) use ($dataChecker) {
-            $output = "";
-            foreach ($row['familyAdults'] as $adult) {
-                $output .= $adult['email'].", ";
-            }
-            return $output;
-        });
+            ->notSortable()
+            ->format(function($row) {
+                return implode(', ', array_column($row['familyAdults'], 'email'));
+            });
 
         echo $table->render($dataUpdates);
     }

--- a/src/Domain/DataUpdater/DataUpdaterGateway.php
+++ b/src/Domain/DataUpdater/DataUpdaterGateway.php
@@ -130,9 +130,6 @@ class DataUpdaterGateway extends Gateway
         foreach ($updatablePeople as $person) {
             $dataUpdatesByType = $this->selectDataUpdatesByPerson($person['gibbonPersonID'], $gibbonPersonID)->fetchGrouped();
 
-            // Skip users who started after the cutoff date
-            if (!empty($person['dateStart']) && $person['dateStart'] >= $cutoffDate) continue;
-
             foreach ($requiredUpdatesByType as $type) {
                 // Skip data update types not applicable to this user
                 if (empty($dataUpdatesByType[$type])) continue;

--- a/src/Domain/DataUpdater/FamilyUpdateGateway.php
+++ b/src/Domain/DataUpdater/FamilyUpdateGateway.php
@@ -70,7 +70,6 @@ class FamilyUpdateGateway extends QueryableGateway
                 'gibbonFamily.gibbonFamilyID', 
                 'gibbonFamily.name as familyName', 
                 'MAX(gibbonFamilyUpdate.timestamp) as familyUpdate', 
-                "MIN(IFNULL(gibbonPerson.dateStart, '0000-00-00')) as earliestDateStart",
                 "MAX(IFNULL(gibbonPerson.dateEnd, NOW())) as latestEndDate",
                 'gibbonFamilyUpdate.gibbonFamilyUpdateID'
             ])
@@ -110,7 +109,7 @@ class FamilyUpdateGateway extends QueryableGateway
                     $havingCutoff .= " OR (earliestMedicalUpdate < :cutoffDate)";
                 }
 
-                $query->having("($havingCutoff) AND (earliestDateStart < :cutoffDate)")
+                $query->having("$havingCutoff")
                     ->bindValue('cutoffDate', $cutoffDate);
             },
         ]);

--- a/src/Domain/DataUpdater/FamilyUpdateGateway.php
+++ b/src/Domain/DataUpdater/FamilyUpdateGateway.php
@@ -109,7 +109,7 @@ class FamilyUpdateGateway extends QueryableGateway
                     $havingCutoff .= " OR (earliestMedicalUpdate < :cutoffDate)";
                 }
 
-                $query->having("$havingCutoff")
+                $query->having($havingCutoff)
                     ->bindValue('cutoffDate', $cutoffDate);
             },
         ]);


### PR DESCRIPTION
This PR reverts the start date logic added in #564 which was causing some inconsistencies in Data Updater reports. The Student & Family Data Updater History reports already filter by student enrollment, which should be sufficient.

I've done some tests to compare the updater history reports to the view that parents see on the My Data Updates page and they appear to be consistent.

This change set also adds some database keys for the Data Updater, Family Adult/Child and Student Enrolment tables. These address the performance issues encountered with the Family Data Updater History, and will generally help speed up any queries involving these tables.

Ross: you'll want to delete the keys you've added before updating, otherwise you'll end up with some unnecessary extra keys on your table. The reason your original keys didn't help with performance was the order of the compound keys: School Year has to be second, because in this case it's not involved in the query, so your keys were not being used. 

I did a diff of the keys on my test database vs. the demo database, the main difference was the enrolment key which I've added here. It appears the likely culprit for slow query speed with your data was that you have more years worth of past updates being joined to the query.