### PR TITLE
Fixed bug internationalization and indentation adjustment

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -63,6 +63,7 @@ v17.0.00
         Finance: added default check to Company email checkbox when editing an invoice
         Finance: adjusted email checkbox list in Edit Invoice to only show parents with status of Full
         Finance: removed Left parents from invoices and receipts
+        Finance: fixed the bug that prevented saving the value of the field "status" in the table "gibbonFinanceBudgetCycle" when the current Gibbon language is other than English 
         Markbook: added school wide-option allowing teachers to specify "Modified Assessment" for student with individual needs
         Markbook: fixed bug in handling personalised attainment targets when using scales other than class scale
         Markbook: removed WordPress Comment Push functionality

--- a/modules/Finance/budgetCycles_manage_add.php
+++ b/modules/Finance/budgetCycles_manage_add.php
@@ -42,36 +42,41 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
     $form = Form::create('budgetCycle', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/budgetCycles_manage_addProcess.php');
     $form->setFactory(DatabaseFormFactory::create($pdo));
 
-	$form->addHiddenValue("address", $_SESSION[$guid]['address']);
+    $form->addHiddenValue("address", $_SESSION[$guid]['address']);
 
-	$row = $form->addRow();
-		$row->addHeading(__("Basic Information"));
+    $row = $form->addRow();
+        $row->addHeading(__("Basic Information"));
 
-	$row = $form->addRow();
-		$row->addLabel("name", __("Name"))->description(__("Must be unique."));
-		$row->addTextField("name")->isRequired()->maxLength(7);
+    $row = $form->addRow();
+        $row->addLabel("name", __("Name"))->description(__("Must be unique."));
+	$row->addTextField("name")->isRequired()->maxLength(7);
 
-        $row = $form->addRow();
-	    $row->addLabel("status", __("Status"));
-		$row->addSelect("status")->fromArray(array(__("Upcoming"), __("Current"), __("Past")));
+    $statusTypes = array(
+        'Upcoming' => __("Upcoming"),
+        'Current' =>  __("Current"),
+        'Past' => __("Past")
+    );
+    
+    $row = $form->addRow();
+	$row->addLabel("status", __("Status"));
+	$row->addSelect("status")->fromArray($statusTypes);
 
-        $row = $form->addRow();
-            $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-            $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceBudgetCycle')->isRequired()->maxLength(3);
+    $row = $form->addRow();
+        $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
+        $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceBudgetCycle')->isRequired()->maxLength(3);
 
-	$row = $form->addRow();
-	    $row->addLabel("dateStart", __("Start Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-	    $row->addDate("dateStart")->isRequired();
+    $row = $form->addRow();
+        $row->addLabel("dateStart", __("Start Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
+        $row->addDate("dateStart")->isRequired();
 
-	$row = $form->addRow();
-	    $row->addLabel("dateEnd", __("End Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-	    $row->addDate("dateEnd")->isRequired();
+    $row = $form->addRow();
+        $row->addLabel("dateEnd", __("End Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
+        $row->addDate("dateEnd")->isRequired();
 
-	$row = $form->addRow();
-	    $row->addHeading(__("Budget Allocations"));
+    $row = $form->addRow();
+        $row->addHeading(__("Budget Allocations"));
 
-
-	try {
+    try {
         $dataBudget = array();
         $sqlBudget = 'SELECT * FROM gibbonFinanceBudget ORDER BY name';
         $resultBudget = $connection2->prepare($sqlBudget);
@@ -79,30 +84,32 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
     } catch (PDOException $e) {
         echo "<div class='error'>".$e->getMessage().'</div>';
     }
-	if ($resultBudget->rowCount() < 1) {
-		$row = $form->addRow();
-			$row->addAlert(__('There are no records to display.'), "error");
-	} else {
-		while ($rowBudget = $resultBudget->fetch()) {
+    
+    if ($resultBudget->rowCount() < 1) {
+        $row = $form->addRow();
+            $row->addAlert(__('There are no records to display.'), "error");
+    } else {
+        while ($rowBudget = $resultBudget->fetch()) {
 
-			$description = "";
-
-			if ($_SESSION[$guid]['currency'] != '') {
+            $description = "";
+            
+            if ($_SESSION[$guid]['currency'] != '') {
                 $description = sprintf(__('Numeric value in %1$s.'), $_SESSION[$guid]['currency']);
             } else {
                 $description = __('Numeric value.');
             }
+            
+            $row = $form->addRow();
+                $row->addLabel('values[]', $rowBudget['name'])->description($description);
+                $row->addNumber("values[]")->maxLength(15)->decimalPlaces(2)->setValue("0.00");
+            
+            $form->addHiddenValue("gibbonFinanceBudgetIDs[]", $rowBudget['gibbonFinanceBudgetID']);
+        }
+    }
 
-			$row = $form->addRow();
-				$row->addLabel('values[]', $rowBudget['name'])->description($description);
-				$row->addNumber("values[]")->maxLength(15)->decimalPlaces(2)->setValue("0.00");
-				$form->addHiddenValue("gibbonFinanceBudgetIDs[]", $rowBudget['gibbonFinanceBudgetID']);
-		}
-	}
-
-	$row = $form->addRow();
-		$row->addFooter();
-		$row->addSubmit();
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
 
     print $form->getOutput();
 }

--- a/modules/Finance/budgetCycles_manage_edit.php
+++ b/modules/Finance/budgetCycles_manage_edit.php
@@ -62,33 +62,39 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
             $form = Form::create('budgetCycle', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/budgetCycles_manage_editProcess.php?gibbonFinanceBudgetCycleID='.$gibbonFinanceBudgetCycleID);
             $form->setFactory(DatabaseFormFactory::create($pdo));
 
-        	$form->addHiddenValue("address", $_SESSION[$guid]['address']);
+            $form->addHiddenValue("address", $_SESSION[$guid]['address']);
 
-        	$row = $form->addRow();
-        		$row->addHeading(__("Basic Information"));
+            $row = $form->addRow();
+                $row->addHeading(__("Basic Information"));
 
-        	$row = $form->addRow();
-        		$row->addLabel("name", __("Name"))->description(__("Must be unique."));
-        		$row->addTextField("name")->isRequired()->maxLength(7);
+            $row = $form->addRow();
+                $row->addLabel("name", __("Name"))->description(__("Must be unique."));
+                $row->addTextField("name")->isRequired()->maxLength(7);
 
-        	$row = $form->addRow();
-        		$row->addLabel("status", __("Status"));
-        		$row->addSelect("status")->fromArray(array(__("Upcoming"), __("Current"), __("Past")));
+            $statusTypes = array(
+                'Upcoming' => __("Upcoming"),
+                'Current' =>  __("Current"),
+                'Past' => __("Past")
+            );
+            
+            $row = $form->addRow();
+                $row->addLabel("status", __("Status"));
+                $row->addSelect("status")->fromArray($statusTypes);
 
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
                 $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceBudgetCycle', $values['sequenceNumber'])->isRequired()->maxLength(3);
 
-        	$row = $form->addRow();
-        		$row->addLabel("dateStart", __("Start Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-        		$row->addDate("dateStart")->isRequired();
+            $row = $form->addRow();
+                $row->addLabel("dateStart", __("Start Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
+                $row->addDate("dateStart")->isRequired();
 
-        	$row = $form->addRow();
-        		$row->addLabel("dateEnd", __("End Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-        		$row->addDate("dateEnd")->isRequired();
-
-        	$row = $form->addRow();
-        		$row->addHeading(__("Budget Allocations"));
+            $row = $form->addRow();
+                $row->addLabel("dateEnd", __("End Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
+                $row->addDate("dateEnd")->isRequired();
+            
+            $row = $form->addRow();
+                $row->addHeading(__("Budget Allocations"));
 
             try {
                 $dataBudget = array('gibbonFinanceBudgetCycleID' => $gibbonFinanceBudgetCycleID);
@@ -105,15 +111,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
                     $row = $form->addRow();
                         $row->addLabel($rowBudget['gibbonFinanceBudgetID'], $rowBudget['name']);
                         $row->addCurrency($rowBudget['gibbonFinanceBudgetID'])->setName('values[]')->isRequired()->maxLength(15)->setValue((is_null($rowBudget['value'])) ? '0.00' : $rowBudget['value']);
-                        $form->addHiddenValue('gibbonFinanceBudgetIDs[]', $rowBudget['gibbonFinanceBudgetID']);
+                    $form->addHiddenValue('gibbonFinanceBudgetIDs[]', $rowBudget['gibbonFinanceBudgetID']);
                 }
             }
 
             $form->loadAllValuesFrom($values);
 
             $row = $form->addRow();
-        		$row->addFooter();
-        		$row->addSubmit();
+                $row->addFooter();
+                $row->addSubmit();
 
             print $form->getOutput();
         }


### PR DESCRIPTION
Fixed the bug that prevented saving the value of the field "status" in the table "gibbonFinanceBudgetCycle" when the current Gibbon language is other than English 

## Motivation and Context
If the current Gibbon language is other than English, DB don't save the values of the field "status", because this field is ENUM('Past', 'Current', 'Upcoming')

## How Has This Been Tested?
Local in languages Portuguese and Italian

