### PR TITLE
Messenger: add a read-only role category field for Quick Wall messages

### DIFF
--- a/modules/Messenger/messenger_manage_edit.php
+++ b/modules/Messenger/messenger_manage_edit.php
@@ -249,7 +249,20 @@ else {
 					$row = $form->addRow()->addClass('roleCategory hiddenReveal');
 						$row->addLabel('roleCategories[]', __('Select Role Categories'));
 						$row->addSelect('roleCategories[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(4)->isRequired()->placeholder()->selected($selected);
-				}
+				} else if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_postQuickWall.php")) {
+                    // Handle the edge case where a user can post a Quick Wall message but doesn't have access to the Role target
+                    $row = $form->addRow();
+						$row->addLabel('roleCategoryLabel', __('Role Category'))->description(__('Users of a certain type.'));
+                        $row->addYesNoRadio('roleCategoryLabel')->checked('Y')->readonly()->isDisabled();
+
+                    $form->addHiddenValue('role', 'N');
+                    $form->addHiddenValue('roleCategory', 'Y');
+                    foreach ($targets as $target) {
+                        if ($target['type'] == 'Role Category') {
+                            $form->addHiddenValue('roleCategories[]', $target['id']);
+                        }
+                    }
+                }
 
 				//Year group
 				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_yearGroups_any")) {

--- a/modules/Messenger/messenger_manage_editProcess.php
+++ b/modules/Messenger/messenger_manage_editProcess.php
@@ -124,7 +124,7 @@ else {
 
 
 				//Role Categories
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_role")) {
+				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_role") || isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_postQuickWall.php")) {
 					if ($_POST["roleCategory"]=="Y") {
 						$choices=$_POST["roleCategories"] ;
 						if ($choices!="") {


### PR DESCRIPTION
Handles the edge case where a user can post a Quick Wall message but doesn't have access to the `New Message_role` target. In this instance, the Role Category target will appear read-only and the targets will be retained via hidden fields:

<img width="761" alt="screen shot 2018-10-15 at 1 41 46 pm" src="https://user-images.githubusercontent.com/897700/46931993-34801280-d080-11e8-98bb-b56dd0cbc2b2.png">


