### PR TITLE
System: change read-only methods to properties in Page, Module, Theme class

### DIFF
--- a/index.php
+++ b/index.php
@@ -255,7 +255,7 @@ $javascriptConfig = [
  */
 
 // Set page scripts: head
-$page->scripts()->addMultiple([
+$page->scripts->addMultiple([
     'lv'             => 'lib/LiveValidation/livevalidation_standalone.compressed.js',
     'jquery'         => 'lib/jquery/jquery.js',
     'jquery-migrate' => 'lib/jquery/jquery-migrate.min.js',
@@ -266,7 +266,7 @@ $page->scripts()->addMultiple([
 ], ['context' => 'head']);
 
 // Set page scripts: foot - jquery
-$page->scripts()->addMultiple([
+$page->scripts->addMultiple([
     'jquery-latex'    => 'lib/jquery-jslatex/jquery.jslatex.js',
     'jquery-form'     => 'lib/jquery-form/jquery.form.js',
     'jquery-date'     => 'lib/jquery-ui/i18n/jquery.ui.datepicker-'.$datepickerLocale.'.js',
@@ -277,15 +277,15 @@ $page->scripts()->addMultiple([
 
 // Set page scripts: foot - misc
 $thickboxInline = 'var tb_pathToImage="'.$session->get('absoluteURL').'/lib/thickbox/loadingAnimation.gif";';
-$page->scripts()->add('thickboxi', $thickboxInline, ['type' => 'inline']);
-$page->scripts()->addMultiple([
+$page->scripts->add('thickboxi', $thickboxInline, ['type' => 'inline']);
+$page->scripts->addMultiple([
     'thickbox' => 'lib/thickbox/thickbox-compressed.js',
     'tinymce'  => 'lib/tinymce/tinymce.min.js',
 ], ['context' => 'foot']);
 
 // Set page scripts: foot - core
-$page->scripts()->add('core-config', 'window.Gibbon = '.json_encode($javascriptConfig).';', ['type' => 'inline']);
-$page->scripts()->add('core-setup', 'resources/assets/js/setup.js');
+$page->scripts->add('core-config', 'window.Gibbon = '.json_encode($javascriptConfig).';', ['type' => 'inline']);
+$page->scripts->add('core-setup', 'resources/assets/js/setup.js');
 
 // Set system analytics code from session cache
 $page->addHeadExtra($session->get('analytics'));
@@ -293,7 +293,7 @@ $page->addHeadExtra($session->get('analytics'));
 /**
  * STYLESHEETS & CSS
  */
-$page->stylesheets()->addMultiple([
+$page->stylesheets->addMultiple([
     'jquery-ui'    => 'lib/jquery-ui/css/blitzer/jquery-ui.css',
     'jquery-time'  => 'lib/jquery-timepicker/jquery.timepicker.css',
     'jquery-token' => 'lib/jquery-tokeninput/styles/token-input-facebook.css',
@@ -309,7 +309,7 @@ if (getSettingByScope($connection2, 'User Admin', 'personalBackground') == 'Y' &
     $backgroundScroll = 'repeat fixed center top';
 }
 
-$page->stylesheets()->add(
+$page->stylesheets->add(
     'personal-background',
     'body { background: url('.$backgroundImage.') '.$backgroundScroll.' #A88EDB!important; }',
     ['type' => 'inline']

--- a/modules/User Admin/user_manage.php
+++ b/modules/User Admin/user_manage.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php
     }
 
     //Proceed!
-    $page->breadcrumbs()->add(__('Manage Users'));
+    $page->breadcrumbs->add(__('Manage Users'));
 
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
     echo '</div>';
 } else {
     //Proceed!
-    $page->breadcrumbs()
+    $page->breadcrumbs
          ->add(__('Manage Users'), 'user_manage.php')
          ->add(__('Add User'));
 

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
     echo '</div>';
 } else {
     //Proceed!
-    $page->breadcrumbs()
+    $page->breadcrumbs
          ->add(__('Manage Users'), 'user_manage.php')
          ->add(__('Edit User'));
 

--- a/modules/User Admin/user_manage_password.php
+++ b/modules/User Admin/user_manage_password.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
     echo '</div>';
 } else {
     //Proceed!
-    $page->breadcrumbs()
+    $page->breadcrumbs
          ->add(__('Manage Users'), 'user_manage.php')
          ->add(__('Reset User Password'));
 

--- a/src/Domain/System/Module.php
+++ b/src/Domain/System/Module.php
@@ -49,12 +49,12 @@ class Module
         $this->stylesheets = new AssetBundle();
         $this->scripts = new AssetBundle();
 
-        $this->stylesheets()->add(
+        $this->stylesheets->add(
             'module',
             'modules/'.$this->name.'/css/module.css',
             ['version' => $this->version]
         );
-        $this->scripts()->add(
+        $this->scripts->add(
             'module',
             'modules/'.$this->name.'/js/module.js',
             ['version' => $this->version, 'context' => 'head']
@@ -90,25 +90,5 @@ class Module
     public function getName()
     {
         return $this->name;
-    }
-
-    /**
-     * Returns the collection of stylesheets used by this module.
-     *
-     * @return AssetBundle
-     */
-    public function stylesheets()
-    {
-        return $this->stylesheets;
-    }
-
-    /**
-     * Returns the collection of scripts used by this module.
-     *
-     * @return AssetBundle
-     */
-    public function scripts()
-    {
-        return $this->scripts;
     }
 }

--- a/src/Domain/System/Theme.php
+++ b/src/Domain/System/Theme.php
@@ -48,18 +48,29 @@ class Theme
         $this->stylesheets = new AssetBundle();
         $this->scripts = new AssetBundle();
 
-        $this->stylesheets()->add(
+        $this->stylesheets->add(
             'theme',
             'themes/'.$this->name.'/css/main.css',
             ['version' => $this->version]
         );
-        $this->scripts()->add(
+        $this->scripts->add(
             'theme',
             'themes/'.$this->name.'/js/common.js',
             ['version' => $this->version]
         );
     }
 
+    /**
+     * Allow read-only access of model properties.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        return isset($this->$name) ? $this->$name : null;
+    }
+    
     /**
      * Get the gibbonThemeID
      *
@@ -78,25 +89,5 @@ class Theme
     public function getName()
     {
         return $this->name;
-    }
-
-    /**
-     * Returns the collection of stylesheets used by this theme.
-     *
-     * @return AssetBundle
-     */
-    public function stylesheets()
-    {
-        return $this->stylesheets;
-    }
-
-    /**
-     * Returns the collection of scripts used by this theme.
-     *
-     * @return AssetBundle
-     */
-    public function scripts()
-    {
-        return $this->scripts;
     }
 }

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -70,6 +70,23 @@ class Page extends View
                 $this->$key = $value;
             }
         }
+
+        // Add the current module entry point to the trail.
+        if (!empty($this->module->name)) {
+            $this->breadcrumbs->setBaseURL('index.php?q=/modules/'.$this->module->name.'/');
+            $this->breadcrumbs->add(__($this->module->name), $this->module->entryURL);
+        }
+    }
+
+    /**
+     * Allow read-only access of page properties.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        return isset($this->$name)? $this->$name : null;
     }
 
     /**
@@ -133,19 +150,19 @@ class Page extends View
      */
     public function getAllStylesheets(string $context = null): array
     {
-        $stylesheets = $this->stylesheets()->getAssets($context);
+        $stylesheets = $this->stylesheets->getAssets($context);
 
         if (!empty($this->getTheme())) {
             $stylesheets = array_replace(
                 $stylesheets,
-                $this->getTheme()->stylesheets()->getAssets($context)
+                $this->getTheme()->stylesheets->getAssets($context)
             );
         }
 
         if (!empty($this->getModule())) {
             $stylesheets = array_replace(
                 $stylesheets,
-                $this->getModule()->stylesheets()->getAssets($context)
+                $this->getModule()->stylesheets->getAssets($context)
             );
         }
 
@@ -162,19 +179,19 @@ class Page extends View
      */
     public function getAllScripts(string $context = null): array
     {
-        $scripts = $this->scripts()->getAssets($context);
+        $scripts = $this->scripts->getAssets($context);
 
         if (!empty($this->getTheme())) {
             $scripts = array_replace(
                 $scripts,
-                $this->getTheme()->scripts()->getAssets($context)
+                $this->getTheme()->scripts->getAssets($context)
             );
         }
 
         if (!empty($this->getModule())) {
             $scripts = array_replace(
                 $scripts,
-                $this->getModule()->scripts()->getAssets($context)
+                $this->getModule()->scripts->getAssets($context)
             );
         }
 
@@ -285,9 +302,12 @@ class Page extends View
      */
     public function gatherData() : array
     {
+        $breadcrumbs = $this->breadcrumbs->getItems();
+        $displayTrail = (empty($this->getModule()) && count($breadcrumbs) > 1) || (!empty($this->getModule()) && count($breadcrumbs) > 2);
+        
         return [
             'title'        => $this->getTitle(),
-            'breadcrumbs'  => $this->breadcrumbs->getItems(),
+            'breadcrumbs'  => $displayTrail ? $breadcrumbs : [],
             'alerts'       => $this->getAlerts(),
             'stylesheets'  => $this->getAllStylesheets(),
             'scriptsHead'  => $this->getAllScripts('head'),
@@ -359,42 +379,5 @@ class Page extends View
         $data['content'] = $this->content;
 
         return parent::render($template, $data);
-    }
-
-    /**
-     * Returns the collection of stylesheets used by this page.
-     *
-     * @return AssetBundle
-     */
-    public function stylesheets(): AssetBundle
-    {
-        return $this->stylesheets;
-    }
-
-    /**
-     * Returns the collection of scripts used by this page.
-     *
-     * @return AssetBundle
-     */
-    public function scripts(): AssetBundle
-    {
-        return $this->scripts;
-    }
-
-    /**
-     * Returns the breadcrumb trail for this page.
-     *
-     * @return Breadcrumbs
-     */
-    public function breadcrumbs()
-    {
-        // Add the current module entry point to the trail. This is here rather than
-        // the constructor to allow incremental refactoring of the hard-coded breadcrumbs.
-        if (empty($this->breadcrumbs->getItems()) && !empty($this->getModule())) {
-            $this->breadcrumbs->setBaseURL('index.php?q=/modules/'.$this->module->name.'/');
-            $this->breadcrumbs->add(__($this->module->name), $this->module->entryURL);
-        }
-
-        return $this->breadcrumbs;
     }
 }

--- a/tests/unit/Domain/System/ModuleTest.php
+++ b/tests/unit/Domain/System/ModuleTest.php
@@ -28,15 +28,15 @@ class ModuleTest extends TestCase
 
     public function testCanAddStylesheets()
     {
-        $this->module->stylesheets()->add('foo', 'bar/baz');
+        $this->module->stylesheets->add('foo', 'bar/baz');
 
-        $this->assertArrayHasKey('foo',  $this->module->stylesheets()->getAssets());
+        $this->assertArrayHasKey('foo',  $this->module->stylesheets->getAssets());
     }
 
     public function testCanAddScripts()
     {
-        $this->module->scripts()->add('fiz', 'bar/baz');
+        $this->module->scripts->add('fiz', 'bar/baz');
 
-        $this->assertArrayHasKey('fiz',  $this->module->scripts()->getAssets());
+        $this->assertArrayHasKey('fiz',  $this->module->scripts->getAssets());
     }
 }

--- a/tests/unit/Domain/System/ThemeTest.php
+++ b/tests/unit/Domain/System/ThemeTest.php
@@ -28,15 +28,15 @@ class ThemeTest extends TestCase
 
     public function testCanAddStylesheets()
     {
-        $this->theme->stylesheets()->add('foo', 'bar/baz');
+        $this->theme->stylesheets->add('foo', 'bar/baz');
 
-        $this->assertArrayHasKey('foo',  $this->theme->stylesheets()->getAssets());
+        $this->assertArrayHasKey('foo',  $this->theme->stylesheets->getAssets());
     }
 
     public function testCanAddScripts()
     {
-        $this->theme->scripts()->add('fiz', 'bar/baz');
+        $this->theme->scripts->add('fiz', 'bar/baz');
 
-        $this->assertArrayHasKey('fiz',  $this->theme->scripts()->getAssets());
+        $this->assertArrayHasKey('fiz',  $this->theme->scripts->getAssets());
     }
 }

--- a/tests/unit/View/PageTest.php
+++ b/tests/unit/View/PageTest.php
@@ -23,13 +23,10 @@ class PageTest extends TestCase
 
     public function setUp()
     {
-        $this->mockModule = $this->createMock(Module::class);
-        $this->mockModule->method('stylesheets')->willReturn(new AssetBundle());
-        $this->mockModule->method('scripts')->willReturn(new AssetBundle());
-
-        $this->mockTheme = $this->createMock(Theme::class);
-        $this->mockTheme->method('stylesheets')->willReturn(new AssetBundle());
-        $this->mockTheme->method('scripts')->willReturn(new AssetBundle());
+        $this->prebuiltPage = new Page(null, [
+            'module' => new Module(),
+            'theme'  => new Theme(),
+        ]);
     }
 
     public function testCanConstructFromParams()
@@ -102,38 +99,41 @@ class PageTest extends TestCase
     public function testCanAddStylesheets()
     {
         $page = new Page();
-        $page->stylesheets()->add('foo', 'bar/baz');
+        $page->stylesheets->add('foo', 'bar/baz');
 
-        $this->assertArrayHasKey('foo',  $page->getAllStylesheets());
+        $this->assertArrayHasKey('foo', $page->getAllStylesheets());
     }
 
     public function testCanGetAllStylesheets()
     {
-        $page = new Page(null, ['module' => $this->mockModule, 'theme' => $this->mockTheme]);
+        $page = $this->prebuiltPage;
 
-        $page->stylesheets()->add('foo', 'bar/baz');
-        $page->getTheme()->stylesheets()->add('buz', 'bar/baz');
-        $page->getModule()->stylesheets()->add('fiz', 'bar/baz');
+        $page->stylesheets->add('foo', 'bar/baz');
+        $page->getTheme()->stylesheets->add('buz', 'bar/baz');
+        $page->getModule()->stylesheets->add('fiz', 'bar/baz');
 
-        $this->assertEquals(['foo', 'buz', 'fiz'], array_keys($page->getAllStylesheets()));
+        $this->assertArrayHasKey('foo', $page->getAllStylesheets());
+        $this->assertArrayHasKey('buz', $page->getAllStylesheets());
+        $this->assertArrayHasKey('fiz', $page->getAllStylesheets());
     }
 
     public function testCanAddScripts()
     {
         $page = new Page();
-        $page->scripts()->add('fiz', 'bar/baz', ['context' => 'head']);
+        $page->scripts->add('fiz', 'bar/baz', ['context' => 'head']);
 
-        $this->assertArrayHasKey('fiz',  $page->getAllScripts('head'));
+        $this->assertArrayHasKey('fiz', $page->getAllScripts('head'));
     }
 
     public function testCanGetAllScripts()
     {
-        $page = new Page(null, ['module' => $this->mockModule, 'theme' => $this->mockTheme]);
+        $page = $this->prebuiltPage;
 
-        $page->scripts()->add('foo', 'bar/baz', ['context' => 'head']);
-        $page->getModule()->scripts()->add('fiz', 'bar/baz', ['context' => 'foot']);
-        $page->getTheme()->scripts()->add('buz', 'bar/baz', ['context' => 'head']);
+        $page->scripts->add('foo', 'bar/baz', ['context' => 'head']);
+        $page->getModule()->scripts->add('fiz', 'bar/baz', ['context' => 'foot']);
+        $page->getTheme()->scripts->add('buz', 'bar/baz', ['context' => 'head']);
 
-        $this->assertEquals(['foo', 'buz'], array_keys($page->getAllScripts('head')));
+        $this->assertArrayHasKey('foo', $page->getAllScripts('head'));
+        $this->assertArrayHasKey('buz', $page->getAllScripts('head'));
     }
 }


### PR DESCRIPTION
I've changed my mind 😅 The use of methods to enforce read-only access to Page properties has been annoying me, because it's hack-ish and the intent of the method isn't clear. Best to make this change sooner rather than later. 

I've removed these methods and opted to use the built-in `__get()` method instead. This allows read-only property access and helps ensure the intent of code using those properties is more readable. 