### PR TITLE
Tests: Gitlab CI compatible tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,70 @@
+before_script:
+  # install apt packages
+  - apt-get update -qy
+  - apt-get install -qy git zip unzip zlib1g-dev gettext
+  # install php extensions
+  - docker-php-ext-install zip gettext pdo_mysql > /dev/null
+  # properly setup php
+  - cp -pdf /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
+  - php --ini
+  # install composer
+  - mkdir $HOME/bin
+  - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+  - php -r "if (hash_file('SHA384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+  - php composer-setup.php --install-dir=$HOME/bin --filename=composer
+  - php -r "unlink('composer-setup.php');"
+  - export PATH=$HOME/bin:$HOME/.phpunit/vendor/bin:$HOME/.composer/vendor/bin:$PATH
+  # run test server for codeception tests
+  - php -S 127.0.0.1:8888 -t $CI_PROJECT_DIR >/dev/null 2>&1 &
+  # install codeception globally in test environment
+  - COMPOSER_HOME=$HOME/.composer composer global require "codeception/codeception:2.1.*@dev" --no-progress
+  # install phpunit globally in test environment, but in different composer home
+  - COMPOSER_HOME=$HOME/.phpunit composer global require "phpunit/phpunit" "$PHPUNIT_VERSION" --no-progress
+  # install dependencies for test
+  - composer install --prefer-dist --no-interaction --no-progress
+
+services:
+  - mariadb:latest
+
+variables:
+  # variables required for Gibbon to test with
+  TEST_ENV: codeception
+  CI_PLATFORM: gitlab_ci
+  GIT_SUBMODULE_STRATEGY: recursive
+  ABSOLUTE_URL: http://127.0.0.1:8888
+  DB_HOST: mariadb
+  DB_NAME: gibbon_test
+  DB_USERNAME: gibbon_test
+  DB_PASSWORD: gibbon_password
+  # variables to setup mariadb docker
+  MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+  MYSQL_DATABASE: gibbon_test
+  MYSQL_USER: gibbon_test
+  MYSQL_PASSWORD: gibbon_password
+
+php:7.0:
+  image: php:7.0
+  variables:
+    PHPUNIT_VERSION: ^6
+  script:
+    - composer test
+  tags:
+    - git-annex
+
+php:7.1:
+  image: php:7.1
+  variables:
+    PHPUNIT_VERSION: ^6
+  script:
+    - composer test
+  tags:
+    - git-annex
+
+php:7.2:
+  image: php:7.2
+  variables:
+    PHPUNIT_VERSION: ^6
+  script:
+    - composer test
+  tags:
+    - git-annex

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ php:
 env:
   global:
     - TEST_ENV='codeception'
+    - CI_PLATFORM='travis_ci'
     - ABSOLUTE_URL='http://127.0.0.1:8888'
     - DB_HOST='127.0.0.1'
     - DB_NAME='gibbon_test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,11 @@ install:
 before_script:
   - php -S 127.0.0.1:8888 -t $TRAVIS_BUILD_DIR >/dev/null 2>&1 &
   - sleep 1
-  - cd tests
 
 # omitting "script:" will default to phpunit
 # use the $DB env variable to determine the phpunit.xml to use
 script:
-  - ~/.composer/vendor/bin/codecept run install --env travis_ci
-  - ~/.composer/vendor/bin/codecept run acceptance --env travis_ci
-  - phpunit --verbose --configuration phpunit.xml
+  - composer test
 
 # configure notifications (email, IRC, campfire etc)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,11 @@ cache:
     - vendor
     - $HOME/.composer/cache
 
-# Disable x-debug to speed up things
 before_install:
+  # Disable x-debug to speed up things
   - phpenv config-rm xdebug.ini
