### PR TITLE
System: add session configuration, Referrer‐Policy and X-Frame-Options

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2730,6 +2730,7 @@ function sidebar($gibbon, $pdo)
             $form = \Gibbon\Forms\Form::create('loginForm', $_SESSION[$guid]['absoluteURL'].'/login.php?'.(isset($_GET['q'])? 'q='.$_GET['q'] : '') );
 
             $form->setFactory(\Gibbon\Forms\DatabaseFormFactory::create($pdo));
+            $form->setAutocomplete(false);
             $form->setClass('noIntBorder fullWidth');
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/resources/templates/head.twig.html
+++ b/resources/templates/head.twig.html
@@ -14,6 +14,7 @@ all stylesheets and scripts with a 'head' context.
 <meta http-equiv="content-language" content="{{ locale }}"/>
 <meta name="author" content="Ross Parker, International College Hong Kong"/>
 <meta name="robots" content="none"/>
+<meta name="Referrer‐Policy" value="no‐referrer | same‐origin"/>
 <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico"/>
 
 {% for asset in page.stylesheets %}

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -222,6 +222,10 @@ class Form implements OutputableInterface
      */
     public function setAutocomplete($value)
     {
+        if (is_bool($value)) {
+            $value = $value? 'on' : 'off';
+        }
+        
         $this->setAttribute('autocomplete', $value);
 
         return $this;

--- a/src/Forms/Input/Password.php
+++ b/src/Forms/Input/Password.php
@@ -95,7 +95,7 @@ class Password extends TextField
      */
     protected function getElement()
     {
-        $output = '<input type="password" '.$this->getAttributeString().'>';
+        $output = '<input type="password" '.$this->getAttributeString().' autocomplete="off">';
 
         return $output;
     }

--- a/src/Gibbon/Session.php
+++ b/src/Gibbon/Session.php
@@ -54,7 +54,10 @@ class Session
             ini_set('session.cache_limiter', 'private');
             session_cache_limiter(false);
         
-            session_start();
+            session_start([
+                'cookie_httponly'  => true,
+                'cookie_secure'    => isset($_SERVER['HTTPS']),
+            ]);
         }
 
         // Backwards compatibility for external modules

--- a/src/Gibbon/Session.php
+++ b/src/Gibbon/Session.php
@@ -53,11 +53,19 @@ class Session
             //Prevent breakage of back button on POST pages
             ini_set('session.cache_limiter', 'private');
             session_cache_limiter(false);
-        
-            session_start([
+
+            $options = [
                 'cookie_httponly'  => true,
                 'cookie_secure'    => isset($_SERVER['HTTPS']),
-            ]);
+            ];
+
+            if (version_compare(phpversion(), '7.3.0', '>=')) {
+                $options['cookie_samesite'] = 'Strict';
+            }
+        
+            session_start($options);
+
+            header('X-Frame-Options: SAMEORIGIN');
         }
 
         // Backwards compatibility for external modules


### PR DESCRIPTION
This PR adds some settings, meta-tags and headers that generally improve the default security of session cookies and cross-site scripts. It also forces autocomplete to be off for the Login form and Password inputs (browsers can still handle their own password management locally)