### PR TITLE
Test: fix gitlab-ci test environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,8 +23,10 @@ before_script:
   # install dependencies for test
   - composer install --prefer-dist --no-interaction --no-progress
   # setup system locale for test
-  - echo -e "zh_TW.UTF-8 UTF-8" > /etc/locale.gen
+  - echo -e "es_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8" > /etc/locale.gen
   - cat /etc/locale.gen
+  - locale-gen es_ES.utf8
+  - locale-gen fr_FR.utf8
   - locale-gen zh_TW.utf8
   - localedef --list-archive
   - locale -a


### PR DESCRIPTION
**Bug Fix**
## Description
* generates es_ES and fr_FR to the docker environment for testing translations.

## Motivation and Context
* test failed to work on Gitlab after #709 because it requires es_ES, fr_FR and zh_TW locale to present in the OS environment for test.

## How Has This Been Tested?
* Locally (with `locale-gen` command)
* [Gitlab CI](https://gitlab.com/yookoala/gibboneducore/-/jobs/124418275)