### PR TITLE
System: replace getGibbonMailer function calls with Mailer class

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,7 +46,7 @@ v17.0.00
         System: increased the max email length to 75 chars for all forms
         System: added Sri Lankan Rupee as a currency option
         System: fixed incorrect return value in Public Registration when user is below the minimum age
-        System: deprecated getGibbonMailer function, replaced with GibbonMailer wrapper
+        System: deprecated getGibbonMailer function, replaced with Mailer wrapper
         Activities: post-OOification fix to include All Users in Staff selection for in Manage Activities
         Activities: fixed incorrect count in Registered column in Activity Enrolment Summary
         Attendance: fixed an error in the parent view of Student History for PHP 7.1+

--- a/cli/behaviour_letters.php
+++ b/cli/behaviour_letters.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
 use Gibbon\Domain\System\NotificationGateway;
@@ -329,7 +330,7 @@ if (!isCommandLineInterface()) { echo __('This script cannot be run from a brows
                                     $body .= '<br/><br/><i>'.sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</i>';
                                     $bodyPlain = emailBodyConvert($body);
 
-                                    $mail = getGibbonMailer($guid);
+                                    $mail = $container->get(Mailer::class);
 
                                     $mail->AddAddress($rowMember['email'], $rowMember['surname'].', '.$rowMember['preferredName']);
                                     if ($_SESSION[$guid]['organisationEmail'] != '') {

--- a/cli/planner_parentWeeklyEmailSummary.php
+++ b/cli/planner_parentWeeklyEmailSummary.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Comms\NotificationEvent;
 
 require getcwd().'/../gibbon.php';
@@ -58,7 +59,7 @@ else {
             echo __('This script cannot be run, as no school email address has been set.');
         } else {
             //Prep for email sending later
-            $mail = getGibbonMailer($guid);
+            $mail = $container->get(Mailer::class);
             $mail->SMTPKeepAlive = true;
 
             //Lock table

--- a/modules/Finance/invoices_manage_editProcess.php
+++ b/modules/Finance/invoices_manage_editProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
+
 include '../../gibbon.php';
 
 //Module includes
@@ -233,7 +235,7 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                                 $body = receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true, $receiptCount)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
                                 $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the receipt. Please reply to this email if you have any questions.';
 
-                                $mail = getGibbonMailer($guid);
+                                $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);
@@ -307,7 +309,7 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                                     }
                                 }
 
-                                $mail = getGibbonMailer($guid);
+                                $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);

--- a/modules/Finance/invoices_manage_issueProcess.php
+++ b/modules/Finance/invoices_manage_issueProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
+
 include '../../gibbon.php';
 
 //Module includes
@@ -199,7 +201,7 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                             $body = invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
                             $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the invoice. Please reply to this email if you have any questions.';
 
-                            $mail = getGibbonMailer($guid);
+                            $mail = $container->get(Mailer::class);
                             $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                             foreach ($emails as $address) {
                                 $mail->AddBCC($address);

--- a/modules/Finance/invoices_manage_processBulk.php
+++ b/modules/Finance/invoices_manage_processBulk.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
+
 include '../../gibbon.php';
 
 $from = getSettingByScope($connection2, 'Finance', 'email');
@@ -306,7 +308,7 @@ if ($gibbonSchoolYearID == '' or $action == '') { echo 'Fatal error loading this
                                 $body = invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
                                 $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the invoice. Please reply to this email if you have any questions.';
 
-                                $mail = getGibbonMailer($guid);
+                                $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);
@@ -458,7 +460,7 @@ if ($gibbonSchoolYearID == '' or $action == '') { echo 'Fatal error loading this
                             }
                         }
 
