### PR TITLE
Departments: don't display courses with no classes or no year groups

### DIFF
--- a/modules/Departments/department.php
+++ b/modules/Departments/department.php
@@ -170,7 +170,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department.php
             if ($resultCourse->rowCount() > 0) {
                 if ($role == 'Coordinator' or $role == 'Assistant Coordinator' or $role == 'Teacher (Curriculum)') {
                     $_SESSION[$guid]['sidebarExtra'] .= '<h4>';
-                    $_SESSION[$guid]['sidebarExtra'] .= 'Current Courses';
+                    $_SESSION[$guid]['sidebarExtra'] .= __('Current Courses');
                     $_SESSION[$guid]['sidebarExtra'] .= '</h4>';
                 } else {
                     $_SESSION[$guid]['sidebarExtra'] .= '<h4>';

--- a/modules/Departments/department.php
+++ b/modules/Departments/department.php
@@ -154,7 +154,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department.php
             //Print current course list
             try {
                 $dataCourse = array('gibbonDepartmentID' => $gibbonDepartmentID);
-                $sqlCourse = "SELECT * FROM gibbonCourse WHERE gibbonDepartmentID=:gibbonDepartmentID AND gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current') ORDER BY nameShort, name";
+                $sqlCourse = "SELECT gibbonCourse.* FROM gibbonCourse 
+                    JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) 
+                    WHERE gibbonDepartmentID=:gibbonDepartmentID 
+                    AND gibbonYearGroupIDList <> '' 
+                    AND gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current') 
+                    GROUP BY gibbonCourse.gibbonCourseID 
+                    ORDER BY nameShort, name";
                 $resultCourse = $connection2->prepare($sqlCourse);
                 $resultCourse->execute($dataCourse);
             } catch (PDOException $e) {


### PR DESCRIPTION
A small tweak to the list of courses in the departments module. It removes courses from the list that either don't have any classes, or don't have any year groups selected. In this case, they could be new courses not setup yet, or possibly not offered in the current year. Any knock-on effects from this change?

_Edit: caught a missing translation function_