### PR TITLE
System: rename GibbonMailer class to Mailer, add to ServiceProvider

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
-use Gibbon\Comms\GibbonMailer;
+use Gibbon\Contracts\Comms\Mailer;
 
 require_once dirname(__FILE__).'/gibbon.php';
 
@@ -4611,7 +4611,7 @@ function countLikesByRecipient($connection2, $gibbonPersonIDRecipient, $mode = '
 }
 
 /**
- * This method has been replaced by the GibbonMailer class, and remains here only to handle legacy calls.
+ * This method has been replaced by the Mailer class, and remains here only to handle legacy calls.
  * The Deprecation error will be logged, and if asked for in php.ini stop execution.
  *
  * @deprecated 30th Nov 2018
@@ -4620,14 +4620,14 @@ function countLikesByRecipient($connection2, $gibbonPersonIDRecipient, $mode = '
  */
 function getGibbonMailer($guid) {
 
-    global $gibbon;
+    global $container;
     $displayErrors = ini_get('display_errors');
 
     ini_set('display_errors', 'Off');
-    trigger_error('getGibbonMailer method is deprecated and replaced by Gibbon\Comms\GibbonMailer class', E_USER_DEPRECATED);
+    trigger_error('getGibbonMailer method is deprecated and replaced by Gibbon\Comms\Mailer class', E_USER_DEPRECATED);
     ini_set('display_errors', $displayErrors);
 
-    $mail = new GibbonMailer($gibbon->session);
+    $mail = $container->get(Mailer::class);
 
     return $mail;
 }

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Comms\GibbonMailer;
+use Gibbon\Contracts\Comms\Mailer;
 
 include '../../gibbon.php';
 
@@ -1939,7 +1939,7 @@ else {
 
 				//Set up email
 				$emailCount=0 ;
-				$mail= new GibbonMailer($gibbon->session);
+				$mail= $container->get(Mailer::class);
 				$mail->SMTPKeepAlive = true;
 				if ($emailReplyTo!="")
 					$mail->AddReplyTo($emailReplyTo, '');

--- a/src/Comms/Mailer.php
+++ b/src/Comms/Mailer.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 namespace Gibbon\Comms;
 
 use Gibbon\Contracts\Services\Session;
+use Gibbon\Contracts\Comms\Mailer as MailerInterface;
 
 /**
  * Mailer class
@@ -27,7 +28,7 @@ use Gibbon\Contracts\Services\Session;
  * @version v14
  * @since   v14
  */
-class GibbonMailer extends \PHPMailer
+class Mailer extends \PHPMailer implements MailerInterface
 {
     protected $session;
 
@@ -45,7 +46,7 @@ class GibbonMailer extends \PHPMailer
         parent::__construct(null);
     }
 
-    public function setupSMTP()
+    protected function setupSMTP()
     {
         $host = $this->session->get('mailerSMTPHost');
         $port = $this->session->get('mailerSMTPPort');

--- a/src/Comms/NotificationSender.php
+++ b/src/Comms/NotificationSender.php
@@ -19,7 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Comms;
 
-use Gibbon\session;
+use Gibbon\Comms\Mailer;
+use Gibbon\Contracts\Services\Session;
 use Gibbon\Domain\System\NotificationGateway;
 
 /**
@@ -46,7 +47,7 @@ class NotificationSender
      * @param  NotificationGateway  $gateway
      * @param  session              $session
      */
-    public function __construct(NotificationGateway $gateway, session $session)
+    public function __construct(NotificationGateway $gateway, Session $session)
     {
         $this->gateway = $gateway;
         $this->session = $session;
@@ -181,7 +182,7 @@ class NotificationSender
      */
     protected function setupEmail()
     {
-        $mail = new GibbonMailer($this->session);
+        $mail = new Mailer($this->session);
 
         // Format the sender
         $organisationName = $this->session->get('organisationName');

--- a/src/Contracts/Comms/Mailer.php
+++ b/src/Contracts/Comms/Mailer.php
@@ -1,0 +1,58 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Contracts\Comms;
+
+/**
+ * An interface for PHPMailer, used by the Mailer wrapper class.
+ */
+interface Mailer
+{
+    public function isHTML($isHtml = true);
+    public function isSMTP();
+    public function isMail();
+    public function isSendmail();
+    public function isQmail();
+
+    public function setFrom($address, $name = '', $auto = true);
+
+    public function addAddress($address, $name = '');
+    public function addCC($address, $name = '');
+    public function addBCC($address, $name = '');
+    public function addReplyTo($address, $name = '');
+    public function addAttachment($path, $name = '', $encoding = 'base64', $type = '', $disposition = 'attachment');
+
+    public function clearAddresses();
+    public function clearCCs();
+    public function clearBCCs();
+    public function clearReplyTos();
+    public function clearAllRecipients();
+    public function clearAttachments();
+
+    public function getToAddresses();
+    public function getCcAddresses();
+    public function getBccAddresses();
+    public function getReplyToAddresses();
+    public function getAllRecipientAddresses();
+    public function getAttachments();
+
+    public function send();
+    public function smtpConnect($options = null);
+    public function smtpClose();
+}

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -23,10 +23,12 @@ use Gibbon\Core;
 use Gibbon\Locale;
 use Gibbon\Session;
 use Gibbon\View\Page;
+use Gibbon\Comms\Mailer;
 use Gibbon\Services\Format;
 use Gibbon\Services\ErrorHandler;
 use Gibbon\Domain\System\Theme;
 use Gibbon\Domain\System\Module;
+use Gibbon\Contracts\Comms\Mailer as MailerInterface;
 use League\Container\ServiceProvider\AbstractServiceProvider;
 use League\Container\ServiceProvider\BootableServiceProviderInterface;
 
@@ -61,6 +63,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
         'page',
         'module',
         'theme',
+        MailerInterface::class,
     ];
 
     /**
@@ -187,6 +190,10 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
             $container->add('errorHandler', new ErrorHandler($session->get('installType'), $page));
 
             return $page;
+        });
+
+        $container->add(MailerInterface::class, function () use ($container) {
+            return new Mailer($container->get('session'));
         });
     }
 }


### PR DESCRIPTION
This PR adds an interface for the Mailer, renames the class, and adds it to the DI container via the CoreServiceProvider. This will help decouple the codebase from the concrete class. The mailer can now be retrieved from the container with the Mailer contract interface, and it's lazy-loaded on request so there's no overhead.