### PR TITLE
Forms: increase the max email length to 75 chars

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -778,4 +778,12 @@ INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`val
 ALTER TABLE `gibbonApplicationForm` ADD `username` VARCHAR(20) NULL AFTER `gender`;end
 ALTER TABLE `gibbonApplicationForm` ADD `studentID` VARCHAR(10) NULL AFTER `gibbonPaymentID`;end
 ALTER TABLE `gibbonRubricColumn` ADD `visualise` ENUM('Y','N') NOT NULL DEFAULT 'Y' AFTER `gibbonScaleGradeID`;end
+ALTER TABLE `gibbonPerson` CHANGE `email` `email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonPerson` CHANGE `emailAlternate` `emailAlternate` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonPersonUpdate` CHANGE `email` `email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonPersonUpdate` CHANGE `emailAlternate` `emailAlternate` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonStaffApplicationForm` CHANGE `email` `email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonApplicationForm` CHANGE `email` `email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonApplicationForm` CHANGE `parent1email` `parent1email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonApplicationForm` CHANGE `parent2email` `parent2email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ v17.0.00
         System: updated vis.js library to v4.21.0
         System: updated robots.txt to disallow all indexing
         System: added ability to set background image
+        System: increased the max email length to 75 chars for all forms
         Activities: post-OOification fix to include All Users in Staff selection for in Manage Activities
         Activities: fixed incorrect count in Registered column in Activity Enrolment Summary
         Attendance: fixed an error in the parent view of Student History for PHP 7.1+

--- a/installer/install.php
+++ b/installer/install.php
@@ -451,7 +451,7 @@ $_SESSION[$guid]['stringReplacement'] = array();
 
                                                 $row = $form->addRow();
                                                     $row->addLabel('email', __('Email'));
-                                                    $row->addEmail('email')->maxLength(50)->isRequired();
+                                                    $row->addEmail('email')->isRequired();
 
                                                 $row = $form->addRow();
                                                     $row->addLabel('support', '<b>'.__('Receive Support?').'</b>')->description(__('Join our mailing list and recieve a welcome email from the team.'));

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -352,7 +352,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
 					$row = $form->addRow();
 						$row->addLabel('email', __('Email'));
-						$email = $row->addEmail('email')->maxLength(50);
+						$email = $row->addEmail('email');
 
 					$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
 					if ($uniqueEmailAddress == 'Y') {
@@ -361,7 +361,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
 					$row = $form->addRow();
 						$row->addLabel('emailAlternate', __('Alternate Email'));
-						$row->addEmail('emailAlternate')->maxLength(50);
+						$row->addEmail('emailAlternate');
 
 					$row = $form->addRow();
 					$row->addAlert(__('Address information for an individual only needs to be set under the following conditions:'), 'warning')

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -106,7 +106,7 @@ else {
 			if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_fromSchool")) {
 				$row = $form->addRow()->addClass('email');
 					$row->addLabel('emailReplyTo', __('Reply To'));
-					$row->addEmail('emailReplyTo')->maxLength(50);
+					$row->addEmail('emailReplyTo');
 			}
 		}
 

--- a/modules/Staff/applicationForm.php
+++ b/modules/Staff/applicationForm.php
@@ -231,7 +231,7 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('email', __('Email'));
-                $email = $row->addEmail('email')->maxLength(50)->isRequired();
+                $email = $row->addEmail('email')->isRequired();
 
             $row = $form->addRow();
                 $row->addLabel('phone1', __('Phone'))->description(__('Type, country code, number.'));
@@ -310,11 +310,11 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('referenceEmail1', __('Referee 1'))->description(__('An email address for a referee at the applicant\'s current school.'));
-                $row->addEmail('referenceEmail1')->maxLength(50)->isRequired();
+                $row->addEmail('referenceEmail1')->isRequired();
 
             $row = $form->addRow();
                 $row->addLabel('referenceEmail2', __('Referee 2'))->description(__('An email address for a second referee.'));
-                $row->addEmail('referenceEmail2')->maxLength(50)->isRequired();
+                $row->addEmail('referenceEmail2')->isRequired();
 
         }
 

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -247,7 +247,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                 $row = $form->addRow();
                     $row->addLabel('email', __('Email'));
