### PR TITLE
Modules: update .gitignore

### DIFF
--- a/modules/.gitignore
+++ b/modules/.gitignore
@@ -51,3 +51,7 @@
 !/Tracking/**
 !/User Admin
 !/User Admin/**
+
+# black list some files and folders
+# in the module folders
+**/.DS_Store

--- a/modules/.gitignore
+++ b/modules/.gitignore
@@ -1,1 +1,53 @@
-Query Builder
+# ignore all modules
+*
+
+# whitelist .gitignore file
+!.gitignore
+
+# whitelist all core modules
+!/Activities
+!/Activities/**
+!/Attendance
+!/Attendance/**
+!/Behaviour
+!/Behaviour/**
+!/Crowd Assessment
+!/Crowd Assessment/**
+!/Data Updater
+!/Data Updater/**
+!/Departments
+!/Departments/**
+!/Finance
+!/Finance/**
+!/Formal Assessment
+!/Formal Assessment/**
+!/Individual Needs
+!/Individual Needs/**
+!/Library
+!/Library/**
+!/Markbook
+!/Markbook/**
+!/Messenger
+!/Messenger/**
+!/Planner
+!/Planner/**
+!/Roll Groups
+!/Roll Groups/**
+!/Rubrics
+!/Rubrics/**
+!/School Admin
+!/School Admin/**
+!/Staff
+!/Staff/**
+!/Students
+!/Students/**
+!/System Admin
+!/System Admin/**
+!/Timetable
+!/Timetable/**
+!/Timetable Admin
+!/Timetable Admin/**
+!/Tracking
+!/Tracking/**
+!/User Admin
+!/User Admin/**


### PR DESCRIPTION
**Nitpicking**

## Description
* Use a whitelist based structure for `modules/.gitignore`.
* Ignore everything except for the core modules.

## Motivation and Context
Kind of a nitpicking. But it seems strange for the current [`modules/.gitignore`](https://github.com/GibbonEdu/core/blob/ca259435be1a8de70d7340b9f643315122f4e819/modules/.gitignore) to specifically only ignore one optional module, "Query Builder".

For the convenience of developing and committing live installation, its seem to be reasonable to ignore everything except for the core modules.

## How Has This Been Tested?
Tested locally.