### PR TITLE
Modules: Class autoloading

### DIFF
--- a/cli/attendance_weeklySummaryEmail.php
+++ b/cli/attendance_weeklySummaryEmail.php
@@ -33,7 +33,6 @@ if (!isCommandLineInterface()) {
     setCurrentSchoolYear($guid, $connection2);
 
     require_once __DIR__ . '/../modules/Attendance/moduleFunctions.php';
-    require_once __DIR__ . '/../modules/Attendance/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
     
     $firstDayOfTheWeek = $gibbon->session->get('firstDayOfTheWeek');

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         }
     },
     "autoload": {
+        "classmap": ["modules/"],
         "files": ["src/Scripts/autoload.php"],
         "psr-4": { "Gibbon\\": ["src/", "src/Gibbon"] }
     }

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         }
     },
     "autoload": {
+        "files": ["src/Scripts/autoload.php"],
         "psr-4": { "Gibbon\\": ["src/", "src/Gibbon"] }
     }
 }

--- a/gibbon.php
+++ b/gibbon.php
@@ -45,16 +45,6 @@ if (!$gibbon->isInstalled() && !$gibbon->isInstalling()) {
     exit;
 }
 
-// Autoload the current module namespace
-if (!empty($gibbon->session->get('module'))) {
-    $moduleNamespace = preg_replace('/[^a-zA-Z0-9]/', '', $gibbon->session->get('module'));
-    $autoloader->addPsr4('Gibbon\\Module\\'.$moduleNamespace.'\\', realpath(__DIR__).'/modules/'.$gibbon->session->get('module').'/src');
-
-    // Temporary backwards-compatibility for external modules (Query Builder)
-    $autoloader->addPsr4('Gibbon\\'.$moduleNamespace.'\\', realpath(__DIR__).'/modules/'.$gibbon->session->get('module'));
-    $autoloader->register(true);
-}
-
 // Initialize using the database connection
 if ($gibbon->isInstalled() == true) {
     

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -23,7 +23,6 @@ use Gibbon\Module\Attendance\AttendanceView;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
-require_once __DIR__ . '/src/AttendanceView.php';
 
 // set page breadcrumb
 $page->breadcrumbs->add(__('Set Future Absence'));

--- a/modules/Attendance/attendance_future_byPersonProcess.php
+++ b/modules/Attendance/attendance_future_byPersonProcess.php
@@ -61,7 +61,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
             header("Location: {$URL}");
         } else {
             //Write to database
-            require_once __DIR__ . '/src/AttendanceView.php';
             $attendance = new AttendanceView($gibbon, $pdo);
 
             $fail = false;

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -23,7 +23,6 @@ use Gibbon\Module\Attendance\AttendanceView;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
-require_once __DIR__ . '/src/AttendanceView.php';
 
 // set page breadcrumb
 $page->breadcrumbs->add(__('Take Attendance by Class'));

--- a/modules/Attendance/attendance_take_byCourseClassProcess.php
+++ b/modules/Attendance/attendance_take_byCourseClassProcess.php
@@ -91,7 +91,6 @@ else {
 				}
 				else {
 					//Write to database
-					require_once __DIR__ . '/src/AttendanceView.php';
 					$attendance = new AttendanceView($gibbon, $pdo);
 
 					try {

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -24,7 +24,6 @@ use Gibbon\Services\Format;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
-require_once __DIR__ . '/src/AttendanceView.php';
 
 // set page breadcrumb
 $page->breadcrumbs->add(__('Take Attendance by Person'));

--- a/modules/Attendance/attendance_take_byPersonProcess.php
+++ b/modules/Attendance/attendance_take_byPersonProcess.php
@@ -66,7 +66,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                     header("Location: {$URL}");
                 } else {
                     //Write to database
-                    require_once __DIR__ . '/src/AttendanceView.php';
                     $attendance = new AttendanceView($gibbon, $pdo);
 
                     $fail = false;

--- a/modules/Attendance/attendance_take_byPerson_edit.php
+++ b/modules/Attendance/attendance_take_byPerson_edit.php
@@ -22,7 +22,6 @@ use Gibbon\Module\Attendance\AttendanceView;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
-require_once __DIR__ . '/src/AttendanceView.php';
 
 $urlParams = ['gibbonPersonID' => $_GET['gibbonPersonID'], 'currentDate' => $_GET['currentDate']];
 

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -23,7 +23,6 @@ use Gibbon\Module\Attendance\AttendanceView;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
-require_once __DIR__ . '/src/AttendanceView.php';
 
 // set page breadcrumb
 $page->breadcrumbs->add(__('Take Attendance by Roll Group'));

--- a/modules/Attendance/attendance_take_byRollGroupProcess.php
+++ b/modules/Attendance/attendance_take_byRollGroupProcess.php
@@ -78,7 +78,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                         header("Location: {$URL}");
                     } else {
                         //Write to database
-                        require_once __DIR__ . '/src/AttendanceView.php';
                         $attendance = new AttendanceView($gibbon, $pdo);
 
                         try {

--- a/modules/Attendance/moduleFunctions.php
+++ b/modules/Attendance/moduleFunctions.php
@@ -25,7 +25,6 @@ function getAbsenceCount($guid, $gibbonPersonID, $connection2, $dateStart, $date
     $queryFail = false;
 
     global $gibbon, $session, $pdo;
-    require_once __DIR__ . '/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
 
     //Get all records for the student, in the date range specified, ordered by date and timestamp taken.
@@ -135,7 +134,6 @@ function getLatenessCount($guid, $gibbonPersonID, $connection2, $dateStart, $dat
 function report_studentHistory($guid, $gibbonPersonID, $print, $printURL, $connection2, $dateStart, $dateEnd)
 {
     global $gibbon, $session, $pdo;
-    require_once __DIR__ . '/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
 
     $attendanceByPersonAccessible = isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson.php');

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -81,7 +81,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_graph_by
     $rollGroups = !empty($_POST['gibbonRollGroupID'])? $_POST['gibbonRollGroupID'] : array('all');
     if (in_array('all', $rollGroups)) $rollGroups = array('all');
 
-    require_once __DIR__ . '/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
 
     if (isset($_POST['types']) && isset($_POST['dateStart'])) {

--- a/modules/Attendance/report_studentsNotOnsite_byDate.php
+++ b/modules/Attendance/report_studentsNotOnsite_byDate.php
@@ -48,7 +48,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname';
     $gibbonYearGroupIDList = (!empty($_GET['gibbonYearGroupIDList']) && is_array($_GET['gibbonYearGroupIDList'])) ? $_GET['gibbonYearGroupIDList'] : null ;
 
-    require_once __DIR__ . '/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');

--- a/modules/Attendance/report_studentsNotOnsite_byDate_print.php
+++ b/modules/Attendance/report_studentsNotOnsite_byDate_print.php
@@ -38,7 +38,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname, preferredName';
     $gibbonYearGroupIDList = (!empty($_GET['gibbonYearGroupIDList'])) ? explode(',', $_GET['gibbonYearGroupIDList']) : null ;
 
-    require_once __DIR__ . '/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
 
     //Proceed!

--- a/modules/Attendance/report_studentsNotPresent_byDate.php
+++ b/modules/Attendance/report_studentsNotPresent_byDate.php
@@ -48,7 +48,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname, preferredName';
     $gibbonYearGroupIDList = (!empty($_GET['gibbonYearGroupIDList']) && is_array($_GET['gibbonYearGroupIDList'])) ? $_GET['gibbonYearGroupIDList'] : null ;
 
-    require_once __DIR__ . '/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');

--- a/modules/Attendance/report_studentsNotPresent_byDate_print.php
+++ b/modules/Attendance/report_studentsNotPresent_byDate_print.php
@@ -38,7 +38,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
     $sort = !empty($_GET['sort'])? $_GET['sort'] : 'surname, preferredName';
     $gibbonYearGroupIDList = (!empty($_GET['gibbonYearGroupIDList'])) ? explode(',', $_GET['gibbonYearGroupIDList']) : null ;
 
-    require_once __DIR__ . '/src/AttendanceView.php';
     $attendance = new AttendanceView($gibbon, $pdo);
 
     //Proceed!

--- a/modules/Markbook/markbook_viewExportAllContents.php
+++ b/modules/Markbook/markbook_viewExportAllContents.php
@@ -67,9 +67,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
         echo __('There are no records to display.');
         echo '</div>';
     } else {
-
-        require_once __DIR__ . '/src/MarkbookView.php';
-
         // Build the markbook object for this class
         $markbook = new MarkbookView($gibbon, $pdo, $gibbonCourseClassID);
 

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -25,10 +25,6 @@ use Gibbon\Services\Format;
 
 	// Lock the file so other scripts cannot call it
 	if (MARKBOOK_VIEW_LOCK !== sha1( $highestAction . $_SESSION[$guid]['gibbonPersonID'] ) . date('zWy') ) return;
-
-	require_once __DIR__ . '/src/MarkbookView.php';
-	require_once __DIR__ . '/src/MarkbookColumn.php';
-
     //Check for access to multiple column add
     $multiAdd = false;
     //Add multiple columns

--- a/modules/Markbook/moduleFunctions.php
+++ b/modules/Markbook/moduleFunctions.php
@@ -239,9 +239,6 @@ function getAlertStyle( $alert, $concern ) {
 }
 
 function renderStudentCumulativeMarks($gibbon, $pdo, $gibbonPersonID, $gibbonCourseClassID) {
-
-    require_once __DIR__ . '/src/MarkbookView.php';
-
     // Build the markbook object for this class & student
     $markbook = new MarkbookView($gibbon, $pdo, $gibbonCourseClassID);
     $assessmentScale = $markbook->getDefaultAssessmentScale();

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -22,7 +22,6 @@ use Gibbon\Forms\Form;
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
 require_once __DIR__ . '/../Attendance/moduleFunctions.php';
-require_once __DIR__ . '/../Attendance/src/AttendanceView.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.php') == false) {
     //Acess denied

--- a/src/Domain/System/Module.php
+++ b/src/Domain/System/Module.php
@@ -102,4 +102,55 @@ class Module
     {
         return $this->name;
     }
+
+    /**
+     * Given a class fullpath string, returns the speculative
+     * full path to the class file.
+     *
+     * All class path should follow this pattern:
+     *   `Gibbon\ModuleName\SubNamespaceIfApplicable\Class`
+     *
+     * The `ModuleName` portion will be processed. All capitalized
+     * word in the module name will be separated by space. I.E.
+     * `ModuleName` will become `Module Name` for directory name.
+     *
+     * @param string $class Full namespaced class name.
+     *
+     * @return string|null  The full file path, or null if the
+     *                      namespaced class name does not match
+     *                      the pattern of a correct Gibbon module
+     *                      class. Note that, if returned, the path
+     *                      is only speculative. The module or file
+     *                      might not exists.
+     */
+    public static function getAutoloadFilepath(string $class)
+    {
+        if (preg_match('/^Gibbon\\\\Module\\\\(.+?)\\\\(.+)$/', $class, $matches)) {
+            list($all, $module, $subclass) = $matches;
+            $basePath = realpath(__DIR__ . '/../../../modules');
+            $modulePath = trim(implode(' ', preg_split('/(?=[A-Z])/', $module)), ' ');
+            $classPath = implode(DIRECTORY_SEPARATOR, explode('\\', $subclass));
+            return $basePath .
+                DIRECTORY_SEPARATOR . $modulePath .
+                DIRECTORY_SEPARATOR . 'src' .
+                DIRECTORY_SEPARATOR . $classPath . '.php';
+        }
+        return null;
+    }
+
+    /**
+     * Given a full namspaced class name, this function
+     * will try to automatically load the class file.
+     *
+     * @param string $class
+     *
+     * @return void
+     */
+    public static function autoload(string $class)
+    {
+        if (($path = static::getAutoloadFilepath($class)) !== null) {
+            include_once $path;
+        }
+        return;
+    }
 }

--- a/src/Scripts/autoload.php
+++ b/src/Scripts/autoload.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\System\Module;
+
+// autoload module class files with Module::autoload
+// static method.
+spl_autoload_register([Module::class, 'autoload']);

--- a/tests/unit/Domain/System/ModuleTest.php
+++ b/tests/unit/Domain/System/ModuleTest.php
@@ -30,14 +30,23 @@ class ModuleTest extends TestCase
     {
         $this->module->stylesheets->add('foo', 'bar/baz');
 
-        $this->assertArrayHasKey('foo',  $this->module->stylesheets->getAssets());
+        $this->assertArrayHasKey('foo', $this->module->stylesheets->getAssets());
     }
 
     public function testCanAddScripts()
     {
         $this->module->scripts->add('fiz', 'bar/baz');
 
-        $this->assertArrayHasKey('fiz',  $this->module->scripts->getAssets());
+        $this->assertArrayHasKey('fiz', $this->module->scripts->getAssets());
+    }
+
+    public function testGetNameFromNamespace()
+    {
+        $this->assertEquals(
+            'Foo Bar',
+            Module::getNameFromNamespace('FooBar'),
+            'Return properly spaced version of a module name.'
+        );
     }
 
     public function testGetAutoloadFilepath()

--- a/tests/unit/Domain/System/ModuleTest.php
+++ b/tests/unit/Domain/System/ModuleTest.php
@@ -39,4 +39,26 @@ class ModuleTest extends TestCase
 
         $this->assertArrayHasKey('fiz',  $this->module->scripts->getAssets());
     }
+
+    public function testGetAutoloadFilepath()
+    {
+        $this->assertEquals(
+            realpath(__DIR__ . '/../../../../modules') . '/Hello World/src/MyClass.php',
+            Module::getAutoloadFilepath('Gibbon\\Module\\HelloWorld\\MyClass'),
+            'Suggested filepath to module HelloWorld does not match expectation.'
+        );
+        $this->assertEquals(
+            realpath(__DIR__ . '/../../../../modules') . '/Hello World/src/SomeDomain/MyClass.php',
+            Module::getAutoloadFilepath('Gibbon\\Module\\HelloWorld\\SomeDomain\\MyClass'),
+            'Suggested filepath to module HelloWorld does not match expectation.'
+        );
+        $this->assertNull(
+            Module::getAutoloadFilepath('Gibbon\\NotModule\\HelloWorld\\SomeDomain\\MyClass'),
+            'Should not suggest any filepath if the pattern is not a module class.'
+        );
+        $this->assertNull(
+            Module::getAutoloadFilepath('Something\\Else\\HelloWorld\\SomeDomain\\MyClass'),
+            'Should not suggest any filepath if the pattern is not a Gibbon class.'
+        );
+    }
 }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -8,6 +8,10 @@ $baseDir = dirname($vendorDir);
 return array(
     'Datamatrix' => $vendorDir . '/tecnickcom/tcpdf/include/barcodes/datamatrix.php',
     'EasyPeasyICS' => $vendorDir . '/phpmailer/phpmailer/extras/EasyPeasyICS.php',
+    'Gibbon\\Module\\Attendance\\AttendanceView' => $baseDir . '/modules/Attendance/src/AttendanceView.php',
+    'Gibbon\\Module\\Finance\\Forms\\FinanceFormFactory' => $baseDir . '/modules/Finance/src/Forms/FinanceFormFactory.php',
+    'Gibbon\\Module\\Markbook\\MarkbookColumn' => $baseDir . '/modules/Markbook/src/MarkbookColumn.php',
+    'Gibbon\\Module\\Markbook\\MarkbookView' => $baseDir . '/modules/Markbook/src/MarkbookView.php',
     'Google_Service_Exception' => $vendorDir . '/google/apiclient/src/Google/Service/Exception.php',
     'Google_Service_Resource' => $vendorDir . '/google/apiclient/src/Google/Service/Resource.php',
     'PDF417' => $vendorDir . '/tecnickcom/tcpdf/include/barcodes/pdf417.php',

--- a/vendor/composer/autoload_files.php
+++ b/vendor/composer/autoload_files.php
@@ -71,4 +71,5 @@ return array(
     'decc78cc4436b1292c6c0d151b19445c' => $vendorDir . '/phpseclib/phpseclib/phpseclib/bootstrap.php',
     '320cde22f66dd4f5d3fd621d3e88b98f' => $vendorDir . '/symfony/polyfill-ctype/bootstrap.php',
     '0e6d7bf4a5811bfa5cf40c5ccd6fae6a' => $vendorDir . '/symfony/polyfill-mbstring/bootstrap.php',
+    'bc86a11a74033a01c8c1cac0d5adf9d1' => $baseDir . '/src/Scripts/autoload.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -72,6 +72,7 @@ class ComposerStaticInit3046e8c42bde92b8c2d990c2f6dd9601
         'decc78cc4436b1292c6c0d151b19445c' => __DIR__ . '/..' . '/phpseclib/phpseclib/phpseclib/bootstrap.php',
         '320cde22f66dd4f5d3fd621d3e88b98f' => __DIR__ . '/..' . '/symfony/polyfill-ctype/bootstrap.php',
         '0e6d7bf4a5811bfa5cf40c5ccd6fae6a' => __DIR__ . '/..' . '/symfony/polyfill-mbstring/bootstrap.php',
+        'bc86a11a74033a01c8c1cac0d5adf9d1' => __DIR__ . '/../..' . '/src/Scripts/autoload.php',
     );
 
     public static $prefixLengthsPsr4 = array (

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -276,6 +276,10 @@ class ComposerStaticInit3046e8c42bde92b8c2d990c2f6dd9601
     public static $classMap = array (
         'Datamatrix' => __DIR__ . '/..' . '/tecnickcom/tcpdf/include/barcodes/datamatrix.php',
         'EasyPeasyICS' => __DIR__ . '/..' . '/phpmailer/phpmailer/extras/EasyPeasyICS.php',
+        'Gibbon\\Module\\Attendance\\AttendanceView' => __DIR__ . '/../..' . '/modules/Attendance/src/AttendanceView.php',
+        'Gibbon\\Module\\Finance\\Forms\\FinanceFormFactory' => __DIR__ . '/../..' . '/modules/Finance/src/Forms/FinanceFormFactory.php',
+        'Gibbon\\Module\\Markbook\\MarkbookColumn' => __DIR__ . '/../..' . '/modules/Markbook/src/MarkbookColumn.php',
+        'Gibbon\\Module\\Markbook\\MarkbookView' => __DIR__ . '/../..' . '/modules/Markbook/src/MarkbookView.php',
         'Google_Service_Exception' => __DIR__ . '/..' . '/google/apiclient/src/Google/Service/Exception.php',
         'Google_Service_Resource' => __DIR__ . '/..' . '/google/apiclient/src/Google/Service/Resource.php',
         'PDF417' => __DIR__ . '/..' . '/tecnickcom/tcpdf/include/barcodes/pdf417.php',


### PR DESCRIPTION
**New Feature**

## Description
A new autoloader script to autoload module class files if the modules are following standard folder structure:

- modules
  - My Module
    - src
      - SubPackage1
        - MyClass1.php
          (`Gibbon\Module\MyModule\SubPackage1\MyClass1`)
      - SubPackage2
        - MyClass2.php
          (`Gibbon\Module\MyModule\SubPackage2\MyClass2`)
      - MyClass.php
        (`Gibbon\Module\MyModule\MyClass`)

That is,
1. All class should be namespaced `Gibbon\Module\{ModuleName}\{SubpackageIfApplicable}`
2. All class files should be within the `src` folder in the module folder.
3. Class files can resides in sub-folder structure. The sub-folder names should also reflect in the namespace subpackage name. (as specified in PSR-4).
4. The `ModuleName` portion will be converted to spaced string `Module Name` for directory search (to provide backward compatibility for spaced module folders).

## Motivation and Context
To easier debug and develop new feature, It is more preferable to have a standardized way to autoload class files from modules. 

## How Has This Been Tested?
* Path speculation is tested with phpunit.
* Functionality is tested with Travis / Codeception.