### PR TITLE
System: fix a delay in the alarm window popup

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -423,13 +423,9 @@ function getNotificationTray($connection2, $guid, $cacheLoad)
                             $type = 'custom';
                         }
                         $return .= "<script>
-                            if ($('div#TB_window').is(':visible')===false) {
-                                var url = '".$_SESSION[$guid]['absoluteURL'].'/index_notification_ajax_alarm.php?type='.$type."&KeepThis=true&TB_iframe=true&width=1000&height=500';
-                                $(document).ready(function() {
-                                    tb_show('', url);
-                                    $('div#TB_window').addClass('alarm') ;
-                                }) ;
-                            }
+                            $(document).ready(function() {
+                                $('#notifications').load('index_notification_ajax.php');
+                            }) ;
                         </script>";
                     }
                 }

--- a/index_notification_ajax_alarm.php
+++ b/index_notification_ajax_alarm.php
@@ -22,7 +22,7 @@ include './gibbon.php';
 
 //Load jQuery
 echo '<script type="text/javascript" src="'.$_SESSION[$guid]['absoluteURL'].'/lib/jquery/jquery.js"></script>';
-echo '<script type="text/javascript" src="'.$_SESSION[$guid]['absoluteURL'].'/lib/jquery/jquery-migrate.min.jsprint"></script>';
+echo '<script type="text/javascript" src="'.$_SESSION[$guid]['absoluteURL'].'/lib/jquery/jquery-migrate.min.js"></script>';
 
 $type = '';
 if (isset($_GET['type'])) {

--- a/modules/System Admin/alarm.php
+++ b/modules/System Admin/alarm.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/alarm.php') =
         'Custom'   => __('Custom'),
     );
 
-    $form = Form::create('alarm', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/alarmProcess.php');
+    $form = Form::create('alarmSettings', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/alarmProcess.php');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 


### PR DESCRIPTION
Fixes a small bug where the alarm window, once triggered, would turn the screen dark but wouldn't popup for several seconds (until the notifications refreshed in the background). This would also happen each time after navigating to a new page.

The fix: since the index_notification_ajax script handles the triggering of the alarm, the functions.php code was tweaked to cause an immediate notification refresh. Beyond that, I resisted the temptation to refactor any of the other parts of these scripts 😁 

Also fixes two random javascript errors that were showing up in the console.