-                        $mail = getGibbonMailer($guid);
+                        $mail = $container->get(Mailer::class);
                         $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                         foreach ($emails as $address) {
                             $mail->AddBCC($address);

--- a/modules/Finance/invoices_payOnlineProcess.php
+++ b/modules/Finance/invoices_payOnlineProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
+
 include '../../gibbon.php';
 
 include './moduleFunctions.php';
@@ -284,7 +286,7 @@ if ($paid != 'Y') { //IF PAID IS NOT Y, LET'S REDIRECT TO MAKE PAYMENT
                 $body = receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true, $receiptCount)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
                 $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the receipt. Please reply to this email if you have any questions.';
 
-                $mail = getGibbonMailer($guid);
+                $mail = $container->get(Mailer::class);
                 $mail->SetFrom(getSettingByScope($connection2, 'Finance', 'email'), sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                 foreach ($emails as $address) {
                     $mail->AddBCC($address);

--- a/modules/Messenger/messenger_manage_report_processBulk.php
+++ b/modules/Messenger/messenger_manage_report_processBulk.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
+
 include '../../gibbon.php';
 
 //Module includes
@@ -79,7 +81,7 @@ if ($gibbonMessengerID == '' or $action != 'resend') { echo 'Fatal error loading
                     $emailCount = 0;
                     $bodyReminder = "<p style='font-style: italic; font-weight: bold'>" . __('This is a reminder for an email that requires your action. Please look for the link in the email, and click it to confirm receipt and reading of this email.') ."</p>" ;
                     $bodyFin = "<p style='font-style: italic'>" . sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]["systemName"], $_SESSION[$guid]["organisationName"]) ."</p>" ;
-                    $mail=getGibbonMailer($guid);
+                    $mail = $container->get(Mailer::class);
     				$mail->SetFrom($_SESSION[$guid]["email"], $_SESSION[$guid]["preferredName"] . " " . $_SESSION[$guid]["surname"]);
     				$mail->CharSet="UTF-8";
     				$mail->Encoding="base64" ;

--- a/modules/Staff/applicationFormProcess.php
+++ b/modules/Staff/applicationFormProcess.php
@@ -17,8 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Comms\NotificationEvent;
 use Gibbon\Services\Format;
+use Gibbon\Contracts\Comms\Mailer;
+use Gibbon\Comms\NotificationEvent;
 
 include '../../gibbon.php';
 
@@ -311,7 +312,7 @@ if ($proceed == false) {
                             $body .= "<p style='font-style: italic;'>".sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</p>';
                             $bodyPlain = emailBodyConvert($body);
 
-                            $mail = getGibbonMailer($guid);
+                            $mail = $container->get(Mailer::class);
                             $mail->SetFrom($_SESSION[$guid]['organisationHREmail'], $_SESSION[$guid]['organisationHRName']);
                             if ($referenceEmail1 != '') {
                                 $mail->AddBCC($referenceEmail1);

--- a/modules/Staff/applicationForm_manage_accept.php
+++ b/modules/Staff/applicationForm_manage_accept.php
@@ -17,9 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Data\UsernameGenerator;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
+use Gibbon\Contracts\Comms\Mailer;
+use Gibbon\Data\UsernameGenerator;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -237,7 +238,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                                 $body .= __('Job Title').': '.dateConvertBack($guid, $values['jobTitle'])."<br/>";
                                 $bodyPlain = emailBodyConvert($body);
 
-                                $mail = getGibbonMailer($guid);
+                                $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($_SESSION[$guid]['organisationAdministratorEmail'], $_SESSION[$guid]['organisationAdministratorName']);
                                 $mail->AddAddress($to);
                                 $mail->CharSet = 'UTF-8';
@@ -351,7 +352,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                                     }
                                     $bodyPlain = emailBodyConvert($body);
 
-                                    $mail = getGibbonMailer($guid);
+                                    $mail = $container->get(Mailer::class);
                                     $mail->SetFrom($_SESSION[$guid]['organisationAdministratorEmail'], $_SESSION[$guid]['organisationAdministratorName']);
                                     $mail->AddAddress($to);
                                     $mail->CharSet = 'UTF-8';

--- a/modules/Students/applicationFormProcess.php
+++ b/modules/Students/applicationFormProcess.php
@@ -17,8 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Comms\NotificationEvent;
 use Gibbon\Services\Format;
+use Gibbon\Contracts\Comms\Mailer;
+use Gibbon\Comms\NotificationEvent;
 
 include '../../gibbon.php';
 
@@ -717,7 +718,7 @@ if ($proceed == false) {
                     $body = sprintf(__('To whom it may concern,%4$sThis email is being sent in relation to the application of a current or former student of your school: %1$s.%4$sIn assessing their application for our school, we would like to enlist your help in completing the following reference form: %2$s.<br/><br/>Please feel free to contact me, should you have any questions in regard to this matter.%4$sRegards,%4$s%3$s'), $officialName, "<a href='$applicationFormRefereeLink' target='_blank'>$applicationFormRefereeLink</a>", $_SESSION[$guid]['organisationAdmissionsName'], '<br/><br/>');
                     $body .= "<p style='font-style: italic;'>".sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</p>';
                     $bodyPlain = emailBodyConvert($body);
-                    $mail = getGibbonMailer($guid);
+                    $mail = $container->get(Mailer::class);
                     $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                     $mail->AddAddress($referenceEmail);
                     $mail->CharSet = 'UTF-8';
@@ -740,7 +741,7 @@ if ($proceed == false) {
                     $body .= sprintf(__('In the meantime, should you have any questions please contact %1$s at %2$s.'), $_SESSION[$guid]['organisationAdmissionsName'], $_SESSION[$guid]['organisationAdmissionsEmail']).'<br/><br/>';
                     $body .= "<p style='font-style: italic;'>".sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</p>';
                     $bodyPlain = emailBodyConvert($body);
-                    $mail = getGibbonMailer($guid);
+                    $mail = $container->get(Mailer::class);
                     $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                     $mail->AddAddress($parent1email);
                     $mail->CharSet = 'UTF-8';
@@ -831,7 +832,7 @@ if ($proceed == false) {
             $body .= "<p style='font-style: italic;'>".sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</p>';
             $bodyPlain = emailBodyConvert($body);
 
-            $mail = getGibbonMailer($guid);
+            $mail = $container->get(Mailer::class);
             $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
             $mail->AddAddress($to);
             $mail->CharSet = 'UTF-8';
@@ -883,7 +884,7 @@ if ($proceed == false) {
                     $body .= "<p style='font-style: italic;'>".sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</p>';
                     $bodyPlain = emailBodyConvert($body);
 
-                    $mail = getGibbonMailer($guid);
+                    $mail = $container->get(Mailer::class);
                     $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                     $mail->AddAddress($to);
                     $mail->CharSet = 'UTF-8';
@@ -926,7 +927,7 @@ if ($proceed == false) {
                     $body .= "<p style='font-style: italic;'>".sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</p>';
                     $bodyPlain = emailBodyConvert($body);
 
-                    $mail = getGibbonMailer($guid);
+                    $mail = $container->get(Mailer::class);
                     $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                     $mail->AddAddress($to);
                     $mail->CharSet = 'UTF-8';

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -18,9 +18,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
-use Gibbon\Comms\NotificationEvent;
-use Gibbon\Data\UsernameGenerator;
 use Gibbon\Services\Format;
+use Gibbon\Contracts\Comms\Mailer;
+use Gibbon\Data\UsernameGenerator;
+use Gibbon\Comms\NotificationEvent;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -344,7 +345,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             $body .= "<p style='font-style: italic;'>".sprintf(__('Email sent via %1$s at %2$s.'), $_SESSION[$guid]['systemName'], $_SESSION[$guid]['organisationName']).'</p>';
                             $bodyPlain = emailBodyConvert($body);
 
-                            $mail = getGibbonMailer($guid);
+                            $mail = $container->get(Mailer::class);
                             $mail->SetFrom($_SESSION[$guid]['organisationAdministratorEmail'], $_SESSION[$guid]['organisationAdministratorName']);
                             $mail->AddAddress($to);
                             $mail->CharSet = 'UTF-8';
@@ -1228,7 +1229,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 }
                                 $bodyPlain = emailBodyConvert($body);
 
-                                $mail = getGibbonMailer($guid);
+                                $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                                 $mail->AddAddress($to);
                                 $mail->CharSet = 'UTF-8';
@@ -1275,7 +1276,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 }
                                 $bodyPlain = emailBodyConvert($body);
 
-                                $mail = getGibbonMailer($guid);
+                                $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($_SESSION[$guid]['organisationAdmissionsEmail'], $_SESSION[$guid]['organisationAdmissionsName']);
                                 $mail->AddAddress($to);
                                 $mail->CharSet = 'UTF-8';

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Contracts\Comms\Mailer;
+
 include './gibbon.php';
 
 //Create password
@@ -109,7 +111,7 @@ else {
             $subject = $_SESSION[$guid]['organisationNameShort'].' '.__('Gibbon Password Reset');
             $body = sprintf(__('A password reset request has been initiated for account %1$s, which is registered to this email address.%2$sIf you did not initiate this request, please ignore this email.%2$sIf you do wish to reset your password, please use the link below to access the reset form:%2$s%3$s%2$s%4$s'), $username, "\n\n", $_SESSION[$guid]['absoluteURL']."/index.php?q=/passwordReset.php&input=$input&step=2&gibbonPersonResetID=$gibbonPersonResetID&key=$key", $_SESSION[$guid]['systemName']." Administrator");
 
-            $mail = getGibbonMailer($guid);
+            $mail = $container->get(Mailer::class);
             $mail->AddAddress($email);
 
             if (isset($_SESSION[$guid]['organisationEmail']) && $_SESSION[$guid]['organisationEmail'] != '') {


### PR DESCRIPTION
Updates the remaining uses of getGibbonMailer in the core with the Mailer class, via the DI container.

Tested locally & with Travis CI.