### PR TITLE
Planner: Name clarification and pre-checked notifications

### DIFF
--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -311,7 +311,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
 					</tr>
 					<tr>
 						<td>
-							<b><?php echo __($guid, 'Name') ?> *</b><br/>
+							<b><?php echo __($guid, 'Name of Lesson Plan') ?> *</b><br/>
 						</td>
 						<td class="right">
 							<input name="name" id="name" maxlength=50 value="" type="text" class="standardWidth">
@@ -1220,7 +1220,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
 							<span class="emphasis small">* <?php echo __($guid, 'denotes a required field'); ?></span>
 						</td>
 						<td class="right">
-							<input type="checkbox" name="notify" value="on">
+							<input type="checkbox" name="notify" value="on" checked="true">
 							<label for="notify"><?php echo __('Notify all class participants') ?></label>
 							<input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
 						</td>

--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -311,7 +311,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
 					</tr>
 					<tr>
 						<td>
-							<b><?php echo __($guid, 'Name of Lesson Plan') ?> *</b><br/>
+							<b><?php echo __($guid, 'Lesson Name') ?> *</b><br/>
 						</td>
 						<td class="right">
 							<input name="name" id="name" maxlength=50 value="" type="text" class="standardWidth">
@@ -1220,7 +1220,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
 							<span class="emphasis small">* <?php echo __($guid, 'denotes a required field'); ?></span>
 						</td>
 						<td class="right">
-							<input type="checkbox" name="notify" value="on" checked="true">
+							<input type="checkbox" name="notify" value="on">
 							<label for="notify"><?php echo __('Notify all class participants') ?></label>
 							<input type="submit" value="<?php echo __($guid, 'Submit'); ?>">
 						</td>


### PR DESCRIPTION
Just a couple of minor changes prompted by feedback from professors. Namely, changing the label of the "Name" field to "Name of Lesson Plan". It seems there was some confusion as to what name to put in there! Also, the "Notify all class participants check box" is now checked by default. Some professors were forgetting to check and it seemed that an opt-out approach was less hazardous.