+  # add composer global bin to PATH to make codeception usable
+  - export PATH=$HOME/.composer/vendor/bin:$PATH
   
 # Install packages those will be required during build
 install:

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,12 @@
             "@test:phpunit"
         ],
         "test:codeception": [
-            "cd tests && codecept run install --env travis_ci",
-            "cd tests && codecept run acceptance --env travis_ci"
+            "cd tests && codecept run install --env $CI_PLATFORM",
+            "cd tests && codecept run acceptance --env $CI_PLATFORM"
         ],
-        "test:phpunit": "cd tests && phpunit --verbose --configuration phpunit.xml"
+        "test:phpunit": [
+            "cd tests && phpunit --verbose --configuration phpunit.xml"
+        ]
     },
     "scripts-descriptions": {
         "test:codeception": "Initialize CI environment and run acceptance tests with Codeception.",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,21 @@
             "email": "ross@rossparker.org"
         }
     ],
+    "scripts": {
+        "test": [
+            "@test:codeception",
+            "@test:phpunit"
+        ],
+        "test:codeception": [
+            "cd tests && ~/.composer/vendor/bin/codecept run install --env travis_ci",
+            "cd tests && ~/.composer/vendor/bin/codecept run acceptance --env travis_ci"
+        ],
+        "test:phpunit": "cd tests && phpunit --verbose --configuration phpunit.xml"
+    },
+    "scripts-descriptions": {
+        "test:codeception": "Initialize CI environment and run acceptance tests with Codeception.",
+        "test:phpunit": "Run unit tests with PHPUnit."
+    },
     "require": {
         "php" : "^5.5 || ^7.0",
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
             "@test:phpunit"
         ],
         "test:codeception": [
-            "cd tests && ~/.composer/vendor/bin/codecept run install --env travis_ci",
-            "cd tests && ~/.composer/vendor/bin/codecept run acceptance --env travis_ci"
+            "cd tests && codecept run install --env travis_ci",
+            "cd tests && codecept run acceptance --env travis_ci"
         ],
         "test:phpunit": "cd tests && phpunit --verbose --configuration phpunit.xml"
     },

--- a/tests/config/envs/.gitignore
+++ b/tests/config/envs/.gitignore
@@ -1,2 +1,3 @@
 *.yml
 !travis_ci.yml
+!gitlab_ci.yml

--- a/tests/config/envs/gitlab_ci.yml
+++ b/tests/config/envs/gitlab_ci.yml
@@ -1,0 +1,14 @@
+# `gitlab_ci` environment config goes here
+modules:
+    enabled:
+        - PhpBrowser:
+            url: "http://127.0.0.1:8888"
+    config:
+        Db:
+            dsn: "mysql:host=mariadb;dbname=gibbon_test"
+            user: "gibbon_test"
+            password: "gibbon_password"
+            dump: 'config/data/dump.sql'
+            populate: true
+            cleanup: false
+            reconnect: true

--- a/tests/install/InstallCept.php
+++ b/tests/install/InstallCept.php
@@ -1,53 +1,60 @@
-<?php 
-$I = new InstallTester($scenario);
-$I->wantTo('install Gibbon');
-$I->amOnPage('/installer/install.php');
+<?php
 
