### PR TITLE
System: add a CoreServiceProvider for initializing services

### DIFF
--- a/gibbon.php
+++ b/gibbon.php
@@ -26,13 +26,9 @@ require_once __DIR__.'/functions.php';
 // Core Services
 $container = new League\Container\Container();
 $container->delegate(new League\Container\ReflectionContainer);
-
-$container->add('config', new Gibbon\Core(__DIR__));
-$container->add('session', new Gibbon\Session($container));
-$container->add('locale', new Gibbon\Locale($container));
 $container->add('autoloader', $autoloader);
 
-\Gibbon\Services\Format::setupFromSession($container->get('session'));
+$container->addServiceProvider(new Gibbon\Services\CoreServiceProvider(__DIR__));
 
 // Globals for backwards compatibility
 $gibbon = $container->get('config');

--- a/src/Contracts/Services/Locale.php
+++ b/src/Contracts/Services/Locale.php
@@ -1,0 +1,82 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Contracts\Services;
+
+/**
+ * Locale Interface
+ *
+ * @version	v17
+ * @since	v17
+ */
+interface Locale
+{
+    /**
+     * Sets the locale for a given code.
+     *
+     * @param string $i18nCode
+     */
+    public function setLocale($i18nCode);
+
+    /**
+     * Gets the current locale code.
+     *
+     * @return string
+     */
+    public function getLocale();
+
+    /**
+     * Sets the default timezone.
+     *
+     * @param string $timezoneIdentifier
+     */
+    public function setTimezone($timezoneIdentifier);
+
+    /**
+     * Gets the default timezone.
+     *
+     * @return string
+     */
+    public function getTimezone();
+
+    /**
+     * Binds the system default text domain.
+     *
+     * @param string $domain
+     * @param string $absolutePath
+     */
+    public function setSystemTextDomain($absolutePath);
+
+    /**
+     * Binds a text domain for a given module by name.
+     *
+     * @param string $module
+     * @param string $absolutePath
+     */
+    public function setModuleTextDomain($module, $absolutePath);
+
+    /**
+     * Translate a string using the current locale and string replacements.
+     *
+     * @param string $text
+     * @param string $domain
+     * @return string
+     */
+    public function translate($text, $domain = null);
+}

--- a/src/Contracts/Services/Session.php
+++ b/src/Contracts/Services/Session.php
@@ -1,0 +1,80 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Contracts\Services;
+
+/**
+ * Session Interface 
+ * Borrowed in part from Illuminate\Contracts\Session\Session
+ *
+ * @version	v17
+ * @since	v17
+ */
+interface Session
+{
+    /**
+     * Checks if one or more keys exist.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function exists($keys);
+
+    /**
+     * Checks if one or more keys are present and not null.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function has($keys);
+
+    /**
+     * Get an item from the session.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function get($key, $default = null);
+
+    /**
+     * Set a key / value pair or array of key / value pairs in the session.
+     *
+     * @param  string|array  $key
+     * @param  mixed       $value
+     * @return void
+     */
+    public function set($key, $value = null);
+
+    /**
+     * Remove an item from the session, returning its value.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function remove($key);
+    
+    /**
+     * Remove one or many items from the session.
+     *
+     * @param  string|array  $keys
+     * @return void
+     */
+    public function forget($keys);
+}

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -42,11 +42,10 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
     }
 
     /**
-     * The provides array is a way to let the container
-     * know that a service is provided by this service
-     * provider. Every service that is registered via
-     * this service provider must have an alias added
-     * to this array or it will be ignored.
+     * The provides array is a way to let the container know that a service 
+     * is provided by this service provider. Every service that is registered 
+     * via this service provider must have an alias added to this array or 
+     * it will be ignored.
      *
      * @var array
      */

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -1,0 +1,91 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Gibbon\Services;
+
+use Gibbon\Core;
+use Gibbon\Locale;
+use Gibbon\Session;
+use Gibbon\Services\Format;
+use League\Container\ServiceProvider\AbstractServiceProvider;
+use League\Container\ServiceProvider\BootableServiceProviderInterface;
+
+/**
+ * DI Container Services for the Core
+ *
+ * @version v17
+ * @since   v17
+ */
+class CoreServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface
+{
+    protected $absolutePath;
+
+    public function __construct($absolutePath)
+    {
+        $this->absolutePath = $absolutePath;
+    }
+
+    /**
+     * The provides array is a way to let the container
+     * know that a service is provided by this service
+     * provider. Every service that is registered via
+     * this service provider must have an alias added
+     * to this array or it will be ignored.
+     *
+     * @var array
+     */
+    protected $provides = [
+        'config',
+        'session',
+        'locale',
+    ];
+
+    /**
+     * In much the same way, this method has access to the container
+     * itself and can interact with it however you wish, the difference
+     * is that the boot method is invoked as soon as you register
+     * the service provider with the container meaning that everything
+     * in this method is eagerly loaded.
+     *
+     * If you wish to apply inflectors or register further service providers
+     * from this one, it must be from a bootable service provider like
+     * this one, otherwise they will be ignored.
+     */
+    public function boot()
+    {
+        $container = $this->getContainer();
+
+        $container->add('config', new Core($this->absolutePath));
+        $container->add('session', new Session($container));
+        $container->add('locale', new Locale($container));
+
+        Format::setupFromSession($container->get('session'));
+    }
+
+    /**
+     * This is where the magic happens, within the method you can
+     * access the container and register or retrieve anything
+     * that you need to, but remember, every alias registered
+     * within this method must be declared in the `$provides` array.
+     */
+    public function register()
+    {
+        
+    }
+}


### PR DESCRIPTION
This is part of the Dependency Injection container setup. I've added a [Service Provider](http://container.thephpleague.com/2.x/advanced/#service-providers) class for the core services, which boots the initial services and can also lazyload non-essential ones. As we get up and running there can be separate Web/API/CLI service providers, as things like the API/CLI won't need any of the presentational stuff like forms and templates, but will still need core services.

Also working to decouple some of the transitional classes introduced during refactoring. I've added some interfaces for the Session and Locale classes. These have inadvertently been referenced as concrete implementations here and there in the codebase. I'll submit a future PR that cleans those up and uses interfaces + DI to access them instead.