### PR TITLE
Markbook: add a search option to the filters in Markbook View

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -59,6 +59,7 @@ v17.0.00
         Markbook: fixed bug in handling personalised attainment targets when using scales other than class scale
         Markbook: removed WordPress Comment Push functionality
         Markbook: fixed shifted table cells in Markbook View class average when cumulative averages are enabled
+        Markbook: added a search option to the filters in Markbook View
         Messenger: restricted Manage Groups view to display groups from the current school year only
         Messenger: fixed minor post-OOification bug causing unnecssary display of Parent 2 resent checkbox in send report
         Messenger: added row colouring to By Roll Group report, and made it default view

--- a/modules/Markbook/markbook_edit_addMultiProcess.php
+++ b/modules/Markbook/markbook_edit_addMultiProcess.php
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
         $gibbonSchoolYearTermID = (!empty($_POST['gibbonSchoolYearTermID']))? $_POST['gibbonSchoolYearTermID'] : null;
         //Sort out attainment
         $attainment = $_POST['attainment'];
-        $attainmentWeighting = null;
+        $attainmentWeighting = 1;
         $attainmentRaw = 'N';
         $attainmentRawMax = null;
         if ($attainment == 'N') {

--- a/modules/Markbook/markbook_edit_addProcess.php
+++ b/modules/Markbook/markbook_edit_addProcess.php
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
         //Sort out attainment
         $attainment = $_POST['attainment'];
-        $attainmentWeighting = null;
+        $attainmentWeighting = 1;
         $attainmentRaw = 'N';
         $attainmentRawMax = null;
         if ($attainment == 'N') {

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -1,4 +1,8 @@
 <?php
+
+use Gibbon\Domain\Planner\PlannerEntryGateway;
+use Gibbon\Domain\Markbook\MarkbookColumnGateway;
+
 	// Lock the file so other scripts cannot call it
 	if (MARKBOOK_VIEW_LOCK !== sha1( $highestAction . $_SESSION[$guid]['gibbonPersonID'] ) . date('zWy') ) return;
 
@@ -109,21 +113,35 @@
     $teacherList = getTeacherList( $pdo, $gibbonCourseClassID );
 	$canEditThisClass = (isset($teacherList[ $_SESSION[$guid]['gibbonPersonID'] ]) || $highestAction2 == 'Edit Markbook_everything');
 
+    // Get criteria filter values, including session defaults
+    $search = $_GET['search'] ?? '';
+    $gibbonSchoolYearTermID = $_GET['gibbonSchoolYearTermID'] ?? $_SESSION[$guid]['markbookTerm'] ?? '';
+    $columnFilter = $_GET['markbookFilter'] ?? $_SESSION[$guid]['markbookFilter'] ?? '';
+    $studentOrderBy = $_GET['markbookOrderBy'] ?? $_SESSION[$guid]['markbookOrderBy'] ?? 'surname';
+
+    $markbookGateway = $container->get(MarkbookColumnGateway::class);
+    $plannerGateway = $container->get(PlannerEntryGateway::class);
+
+    // QUERY
+    $criteria = $markbookGateway->newQueryCriteria()
+        ->searchBy($markbookGateway->getSearchableColumns(), $search)
+        ->sortBy(['gibbonMarkbookColumn.sequenceNumber', 'gibbonMarkbookColumn.date', 'gibbonMarkbookColumn.complete', 'gibbonMarkbookColumn.completeDate'])
+        ->filterBy('term', $gibbonSchoolYearTermID)
+        ->filterBy('show', $columnFilter)
+        ->fromPOST();
+
+    $columns = $markbookGateway->queryMarkbookColumnsByClass($criteria, $gibbonCourseClassID);
+    $columns->transform(function ($column) use ($plannerGateway) {
+        if (isset($column['gibbonPlannerEntryID'])) {
+            $column['gibbonPlannerEntry'] = $plannerGateway->getPlannerEntryByID($column['gibbonPlannerEntryID']);
+        }
+    });
+
     // Build the markbook object for this class
     $markbook = new Module\Markbook\markbookView($gibbon, $pdo, $gibbonCourseClassID );
 
-    // Add a school term filter if one exists
-    $gibbonSchoolYearTermID = (isset($_GET['gibbonSchoolYearTermID']))? $_GET['gibbonSchoolYearTermID'] : $_SESSION[$guid]['markbookTerm'];
-    $markbook->filterByTerm( $gibbonSchoolYearTermID );
-
-    // Add class chooser filters
-    $columnFilter = (isset($_GET['markbookFilter']))? $_GET['markbookFilter'] : $_SESSION[$guid]['markbookFilter'];
-    $markbook->filterByFormOptions( $columnFilter );
-
-    // Get the sort order, if it exists
-    $studentOrderBy = (isset($_SESSION[$guid]['markbookOrderBy']))? $_SESSION[$guid]['markbookOrderBy'] : 'surname';
-    $studentOrderBy = (isset($_GET['markbookOrderBy']))? $_GET['markbookOrderBy'] : $studentOrderBy;
-
+    // Load the columns for the current page
+    $markbook->loadColumnsFromDataSet($columns);
 
     if ($markbook == NULL || $markbook->getColumnCountTotal() < 1) {
         echo "<div class='linkTop'>";
@@ -147,9 +165,6 @@
         $pageNum = (isset($_GET['page']))? $_GET['page'] : $pageNum;
 
         $_SESSION[$guid]['markbookPage'] = $pageNum;
-
-        // Load the columns for the current page
-        $markbook->loadColumns( $pageNum );
 
         // Cache all personalized target data
         $markbook->cachePersonalizedTargets( $gibbonCourseClassID );
@@ -986,7 +1001,7 @@
             }
 
             // Cumulative Average
-            $cumulativeAverage = ($count > 0 && $totals['cumulativeAverage'] > 0)? ($totals['cumulativeAverage'] / $count) : '';
+            $cumulativeAverage = ($count > 0 && !empty($totals['cumulativeAverage']))? ($totals['cumulativeAverage'] / $count) : '';
             echo '<td class="dataColumn dataDivider dataDividerTop">'.$markbook->getFormattedAverage($cumulativeAverage).'</td>';
 
             if ($markbook->getSetting('enableTypeWeighting') == 'Y' && count($markbook->getGroupedMarkbookTypes('year')) > 0 && $gibbonSchoolYearTermID <= 0) {

--- a/modules/Markbook/moduleFunctions.php
+++ b/modules/Markbook/moduleFunctions.php
@@ -67,6 +67,14 @@ function classChooser($guid, $pdo, $gibbonCourseClassID)
 
     $col = $form->addRow()->addColumn()->addClass('inline right');
 
+    // SEARCH
+    $search = $_GET['search'] ?? '';
+
+    $col->addContent(__('Search').':');
+    $col->addTextField('search')
+        ->setClass('shortWidth')
+        ->setValue($search);
+
     // TERM
     if ($enableGroupByTerm == 'Y' ) {
         $selectTerm = (isset($_SESSION[$guid]['markbookTerm']))? $_SESSION[$guid]['markbookTerm'] : 0;
@@ -77,7 +85,7 @@ function classChooser($guid, $pdo, $gibbonCourseClassID)
         $result = $pdo->executeQuery($data, $sql);
         $terms = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
 
-        $col->addContent(__('Term').':');
+        $col->addContent(__('Term').':')->prepend('&nbsp;&nbsp;');
         $col->addSelect('gibbonSchoolYearTermID')
             ->fromArray(array('-1' => __('All Terms')))
             ->fromArray($terms)
@@ -136,6 +144,14 @@ function classChooser($guid, $pdo, $gibbonCourseClassID)
         ->selected($gibbonCourseClassID);
 
     $col->addSubmit(__('Go'));
+
+    if (!empty($search)) {
+        $clearURL = $_SESSION[$guid]['absoluteURL'].'/index.php?q='.$_SESSION[$guid]['address'];
+        $clearLink = sprintf('<a href="%s" class="small" style="">%s</a> &nbsp;', $clearURL, __('Clear Search'));
+
+        $form->addRow()->addContent($clearLink)->addClass('right');
+    }
+
 
     $output .= $form->getOutput();
 

--- a/modules/Markbook/src/markbookView.php
+++ b/modules/Markbook/src/markbookView.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 namespace Module\Markbook ;
 
 use Gibbon\session;
+use Gibbon\Domain\DataSet;
 use Gibbon\Contracts\Database\Connection;
 
 /**
@@ -204,7 +205,6 @@ class markbookView
      * @return  int
      */
     public function getColumnCountTotal() {
-
         if ($this->columnCountTotal > -1) return $this->columnCountTotal;
 
         // Build the initial column counts for this class
@@ -226,6 +226,7 @@ class markbookView
     /**
      * Load Columns
      *
+     * @deprecated v17
      * @version 7th May 2016
      * @since   7th May 2016
      * @param   int    $pageNum
@@ -291,6 +292,38 @@ class markbookView
         }
 
         return (count($this->columns) > 0);
+    }
+
+    /**
+     * Load the current markbook columns from a DataSet.
+     *
+     * @param   DataSet $dataSet
+     * @return  bool    true if there are columns
+     */
+    public function loadColumnsFromDataSet(DataSet $dataSet)
+    {
+        $this->columns = [];
+        $this->columnCountTotal = $dataSet->getResultCount();
+        $this->columnsThisPage = count($dataSet);
+
+        // Grab the minimum sequenceNumber for the current page set, to pass to markbook_viewAjax.php
+        $this->minSequenceNumber = array_reduce($this->columns, function ($minimum, $item) {
+            return min($minimum, $item['sequenceNumber']);
+        }, 0);
+
+        // Build a markbookColumn object for each row
+        foreach ($dataSet as $i => $columnData) {
+            if ($column = new markbookColumn($columnData, $this->settings['enableEffort'], $this->settings['enableRubrics'])) {
+                $this->columns[$i] = $column;
+
+                // Attach planner info to help determine if theres homework submissions for this column
+                if (!empty($columnData['gibbonPlannerEntry'])) {
+                    $column->setSubmissionDetails($columnData['gibbonPlannerEntry']);
+                }
+            }
+        }
+
+        return !empty($this->columns);
     }
 
     /**
@@ -882,6 +915,7 @@ class markbookView
     /**
      * Creates a date range SQL filter, also checks validity of dates provided
      *
+     * @deprecated v17
      * @version 7th May 2016
      * @since   7th May 2016
      * @param   string $startDate  YYYY-MM-DD Format
@@ -909,6 +943,7 @@ class markbookView
     /**
      * Filter By Term
      *
+     * @deprecated v17
      * @version 7th May 2016
      * @since   7th May 2016
      * @param   int|string $gibbonSchoolYearTermID
@@ -935,6 +970,7 @@ class markbookView
     /**
      * Creates simple SQL statements for options from the Class Selector
      *
+     * @deprecated v17
      * @version 7th May 2016
      * @since   7th May 2016
      * @param   string $filter
@@ -954,6 +990,7 @@ class markbookView
     /**
      * Add a raw SQL statement to the filters
      *
+     * @deprecated v17
      * @version 7th May 2016
      * @since   7th May 2016
      * @param   string $query
@@ -969,6 +1006,7 @@ class markbookView
     /**
      * Get a SQL frieldly string of query modifiers
      *
+     * @deprecated v17
      * @version 7th May 2016
      * @since   7th May 2016
      * @return  string

--- a/src/Domain/Markbook/MarkbookColumnGateway.php
+++ b/src/Domain/Markbook/MarkbookColumnGateway.php
@@ -1,0 +1,73 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Markbook;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * Markbook Column Gateway
+ *
+ * @version v17
+ * @since   v17
+ */
+class MarkbookColumnGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonMarkbookColumn';
+    private static $searchableColumns = ['name', 'description', 'type'];
+    
+    /**
+     * 
+     */
+    public function queryMarkbookColumnsByClass(QueryCriteria $criteria, $gibbonCourseClassID)
+    {
+        $query = $this
+            ->newQuery()
+            ->from('gibbonMarkbookColumn')
+            ->cols(['*'])
+            ->where('gibbonMarkbookColumn.gibbonCourseClassID = :gibbonCourseClassID')
+            ->bindValue('gibbonCourseClassID', $gibbonCourseClassID)
+            ->groupBy(['gibbonMarkbookColumn.gibbonMarkbookColumnID']);
+
+        $criteria->addFilterRules([
+            'term' => function ($query, $gibbonSchoolYearTermID) {
+                if ($gibbonSchoolYearTermID <= 0) return $query;
+
+                return $query
+                    ->innerJoin('gibbonSchoolYearTerm', 'gibbonSchoolYearTerm.gibbonSchoolYearTermID=gibbonMarkbookColumn.gibbonSchoolYearTermID 
+                        OR gibbonMarkbookColumn.date BETWEEN gibbonSchoolYearTerm.firstDay AND gibbonSchoolYearTerm.lastDay')
+                    ->where('gibbonSchoolYearTerm.gibbonSchoolYearTermID = :gibbonSchoolYearTermID')
+                    ->bindValue('gibbonSchoolYearTermID', $gibbonSchoolYearTermID);
+            },
+            'show' => function ($query, $show) {
+                switch ($show) {
+                    case 'marked'  : $query->where("complete = 'Y'"); break;
+                    case 'unmarked': $query->where("complete = 'N'"); break;
+                }
+                return $query;
+            },
+        ]);
+
+        return $this->runQuery($query, $criteria);
+    }
+}

--- a/src/Domain/Planner/PlannerEntryGateway.php
+++ b/src/Domain/Planner/PlannerEntryGateway.php
@@ -1,0 +1,46 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Planner;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * Planner Entry Gateway
+ *
+ * @version v17
+ * @since   v17
+ */
+class PlannerEntryGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonPlannerEntry';
+    private static $searchableColumns = [];
+    
+    public function getPlannerEntryByID($gibbonPlannerEntryID)
+    {
+        $data = ['gibbonPlannerEntryID' => $gibbonPlannerEntryID];
+        $sql = "SELECT * FROM gibbonPlannerEntry WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID";
+
+        return $this->db()->selectOne($sql, $data);
+    }
+}


### PR DESCRIPTION
**New Feature**

Adds a search option, inline with the other filters in the teacher-view of the markbook. This PR also sets up the gateway classes for MarkbookColumn and PlannerEntry. It's nowhere near a complete refactoring (that's still on the list), just a step in the right direction. Also marked a few methods as deprecated and fixed a default attainmentWeighting value.

## Motivation and Context

Teachers using markbook types may wish to filter the markbook to see only columns of one type (Formative vs. Summative, or Homework vs Tests). Rather than limiting it to just this purpose, I've added this feature as a text search which looks at the name, description and type fields.

## Screenshots (if appropriate):

<img width="1071" alt="screen shot 2018-10-29 at 4 12 30 pm" src="https://user-images.githubusercontent.com/897700/47637069-7a1b0000-db95-11e8-8051-99d31e54c759.png">
