### PR TITLE
Markbook: fix shifted table cells in Markbook View class average 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ v17.0.00
         Markbook: added school wide-option allowing teachers to specify "Modified Assessment" for student with individual needs
         Markbook: fixed bug in handling personalised attainment targets when using scales other than class scale
         Markbook: removed WordPress Comment Push functionality
+        Markbook: fixed shifted table cells in Markbook View class average when cumulative averages are enabled
         Messenger: restricted Manage Groups view to display groups from the current school year only
         Messenger: fixed minor post-OOification bug causing unnecssary display of Parent 2 resent checkbox in send report
         Messenger: added row colouring to By Roll Group report, and made it default view

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -906,7 +906,10 @@
                     echo '<td class="dataColumn dataDivider">';
                     echo $markbook->getFormattedAverage( $markbook->getCumulativeAverage($rowStudents['gibbonPersonID']) );
                     echo '</td>';
-                    @$totals['cumulativeAverage'] += $markbook->getCumulativeAverage($rowStudents['gibbonPersonID']);
+                    if ($markbook->getCumulativeAverage($rowStudents['gibbonPersonID']) != '') {
+                        @$totals['cumulativeAverage'] += $markbook->getCumulativeAverage($rowStudents['gibbonPersonID']);
+                        @$totals['count'] += 1;
+                    }
 
                     if ($markbook->getSetting('enableTypeWeighting') == 'Y' && count($markbook->getGroupedMarkbookTypes('year')) > 0 && $gibbonSchoolYearTermID <= 0) {
 
@@ -958,6 +961,8 @@
                 }
             }
 
+            $count = isset($totals['count'])? min($totals['count'], $count) : $count;
+            
             // Type Averages
             if ($columnFilter == 'averages') {
                 if ($markbook->getSetting('enableTypeWeighting') == 'Y' ) {

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -937,6 +937,10 @@
             echo '<tr>';
             echo '<td class="firstColumn right dataDividerTop">'.__($guid, 'Class Average').':</td>';
 
+            if ($markbook->hasExternalAssessments()) {
+                echo '<td class="dataColumn dataDividerTop"></td>';
+            }
+            
             if ($markbook->hasPersonalizedTargets()) {
                 echo '<td class="dataColumn dataDividerTop"></td>';
             }


### PR DESCRIPTION
**Bug Fix**

Fixes a bug identified by Andy on the forums: https://ask.gibbonedu.org/discussion/2292/shifted-averages-in-display-grid 

The bug occurs as a visual glitch in the markbook view when both External Assessment and Target columns are active, the bottom class average is shifted one cell to the right. This also updates the counter for the class to exclude students with no final mark from the overall class average.