### PR TITLE
Attendance: fix PHP 7.1+ exception in parent view of Student History

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ v17.0.00
         System: updated robots.txt to disallow all indexing
         Activities: post-OOification fix to include All Users in Staff selection for in Manage Activities
         Activities: fixed incorrect count in Registered column in Activity Enrolment Summary
+        Attendance: fixed an error in the parent view of Student History for PHP 7.1+
         Behaviour: added a notification event for Updated Behaviour Record
         Data Updater: added a Family Data Updater History report
         Data Updater: fixed comment bug in Medical Updates

--- a/modules/Attendance/report_studentHistory.php
+++ b/modules/Attendance/report_studentHistory.php
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentH
             } else {
                 //Get child list
                 $countChild = 0;
-                $options = '';
+                $options = [];
                 while ($row = $result->fetch()) {
                     try {
                         $dataChild = array('gibbonFamilyID' => $row['gibbonFamilyID'], 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);

--- a/src/Forms/Traits/MultipleOptionsTrait.php
+++ b/src/Forms/Traits/MultipleOptionsTrait.php
@@ -40,6 +40,10 @@ trait MultipleOptionsTrait
      */
     public function fromString($value)
     {
+        if (empty($values)) {
+            $values = '';
+        }
+
         if (!is_string($value)) {
             throw new \InvalidArgumentException(sprintf('Element %s: fromString expects value to be a string, %s given.', $this->getName(), gettype($value)));
         }
@@ -63,6 +67,10 @@ trait MultipleOptionsTrait
      */
     public function fromArray($values)
     {
+        if (empty($values)) {
+            $values = [];
+        }
+
         if (!is_array($values)) {
             throw new \InvalidArgumentException(sprintf('Element %s: fromArray expects value to be an Array, %s given.', $this->getName(), gettype($values)));
         }


### PR DESCRIPTION
**Bug Fix**

This appears to be caused by PHP 7.1+ no longer implicitly converting an empty string to an array:
http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.empty-string-index-operator

in < PHP 7.1, the following code would run:
```php
$options = '';
$options['foo'] = 'Bar';

echo is_array($options)? "Yep, it's an array" : "Is not an array!! Commence breaking stuff...";
```
After 7.1 it'll generate an error. I've looked for other instances in the parent-child selectors that might break and didn't see any, but we will certainly need to keep an eye out for these backwards-incompatible changes.

I've also added an extra check to MultipleOptionsTrait to be more forgiving with empty values passed to `fromString` and `fromArray` (because they can come from many sources including user-defined lists).