### PR TITLE
System: add a Chart class

### DIFF
--- a/index.php
+++ b/index.php
@@ -287,6 +287,9 @@ $page->scripts->addMultiple([
 $page->scripts->add('core-config', 'window.Gibbon = '.json_encode($javascriptConfig).';', ['type' => 'inline']);
 $page->scripts->add('core-setup', 'resources/assets/js/setup.js');
 
+// Register scripts available to the core, but not included by default
+$page->scripts->register('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js');
+
 // Set system analytics code from session cache
 $page->addHeadExtra($session->get('analytics'));
 

--- a/src/UI/Chart/Chart.php
+++ b/src/UI/Chart/Chart.php
@@ -1,0 +1,398 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\UI\Chart;
+
+class Chart
+{
+    protected $elementID = 'chart';
+    protected $chartType = '';
+
+    protected $labels = [];
+    protected $options = [];
+    protected $datasets = [];
+    protected $events = [];
+    protected $metadata = [];
+
+    protected $useFillZero = false;
+    protected $useDefaultColors = true;
+
+    protected $defaultColors = [
+        'rgba(153, 102, 255, 1.0)',
+        'rgba(255, 99, 132, 1.0)',
+        'rgba(255, 206, 86, 1.0)',
+        'rgba(54, 162, 235, 1.0)',
+        'rgba(152, 221, 95, 1.0)',
+        'rgba(255, 159, 64, 1.0)',
+        'rgba(237, 85, 88, 1.0)',
+        'rgba(75, 192, 192, 1.0)',
+        'rgba(161, 89, 173, 1.0)',
+        'rgba(29, 109, 163, 1.0)',
+        'rgba(133, 233, 194, 1.0)',
+    ];
+
+    private $allowedChartTypes = [
+        'bar',
+        'horizontalBar',
+        'doughnut',
+        'line',
+        'pie',
+        'polarArea',
+        'radar',
+        'bubble',
+        'scatter',
+    ];
+
+    /**
+     * Chart Constructor
+     *
+     * @param string $elementID
+     * @param string $chartType
+     */
+    public function __construct($elementID, $chartType)
+    {
+        if (!preg_match('/^[a-zA-Z_]+[0-9a-zA-Z_]*$/', $elementID)) {
+            throw new \InvalidArgumentException('The chartID value must be a valid HTML element id.');
+        }
+
+        if (!in_array($chartType, $this->allowedChartTypes)) {
+            throw new \InvalidArgumentException(sprintf('The chart type %s is not one of the available types in the chart.js library.', $chartType));
+        }
+
+        $this->setElementId($elementID);
+        $this->chartType = $chartType;
+    }
+
+    public static function create($elementID, $chartType)
+    {
+        return new self($elementID, $chartType);
+    }
+
+    /**
+     * Get the HTML element id of the chart.
+     * @return string
+     */
+    public function getElementID()
+    {
+        return $this->elementID;
+    }
+    
+    /**
+     * Set the HTML element ID for the chart.
+     * @param string $id
+     */
+    public function setElementID($id)
+    {
+        $this->elementID = $id;
+
+        return $this;
+    }
+
+    /**
+     * Get a pre-defined color by numeric index, using defaultColors as a circular array.
+     *
+     * @param  number $index
+     * @return string
+     */
+    private function getColor($index)
+    {
+        $n = $index % count($this->defaultColors);
+
+        return $this->defaultColors[$n];
+    }
+
+    /**
+     * Set an array of labels.
+     * @param array $labels
+     * @return self
+     */
+    public function setLabels($labels)
+    {
+        // Use only the array keys if an associative array is passed in.
+        if (array_values($labels) !== $labels) {
+            $labels = array_keys($labels);
+        }
+
+        $this->labels = $labels;
+
+        return $this;
+    }
+
+    /**
+     * Set options of chart
+     * @param array $options
+     * @return self
+     */
+    public function setOptions($options)
+    {
+        $this->options = array_replace($this->options, $options);
+        
+        return $this;
+    }
+    
+    /**
+     * Set the default color array to apply to data sets.
+     *
+     * @param array $defaultColors
+     * @return self
+     */
+    public function setColors($defaultColors)
+    {
+        $this->defaultColors = $defaultColors;
+
+        return $this;
+    }
+
+    /**
+     * Add miscellaneous data to the chart config. Useful for onClick functions.
+     *
+     * @param array $metadata
+     * @return self
+     */
+    public function setMetaData($metadata)
+    {
+        $this->metadata = $metadata;
+
+        return $this;
+    }
+
+    public function setLegend($value)
+    {
+        $this->options['legend'] = is_array($value)
+            ? $value
+            : ['display' => $value == true];
+
+        return $this;
+    }
+
+    public function setTitle($value)
+    {
+        $this->options['title'] = is_array($value)
+            ? $value
+            : ['display' => !empty($value), 'text' => $value];
+
+        return $this;
+    }
+
+    /**
+     * Datasets will have their values initialized to 0.
+     *
+     * @return self
+     */
+    public function useFillZero($value)
+    {
+        $this->useFillZero = $value;
+
+        return $this;
+    }
+
+    /**
+     * Use the default colors for backgroundColor & borderColor properties on datasets.
+     *
+     * @return self
+     */
+    public function useDefaultColors($value)
+    {
+        $this->useDefaultColors = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add an onClick event to the chart. Can be the name of a function or the function itself.
+     *
+     * @param string $function
+     * @return self
+     */
+    public function onClick($function, $pointerOnHover = true)
+    {
+        $this->events['onClick'] = $function;
+        if ($pointerOnHover) {
+            $this->onHover('function(elements) { document.body.style.cursor = (elements.length) ? "pointer" : "default";}');
+        }
+        return $this;
+    }
+
+    /**
+     * Add an onHover event to the chart. Can be the name of a function or the function itself.
+     *
+     * @param string $function
+     * @return self
+     */
+    public function onHover($function)
+    {
+        $this->events['onHover'] = $function;
+        return $this;
+    }
+
+    /**
+     * Get an event type by name (eg: onClick, onHover)
+     *
+     * @param  string $eventType
+     * @return string
+     */
+    public function getEvent($eventType)
+    {
+        return isset($this->events[$eventType])? $this->events[$eventType] : '';
+    }
+
+    /**
+     * Add a new dataset with a given id and optional label.
+     *
+     * @param string $id
+     * @param string $label
+     */
+    public function addDataset($id, $label = '')
+    {
+        if ($this->hasDataset($id)) {
+            throw new \InvalidArgumentException(sprintf('A dataset with the id %s is already defined.', $id));
+        }
+
+        $dataset = new ChartDataset($label);
+        $this->datasets[$id] = $dataset;
+
+        if ($this->useFillZero) {
+            $dataset->setData(array_fill(0, count($this->labels), 0));
+        }
+
+        return $dataset;
+    }
+
+    /**
+     * Get a dataset for a given id.
+     *
+     * @param  string $id
+     * @return ChartDataset
+     */
+    public function dataset($id)
+    {
+        if (!$this->hasDataset($id)) {
+            throw new \InvalidArgumentException(sprintf('Dataset %s is not defined', $id));
+        }
+
+        return $this->datasets[$id];
+    }
+
+    /**
+     * Check if a dataset for the given id has been defined.
+     *
+     * @param  string  $id
+     * @return boolean
+     */
+    public function hasDataset($id)
+    {
+        return isset($this->datasets[$id]);
+    }
+
+    /**
+     * Generate chart configuration.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        $config = array(
+            'type' => $this->chartType,
+            'data'=> array(
+                'datasets'=> []
+            )
+        );
+
+        if (!empty($this->labels)) {
+            $config['data']['labels'] = $this->labels;
+        }
+
+        // Index for the default color set
+        $index = 0;
+
+        foreach ($this->datasets as $dataset) {
+            $chartDataset = $dataset->getProperties();
+            $chartDataset['data'] = $dataset->getData();
+            
+            if (!empty($dataset->getLabel())) {
+                $chartDataset['label'] = $dataset->getLabel();
+            }
+            
+            if ($this->useDefaultColors) {
+                if (in_array($this->chartType, array('doughnut', 'pie', 'polarArea'))) {
+                    $chartDataset['backgroundColor'] = [];
+                    $chartDataset['borderColor'] = 'rgba(0,0,0,0)';
+                    foreach ($chartDataset['data'] as $key => $value) {
+                        $chartDataset['backgroundColor'][] = $this->getColor($index);
+                        $index++;
+                    }
+                    // Initialize the index again for next dataset (based on chart type)
+                    $index = 0;
+                } else {
+                    $color = $this->getColor($index);
+                    $chartDataset['pointBackgroundColor'] = $color;
+                    $chartDataset['backgroundColor'] = $color;
+                    $chartDataset['borderColor'] = $color;
+                    $index++;
+                }
+            }
+
+            $config['data']['datasets'][] = $chartDataset;
+        }
+
+        $config['options'] = $this->options;
+
+        if (!empty($this->events)) {
+            $config['options']['onClick'] = !empty($this->events['onClick']) ? '__ON_CLICK_EVENT__' : '';
+            $config['options']['hover']['onHover'] = !empty($this->events['onHover']) ? '__ON_HOVER_EVENT__' : '';
+        }
+
+        if (!empty($this->metadata)) {
+            $config['metadata'] = $this->metadata;
+        }
+
+        return $config;
+    }
+
+    public function getScriptContents()
+    {
+        $output = '';
+        $config = json_encode($this->getConfig(), JSON_NUMERIC_CHECK);
+        $key = $this->getElementID();
+
+        // Workaround to enable javascript functions for onClick and onHover events (after json_encoding).
+        $config = str_replace('"__ON_CLICK_EVENT__"', $this->getEvent('onClick'), $config);
+        $config = str_replace('"__ON_HOVER_EVENT__"', $this->getEvent('onHover'), $config);
+
+        $output .= sprintf('var chart_config_%s = %s;', $key, $config);
+        $output .= sprintf('var chart_context_%s = document.getElementById("%s").getContext("2d");', $key, $this->getElementID());
+        $loaderScript = sprintf('window.chart_%s = new Chart(chart_context_%s, chart_config_%s);', $key, $key, $key);
+        $output .= sprintf("\n$(function() {\n%s\n});", $loaderScript) . "\n";
+
+        return $output;
+    }
+
+    /**
+     * Render a HTML canvas element and script tag for the current chart.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        $canvas = '<canvas id="'.$this->getElementID().'" height="'.($this->options['height'] ?? '').'"></canvas>';
+        $script = '<script type="text/javascript">'.$this->getScriptContents().'</script>';
+
+        return $canvas . $script;
+    }
+}

--- a/src/UI/Chart/ChartDataset.php
+++ b/src/UI/Chart/ChartDataset.php
@@ -1,0 +1,153 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\UI\Chart;
+
+class ChartDataset
+{
+    protected $label = '';
+    protected $properties = [];
+    protected $data = [];
+
+    /**
+     * ChartDataset Constructor
+     *
+     * @param string $label
+     */
+    public function __construct($label = '')
+    {
+        $this->label = $label;
+    }
+
+    /**
+     * Get the current dataset label.
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * Set the current dataset label.
+     *
+     * @return string
+     */
+    public function setLabel($label)
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Get the array of dataset properties.
+     *
+     * @return array
+     */
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+
+    /**
+     * Set a key => value pair of properties.
+     *
+     * @param string $key
+     * @param string $value
+     * @return self
+     */
+    public function setProperty($key, $value)
+    {
+        if ($key == 'data' || $key == 'label') {
+            throw new \InvalidArgumentException('Cannot assign data or label values with the setProperty method.');
+        }
+
+        $this->properties[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set an array of key => value properties.
+     *
+     * @param array $properties
+     * @return self
+     */
+    public function setProperties($properties)
+    {
+        if (!empty($properties) && array_values($properties) === $properties) {
+            throw new \InvalidArgumentException('The argument passed to setProperties must be an associative array.');
+        }
+
+        if (isset($properties['data']) || isset($properties['label'])) {
+            throw new \InvalidArgumentException('Cannot assign data or label values with the setProperty method.');
+        }
+
+        $this->properties = $properties;
+
+        return $this;
+    }
+
+    /**
+     * Returns the array of chart data.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+    
+    /**
+     * Set a single key => value pair of chart data, or optionally a whole array.
+     *
+     * @param number|array $index
+     * @param mixed        $value
+     * @return self
+     */
+    public function setData($key, $value = null)
+    {
+        if ($value === null && is_array($key)) {
+            $this->data = array_values($key);
+        } else {
+            if (!isset($this->data[$key])) {
+                throw new \InvalidArgumentException(sprintf('Cannot set data on an uninitialized data point %s.', $key));
+            }
+
+            $this->data[$key] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Append data to the current dataset.
+     *
+     * @param  mixed  $value
+     * @return self
+     */
+    public function appendData($value)
+    {
+        $this->data[] = $value;
+
+        return $this;
+    }
+}

--- a/tests/unit/UI/Chart/ChartDatasetTest.php
+++ b/tests/unit/UI/Chart/ChartDatasetTest.php
@@ -1,0 +1,111 @@
+<?php 
+use PHPUnit\Framework\TestCase;
+use Gibbon\UI\Chart\Chart;
+
+class ChartDatasetTest extends TestCase {
+
+    public function testGetLabel() {
+        $chart = Chart::create('line_test_get_label', 'line');
+        $dataset = $chart->addDataset('data_january', 'January');
+        $this->assertEquals($dataset->getLabel(), 'January');
+    }
+
+    public function testSetProperty() {
+        $chart = Chart::create('line_test_set_property', 'line');
+        $dataset = $chart->addDataset('data_january', 'January');
+        $dataset->setProperty('backgroundColor', 'rgba(0,0,0,.4)');
+        $this->assertEquals($dataset->getProperties(), array('backgroundColor'=> 'rgba(0,0,0,.4)'));
+        $dataset->setProperty('borderColor', 'rgba(0,0,0,.8)');
+        $this->assertEquals($dataset->getProperties(), 
+                array(
+                        'backgroundColor' => 'rgba(0,0,0,.4)', 
+                        'borderColor' => 'rgba(0,0,0,.8)'
+                    )
+        );
+        $dataset->setProperty('backgroundColor', 'rgba(0,0,0,.5)');
+        $this->assertEquals($dataset->getProperties(), 
+                array(
+                        'backgroundColor' => 'rgba(0,0,0,.5)', 
+                        'borderColor' => 'rgba(0,0,0,.8)'
+                    )
+        );
+
+        $this->expectException('InvalidArgumentException');
+        $dataset->setProperty('data', array(1,2));
+    }
+
+    public function testSetProperties() {
+        $chart = Chart::create('line_test_set_properties', 'line');
+        $dataset = $chart->addDataset('data_january', 'January');
+        $dataset->setProperties(array(
+                        'backgroundColor' => 'rgba(0,0,0,.4)', 
+                        'borderColor' => 'rgba(0,0,0,.8)'
+                    ));
+        $this->assertEquals($dataset->getProperties(), 
+                array(
+                        'backgroundColor' => 'rgba(0,0,0,.4)', 
+                        'borderColor' => 'rgba(0,0,0,.8)'
+                    )
+        );
+        $dataset->setProperties(array(
+                        'backgroundColor' => 'rgba(0,0,0,.4)'
+                    ));
+        $this->assertEquals($dataset->getProperties(), 
+                array(
+                        'backgroundColor' => 'rgba(0,0,0,.4)'
+                    )
+        );
+    }
+
+    public function testSetPropertiesUsingSequenceArray() {
+        $chart = Chart::create('line_test_set_properties_sequence_arr', 'line');
+        $dataset = $chart->addDataset('data_january', 'January');
+        $this->expectException('InvalidArgumentException');
+        $dataset->setProperties(array(
+            array(
+                    'backgroundColor' => 'rgba(0,0,0,.4)', 
+                    'borderColor' => 'rgba(0,0,0,.8)'
+                )
+        ));   
+    }
+
+    public function testSetPropertiesWithDataAndLabel() {
+        $chart = Chart::create('line_test_set_properties_with_data_label', 'line');
+        $dataset = $chart->addDataset('data_january', 'January');
+        $this->expectException('InvalidArgumentException');
+        $dataset->setProperties(array(
+            'backgroundColor' => 'rgba(0,0,0,.4)', 
+            'borderColor' => 'rgba(0,0,0,.8)',
+            'label'=>'January',
+            'data'=> array(0,1)
+        ));   
+    }
+
+    public function testSetData() {
+        $chart = Chart::create('line_test_set_data', 'line');
+        $chart->setLabels(array('January', 'February', 'Maret', 'April'));
+        $dataset = $chart->addDataset('2017', '2017');
+        $dataset->setData(array(4, 10, 2, 13));
+        $this->assertEquals($chart->dataset('2017')->getData(), array(4, 10, 2, 13));
+        $dataset->setData(1, 31);
+        $this->assertEquals($chart->dataset('2017')->getData(), array(4, 31, 2, 13));
+        
+        try {
+            $chart->dataset('2017')->setData(10, 20);
+        } catch(InvalidArgumentException $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testAppendData() {
+        $chart = Chart::create('line_test_append_data', 'line');
+        $chart->setLabels(array('January', 'February', 'Maret', 'April'));
+        $dataset = $chart->addDataset('2017', '2017');
+        $dataset->appendData(20);
+        $this->assertEquals($chart->dataset('2017')->getData(), array(20));
+        $dataset->appendData(21);
+        $this->assertEquals($chart->dataset('2017')->getData(), array(20, 21));
+    }
+}

--- a/tests/unit/UI/Chart/ChartTest.php
+++ b/tests/unit/UI/Chart/ChartTest.php
@@ -1,0 +1,204 @@
+<?php 
+use PHPUnit\Framework\TestCase;
+use Gibbon\UI\Chart\Chart;
+
+class ChartTest extends TestCase {
+    public function testSetLabels() {
+        $labels = array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December');
+
+        $chart = Chart::create('line_set_labels', 'line');
+        $chart->setLabels($labels);
+        $config = $chart->getConfig();
+
+        // Test using sequence array
+        $this->assertEquals(count($labels), count($config['data']['labels']));
+    }
+
+    public function testSetOptions() {
+        $options = array(
+            'responsive'=>true,
+            'title' => array(
+                'display' => true,
+                'text' => 'ChartFactory'
+            ),
+            'tooltips'=> array(
+                    'mode'=> 'index',
+                    'intersect'=> false,
+            ),
+            'hover'=> array(
+                'mode'=> 'nearest',
+                'intersect'=> true
+            ),
+            'scales'=> array(
+                'xAxes'=> array(array(
+                    'display'=> true,
+                    'scaleLabel'=> array(
+                        'display'=> true,
+                        'labelString'=> 'Month'
+                    )
+                )),
+                'yAxes'=> array(array(
+                    'display'=> true,
+                    'scaleLabel'=> array(
+                        'display'=> true,
+                        'labelString'=> 'Value'
+                    )
+                ))
+            )
+        );
+
+        $chart = Chart::create('line_test_set_options', 'line');
+        $chart->setOptions($options);
+        $config = $chart->getConfig();
+        $this->assertEquals($options, $config['options']);
+    }
+
+    public function testUseFillZero() {
+        $chart = Chart::create('line_test_use_fill_zero', 'line');
+        $labels = array('January', 'February');
+        $chart->setLabels($labels);
+        $chart->useFillZero(true);
+        $dataset = $chart->addDataset('2017', '2017');
+        $this->assertEquals(count($labels), count($dataset->getData()));
+
+        foreach ($dataset->getData() as $value) {
+            $this->assertEquals($value, 0);
+        }
+    }
+
+    public function testuseDefaultColors() {
+        $chart = Chart::create('line_test_use_rainbow_color', 'line');
+        $chart->setLabels(array('January', 'February', 'March', 'April'));
+        $chart->useFillZero(true);
+        $dataset = $chart->addDataset('2017','2017');
+        $dataset->setProperty('backgroundColor', 'rgba(0,0,0,1)');
+        
+        $chart->useDefaultColors(false);
+        $config = $chart->getConfig();
+        $this->assertEquals($config['data']['datasets'][0]['backgroundColor'], 'rgba(0,0,0,1)');
+        
+        $chart->useDefaultColors(true);
+        $config = $chart->getConfig();
+        $this->assertNotEquals($config['data']['datasets'][0]['backgroundColor'], 'rgba(0,0,0,1)');
+    }
+
+    public function testaddDataset() {
+        $chart = Chart::create('line_test_create_dataset', 'line');
+        $dataset = $chart->addDataset('2017', '2017');
+        $this->assertEquals($chart->hasDataset('2017'), true);
+        $this->assertEquals($chart->dataset('2017'), $dataset);
+
+        try {
+            $chart->addDataset('2017', '2017');
+        } catch(InvalidArgumentException $e) {
+            return;
+        }
+
+        $this->fail();
+    }
+
+    public function testInvalidDataset() {
+        $chart = Chart::create('line_test_invalid_dataset', 'line');
+        
+        $this->expectException('InvalidArgumentException');
+        $chart->dataset('2018');
+    }
+
+    public function testGetConfig() {
+        $labels = array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December');
+        $options = array(
+            'responsive'=>true,
+            'title' => array(
+                'display' => true,
+                'text' => 'ChartFactory'
+            ),
+            'tooltips'=> array(
+                    'mode'=> 'index',
+                    'intersect'=> false,
+            ),
+            'hover'=> array(
+                'mode'=> 'nearest',
+                'intersect'=> true
+            ),
+            'scales'=> array(
+                'xAxes'=> array(array(
+                    'display'=> true,
+                    'scaleLabel'=> array(
+                        'display'=> true,
+                        'labelString'=> 'Month'
+                    )
+                )),
+                'yAxes'=> array(array(
+                    'display'=> true,
+                    'scaleLabel'=> array(
+                        'display'=> true,
+                        'labelString'=> 'Value'
+                    )
+                ))
+            )
+        );
+        $indonesianChartData = array(rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand());
+        $englishChartData = array(rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand(), rand());
+        $chart = Chart::create('line_test_get_config', 'line');
+        $chart->setLabels($labels);
+        $chart->setOptions($options);
+        $chart->useDefaultColors(true);
+        $indonesianDataset = $chart->addDataset('indonesian', 'Indonesian');
+        $englishDataset = $chart->addDataset('english', 'English');
+
+        $indonesianDataset->setData($indonesianChartData);
+        $englishDataset->setData($englishChartData);
+
+        $config = $chart->getConfig();
+        $this->assertEquals($config['data']['labels'], $labels);
+        $this->assertEquals(count($config['data']['datasets']), 2);
+        $this->assertEquals(count($config['data']['datasets'][0]['data']), 12);
+        $this->assertEquals($config['options'], $options);
+    }
+
+    public function testGetConfigPieChart() {
+        $sampleData = array(
+            'Like'=> rand(20, 100),
+            'Hate'=> rand(20, 100),
+            'Simple'=> rand(20, 100)
+        );
+        $colorMap = array(
+            'Like'=> 'rgba(237,35,73,.6)',
+            'Hate'=> 'rgba(56,140,203,.6)',
+            'Simple'=> 'rgba(82,203,56,.6)'
+        );
+        
+        $chart = Chart::create('pie_test_get_config_pie1', 'pie');
+        $chart2 = Chart::create('pie_test_get_config_pie2', 'pie');
+
+        $chart->setLabels(array_keys($sampleData));
+        $chart2->setLabels(array_keys($sampleData));
+        
+        $chart->useFillZero(true);
+        $chart2->useFillZero(true);
+        
+        $chart2->useDefaultColors(true);
+
+        $dataset = $chart->addDataset('vote', 'vote');
+        $dataset2 = $chart2->addDataset('vote', 'vote');
+        $dataset->setData(array_values($sampleData));
+        $dataset2->setData(array_values($sampleData));
+        $dataset->setProperties(array('backgroundColor'=> array_values($colorMap)));
+
+        $config = $chart->getConfig();
+        $config2 = $chart2->getConfig();
+
+        $this->assertEquals(count($config['data']['datasets'][0]['data']), count($sampleData));
+        $this->assertEquals(count($config2['data']['datasets'][0]['data']), count($sampleData));
+
+        $this->assertEquals(count($config['data']['datasets'][0]['backgroundColor']), count($sampleData));
+        $this->assertEquals(count($config2['data']['datasets'][0]['backgroundColor']), count($sampleData));
+    }
+
+    public function testSetElementId() {
+        $chart = Chart::create('test_set_element_id', 'line');
+        $this->assertEquals('test_set_element_id', $chart->getElementId());
+        $chart->setElementId('line_chart');
+        $this->assertEquals('line_chart', $chart->getElementId());
+    }
+}


### PR DESCRIPTION
**New Feature**

Adds some basic PHP classes to make creating & rendering chart.js charts easier.

Refactors the Student Enrolment Trends chart.

Example usage:
```
$chart1 = Chart::create('roles', 'doughnut')
    ->setTitle(__('Active Users by Role Category'))
    ->setOptions(['height' => '250', 'legend' => false])
    ->setLabels($chartData);

$chart1->addDataset('pie')
       ->setData($chartData);

$chart1->render();
```