### PR TITLE
System: add a base View class, adjust index.php processing order 

### DIFF
--- a/resources/templates/welcome.twig.html
+++ b/resources/templates/welcome.twig.html
@@ -1,0 +1,50 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+<h2>{{ __('Welcome') }}</h2>
+<p>
+    {{ indexText }}
+</p>
+
+{% if publicStudentApplications %}
+    <h2 style='margin-top: 30px'>{{ __('Student Applications') }}</h2>
+    <p>
+        {% set url = absoluteURL ~ "/?q=/modules/Students/applicationForm.php" %}
+        {{ __('Parents of students interested in study at %1$s may use our %2$s online form%3$s to initiate the application process.')|format(organisationName, '<a href="' ~ url ~ '">', '</a>')|raw }}
+    </p>
+{% endif %}
+
+{% if publicStaffApplications %}
+    <h2 style='margin-top: 30px'>{{ __('Staff Applications') }}</h2>
+    <p>
+        {% set url = absoluteURL ~ "/?q=/modules/Staff/applicationForm_jobOpenings_view.php" %}
+        {{ __('Individuals interested in working at %1$s may use our %2$s online form%3$s to view job openings and begin the recruitment process.')|format(organisationName, '<a href="' ~ url ~ '">', '</a>')|raw }}
+    </p>
+{% endif %}
+
+{% if makeDepartmentsPublic %}
+    <h2 style='margin-top: 30px'>{{ __('Departments') }}</h2>
+    <p>
+        {% set url = absoluteURL ~ "/?q=/modules/Departments/departments.php" %}
+        {{ __('Please feel free to %1$sbrowse our departmental information%2$s, to learn more about %3$s.')|format('<a href="' ~ url ~ '">', '</a>', organisationName)|raw }}
+    </p>
+{% endif %}
+
+{% if makeUnitsPublic %}
+    <h2 style='margin-top: 30px'>{{ __('Learn With Us') }}</h2>
+    <p>
+        {% set url = absoluteURL ~ "/?q=/modules/Planner/units_public.php&sidebar=false" %}
+        {{ __('We are sharing some of our units of study with members of the public, so you can learn with us. Feel free to %1$sbrowse our public units%2$s.')|format('<a href="' ~ url ~ '">', '</a>', organisationName)|raw }}
+    </p>
+{% endif %}
+
+{% for hook in indexHooks %}
+    <h2 style='margin-top: 30px'>{{ hook.title }}</h2>
+    <p>
+        {{ hook.text|raw }}
+    </p>
+{% endfor %}

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -311,7 +311,7 @@ class Page extends View
     }
 
     /**
-     * Write a string to the view's internal content property.
+     * Writes a string to the page's internal content property.
      *
      * @param string $value
      */
@@ -321,7 +321,7 @@ class Page extends View
     }
 
     /**
-     * Write the output buffered result from a PHP script to the view's content.
+     * Writes the output buffered result from a PHP script to the page's content.
      *
      * @param string $filepath
      * @param array $data
@@ -332,7 +332,7 @@ class Page extends View
     }
 
     /**
-     * Writes a rendered template file to the view's content.
+     * Writes a rendered template file to the page's content.
      *
      * @param string $template
      * @param array $data

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\View;
 
+use Gibbon\View\View;
 use Gibbon\View\AssetBundle;
 
 /**
@@ -27,10 +28,8 @@ use Gibbon\View\AssetBundle;
  * @version  v17
  * @since    v17
  */
-class Page
+class Page extends View
 {
-    protected $templateEngine;
-
     /**
      * After constructing these class properties are publicly read-only.
      */
@@ -57,8 +56,8 @@ class Page
      */
     public function __construct($templateEngine = null, array $params = [])
     {
-        $this->templateEngine = $templateEngine;
-
+        parent::__construct($templateEngine);
+        
         $this->stylesheets = new AssetBundle();
         $this->scripts = new AssetBundle();
 
@@ -295,7 +294,13 @@ class Page
         ];
     }
 
