### PR TITLE
CI: add php 7.1 and 7.2 for CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ os:
 # list any PHP version you want to test against
 php:
   - 7.0
+  - 7.1
+  - 7.2
 
 # optionally specify a list of environments, for example to test different RDBMS
 env:


### PR DESCRIPTION
* To test forward compatibility, added PHP 7.1 and 7.2 to Travis
  test.

## Description
* Add php 7.1 and 7.2 to Travis CI test target.

## Motivation and Context
* To test forward compatibility.

## How Has This Been Tested?
* Tested with Travis.