### PR TITLE
Forms: add Range input type, Charts: add onTooltip method

### DIFF
--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -456,8 +456,9 @@ class DatabaseFormFactory extends FormFactory
     {
         // Check params and set defaults if not defined
         $params = array_replace(array(
-            'honourDefault' => true, 
-            'valueMode' => 'value'
+            'honourDefault' => true,
+            'valueMode' => 'value',
+            'labelMode' => 'value',
         ), $params);
 
         $valueQuery = ($params['valueMode'] == 'id')? 'gibbonScaleGradeID as value' : 'value';

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -461,9 +461,10 @@ class DatabaseFormFactory extends FormFactory
         ), $params);
 
         $valueQuery = ($params['valueMode'] == 'id')? 'gibbonScaleGradeID as value' : 'value';
+        $labelQuery = ($params['labelMode'] == 'descriptor')? 'descriptor' : 'value';
 
         $data = array('gibbonScaleID' => $gibbonScaleID);
-        $sql = "SELECT {$valueQuery}, value as name, isDefault FROM gibbonScaleGrade WHERE gibbonScaleID=:gibbonScaleID ORDER BY sequenceNumber";
+        $sql = "SELECT {$valueQuery}, {$labelQuery} as name, isDefault FROM gibbonScaleGrade WHERE gibbonScaleID=:gibbonScaleID ORDER BY sequenceNumber";
         $results = $this->pdo->executeQuery($data, $sql);
 
         $grades = ($results->rowCount() > 0)? $results->fetchAll() : array();

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -115,6 +115,11 @@ class FormFactory implements FormFactoryInterface
         return new Input\TextField($name);
     }
 
+    public function createRange($name, $min, $max, $step = null)
+    {
+        return new Input\Range($name, $min, $max, $step);
+    }
+
     public function createFinder($name)
     {
         return new Input\Finder($name);

--- a/src/Forms/Input/Range.php
+++ b/src/Forms/Input/Range.php
@@ -1,0 +1,55 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Forms\Input;
+
+use Gibbon\Forms\Element;
+
+/**
+ * Range
+ *
+ * @version v14
+ * @since   v14
+ */
+class Range extends Input
+{
+    /**
+     * Create an HTML range slider.
+     * @param  string  $name
+     */
+    public function __construct($name, $min, $max, $step = 1)
+    {
+        parent::__construct($name);
+
+        $this->setAttribute('min', $min);
+        $this->setAttribute('max', $max);
+        $this->setAttribute('step', $step);
+    }
+
+    /**
+     * Gets the HTML output for this form element.
+     * @return  string
+     */
+    protected function getElement()
+    {
+        $output = '<input type="range" '.$this->getAttributeString().'>';
+
+        return $output;
+    }
+}

--- a/src/Forms/Input/Range.php
+++ b/src/Forms/Input/Range.php
@@ -22,10 +22,10 @@ namespace Gibbon\Forms\Input;
 use Gibbon\Forms\Element;
 
 /**
- * Range
+ * Range Slider
  *
- * @version v14
- * @since   v14
+ * @version v17
+ * @since   v17
  */
 class Range extends Input
 {

--- a/src/UI/Chart/Chart.php
+++ b/src/UI/Chart/Chart.php
@@ -110,7 +110,7 @@ class Chart
      * @param  number $index
      * @return string
      */
-    private function getColor($index)
+    public function getColor($index)
     {
         $n = $index % count($this->defaultColors);
 
@@ -231,7 +231,7 @@ class Chart
      */
     public function onClick($function, $pointerOnHover = true)
     {
-        $this['options']['onClick'] = $this->addFunction($function);
+        $this->options['onClick'] = $this->addFunction($function);
 
         if ($pointerOnHover) {
             $this->onHover('function(elements) { document.body.style.cursor = (elements.length) ? "pointer" : "default";}');
@@ -247,7 +247,26 @@ class Chart
      */
     public function onHover($function)
     {
-        $config['options']['hover']['onHover'] = $this->addFunction($function);
+        $this->options['hover']['onHover'] = $this->addFunction($function);
+
+        return $this;
+    }
+
+    /**
+     * Add a custom tooltip function to the chart. Can be the name of a function or the function itself.
+     *
+     * @param string $function
+     * @return self
+     */
+    public function onTooltip($labelFunction = null, $titleFunction = null)
+    {
+        if ($labelFunction) {
+            $this->options['tooltips']['callbacks']['label'] = $this->addFunction($labelFunction);
+        }
+
+        if ($titleFunction) {
+            $this->options['tooltips']['callbacks']['title'] = $this->addFunction($titleFunction);
+        }
 
         return $this;
     }


### PR DESCRIPTION
A couple minor tweaks and changes to the forms and charts, aslo adds a Range slider as a input type, and adds an onTooltip method for charts to customize the tooltip data via the chart.js api