### PR TITLE
System: fix position of main menu items for RTL languages

### DIFF
--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -289,13 +289,13 @@ div.minorLinks a:hover {
 	padding: 2px;
 	position: absolute;
 	font-weight:normal;
-	left: -999em;
 	text-shadow: none;
-	width: 180px ;
+    width: 180px ;
+    display: none;
 }
 #nav li:hover ul, #nav li.sfhover ul {
-	left: 0;
-	z-index:99999;
+    z-index:99999;
+    display: block;
 }
 
 #nav li li {

--- a/themes/Default/css/main_rtl.css
+++ b/themes/Default/css/main_rtl.css
@@ -40,6 +40,7 @@ Add any extra code here to make right to left languages (such as Arabic) work.
 
 div.minorLinks {
     text-align: left;
+    padding-left: 13px;
 }
 
 div.trail {
@@ -63,6 +64,10 @@ div.trailHead {
 #nav li {
     position: relative;
     float: right;
+}
+
+#nav li li {
+    text-align: right;
 }
 
 ul.moduleMenu ul li {


### PR DESCRIPTION
The main menu css was using `left: -999em;/left: 0;` to hide menu items. Switched it to `display: none;/ display: block;`, which fixes the visual glitch in the menu for rtl languages. Also right-aligns the text inside the menu.