### PR TITLE
Composer: officially remove PHP 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "test:phpunit": "Run unit tests with PHPUnit."
     },
     "require": {
-        "php" : "^5.5 || ^7.0",
+        "php" : "^7.0",
         "ext-curl": "*",
         "ext-mbstring": "*",
         "ext-gettext": "*",


### PR DESCRIPTION
Extremely minor issue. The composer.json declared that PHP version supported is `"^5.5 || ^7.0"`, but it is announced that Gibbon will only support PHP 7.0 and above. This PR simply changed that.