### PR TITLE
Security Robot IP Check at Login/Google Login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ nbproject/
 /vendor/**/unitTests
 /vendor/**/Examples
 /vendor/**/examples
+
+.idea

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -786,4 +786,5 @@ ALTER TABLE `gibbonStaffApplicationForm` CHANGE `email` `email` VARCHAR(75) CHAR
 ALTER TABLE `gibbonApplicationForm` CHANGE `email` `email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 ALTER TABLE `gibbonApplicationForm` CHANGE `parent1email` `parent1email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 ALTER TABLE `gibbonApplicationForm` CHANGE `parent2email` `parent2email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('System', 'ipWhiteList', 'IP WhiteList', 'Comma-separated list of ip addresses, partial ip addresses and network subnets to ignore when checking login failures from machines. e.g. 127.0.0.1,172.16.0,10.0.0.0/24  This would match 127.0.0.1, 172.16.0.x and 10.0.0.x', '');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ v17.0.00
         System: removed upgrade path for v11.0.00 and below
 
     Security
+        Added ability for robots trying to hack the system to be ignored.  Whitelist of IP's available to school admin.
 
     Tweaks & Bug Fixes
         System: fixed IE incompatibility with javascript and select inputs

--- a/functions.php
+++ b/functions.php
@@ -2739,6 +2739,8 @@ function sidebar($gibbon, $pdo)
             $loginReturnMessage = sprintf(__('Gmail account does not match the email stored in %1$s. If you have logged in with your school Gmail account please contact %2$s if you have any questions.'), $_SESSION[$guid]['systemName'], "<a href='mailto:".$_SESSION[$guid]['organisationDBAEmail']."'>".$_SESSION[$guid]['organisationDBAName'].'</a>');
         } elseif ($loginReturn == 'fail9') {
             $loginReturnMessage = __('Your primary role does not support the ability to log into the specified year.');
+        } elseif ($loginReturn == 'faila') {
+            $loginReturnMessage = __('Too many failed logins from this machine.  The machine will be available in {minutes} minutes.', ['minutes' => $_GET['loginAvailableTime'] + 1]);
         }
 
         echo "<div class='error'>";

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -1,8 +1,25 @@
 <?php
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Services\SecurityManager;
 
 include "../../gibbon.php";
+
+$secMan = new SecurityManager($pdo);
+if (! $secMan->isIPToBeIgnored()) {
+
+    $data = array('ip' => $_SERVER['REMOTE_ADDR'], 'timestamp' => date('Y-m-d H:i:s', strtotime('-20 minutes')));
+    $sql = "SELECT title, timestamp FROM gibbonLog WHERE ip=:ip AND timestamp >= :timestamp ORDER BY timestamp DESC";
+    $ipCount = $pdo->select($sql, $data)->fetchAll();
+    if (count($ipCount) >= 3)
+    {
+        $last = new \DateTime($ipCount[0]['timestamp']);
+        $wasLast = 20 - $last->diff(new DateTime('now'), true)->format('%i');
+        $URL .= '?loginReturn=faila&loginAvailableTime='.$wasLast;
+        header("Location: {$URL}");
+        exit;
+    }
+}
 
 setCurrentSchoolYear($guid, $connection2);
 

--- a/modules/System Admin/systemSettings.php
+++ b/modules/System Admin/systemSettings.php
@@ -258,8 +258,13 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
 
     $setting = getSettingByScope($connection2, 'System', 'defaultAssessmentScale', true);
     $row = $form->addRow();
-        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromQuery($pdo, $sql)->selected($setting['value']);
+    $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+    $row->addSelect($setting['name'])->fromQuery($pdo, $sql)->selected($setting['value']);
+
+    $setting = getSettingByScope($connection2, 'System', 'ipWhiteList', true);
+    $row = $form->addRow();
+    $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+    $row->addTextArea($setting['name'])->setValue($setting['value'])->setRows(8);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/src/Services/SecurityManager.php
+++ b/src/Services/SecurityManager.php
@@ -1,0 +1,112 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * User: craig
+ * Date: 27/11/2018
+ * Time: 22:22
+ */
+namespace Gibbon\Services;
+
+use Gibbon\Database\Connection;
+
+class SecurityManager
+{
+    /**
+     * @var Connection|null
+     */
+    private $connection;
+
+    /**
+     * @return Connection|null
+     */
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
+    /**
+     * @param Connection $connection
+     * @return SecurityManager
+     */
+    public function setConnection(Connection $connection): SecurityManager
+    {
+        $this->connection = $connection;
+        return $this;
+    }
+
+    /**
+     * SecurityManager constructor.
+     * @param Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->setConnection($connection);
+    }
+
+    /**
+     * @var SettingManager|null
+     */
+    private $settingManager;
+
+    /**
+     * @return SettingManager|null
+     */
+    public function getSettingManager(): SettingManager
+    {
+        if (empty($this->settingManager))
+            $this->settingManager = new SettingManager($this->getConnection());
+        return $this->settingManager;
+    }
+
+    /**
+     * @param null $ip
+     * @return bool
+     */
+    public function isIPToBeIgnored($ip = null): bool
+    {
+        if (is_null($ip))
+            $ip = $_SERVER['REMOTE_ADDR'];
+        foreach(array_merge(['127.0.0.1'],$this->getSettingManager()->getSettingByScopeAsArray('System', 'ipWhiteList')) as $range)
+        {
+            if (strpos($ip, $range) === 0)
+                return true;
+            if ($this->ipInRange($ip, $range))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param $ip
+     * @param $range
+     * @return bool
+     */
+    private function ipInRange( $ip, $range ) {
+        $ipRegex = '#^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}$#';
+        if ( preg_match($ipRegex, $range) ) {
+            $range .= '/32';
+        }
+        // $range is in IP/CIDR format eg 127.0.0.1/24
+        list( $range, $netmask ) = explode( '/', $range, 2 );
+        $range_decimal = ip2long( $range );
+        $ip_decimal = ip2long( $ip );
+        $wildcard_decimal = pow( 2, ( 32 - $netmask ) ) - 1;
+        $netmask_decimal = ~ $wildcard_decimal;
+        return ( ( $ip_decimal & $netmask_decimal ) == ( $range_decimal & $netmask_decimal ) );
+    }
+}

--- a/src/Services/SettingManager.php
+++ b/src/Services/SettingManager.php
@@ -1,0 +1,102 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * User: craig
+ * Date: 27/11/2018
+ * Time: 22:27
+ */
+namespace Gibbon\Services;
+
+use Gibbon\Database\Connection;
+
+class SettingManager
+{
+    /**
+     * @var Connection|null
+     */
+    private $connection;
+
+    /**
+     * @return Connection|null
+     */
+    public function getConnection(): Connection
+    {
+        return $this->connection;
+    }
+
+    /**
+     * @param Connection $connection
+     * @return SettingManager
+     */
+    public function setConnection(Connection $connection): SettingManager
+    {
+        $this->connection = $connection;
+        return $this;
+    }
+
+    /**
+     * SecurityManager constructor.
+     * @param Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->setConnection($connection);
+    }
+
+    /**
+     * @param $connection2
+     * @param $scope
+     * @param $name
+     * @param bool $returnRow
+     * @return bool
+     */
+    function getSettingByScope($scope, $name, $returnRow = false )
+    {
+        try {
+            $data = array('scope' => $scope, 'name' => $name);
+            $sql = 'SELECT * FROM gibbonSetting WHERE scope=:scope AND name=:name';
+            $result = $this->getConnection()->selectOne($sql, $data);
+        } catch (\PDOException $e) {
+        }
+
+        if ($result && count($result) == 1) {
+
+            if ($returnRow) {
+                return $result;
+            } else {
+                return $result['value'];
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $connection2
+     * @param $scope
+     * @param $name
+     * @param bool $returnRow
+     * @return bool
+     */
+    function getSettingByScopeAsArray($scope, $name): array
+    {
+        if ($result = $this->getSettingByScope($scope, $name) === false)
+            return [];
+        return explode(',', $result);
+    }
+}


### PR DESCRIPTION
## Security Robot IP Check at Login
This feature is design to identify machines by IP address that have attempted more that 3 login (failures) within the last 20 minutes and ignore that IP Address for a maximum of 20 minutes.

The system Admin is able to whilte list IP addresses on the System Admin Setting page (Misc Section) using unique IP, subnet or partial IP addresses in a standard comma separated list. e.g 127.0.0.1, 172.16.0 and 192.168.1.1/24 are all valid. Invalid entries are ignored.

127.0.0.1 matches 127.0.0.1
172.16.0 matches 172.16.0.x
192.168.1.1.24 matches 192.168.1.x (this does a bit wise test, so 192.168.1.1/28 would match 16 machines. (Actually 15, due to match all requests on the network.)

### How was this tested?
Tested Both Locally and on Travis