### PR TITLE
Deprecated getGibbonMailer and call GibbonMailer wrapper to remove duplicate code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ nbproject/
 /vendor/**/unitTests
 /vendor/**/Examples
 /vendor/**/examples
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,3 @@ nbproject/
 /vendor/**/unitTests
 /vendor/**/Examples
 /vendor/**/examples
-
-.idea

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -75,6 +75,9 @@ v17.0.00
         Messenger: updated the Year Group target for Staff to only include tutors and teachers of courses in the same year group
         Messenger: fixed empty target type in gibbonMessengerReceipt when Group target is used
         Messenger: added an option in Messenger Settings to bcc all messenger emails to a set of recipients
+        Messenger: PHPMailer wrapper updated for use with GMAIL, which requires SMTPSecure = 'ssl'
+                   Deprecated getGibbonMailer and call GibbonMailer wrapper to remove duplicate code.
+                   Refactored Messenger Post Process to use GibbonMailer.
         Planner: added SMTP persistence to weekly summary CLI script
         Planner: improved accessibility of link from Scope & Sequence to Dump Unit
         Planner: fixed school year name on Edit Unit page

--- a/functions.php
+++ b/functions.php
@@ -4649,9 +4649,12 @@ function countLikesByRecipient($connection2, $gibbonPersonIDRecipient, $mode = '
  */
 function getGibbonMailer($guid) {
 
-    trigger_error('getGibbonMailer method is deprecated and replaced by Gibbon\Comms\GibbonMailer class.  ', E_USER_DEPRECATED);
-
     global $gibbon;
+    $displayErrors = ini_get('display_errors');
+
+    ini_set('display_errors', 'Off');
+    trigger_error('getGibbonMailer method is deprecated and replaced by Gibbon\Comms\GibbonMailer class.  ', E_USER_DEPRECATED);
+    ini_set('display_errors', $displayErrors);
 
     $mail = new GibbonMailer($gibbon->session);
 

--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
+use Gibbon\Comms\GibbonMailer;
 
 require_once dirname(__FILE__).'/gibbon.php';
 
@@ -4641,35 +4642,18 @@ function countLikesByRecipient($connection2, $gibbonPersonIDRecipient, $mode = '
  * @version 1st September 2016
  * @since   1st September 2016
  * @author  Sandra Kuipers
+ * @deprecated 30th Nov 2018
+ * This method has been replaced by the GibbonMailer class, and remains here ONLY to handle legacy calls.
+ * The Deprecation error will be logged, and if asked for in php.ini stop execution.
+ * Productions sites should NOT have display_errors set to true, and therefore not a problem.
  */
 function getGibbonMailer($guid) {
-    $mail = new PHPMailer();
 
-    $smtpEnabled = $_SESSION[$guid]['enableMailerSMTP'];
+    trigger_error('getGibbonMailer method is deprecated and replaced by Gibbon\Comms\GibbonMailer class.  ', E_USER_DEPRECATED);
 
-    if ($smtpEnabled == 'Y') {
+    global $gibbon;
 
-        $mail->IsSMTP();
-        $mail->CharSet = 'UTF-8';
-
-        $host = $_SESSION[$guid]['mailerSMTPHost'];
-        $port = $_SESSION[$guid]['mailerSMTPPort'];
-
-        if ( !empty($host) && !empty($port) ) {
-
-            $username = $_SESSION[$guid]['mailerSMTPUsername'];
-            $password = $_SESSION[$guid]['mailerSMTPPassword'];
-            $auth = ( !empty($username) && !empty($password) );
-
-            $mail->Host       = $host;      // SMTP server example
-            $mail->SMTPDebug  = 0;          // enables SMTP debug information (for testing)
-            $mail->SMTPAuth   = $auth;      // enable SMTP authentication
-            $mail->Port       = $port;      // set the SMTP port for the GMAIL server
-            $mail->Username   = $username;  // SMTP account username example
-            $mail->Password   = $password;  // SMTP account password example
-            $mail->Helo       = parse_url($_SESSION[$guid]['absoluteURL'], PHP_URL_HOST);
-        }
-    }
+    $mail = new GibbonMailer($gibbon->session);
 
     return $mail;
 }

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Comms\GibbonMailer;
+
 include '../../gibbon.php';
 
 //Increase max execution time, as this stuff gets big
@@ -1937,7 +1939,7 @@ else {
 
 				//Set up email
 				$emailCount=0 ;
-				$mail=getGibbonMailer($guid);
+				$mail= new GibbonMailer($gibbon->session);
 				$mail->SMTPKeepAlive = true;
 				if ($emailReplyTo!="")
 					$mail->AddReplyTo($emailReplyTo, '');

--- a/src/Comms/GibbonMailer.php
+++ b/src/Comms/GibbonMailer.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Comms;
 
-use Gibbon\session;
+use Gibbon\Session;
 
 /**
  * Mailer class
@@ -31,7 +31,7 @@ class GibbonMailer extends \PHPMailer
 {
     protected $session;
 
-    public function __construct(session $session)
+    public function __construct(Session $session)
     {
         $this->session = $session;
         $this->CharSet = 'UTF-8';
@@ -39,20 +39,20 @@ class GibbonMailer extends \PHPMailer
         $this->IsHTML(true);
 
         if ($this->session->get('enableMailerSMTP') == 'Y') {
-            $this->setupSMTP($this->session);
+            $this->setupSMTP();
         }
 
         parent::__construct(null);
     }
 
-    public function setupSMTP(session $session)
+    public function setupSMTP()
     {
-        $host = $session->get('mailerSMTPHost');
-        $port = $session->get('mailerSMTPPort');
+        $host = $this->session->get('mailerSMTPHost');
+        $port = $this->session->get('mailerSMTPPort');
 
         if ( !empty($host) && !empty($port) ) {
-            $username = $session->get('mailerSMTPUsername');
-            $password = $session->get('mailerSMTPPassword');
+            $username = $this->session->get('mailerSMTPUsername');
+            $password = $this->session->get('mailerSMTPPassword');
             $auth = ( !empty($username) && !empty($password) );
 
             $this->IsSMTP();
@@ -62,6 +62,11 @@ class GibbonMailer extends \PHPMailer
             $this->Port       = $port;      // set the SMTP port for the GMAIL server
             $this->Username   = $username;  // SMTP account username example
             $this->Password   = $password;  // SMTP account password example
+
+            if ($this->Host === 'smtp.gmail.com')
+            {
+                $this->SMTPSecure = 'ssl';
+            }
         }
     }
 }


### PR DESCRIPTION
Deprecated getGibbonMailer and call GibbonMailer wrapper to remove duplicate code.
PHPMailer wrapper updated for use with GMAIL, which requires SMTPSecure = 'ssl'
Refactored Messenger Post Process to use GibbonMailer.

**Bug Fix | New Feature**

## Description
Changes are made to remove duplicate code for use of PHPMailer whilst maintaining backwards compatibility.  I added a @deprecated tag for development, and also added a E_USER_DEPRECATED throw to be logged when this old code is used.  Check php_error log for results.

> [30-Nov-2018 11:15:55 Australia/Sydney] PHP Deprecated:  getGibbonMailer method is deprecated and replaced by Gibbon\Comms\GibbonMailer class.   in F:\websites\crayner\Gibbon\functions.php on line 4648
> [30-Nov-2018 11:15:55 Australia/Sydney] PHP Stack trace:
> [30-Nov-2018 11:15:55 Australia/Sydney] PHP   1. {main}() F:\websites\crayner\Gibbon\modules\Messenger\messenger_postProcess.php:0
> [30-Nov-2018 11:15:55 Australia/Sydney] PHP   2. getGibbonMailer() F:\websites\crayner\Gibbon\modules\Messenger\messenger_postProcess.php:1940
> [30-Nov-2018 11:15:55 Australia/Sydney] PHP   3. trigger_error() F:\websites\crayner\Gibbon\functions.php:4648


GibbonMailer looks for gmail setting and sets SMTPSecure = 'ssl' 
(Could look for port 465 to do this, but this would NOT maintain backwards compatibility.)

messenger_postProcess modified as part of the testing.

## Motivation and Context
The settup did not work for SMTP servers requiring SSL

> [30-Nov-2018 11:11:57 Australia/Sydney] Connection: opened
> [30-Nov-2018 11:12:07 Australia/Sydney] SERVER -> CLIENT: 
> [30-Nov-2018 11:12:07 Australia/Sydney] SMTP NOTICE: EOF caught while checking if connected
> [30-Nov-2018 11:12:07 Australia/Sydney] Connection: closed
> [30-Nov-2018 11:12:07 Australia/Sydney] SMTP Error: Could not authenticate.
> [30-Nov-2018 11:12:07 Australia/Sydney] SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting

## How Has This Been Tested?
Locally  I tested the Messenger Post Process both pre and post changes to ensure that the old call still worked, and that the new call also worked.

Travis

## Screenshots (if appropriate):
No changes to any templates.