-    public function isAddressValid($address)
+    /**
+     * Check is a given address is valid and does not contain illegal strings.
+     *
+     * @param string $address
+     * @return bool
+     */
+    public function isAddressValid($address) : bool
     {
         return !(stripos($address, '..') !== false
             || strstr($address, 'installer')
@@ -306,7 +311,7 @@ class Page
     }
 
     /**
-     * Writes a string to the page's internal content property.
+     * Write a string to the view's internal content property.
      *
      * @param string $value
      */
@@ -316,7 +321,7 @@ class Page
     }
 
     /**
-     * Writes the output buffered result from a PHP script to the page's content.
+     * Write the output buffered result from a PHP script to the view's content.
      *
      * @param string $filepath
      * @param array $data
@@ -327,7 +332,7 @@ class Page
     }
 
     /**
-     * Writes a rendered template file to the page's content.
+     * Writes a rendered template file to the view's content.
      *
      * @param string $template
      * @param array $data
@@ -335,49 +340,6 @@ class Page
     public function writeFromTemplate(string $template, array $data = [])
     {
         $this->write($this->fetchFromTemplate($template, $data));
-    }
-
-    /**
-     * Includes a PHP file in a protected scope, and returns the
-     * output-buffered contents as a string.
-     *
-     * @param string $filepath
-     * @param array  $data
-     * @return string
-     */
-    public function fetchFromFile(string $filepath, array $data = []) : string
-    {
-        if (!is_file($filepath)) {
-            return '';
-        }
-
-        // Extracts the array of data into individual variables in the current scope.
-        extract($data);
-
-        try {
-            ob_start();
-            $included = include $filepath;
-            $output = ob_get_clean() . (is_string($included)? $included : '');
-        } catch (\Exception $e) {
-            $output = '';
-            ob_end_clean();
-            throw $e;
-        }
-
-        return $output;
-    }
-
-    /**
-     * Renders a given template using the template engine + provided data
-     * and returns the result as a string.
-     *
-     * @param string $template
-     * @param array  $data
-     * @return string
-     */
-    public function fetchFromTemplate(string $template, array $data = []) : string
-    {
-        return $this->templateEngine->render($template, $data);
     }
 
     /**
@@ -392,7 +354,7 @@ class Page
         $data['page'] = $this->gatherData();
         $data['content'] = $this->content;
 
-        return $this->templateEngine->render($template, $data);
+        return parent::render($template, $data);
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1,0 +1,163 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\View;
+
+/**
+ * Base class for Views.
+ *
+ * @version  v17
+ * @since    v17
+ */
+class View implements \ArrayAccess
+{
+    protected $templateEngine;
+
+    protected $data = [];
+
+    /**
+     * Create a new view.
+     *
+     * @param $templateEngine
+     */
+    public function __construct($templateEngine = null)
+    {
+        // Do some duck typing, since Twig does not have a common Interface.
+        if (!is_null($templateEngine) && !method_exists($templateEngine, 'render')) {
+            throw new \InvalidArgumentException("The template engine passed into a View constructor must implement a render() method.");
+        }
+
+        $this->templateEngine = $templateEngine;
+    }
+
+    /**
+     * Add a piece of data to the view.
+     *
+     * @param  string|array  $key
+     * @param  mixed   $value
+     */
+    public function addData($key, $value = null)
+    {
+        if (is_array($key)) {
+            $this->data = array_merge($this->data, $key);
+        } else {
+            $this->data[$key] = $value;
+        }
+    }
+
+    /**
+     * Include a PHP file in a protected scope, and returns the output-buffered
+     * contents as a string. The data array is extracted into individual
+     * variables in the current scope.
+     *
+     * @param string $filepath
+     * @param array  $data
+     * @return string
+     */
+    public function fetchFromFile(string $filepath, array $data = []) : string
+    {
+        if (!is_file($filepath)) {
+            return '';
+        }
+
+        extract($data);
+
+        try {
+            ob_start();
+            $included = include $filepath;
+            $output = ob_get_clean() . (is_string($included)? $included : '');
+        } catch (\Exception $e) {
+            $output = '';
+            ob_end_clean();
+            throw $e;
+        }
+
+        return $output;
+    }
+
+    /**
+     * Render a given template using the template engine + provided data
+     * and returns the result as a string.
+     *
+     * @param string $template
+     * @param array  $data
+     * @return string
+     */
+    public function fetchFromTemplate(string $template, array $data = []) : string
+    {
+        return $this->templateEngine->render($template, $data);
+    }
+
+    /**
+     * Render the view with the given template and return the result as a string.
+     *
+     * @param string $template
+     * @param array $data
+     * @return string
+     */
+    public function render(string $template, array $data = []) : string
+    {
+        $data = array_merge($this->data, $data);
+
+        return $this->templateEngine->render($template, $data);
+    }
+
+    /**
+     * Determine if a piece of data is bound.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function offsetExists($key) : bool
+    {
+        return array_key_exists($key, $this->data);
+    }
+
+    /**
+     * Get a piece of bound data to the view.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->data[$key];
+    }
+
+    /**
+     * Set a piece of data on the view.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->with($key, $value);
+    }
+
+    /**
+     * Unset a piece of data from the view.
+     *
+     * @param  string  $key
+     */
+    public function offsetUnset($key)
+    {
+        unset($this->data[$key]);
+    }
+}


### PR DESCRIPTION
- Moves the template rendering logic from the Page class into a base View class. There are other instances in the codebase where we will want to render templated content, specifically emails.

- Re-orders some of the index logic so that the template variables are assigned before the include() for the page's content is run. This helps ensure the page can render even if a fatal error is encountered in the run-time of the included file (see #659).

- Rewrites the welcome page as a template, moving some more display-related code out of the index.