### PR TITLE
Modules: remove uses of getAge

### DIFF
--- a/modules/Students/report_students_byRollGroup_print.php
+++ b/modules/Students/report_students_byRollGroup_print.php
@@ -151,7 +151,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_b
                 echo '</td>';
                 echo '<td>';
                 if (is_null($row['dob']) == false and $row['dob'] != '0000-00-00') {
-                    echo getAge($guid, dateConvertToTimestamp($row['dob']), true).'<br/>';
+                    echo Format::age(date('Y-m-d', Format::timestamp($row['dob'])), true).'<br/>';
                     echo "<span style='font-style: italic; font-size: 85%'>".dateConvertBack($guid, $row['dob']).'</span>';
                 }
                 echo '</td>';

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -498,7 +498,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
                         echo "<span style='font-size: 115%; font-weight: bold'>".__('Age').'</span><br/>';
                         if (is_null($row['dob']) == false and $row['dob'] != '0000-00-00') {
-                            echo getAge($guid, dateConvertToTimestamp($row['dob']));
+                            echo Format::age(date('Y-m-d', Format::timestamp($row['dob'])));
                         }
                         echo '</td>';
                         echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
@@ -802,7 +802,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
                         echo "<span style='font-size: 115%; font-weight: bold'>".__('Age').'</span><br/>';
                         if (is_null($row['dob']) == false and $row['dob'] != '0000-00-00') {
-                            echo getAge($guid, dateConvertToTimestamp($row['dob']));
+                            echo Format::age(Format::timestamp($row['dob']));
                         }
                         echo '</td>';
                         echo '</tr>';

--- a/publicRegistrationProcess.php
+++ b/publicRegistrationProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Services\Format;
 
 include './gibbon.php';
 
@@ -139,7 +140,7 @@ if ($proceed == false) {
                 $ageFail = false;
                 if ($publicRegistrationMinimumAge == '') {
                     $ageFail = true;
-                } elseif ($publicRegistrationMinimumAge > 0 and $publicRegistrationMinimumAge > getAge($guid, dateConvertToTimestamp($dob), true, true)) {
+                } elseif ($publicRegistrationMinimumAge > 0 and $publicRegistrationMinimumAge > (new DateTime('@'.Format::timestamp($dob)))->diff(new DateTime())->y) {
                     $ageFail = true;
                 }
 


### PR DESCRIPTION
**Refactor**
## Description
* remove all usage of the function `getAge()` in the codebase.

## Motivation and Context
There is only a few usage left of `getAge()` in the core. Removing them helps to lift dependencies from it and make it ready to be removed.

## How Has This Been Tested?
* Locally
* Travis