-                    $email = $row->addEmail('email')->maxLength(50)->isRequired();
+                    $email = $row->addEmail('email')->isRequired();
 
                     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
                     if ($uniqueEmailAddress == 'Y') {
@@ -337,11 +337,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                 $row = $form->addRow();
                     $row->addLabel('referenceEmail1', __('Referee 1'))->description(__('An email address for a referee at the applicant\'s current school.'));
-                    $row->addEmail('referenceEmail1')->maxLength(50)->isRequired();
+                    $row->addEmail('referenceEmail1')->isRequired();
 
                 $row = $form->addRow();
                     $row->addLabel('referenceEmail2', __('Referee 2'))->description(__('An email address for a second referee.'));
-                    $row->addEmail('referenceEmail2')->maxLength(50)->isRequired();
+                    $row->addEmail('referenceEmail2')->isRequired();
 
             }
 

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -291,7 +291,7 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('email', __('Email'));
-        $email = $row->addEmail('email')->maxLength(50);
+        $email = $row->addEmail('email');
         if ($uniqueEmailAddress == 'Y') {
             $email->isUnique('./publicRegistrationCheck.php');
         }
@@ -616,7 +616,7 @@ if ($proceed == false) {
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}email", __('Email'));
-                $email = $row->addEmail("parent{$i}email")->isRequired($i == 1)->maxLength(50)->loadFrom($application);
+                $email = $row->addEmail("parent{$i}email")->isRequired($i == 1)->loadFrom($application);
                 if ($uniqueEmailAddress == 'Y') {
                     $email->isUnique('./publicRegistrationCheck.php', array('fieldName' => 'email'));
                 }

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -386,7 +386,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('email', __('Email'));
-        $email = $row->addEmail('email')->maxLength(50);
+        $email = $row->addEmail('email');
         if ($uniqueEmailAddress == 'Y') {
             $email->isUnique('./modules/User Admin/user_manage_emailAjax.php');
         }
@@ -637,7 +637,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}email", __('Email'));
-                $email = $row->addEmail("parent{$i}email")->isRequired($i == 1)->maxLength(50);
+                $email = $row->addEmail("parent{$i}email")->isRequired($i == 1);
 
                 if ($uniqueEmailAddress == 'Y') {
                     $email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('fieldName' => 'email'));

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -170,7 +170,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 
     $row = $form->addRow();
         $emailLabel = $row->addLabel('email', __('Email'));
-        $email = $row->addEmail('email')->maxLength(50);
+        $email = $row->addEmail('email');
         
     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
     if ($uniqueEmailAddress == 'Y') {
@@ -179,7 +179,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 
     $row = $form->addRow();
         $row->addLabel('emailAlternate', __('Alternate Email'));
-        $row->addEmail('emailAlternate')->maxLength(50);
+        $row->addEmail('emailAlternate');
 
     $row = $form->addRow();
     $row->addAlert(__('Address information for an individual only needs to be set under the following conditions:'), 'warning')

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -232,7 +232,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$row = $form->addRow();
                 $emailLabel = $row->addLabel('email', __('Email'));
-                $email = $row->addEmail('email')->maxLength(50);
+                $email = $row->addEmail('email');
 
 			$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
 			if ($uniqueEmailAddress == 'Y') {
@@ -241,7 +241,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$row = $form->addRow();
 				$row->addLabel('emailAlternate', __('Alternate Email'));
-				$row->addEmail('emailAlternate')->maxLength(50);
+				$row->addEmail('emailAlternate');
 
 			$row = $form->addRow();
 			$row->addAlert(__('Address information for an individual only needs to be set under the following conditions:'), 'warning')

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -81,7 +81,7 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('email', __('Email'));
-        $email = $row->addEmail('email')->maxLength(50)->isRequired();
+        $email = $row->addEmail('email')->isRequired();
 
     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
     if ($uniqueEmailAddress == 'Y') {

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -127,7 +127,7 @@ class FormFactory implements FormFactoryInterface
 
     public function createEmail($name)
     {
-        return (new Input\TextField($name))->addValidation('Validate.Email');
+        return (new Input\TextField($name))->addValidation('Validate.Email')->maxLength(75);
     }
 
     //A URL web link


### PR DESCRIPTION
This PR updates the FormFactory to apply the max length to all email fields, and removes the individual max lengths from existing fields. This will help standardize the forms, as there's many places where an email can be copied from one form to another (application acceptance, data updaters, etc.). Also applies the increased limit of 75 chars to email fields in the database.