### PR TITLE
Behaviour: add a notification event for editing behaviour records

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -773,4 +773,5 @@ ALTER TABLE `gibbonFamilyChild` ADD INDEX `gibbonPersonIndex` (`gibbonPersonID`)
 ALTER TABLE `gibbonFamilyChild` ADD INDEX `gibbonFamilyIndex` (`gibbonFamilyID`);end
 ALTER TABLE `gibbonStudentEnrolment` ADD KEY `gibbonPersonIndex` (`gibbonPersonID`,`gibbonSchoolYearID`);end
 UPDATE gibboni18n SET active='Y' WHERE code='he_IL';end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Updated Behaviour Record', 'Behaviour', 'View Behaviour Records_all', 'Core', 'All,gibbonPersonIDStudent,gibbonYearGroupID', 'Y');end
 ";

--- a/modules/Behaviour/behaviour_manage_editProcess.php
+++ b/modules/Behaviour/behaviour_manage_editProcess.php
@@ -17,6 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\School\RollGroupGateway;
+use Gibbon\Domain\Students\StudentGateway;
+
 include '../../gibbon.php';
 
 $enableDescriptors = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors');
@@ -60,6 +64,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 $URL .= '&return=error2';
                 header("Location: {$URL}");
             } else {
+                $behaviourRecord = $result->fetch();
+
                 $gibbonPersonID = $_POST['gibbonPersonID'];
                 $date = $_POST['date'];
                 $type = $_POST['type'];
@@ -94,6 +100,39 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                         exit();
                     }
 
+                    // Send a notification to student's tutors and anyone subscribed to the notification event
+                    $studentGateway = $container->get(StudentGateway::class);
+                    $rollGroupGateway = $container->get(RollGroupGateway::class);
+
+                    $student = $studentGateway->selectActiveStudentByPerson($_SESSION[$guid]['gibbonSchoolYearID'], $gibbonPersonID)->fetch();
+                    if (!empty($student)) {
+                        $studentName = formatName('', $student['preferredName'], $student['surname'], 'Student', false);
+                        $editorName = formatName('', $_SESSION[$guid]['preferredName'], $_SESSION[$guid]['surname'], 'Staff', false);
+                        $actionLink = "/index.php?q=/modules/Behaviour/behaviour_manage_edit.php&gibbonPersonID=$gibbonPersonID&gibbonRollGroupID=&gibbonYearGroupID=&type=$type&gibbonBehaviourID=$gibbonBehaviourID";
+
+                        // Raise a new notification event
+                        $event = new NotificationEvent('Behaviour', 'Updated Behaviour Record');
+
+                        $event->setNotificationText(sprintf(__('A %1$s behaviour record for %2$s has been updated by %3$s.'), strtolower($type), $studentName, $editorName));
+                        $event->setActionLink($actionLink);
+
+                        $event->addScope('gibbonPersonIDStudent', $gibbonPersonID);
+                        $event->addScope('gibbonYearGroupID', $student['gibbonYearGroupID']);
+
+                        // Add the person who created the behaviour record, if edited by someone else
+                        if ($behaviourRecord['gibbonPersonIDCreator'] != $_SESSION[$guid]['gibbonPersonID']) {
+                            $event->addRecipient($behaviourRecord['gibbonPersonIDCreator']);
+                        }
+
+                        // Add direct notifications to roll group tutors
+                        $tutors = $rollGroupGateway->selectTutorsByRollGroup($student['gibbonRollGroupID'])->fetchAll();
+                        foreach ($tutors as $tutor) {
+                            $event->addRecipient($tutor['gibbonPersonID']);
+                        }
+
+                        $event->sendNotificationsAsBcc($pdo, $gibbon->session);
+                    }
+                    
                     $URL .= '&return=success0';
                     header("Location: {$URL}");
                 }


### PR DESCRIPTION
**New Feature**
There are currently notification events for adding new behaviour records but not for editing them. This adds an `Updated Behaviour Record` event, which is triggered when editing a behaviour record (esp. to add follow-up). It will notify the student's form group tutors, the person who created the record (if someone else edits it), and optionally anyone else subscribed to the event.

As with other notification events, a user can be subscribed to receive all notification, or only those for a particular year group or student. This can help if there's leadership or support staff who wish to receive notifications for a particular purpose.

Uses the `sendNotificationsAsBcc()` method to ideally speed up the sending of multiple emails.
