### PR TITLE
System: update AssetBundle to handle uasort with a default weight of 0

### DIFF
--- a/src/View/AssetBundle.php
+++ b/src/View/AssetBundle.php
@@ -65,7 +65,8 @@ class AssetBundle
             'context' => 'foot',
             'media'   => 'all',
             'version' => null,
-            'weight'  => count($this->allAssets),
+            'weight'  => 0,
+            'index'   => count($this->allAssets),
         ], $options);
     }
 
@@ -101,7 +102,8 @@ class AssetBundle
     }
 
     /**
-     * Get all assets sorted by weight, ascending.
+     * Get all assets sorted by weight, ascending. The index value is used to
+     * maintain the original array order when weights are equal.
      *
      * @param string $context Optionally filter returned assets by context.
      * @return array
@@ -111,7 +113,11 @@ class AssetBundle
         $usedAssets = array_intersect_key($this->allAssets, $this->usedAssetsByName);
 
         uasort($usedAssets, function ($a, $b) {
-            return $a['weight'] <=> $b['weight'];
+            if ($a['weight'] != $b['weight']) {
+                return $a['weight'] <=> $b['weight'];
+            }
+            
+            return $a['index'] <=> $b['index'];
         });
 
         return array_filter($usedAssets, function ($item) use ($context) {

--- a/tests/unit/View/AssetBundleTest.php
+++ b/tests/unit/View/AssetBundleTest.php
@@ -78,4 +78,19 @@ class AssetBundleTest extends TestCase
 
         $this->assertEquals(['fiz', 'foo', 'biz', 'bus'], array_keys($assets->getAssets()));
     }
+
+    public function testSortsAssetsByWeightAndOriginalOrder()
+    {
+        $assets = new AssetBundle();
+
+        $assets->add('foo', 'bar/baz', ['weight' => 1]);
+
+        $assets->add('bar', 'bar/baz');
+        $assets->add('baz', 'bar/baz');
+        $assets->add('bus', 'bar/baz');
+
+        $assets->add('fiz', 'bar/baz', ['weight' => -1]);
+
+        $this->assertEquals(['fiz', 'bar', 'baz', 'bus', 'foo'], array_keys($assets->getAssets()));
+    }
 }


### PR DESCRIPTION
This PR tweaks the behaviour of sorting in AssetBundle, based on @yookoala's suggestions https://github.com/GibbonEdu/core/pull/653#issuecomment-427787522  

It uses the index of the array internally as a secondary sorting criteria, so that all assets can use a default weight of 0 and still maintain the original order they were added to the array. 

Adds an extra check to the AssetBundle unit tests.