### PR TITLE
School Admin: add an alert to Enable Column Weighting based on Default Assessment Scale

### DIFF
--- a/modules/School Admin/markbookSettings.php
+++ b/modules/School Admin/markbookSettings.php
@@ -57,6 +57,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/markbookSetti
 
     $form->toggleVisibilityByClass('columnWeighting')->onSelect('enableColumnWeighting')->when('Y');
 
+    $defaultAssessmentScale = getSettingByScope($connection2, 'System', 'defaultAssessmentScale');
+    if (intval($defaultAssessmentScale) != 4) {
+        $row = $form->addRow()->addClass('columnWeighting');
+            $row->addAlert(__('Calculation of cumulative marks and weightings is currently only available when using Percentage as the Default Assessment Scale. This value can be changed in System Settings.'));
+    }
+    
     $setting = getSettingByScope($connection2, 'Markbook', 'enableDisplayCumulativeMarks', true);
     $row = $form->addRow()->addClass('columnWeighting');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));


### PR DESCRIPTION
Adds an alert to Markbook Settings when turning on Enable Column Weighting if the current Default Assessment Scale is not percentage.

Related forum post: https://ask.gibbonedu.org/discussion/comment/4668/#Comment_4668
