### PR TITLE
School Admin: fix acceptance test for add department

### DIFF
--- a/tests/acceptance/School Admin/DepartmentsManageCept.php
+++ b/tests/acceptance/School Admin/DepartmentsManageCept.php
@@ -6,7 +6,7 @@ $I->amOnModulePage('School Admin', 'department_manage.php');
 
 // Add ------------------------------------------------
 $I->clickNavigation('Add');
-$I->seeBreadcrumb('Add Learning Area');
+$I->seeBreadcrumb('Add Department');
 
 $addFormValues = array(
     'type'           => 'Learning Area',


### PR DESCRIPTION
**Bug Fix**
## Description

* Acceptance test expecting the wrong breadcrumb "Add Learning Area"
  in the "School Admin" > "Manage Deparments" > "Add Department" page.
  Alter the test to expect "Add Department" instead.

## Motivation and Context
Mane the test reasonable again :-)

## How Has This Been Tested?
* Travis