### PR TITLE
System: improve support for right-to-left languages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,7 @@ v17.0.00
 --------
     Headlines
         Languages can now be installed and updated through Manage Languages in System Admin
-        System: added Hebrew an active language
+        Added Hebrew an active language and improved the display of right-to-left languages
 
     Changes With Important Notices
 

--- a/index.php
+++ b/index.php
@@ -303,6 +303,11 @@ $page->stylesheets->addMultiple([
     'thickbox'     => 'lib/thickbox/thickbox.css',
 ]);
 
+// Add right-to-left stylesheet
+if ($session->get('i18n')['rtl'] == 'Y') {
+    $page->theme->stylesheets->add('theme-rtl', '/themes/'.$session->get('gibbonThemeName').'/css/main_rtl.css', ['weight' => 1]);
+}
+
 // Set personal, organisational or theme background     
 if (getSettingByScope($connection2, 'User Admin', 'personalBackground') == 'Y' && $session->has('personalBackground')) {
     $backgroundImage = htmlPrep($session->get('personalBackground'));
@@ -469,6 +474,7 @@ $page->addData([
     'sidebar'           => $showSidebar,
     'version'           => $gibbon->getVersion(),
     'versionName'       => 'v'.$gibbon->getVersion().($session->get('cuttingEdgeCode') == 'Y'? 'dev' : ''),
+    'rightToLeft'       => $session->get('i18n')['rtl'] == 'Y',
 ]);
 
 if ($isLoggedIn) {

--- a/modules/System Admin/update.php
+++ b/modules/System Admin/update.php
@@ -52,6 +52,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
         $_SESSION[$guid]['systemUpdateError'] = null;
     }
 
+    getSystemSettings($guid, $connection2);
+
     $versionDB = getSettingByScope($connection2, 'System', 'version');
     $versionCode = $version;
 

--- a/modules/System Admin/update.php
+++ b/modules/System Admin/update.php
@@ -52,8 +52,6 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
         $_SESSION[$guid]['systemUpdateError'] = null;
     }
 
-    getSystemSettings($guid, $connection2);
-
     $versionDB = getSettingByScope($connection2, 'System', 'version');
     $versionCode = $version;
 

--- a/resources/templates/index.twig.html
+++ b/resources/templates/index.twig.html
@@ -9,7 +9,7 @@ TODO: add template variable details.
 -->#}
 
 <!DOCTYPE html>
-<html>
+<html {{ rightToLeft ? 'dir="rtl"' : '' }}>
     <head>
         {{ include('head.twig.html') }}
     </head>

--- a/themes/Default/css/main_rtl.css
+++ b/themes/Default/css/main_rtl.css
@@ -20,3 +20,128 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 Add any extra code here to make right to left languages (such as Arabic) work.
 */
 
+
+#header-finder {
+    float: left;
+    right: auto;
+    left: 24px;
+}
+
+#content {
+    float: right;
+    border-left: 1px solid rgba(0, 0, 0, 0.15);
+    text-align: right;
+}
+
+.ui-tabs .ui-tabs-nav li {
+    list-style: none;
+    float: right;
+}
+
+div.minorLinks {
+    text-align: left;
+}
+
+div.trail {
+    text-align: right;
+}
+
+div.trailEnd {
+    padding-right: 3px;
+    float: right;
+}
+
+div.trailHead {
+    float: right;
+    white-space: nowrap;
+}
+
+#nav {
+    float: right;
+}
+
+#nav li {
+    position: relative;
+    float: right;
+}
+
+ul.moduleMenu ul li {
+    text-align: right;
+}
+
+p {
+    margin: 0px 0px 15px 0px;
+    text-align: right;
+}
+ol,
+ul {
+    margin: 0 0 1px;
+    text-align: right;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    margin: 20px 0 10px 0;
+    text-align: right;
+}
+
+li {
+    padding-right: 5px;
+    text-align: right;
+}
+
+table th,
+table td {
+    text-align: right;
+}
+
+table tr:first-child th:first-child {
+    text-align: right;
+    padding-left: 15px;
+}
+table td:first-child {
+    text-align: right;
+}
+
+input[type="file"] {
+    text-align: right;
+}
+
+select {
+    float: left;
+}
+
+input.standardWidth,
+textarea.standardWidth,
+.input-box.standardWidth {
+    float: left;
+}
+
+li.token-input-input-token-facebook {
+    float: right;
+}
+
+div.error {
+    font-size: default;
+}
+
+div.warning {
+    text-align: right;
+}
+
+div.success {
+    text-align: right;
+}
+
+div.notificationTray {
+    float: left;
+}
+
+td.right {
+    text-align: left !important;
+}
+


### PR DESCRIPTION
- Adds the theme `main_rtl.css` file contributed by Haim Hillel 👍 
- Adds the HTML `dir="rtl"` attribute to enable browser-based rtl rendering
- Commits the most recent i18n submodule changes to the core
- Removes a `getSystemSettings()` call from update.php which was causing the session to overwrite the personal language selection

## Screenshots:

<img width="1164" alt="screen shot 2018-11-01 at 9 53 37 am" src="https://user-images.githubusercontent.com/897700/47828440-13c4f600-ddbe-11e8-9db5-454b5cd55f23.png">

<img width="1155" alt="screen shot 2018-11-01 at 9 53 08 am" src="https://user-images.githubusercontent.com/897700/47828442-16275000-ddbe-11e8-94b1-5033ccdcfe4e.png">


