### PR TITLE
System: add a function to help with module translations

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -133,6 +133,26 @@ function __n(string $singular, string $plural, int $n, array $params = [], array
     return $gibbon->locale->translateN($singular, $plural, $n, $params, $options);
 }
 
+/**
+ * Identical to __() but automatically includes the current module as the text domain.
+ *
+ * @see __()
+ * @param string $text
+ * @param array  $params
+ * @param array  $options
+ * @return string
+ */
+function __d(string $text, array $params = [], array $options = [])
+{
+    global $gibbon;
+
+    if ($gibbon->session->has('module')) {
+        $options['domain'] = $gibbon->session->get('module');
+    }
+
+    return $gibbon->locale->translate($text, $params, $options);
+}
+
 //$valueMode can be "value" or "id" according to what goes into option's value field
 //$selectMode can be "value" or "id" according to what is used to preselect an option
 //$honourDefault can TRUE or FALSE, and determines whether or not the default grade is selected

--- a/functions.php
+++ b/functions.php
@@ -142,7 +142,7 @@ function __n(string $singular, string $plural, int $n, array $params = [], array
  * @param array  $options
  * @return string
  */
-function __d(string $text, array $params = [], array $options = [])
+function __m(string $text, array $params = [], array $options = [])
 {
     global $gibbon;
 


### PR DESCRIPTION
While translating additional modules outside the core, it becomes a bit clunky to include the module name for each string, especially with it now being an array parameter. Since the system already knows the name of the current module for any given page, it'd be pretty easy to include this automatically.

With this change, the following:
`__('Import From File', [], ['domain' => 'Data Admin'])`

is identical to:
`__d('Import From File')`

This can also help to ensure module strings are not accidentally included in the core, as the xgettext script won't be looking at `__d()` functions.

@yookoala What do you think?