-// INSTALLED: Cancel out now if already installed
-if (file_exists(getcwd().'/../config.php')) {
-    $I->see('config.php already exists', '.error');
-    return;
+try {
+    $I = new InstallTester($scenario);
+    $I->wantTo('install Gibbon');
+    $I->amOnPage('/installer/install.php');
+
+    // INSTALLED: Cancel out now if already installed
+    if (file_exists(getcwd().'/../config.php')) {
+        $I->see('config.php already exists', '.error');
+        return;
+    }
+
+    // STEP 1 --------------------------------------
+    $I->see('Installation - Step 1', 'h2');
+    $I->click('Submit');
+
+    // STEP 2 --------------------------------------
+    $I->see('Installation - Step 2', 'h2');
+
+    $I->fillField('databaseServer', getenv('DB_HOST'));
+    $I->fillField('databaseName', getenv('DB_NAME'));
+    $I->fillField('databaseUsername', getenv('DB_USERNAME'));
+    $I->fillField('databasePassword', getenv('DB_PASSWORD'));
+    $I->selectOption('demoData', 'Y');
+
+    $I->click('Submit');
+
+    // STEP 3 --------------------------------------
+    $I->see('Installation - Step 3', 'h2');
+
+    $formValues = array(
+        'title'                 => 'Mr.',
+        'surname'               => 'CI',
+        'firstName'             => 'Travis',
+        'email'                 => 'testing@gibbon.test',
+        'username'              => 'admin',
+        'passwordNew'           => 'travisci',
+        'passwordConfirm'       => 'travisci',
+        'systemName'            => 'Gibbon',
+        'installType'           => 'Testing',
+        'cuttingEdgeCode'       => 'Y',
+        'cuttingEdgeCodeHidden' => 'Y',
+        'statsCollection'       => 'N',
+        'organisationName'      => 'Gibbon Testing',
+        'organisationNameShort' => 'GiT',
+        'currency'              => 'HKD $',
+        'country'               => 'Hong Kong',
+        'timezone'              => 'Asia/Hong_Kong',
+    );
+
+    $I->uncheckOption('#support');
+    $I->submitForm('#content form', $formValues, 'Submit');
+
+    $I->see('Congratulations, your installation is complete.', '.success');
+
+} catch (Exception $e) {
+    codecept_debug($I->grabTextFrom('body'));
+    throw $e;
 }
-
-// STEP 1 --------------------------------------
-$I->see('Installation - Step 1', 'h2');
-$I->click('Submit');
-
-// STEP 2 --------------------------------------
-$I->see('Installation - Step 2', 'h2');
-
-$I->fillField('databaseServer', getenv('DB_HOST') );
-$I->fillField('databaseName', getenv('DB_NAME') );
-$I->fillField('databaseUsername', getenv('DB_USERNAME') );
-$I->fillField('databasePassword', getenv('DB_PASSWORD') );
-$I->selectOption('demoData', 'Y');
-
-$I->click('Submit');
-
-// STEP 3 --------------------------------------
-$I->see('Installation - Step 3', 'h2');
-
-$formValues = array(
-    'title'                 => 'Mr.',
-    'surname'               => 'CI',
-    'firstName'             => 'Travis',
-    'email'                 => 'testing@gibbon.test',
-    'username'              => 'admin',
-    'passwordNew'           => 'travisci',
-    'passwordConfirm'       => 'travisci',
-    'systemName'            => 'Gibbon',
-    'installType'           => 'Testing',
-    'cuttingEdgeCode'       => 'Y',
-    'cuttingEdgeCodeHidden' => 'Y',
-    'statsCollection'       => 'N',
-    'organisationName'      => 'Gibbon Testing',
-    'organisationNameShort' => 'GiT',
-    'currency'              => 'HKD $',
-    'country'               => 'Hong Kong',
-    'timezone'              => 'Asia/Hong_Kong',
-);
-
-$I->uncheckOption('#support');
-$I->submitForm('#content form', $formValues, 'Submit');
-
-$I->see('Congratulations, your installation is complete.', '.success');


### PR DESCRIPTION
**New Feature**

## Description

This PR aims to make it easier to test with other CI platform. In particular, this PR
* extracts CI test from .travis.yml to composer.json. And then;
* implemented a Gitlab CI configuration as a demonstration. And; 
* some minor improvement for debugging codeception install script.

## Motivation and Context

The workflow of Gibbon development depends heavily on the Github/Travis combo. This make it hard for developers to work on this project with other platform. And make it hard to, potentially, migrate to other Git hosting platform.

It is much more flexible to have CI-platform-independent tests that could even work locally. Like this:
```
composer test
```

## How Has This Been Tested?

Besides testing on Travis, the code in PR is also tested with [Gitlab CI](https://gitlab.com/yookoala/gibboneducore/pipelines) to make sure everything works.