### PR TITLE
Markbook: refactor breadcrumb translations

### DIFF
--- a/modules/Markbook/markbook_edit.php
+++ b/modules/Markbook/markbook_edit.php
@@ -88,14 +88,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
             } else {
                 $row = $result->fetch();
 
-                $page->breadcrumbs->add(strtr(
-                    ':action :courseClass :property',
-                    [
-                        ':action' => __('Edit'),
-                        ':courseClass' => Format::courseClassName($row['course'], $row['class']),
-                        ':property' => __('Markbook'),
-                    ]
-                ));
+                $page->breadcrumbs->add(__('Edit {courseClass} Markbook', [
+                    'courseClass' => Format::courseClassName($row['course'], $row['class']),
+                ]));
 
                 if (isset($_GET['return'])) {
                     returnProcess($guid, $_GET['return'], null, null);

--- a/modules/Markbook/markbook_edit_add.php
+++ b/modules/Markbook/markbook_edit_add.php
@@ -82,14 +82,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                 $page->breadcrumbs
                     ->add(
-                        strtr(
-                            ':action :courseClass :property',
-                            [
-                                ':action' => __('View'),
-                                ':courseClass' => Format::courseClassName($course['course'], $course['class']),
-                                ':property' => __('Markbook'),
-                            ]
-                        ),
+                        __('View {courseClass} Markbook', [
+                            ':courseClass' => Format::courseClassName($course['course'], $course['class']),
+                        ]),
                         'markbook_view.php',
                         [
                             'gibbonCourseClassID' => $gibbonCourseClassID,

--- a/modules/Markbook/markbook_edit_copy.php
+++ b/modules/Markbook/markbook_edit_copy.php
@@ -71,29 +71,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_cop
             } else {
                 $course = $result->fetch();
 
-	        	//Get teacher list
-	            $teacherList = getTeacherList( $pdo, $gibbonCourseClassID );
-	            $teaching = (isset($teacherList[ $_SESSION[$guid]['gibbonPersonID'] ]) );
-	            $isCoordinator = isDepartmentCoordinator( $pdo, $_SESSION[$guid]['gibbonPersonID'] );
+                //Get teacher list
+                $teacherList = getTeacherList($pdo, $gibbonCourseClassID);
+                $teaching = isset($teacherList[$_SESSION[$guid]['gibbonPersonID']]);
+                $isCoordinator = isDepartmentCoordinator($pdo, $_SESSION[$guid]['gibbonPersonID']);
 
-	            $canEditThisClass = ($teaching == true || $isCoordinator == true or $highestAction2 == 'Edit Markbook_multipleClassesAcrossSchool' or $highestAction2 == 'Edit Markbook_everything');
+                $canEditThisClass = ($teaching == true || $isCoordinator == true or $highestAction2 == 'Edit Markbook_multipleClassesAcrossSchool' or $highestAction2 == 'Edit Markbook_everything');
 
-	            if ($canEditThisClass == false) {
-	            	//Acess denied
-				    echo "<div class='error'>";
-				    echo __('You do not have access to this action.');
-				    echo '</div>';
-	            } else {
+                if ($canEditThisClass == false) {
+                    //Acess denied
+                    echo "<div class='error'>";
+                    echo __('You do not have access to this action.');
+                    echo '</div>';
+                } else {
                     $page->breadcrumbs
                         ->add(
-                            strtr(
-                                ':action :courseClass :property',
-                                [
-                                    ':action' => __('Edit'),
-                                    ':courseClass' => Format::courseClassName($course['course'], $course['class']),
-                                    ':property' => __('Markbook'),
-                                ]
-                            ),
+                            __('Edit {courseClass} Markbook', [
+                                'courseClass' => Format::courseClassName($course['course'], $course['class']),
+                            ]),
                             'markbook_edit.php',
                             [
                                 'gibbonCourseClassID' => $gibbonCourseClassID,
@@ -115,7 +110,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_cop
 	                    echo __('There are no records to display.');
 	                    echo '</div>';
 	                } else {
-
 	                	try {
 		                    $data2 = array('gibbonCourseClassID' => $gibbonMarkbookCopyClassID);
 		                    $sql2 = 'SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonCourseClassID=:gibbonCourseClassID';

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -180,14 +180,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
 
                     $page->breadcrumbs
                         ->add(
-                            strtr(
-                                ':action :courseClass :property',
-                                [
-                                    ':action' => __('View'),
-                                    ':courseClass' => Format::courseClassName($course['course'], $course['class']),
-                                    ':property' => __('Markbook'),
-                                ]
-                            ),
+                            __('View {courseClass} Markbook', [
+                                'courseClass' => Format::courseClassName($course['course'], $course['class']),
+                            ]),
                             'markbook_view.php',
                             [
                                 'gibbonCourseClassID' => $gibbonCourseClassID,

--- a/modules/Markbook/markbook_edit_edit.php
+++ b/modules/Markbook/markbook_edit_edit.php
@@ -97,14 +97,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
 
                     $page->breadcrumbs
                         ->add(
-                            strtr(
-                                ':action :courseClass :property',
-                                [
-                                    ':action' => __('View'),
-                                    ':courseClass' => Format::courseClassName($course['course'], $course['class']),
-                                    ':property' => __('Markbook'),
-                                ]
-                            ),
+                            __('View {courseClass} Markbook', [
+                                'courseClass' => Format::courseClassName($course['course'], $course['class']),
+                            ]),
                             'markbook_view.php',
                             [
                                 'gibbonCourseClassID' => $gibbonCourseClassID,

--- a/modules/Markbook/markbook_edit_targets.php
+++ b/modules/Markbook/markbook_edit_targets.php
@@ -67,14 +67,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_tar
 
                 $page->breadcrumbs
                     ->add(
-                        strtr(
-                            ':action :courseClass :property',
-                            [
-                                ':action' => __('View'),
-                                ':courseClass' => Format::courseClassName($course['course'], $course['class']),
-                                ':property' => __('Markbook'),
-                            ]
-                        ),
+                        __('View {courseClass} Markbook', [
+                            'courseClass' => Format::courseClassName($course['course'], $course['class']),
+                        ]),
                         'markbook_view.php',
                         [
                             'gibbonCourseClassID' => $gibbonCourseClassID,

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -99,14 +99,9 @@ use Gibbon\Services\Format;
     $courseName = $class['courseName'];
     $gibbonYearGroupIDList = $class['gibbonYearGroupIDList'];
 
-    $page->breadcrumbs->add(strtr(
-        ':action :courseClass :property',
-        [
-            ':action' => __('View'),
-            ':courseClass' => Format::courseClassName($class['course'], $class['class']),
-            ':property' => __('Markbook'),
-        ]
-    ));
+    $page->breadcrumbs->add(__('View {courseClass} Markbook', [
+        'courseClass' => Format::courseClassName($class['course'], $class['class']),
+    ]));
 
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);

--- a/modules/Markbook/weighting_manage.php
+++ b/modules/Markbook/weighting_manage.php
@@ -90,21 +90,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.
             } else {
                 $row = $result->fetch();
 
-                $page->breadcrumbs->add(strtr(
-                    ':action :courseClass :property',
-                    [
-                        ':action' => __('Manage'),
-                        ':courseClass' => Format::courseClassName($row['course'], $row['class']),
-                        ':property' => __('Weightings'),
-                    ]
-                ));
+                $page->breadcrumbs->add(__('Manage {courseClass} Weightings', [
+                    'courseClass' => Format::courseClassName($row['course'], $row['class']),
+                ]));
 
                 if (isset($_GET['return'])) {
                     returnProcess($guid, $_GET['return'], null, null);
                 }
 
                 //Get teacher list
-                $teacherList = getTeacherList( $pdo, $gibbonCourseClassID );
+                $teacherList = getTeacherList($pdo, $gibbonCourseClassID);
                 $teaching = (isset($teacherList[ $_SESSION[$guid]['gibbonPersonID'] ]) );
 
                 //Print mark

--- a/modules/Markbook/weighting_manage_add.php
+++ b/modules/Markbook/weighting_manage_add.php
@@ -85,21 +85,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
             } else {
                 $row = $result->fetch();
 
-                $page->breadcrumbs->add(
-                    strtr(
-                        ':action :courseClass :property',
-                        [
-                            ':action' => __('Manage'),
-                            ':courseClass' => Format::courseClassName($row['course'], $row['class']),
-                            ':property' => __('Weightings'),
-                        ]
-                    ),
-                    'weighting_manage.php',
-                    [
-                        'gibbonCourseClassID' => $gibbonCourseClassID,
-                    ]
-                )                    
-                ->add(__('Add Weighting'));
+                $page->breadcrumbs
+                    ->add(
+                        __('Manage {courseClass} Weightings', [
+                            'courseClass' => Format::courseClassName($row['course'], $row['class']),
+                        ]),
+                        'weighting_manage.php',
+                        ['gibbonCourseClassID' => $gibbonCourseClassID]
+                    )
+                    ->add(__('Add Weighting'));
                 // Show add weighting form
                 $form = Form::create('manageWeighting', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/weighting_manage_addProcess.php?gibbonCourseClassID=$gibbonCourseClassID");
                 

--- a/modules/Markbook/weighting_manage_edit.php
+++ b/modules/Markbook/weighting_manage_edit.php
@@ -105,21 +105,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
                     $course = $result->fetch();
                     $values = $result2->fetch();
 
-                    $page->breadcrumbs->add(
-                        strtr(
-                            ':action :courseClass :property',
-                            [
-                                ':action' => __('Manage'),
-                                ':courseClass' => Format::courseClassName($course['course'], $course['class']),
-                                ':property' => __('Weightings'),
-                            ]
-                        ),
-                        'weighting_manage.php',
-                        [
-                            'gibbonCourseClassID' => $gibbonCourseClassID,
-                        ]
-                    )  
-                    ->add(__('Edit Weighting'));
+                    $page->breadcrumbs
+                        ->add(
+                            __('Manage {courseClass} Weightings', [
+                                'courseClass' => Format::courseClassName($course['course'], $course['class']),
+                            ]),
+                            'weighting_manage.php',
+                            ['gibbonCourseClassID' => $gibbonCourseClassID]
+                        )
+                        ->add(__('Edit Weighting'));
 
                     $form = Form::create('manageWeighting', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/weighting_manage_editProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonMarkbookWeightID=$gibbonMarkbookWeightID");
                 


### PR DESCRIPTION
**Refactor**
## Description
* use __() to replace previously used strtr() logics.
* New translation string: "`View {courseClass} Markbook`".
* New translation string: "`Edit {courseClass} Markbook`".
* New translation string: "`Manage {courseClass} Weightings`".

## Motivation and Context
* see #701 and #709.

## How Has This Been Tested?
* Travis