### PR TITLE
Planner: refactor breadcrumb translations

### DIFF
--- a/modules/Planner/planner.php
+++ b/modules/Planner/planner.php
@@ -528,9 +528,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == f
         elseif ($highestAction == 'Lesson Planner_viewMyClasses' or $highestAction == 'Lesson Planner_viewAllEditMyClasses' or $highestAction == 'Lesson Planner_viewEditAllClasses') {
             $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
             if ($viewBy == 'date') {
-                $page->breadcrumbs->add(strtr(':planner :target', [
-                    ':planner' => __('Planner'),
-                    ':target' => dateConvertBack($guid, $date),
+                $page->breadcrumbs->add(__('Planner of {classDesc}', [
+                    'classDesc' => dateConvertBack($guid, $date),
                 ]));
 
                 //Get Smart Workflow help message
@@ -751,9 +750,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == f
                     } else {
                         $row = $result->fetch();
 
-                        $page->breadcrumbs->add(strtr(':planner :target', [
-                            ':planner' => __('Planner'),
-                            ':target' => $row['course'].'.'.$row['class'],
+                        $page->breadcrumbs->add(__('Planner of {classDesc}', [
+                            'classDesc' => $row['course'].'.'.$row['class'],
                         ]));
 
                         //Get Smart Workflow help message
@@ -1250,4 +1248,3 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == f
         $_SESSION[$guid]['sidebarExtra'] = sidebarExtra($guid, $connection2, $todayStamp, $gibbonPersonID, $dateStamp, $gibbonCourseClassID);
     }
 }
-?>

--- a/modules/Planner/planner.php
+++ b/modules/Planner/planner.php
@@ -528,7 +528,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == f
         elseif ($highestAction == 'Lesson Planner_viewMyClasses' or $highestAction == 'Lesson Planner_viewAllEditMyClasses' or $highestAction == 'Lesson Planner_viewEditAllClasses') {
             $gibbonPersonID = $_SESSION[$guid]['gibbonPersonID'];
             if ($viewBy == 'date') {
-                $page->breadcrumbs->add(__('Planner of {classDesc}', [
+                $page->breadcrumbs->add(__('Planner for {classDesc}', [
                     'classDesc' => dateConvertBack($guid, $date),
                 ]));
 
@@ -750,7 +750,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == f
                     } else {
                         $row = $result->fetch();
 
-                        $page->breadcrumbs->add(__('Planner of {classDesc}', [
+                        $page->breadcrumbs->add(__('Planner for {classDesc}', [
                             'classDesc' => $row['course'].'.'.$row['class'],
                         ]));
 

--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -122,10 +122,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
             echo '</div>';
         } else {
             $page->breadcrumbs
-                ->add(strtr(':planner :target', [
-                    ':planner' => __('Planner'),
-                    ':target' => $extra,
-                ]), 'planner.php', $params)
+                ->add(
+                    empty($extra) ?
+                        __('Planner') :
+                        __('Planner of {classDesc}', ['classDesc' => $extra]),
+                    'planner.php',
+                    $params
+                )
                 ->add(__('Add Lesson Plan'));
 
             $editLink = '';

--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -125,7 +125,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
                 ->add(
                     empty($extra) ?
                         __('Planner') :
-                        __('Planner of {classDesc}', ['classDesc' => $extra]),
+                        __('Planner for {classDesc}', ['classDesc' => $extra]),
                     'planner.php',
                     $params
                 )

--- a/modules/Planner/planner_bump.php
+++ b/modules/Planner/planner_bump.php
@@ -106,9 +106,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_bump.php')
                     $row = $result->fetch();
 
                     $page->breadcrumbs
-                        ->add(strtr(':planner :target', [
-                            ':planner' => __('Planner'),
-                            ':target' => $row['course'].'.'.$row['class'],
+                        ->add(__('Planner of {classDesc}', [
+                            'classDesc' => $row['course'].'.'.$row['class'],
                         ]), 'planner.php', $params)
                         ->add(__('Bump Lesson Plan'));
 

--- a/modules/Planner/planner_bump.php
+++ b/modules/Planner/planner_bump.php
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_bump.php')
                     $row = $result->fetch();
 
                     $page->breadcrumbs
-                        ->add(__('Planner of {classDesc}', [
+                        ->add(__('Planner for {classDesc}', [
                             'classDesc' => $row['course'].'.'.$row['class'],
                         ]), 'planner.php', $params)
                         ->add(__('Bump Lesson Plan'));

--- a/modules/Planner/planner_edit.php
+++ b/modules/Planner/planner_edit.php
@@ -134,13 +134,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                 }
                 $gibbonYearGroupIDList = $row['gibbonYearGroupIDList'];
 
-				$page->breadcrumbs
-					->add(strtr(':planner :target', [
-						':planner' => __('Planner'),
-						':target' => $extra,
-					]), 'planner.php', $params)
-					->add(__('Edit Lesson Plan'));
-			
+                $page->breadcrumbs
+                    ->add(__('Planner of {classDesc}', [
+                        'classDesc' => $extra,
+                    ]), 'planner.php', $params)
+                    ->add(__('Edit Lesson Plan'));
+
                 //CHECK IF UNIT IS GIBBON OR HOOKED
                 if ($row['gibbonHookID'] == null) {
                     $hooked = false;

--- a/modules/Planner/planner_edit.php
+++ b/modules/Planner/planner_edit.php
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                 $gibbonYearGroupIDList = $row['gibbonYearGroupIDList'];
 
                 $page->breadcrumbs
-                    ->add(__('Planner of {classDesc}', [
+                    ->add(__('Planner for {classDesc}', [
                         'classDesc' => $extra,
                     ]), 'planner.php', $params)
                     ->add(__('Edit Lesson Plan'));

--- a/modules/Planner/planner_unitOverview.php
+++ b/modules/Planner/planner_unitOverview.php
@@ -149,10 +149,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_unitOvervi
                 $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                 $page->breadcrumbs
-                    ->add(__('Planner of {classDesc}', [
+                    ->add(__('Planner for {classDesc}', [
                         'classDesc' => $target,
                     ]), 'planner.php', $params)
-                    ->add(__('View Lesson Plan of {classDesc}', [
+                    ->add(__('View Lesson Plan for {classDesc}', [
                         'classDesc' => $target,
                     ]), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID, 'search' => $gibbonPersonID])
                     ->add(__('Unit Overview'));

--- a/modules/Planner/planner_unitOverview.php
+++ b/modules/Planner/planner_unitOverview.php
@@ -149,13 +149,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_unitOvervi
                 $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                 $page->breadcrumbs
-                    ->add(strtr(':planner :target', [
-                        ':planner' => __('Planner'),
-                        ':target' => $target,
+                    ->add(__('Planner of {classDesc}', [
+                        'classDesc' => $target,
                     ]), 'planner.php', $params)
-                    ->add(strtr(':action :target', [
-                        ':action' => __('View Lesson Plan'),
-                        ':target' => $target,
+                    ->add(__('View Lesson Plan of {classDesc}', [
+                        'classDesc' => $target,
                     ]), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID, 'search' => $gibbonPersonID])
                     ->add(__('Unit Overview'));
 

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -235,9 +235,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                     $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                     $page->breadcrumbs
-                        ->add(strtr(':planner :target', [
-                            ':planner' => __('Planner'),
-                            ':target' => $target,
+                        ->add(strtr('Planner of {classDesc}', [
+                            'classDesc' => $target,
                         ]), 'planner.php', $params)
                         ->add(__('View Lesson Plan'));
 

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -235,7 +235,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                     $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                     $page->breadcrumbs
-                        ->add(strtr('Planner of {classDesc}', [
+                        ->add(strtr('Planner for {classDesc}', [
                             'classDesc' => $target,
                         ]), 'planner.php', $params)
                         ->add(__('View Lesson Plan'));

--- a/modules/Planner/planner_view_full_post.php
+++ b/modules/Planner/planner_view_full_post.php
@@ -143,11 +143,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
                 $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                 $page->breadcrumbs
-                    ->add(strtr(':planner :target', [
-                        ':planner' => __('Planner'),
-                        ':target' => $target,
+                    ->add(strtr('Planner of {classDesc}', [
+                        'classDesc' => $target,
                     ]), 'planner.php', $params)
-                    ->add(__('View Lesson Plan'), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID])
+                    ->add(__('View Lesson Plan of {classDesc}', [
+                        'classDesc' => $target,
+                    ]), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID])
                     ->add(__('Add Comment'));
 
                 if (isset($_GET['return'])) {

--- a/modules/Planner/planner_view_full_post.php
+++ b/modules/Planner/planner_view_full_post.php
@@ -143,10 +143,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
                 $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                 $page->breadcrumbs
-                    ->add(strtr('Planner of {classDesc}', [
+                    ->add(strtr('Planner for {classDesc}', [
                         'classDesc' => $target,
                     ]), 'planner.php', $params)
-                    ->add(__('View Lesson Plan of {classDesc}', [
+                    ->add(__('View Lesson Plan for {classDesc}', [
                         'classDesc' => $target,
                     ]), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID])
                     ->add(__('Add Comment'));

--- a/modules/Planner/planner_view_full_submit_edit.php
+++ b/modules/Planner/planner_view_full_submit_edit.php
@@ -107,10 +107,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
                 $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                 $page->breadcrumbs
-                    ->add(strtr('Planner of {classDesc}', [
+                    ->add(strtr('Planner for {classDesc}', [
                         'classDesc' => $target,
                     ]), 'planner.php', $params)
-                    ->add(__('View Lesson Plan of {classDesc}', [
+                    ->add(__('View Lesson Plan for {classDesc}', [
                         'classDesc' => $target,
                     ]), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID])
                     ->add(__('Add Comment'));

--- a/modules/Planner/planner_view_full_submit_edit.php
+++ b/modules/Planner/planner_view_full_submit_edit.php
@@ -107,11 +107,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
                 $paramsVar = '&' . http_build_query($params); // for backward compatibile uses below (should be get rid of)
 
                 $page->breadcrumbs
-                    ->add(strtr(':planner :target', [
-                        ':planner' => __('Planner'),
-                        ':target' => $target,
-					]), 'planner.php', $params)
-					->add(__('View Lesson Plan'), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID])
+                    ->add(strtr('Planner of {classDesc}', [
+                        'classDesc' => $target,
+                    ]), 'planner.php', $params)
+                    ->add(__('View Lesson Plan of {classDesc}', [
+                        'classDesc' => $target,
+                    ]), 'planner_view_full.php', $params + ['gibbonPlannerEntryID' => $gibbonPlannerEntryID])
                     ->add(__('Add Comment'));
 
                 if (isset($_GET['return'])) {


### PR DESCRIPTION
**Refactor**
## Description
* use __() to replace previously used strtr() logics.
* New translation string: "`Planner for {classDesc}`".
* New translation string: "`View Lesson Plan for {classDesc}`".

## Motivation and Context
* see #701 and #709.

## How Has This Been Tested?
* Travis