### PR TITLE
Rubrics: refactor visualisations to use the Chart class

### DIFF
--- a/fullscreen.php
+++ b/fullscreen.php
@@ -36,6 +36,9 @@ if (!$session->has('systemSettingsSet')) {
 
 $address = $page->getAddress();
 
+// Register scripts available to the core, but not included by default
+$page->scripts->register('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js', ['context' => 'head']);
+
 if (empty($address)) {
     $page->addWarning(__('There is no content to display'));
 } elseif ($page->isAddressValid($address) == false) {

--- a/modules/Markbook/markbook_view_rubric.php
+++ b/modules/Markbook/markbook_view_rubric.php
@@ -126,6 +126,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
                                 $mark = false;
                             }
                         }
+
+                        $page->scripts->add('chart');
+
                         echo rubricView($guid, $connection2, $gibbonRubricID, $mark, $row4['gibbonPersonID'], 'gibbonMarkbookColumn', 'gibbonMarkbookColumnID', $gibbonMarkbookColumnID,  $contextDBTableGibbonRubricIDField, 'name', 'completeDate');
                     }
                 }

--- a/modules/Markbook/markbook_view_rubric.php
+++ b/modules/Markbook/markbook_view_rubric.php
@@ -127,8 +127,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
                             }
                         }
 
-                        $page->scripts->add('chart');
-
                         echo rubricView($guid, $connection2, $gibbonRubricID, $mark, $row4['gibbonPersonID'], 'gibbonMarkbookColumn', 'gibbonMarkbookColumnID', $gibbonMarkbookColumnID,  $contextDBTableGibbonRubricIDField, 'name', 'completeDate');
                     }
                 }

--- a/modules/Rubrics/moduleFunctions.php
+++ b/modules/Rubrics/moduleFunctions.php
@@ -138,7 +138,7 @@ function rubricEdit($guid, $connection2, $gibbonRubricID, $scaleName = '', $sear
 //If $mark=TRUE, then marking tools are made available, otherwise it is view only
 function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID = '', $contextDBTable = '', $contextDBTableIDField = '', $contextDBTableID = '', $contextDBTableGibbonRubricIDField = '', $contextDBTableNameField = '', $contextDBTableDateField = '')
 {
-    global $pdo;
+    global $pdo, $page;
     
     $output = false;
     $hasContexts = $contextDBTable != '' and $contextDBTableIDField != '' and $contextDBTableID != '' and $contextDBTableGibbonRubricIDField != '' and $contextDBTableNameField != '' and $contextDBTableDateField != '';
@@ -419,6 +419,8 @@ function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID
                         : 0;
                 }, $means);
 
+                $page->scripts->add('chart');
+                
                 $chart = Chart::create('visualisation', 'polarArea')
                     ->setLegend(['display' => true, 'position' => 'right'])
                     ->setLabels(array_column($means, 'title'))

--- a/modules/Rubrics/rubrics_view_full.php
+++ b/modules/Rubrics/rubrics_view_full.php
@@ -55,8 +55,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_view_full.
             echo $row3['name'].'<br/>';
             echo '</h2>';
 
-            $page->scripts->add('chart');
-
             echo rubricView($guid, $connection2, $gibbonRubricID, false);
         }
     }

--- a/modules/Rubrics/rubrics_view_full.php
+++ b/modules/Rubrics/rubrics_view_full.php
@@ -55,6 +55,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_view_full.
             echo $row3['name'].'<br/>';
             echo '</h2>';
 
+            $page->scripts->add('chart');
+
             echo rubricView($guid, $connection2, $gibbonRubricID, false);
         }
     }


### PR DESCRIPTION
Updates the recently added rubric visualization.

Also updates the Chart class to handle embedding ad-hoc functions in the chart configuration. It does this by adding an `addFunction()` method to the class, which returns a string identifier used internally to string-replace the function after the json_encode step, because otherwise the function would be wrapped in "".

Eg:
```
'callback' => $chart->addFunction('function(tickValue, index, ticks) {
    return Number(tickValue).toFixed(1);
}'),
```

The above function has been added to the rubric chart to fix the chart labels. Looks like the bug with the polar area float precision has been fixed in a more recent version.

<img width="1149" alt="screen shot 2018-11-01 at 1 17 49 pm" src="https://user-images.githubusercontent.com/897700/47834211-b3dc4880-ddd9-11e8-8266-fab6ef73f4e0.png">
