### PR TITLE
System Admin: add the ability to select an SMS gateway in Third Party Settings

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -787,4 +787,6 @@ ALTER TABLE `gibbonApplicationForm` CHANGE `email` `email` VARCHAR(75) CHARACTER
 ALTER TABLE `gibbonApplicationForm` CHANGE `parent1email` `parent1email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 ALTER TABLE `gibbonApplicationForm` CHANGE `parent2email` `parent2email` VARCHAR(75) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 ALTER TABLE `gibbonYearGroup` CHANGE `name` `name` VARCHAR(15) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) SELECT 'Messenger', 'smsGateway', 'SMS Gateway', '', (CASE WHEN gibbonSetting.value <> '' THEN 'OneWaySMS' ELSE '' END) FROM `gibbonSetting` WHERE scope='Messenger' AND name='smsUsername';end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) SELECT 'Messenger', 'smsSenderID', 'SMS Sender ID', 'The sender name or phone number. Depends on the gateway used.', gibbonSetting.value FROM `gibbonSetting` WHERE scope='System' AND name='organisationNameShort';end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ v17.0.00
         Added data visualisation to Rubrics
         Languages can now be installed and updated through Manage Languages in System Admin
         Added Hebrew an active language and improved the display of right-to-left languages
+        Added ability to select SMS gateway: OneWaySMS, Twilio, Nexmo, Clockwork, TextLocal, and Mail to SMS
 
     Changes With Important Notices
         System: increased minimum PHP version to 7.0

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "twig/twig": "^2.0",
         "slim/slim": "^3.0",
         "phpmailer/phpmailer": "5.2.*",
-        "phpoffice/phpexcel": "1.8.*"
+        "phpoffice/phpexcel": "1.8.*",
+        "matthewbdaly/sms-client": "^1.0"
     },
     "require-dev": {
         "twbs/bootstrap": "^4.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f1a48a4541891109015990423ac6289",
+    "content-hash": "e784c1cde8342fd71ed4678e54b176e6",
     "packages": [
         {
             "name": "aura/sqlquery",
@@ -533,6 +533,54 @@
                 "service"
             ],
             "time": "2017-05-10T09:20:27+00:00"
+        },
+        {
+            "name": "matthewbdaly/sms-client",
+            "version": "1.0.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/matthewbdaly/sms-client.git",
+                "reference": "36b22d684cc38a189afcf7b900251931843882d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/matthewbdaly/sms-client/zipball/36b22d684cc38a189afcf7b900251931843882d0",
+                "reference": "36b22d684cc38a189afcf7b900251931843882d0",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.2"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "3.*",
+                "phpspec/phpspec": "^3.2",
+                "psy/psysh": "^0.8.0",
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allows using the AWS SNS driver"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matthewbdaly\\SMS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Daly",
+                    "email": "matthewbdaly@gmail.com"
+                }
+            ],
+            "description": "A generic SMS client library. Supports multiple swappable drivers.",
+            "keywords": [
+                "sms"
+            ],
+            "time": "2018-06-16T16:42:15+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1458,7 +1506,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.0",
         "ext-curl": "*",
         "ext-mbstring": "*",
         "ext-gettext": "*",

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -125,12 +125,12 @@ else {
 				$col->addDate('date3');
 		}
 
-		//Delivery by SMS
-		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_bySMS")) {
-			$smsUsername=getSettingByScope( $connection2, "Messenger", "smsUsername" ) ;
-			$smsPassword=getSettingByScope( $connection2, "Messenger", "smsPassword" ) ;
-			$smsURL=getSettingByScope( $connection2, "Messenger", "smsURL" ) ;
-			if ($smsUsername == "" OR $smsPassword == "" OR $smsURL == "") {
+        //Delivery by SMS
+        $smsGateway = getSettingByScope($connection2, 'Messenger', 'smsGateway');
+		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_bySMS") && !empty($smsGateway)) {
+			$smsUsername = getSettingByScope($connection2, 'Messenger', 'smsUsername');
+
+			if (empty($smsUsername)) {
 				$form->addRow()->addAlert(sprintf(__('SMS NOT CONFIGURED. Please contact %1$s for help.'), "<a href='mailto:" . $_SESSION[$guid]["organisationAdministratorEmail"] . "'>" . $_SESSION[$guid]["organisationAdministratorName"] . "</a>"), 'error');
 			}
 			else {

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Contracts\Comms\SMS;
 
 require_once __DIR__ . '/moduleFunctions.php';
 
@@ -129,7 +130,6 @@ else {
 			$smsUsername=getSettingByScope( $connection2, "Messenger", "smsUsername" ) ;
 			$smsPassword=getSettingByScope( $connection2, "Messenger", "smsPassword" ) ;
 			$smsURL=getSettingByScope( $connection2, "Messenger", "smsURL" ) ;
-			$smsURLCredit=getSettingByScope( $connection2, "Messenger", "smsURLCredit" ) ;
 			if ($smsUsername == "" OR $smsPassword == "" OR $smsURL == "") {
 				$form->addRow()->addAlert(sprintf(__('SMS NOT CONFIGURED. Please contact %1$s for help.'), "<a href='mailto:" . $_SESSION[$guid]["organisationAdministratorEmail"] . "'>" . $_SESSION[$guid]["organisationAdministratorName"] . "</a>"), 'error');
 			}
@@ -140,17 +140,14 @@ else {
 
 				$form->toggleVisibilityByClass('sms')->onRadio('sms')->when('Y');
 
-				$smsAlert = __('SMS messages are sent to local and overseas numbers, but not all countries are supported. Please see the SMS Gateway provider\'s documentation or error log to see which countries are not supported. The subject does not get sent, and all HTML tags are removed. Each message, to each recipient, will incur a charge (dependent on your SMS gateway provider). Messages over 140 characters will get broken into smaller messages, and will cost more.').'<br/><br/>';
-				if ($smsURLCredit!="") {
-					$query="?apiusername=" . $smsUsername . "&apipassword=" . $smsPassword ;
-					$result=@implode('', file($smsURLCredit . $query)) ;
-					if (is_numeric($result)==FALSE) {
-						$result=0 ;
-					}
-					if ($result>=0) {
-						$smsAlert .= "<b>" . sprintf(__('Current balance: %1$s credit(s).'), $result) . "</u></b>" ;
-					}
-				}
+				$smsAlert = __('SMS messages are sent to local and overseas numbers, but not all countries are supported. Please see the SMS Gateway provider\'s documentation or error log to see which countries are not supported. The subject does not get sent, and all HTML tags are removed. Each message, to each recipient, will incur a charge (dependent on your SMS gateway provider). Messages over 140 characters will get broken into smaller messages, and will cost more.');
+                
+                $sms = $container->get(SMS::class);
+
+                if ($smsCredits = $sms->getCreditBalance()) {
+                    $smsAlert .= "<br/><br/><b>" . sprintf(__('Current balance: %1$s credit(s).'), $smsCredits) . "</u></b>" ;
+                }
+
 				$form->addRow()->addAlert($smsAlert, 'error')->addClass('sms');
 			}
 		}

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -2054,18 +2054,19 @@ else {
                     }, []));
 
                     $sms = $container->get(SMS::class);
-                    $smsCount = count($recipients);
-                    $smsBatchCount = ceil($smsCount/10);
-
+                    
                     $result = $sms
                         ->content($body)
                         ->send($recipients);
 
+                    $smsCount = count($recipients);
+                    $smsBatchCount = count($result);
+
                     $smsStatus = $result ? 'OK' : 'Not OK';
-                    $partialFail &= $result;
+                    $partialFail &= !empty($result);
 
 					//Set log
-					setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], getModuleID($connection2, $_POST["address"]), $_SESSION[$guid]['gibbonPersonID'], 'SMS Send Status', array('Status' => $smsStatus, 'Result' => $result, 'Recipients' => $recipients));
+					setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], getModuleID($connection2, $_POST["address"]), $_SESSION[$guid]['gibbonPersonID'], 'SMS Send Status', array('Status' => $smsStatus, 'Result' => count($result), 'Recipients' => $recipients));
 				}
 			}
 

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Contracts\Comms\Mailer;
+use Gibbon\Contracts\Comms\SMS;
 
 include '../../gibbon.php';
 
@@ -2045,61 +2046,26 @@ else {
 
 			if ($sms=="Y") {
 				if ($countryCode=="") {
-					$partialFail=TRUE ;
-				}
-				else {
-					$smsUsername=getSettingByScope( $connection2, "Messenger", "smsUsername" ) ;
-					$smsPassword=getSettingByScope( $connection2, "Messenger", "smsPassword" ) ;
-					$smsURL=getSettingByScope( $connection2, "Messenger", "smsURL" ) ;
+					$partialFail = true;
+				} else {
+                    $recipients = array_filter(array_reduce($report, function ($phoneNumbers, $reportEntry) {
+                        if ($reportEntry[3] == 'SMS') $phoneNumbers[] = '+'.$reportEntry[4];
+                        return $phoneNumbers;
+                    }, []));
 
-					if ($smsUsername!="" AND $smsPassword!="" AND $smsURL!="") {
-						$smsCount = 0;
-						foreach ($report as $reportEntry) {
-							if ($reportEntry[3] == 'SMS') {
-								$smsCount ++;
-							}
-						}
+                    $sms = $container->get(SMS::class);
+                    $smsCount = count($recipients);
+                    $smsBatchCount = ceil($smsCount/10);
 
-						$numbersPerSend=10 ;
-						$sendReps=ceil(($smsCount/$numbersPerSend)) ;
-						$smsCount=0 ;
-						$smsBatchCount=0 ;
-						for ($i=0; $i<$sendReps; $i++) {
-							$numCache="" ;
-							for ($n=0; $n<$numbersPerSend; $n++) {
-								if (!(is_null($report[($i*$numbersPerSend)+$n][3]))) {
-									if ($report[($i*$numbersPerSend)+$n][3] == 'SMS') {
-										$numCache.=$report[($i*$numbersPerSend)+$n][4] . "," ;
-										$smsCount++ ;
-									}
-								}
-							}
+                    $result = $sms
+                        ->content($body)
+                        ->send($recipients);
 
-							$query="?apiusername=" . $smsUsername . "&apipassword=" . $smsPassword . "&senderid=" . rawurlencode($_SESSION[$guid]["organisationNameShort"]) . "&mobileno=" . rawurlencode(substr($numCache,0,-1)) . "&message=" . rawurlencode(stripslashes(strip_tags($body))) . "&languagetype=1" ;
-							$result=@implode('', file($smsURL . $query)) ;
-							$smsStatus = 'OK';
+                    $smsStatus = $result ? 'OK' : 'Not OK';
+                    $partialFail &= $result;
 
-							if ($result) {
-								if ($result<=0) {
-									$partialFail=TRUE ;
-									$smsStatus = 'Not OK';
-								}
-							}
-							else {
-								$partialFail=TRUE ;
-								$smsStatus = 'Not OK';
-								$result = 'N/A';
-							}
-
-							//Set log
-							setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], getModuleID($connection2, $_POST["address"]), $_SESSION[$guid]['gibbonPersonID'], 'SMS Send Status', array('Status' => $smsStatus, 'Result' => $result, 'Recipients' => substr($numCache,0,-1)));
-
-							$smsBatchCount++ ;
-						}
-					}
-					else {
-						$partialFail=TRUE ;
-					}
+					//Set log
+					setLog($connection2, $_SESSION[$guid]['gibbonSchoolYearIDCurrent'], getModuleID($connection2, $_POST["address"]), $_SESSION[$guid]['gibbonPersonID'], 'SMS Send Status', array('Status' => $smsStatus, 'Result' => $result, 'Recipients' => $recipients));
 				}
 			}
 

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -105,8 +105,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
         $row->addTextField($setting['name'])->setValue($setting['value']);
 
     // SMS
-    $form->addRow()->addHeading(__('SMS Settings'))->append(sprintf(__('Gibbon is designed to use the %1$sOne Way SMS%2$s gateway to send out SMS messages. This is a paid service, not affiliated with Gibbon, and you must create your own account with them before being able to send out SMSs using the Messenger module. It is possible that completing the fields below with details from other gateways may work.'), "<a href='http://onewaysms.com' target='_blank'>", '</a>'));
+    $form->addRow()->addHeading(__('SMS Settings'))->append(__('Gibbon can use a number of different gateways to send out SMS messages. These are paid services, not affiliated with Gibbon, and you must create your own account with them before being able to send out SMSs using the Messenger module.'));
 
+    // SMS Gateway Options - these are not translated, as they represent company names
     $smsGateways = ['OneWaySMS', 'Twilio', 'Nexmo', 'Clockwork', 'TextLocal', 'Mail to SMS'];
     $setting = getSettingByScope($connection2, 'Messenger', 'smsGateway', true);
     $row = $form->addRow();
@@ -118,8 +119,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
 
     $form->toggleVisibilityByClass('smsSettings')->onSelect($setting['name'])->whenNot('');
     $form->toggleVisibilityByClass('smsSettingsOneWay')->onSelect($setting['name'])->when('OneWaySMS');
-    $form->toggleVisibilityByClass('smsAccountID')->onSelect($setting['name'])->when('Twilio');
-    $form->toggleVisibilityByClass('smsAPIKey')->onSelect($setting['name'])->when(['Nexmo', 'Clockwork', 'TextLocal']);
+    $form->toggleVisibilityByClass('smsAPIKey')->onSelect($setting['name'])->when(['Twilio', 'Nexmo', 'Clockwork', 'TextLocal']);
     $form->toggleVisibilityByClass('smsAPIToken')->onSelect($setting['name'])->when(['Twilio', 'Nexmo']);
     $form->toggleVisibilityByClass('smsDomain')->onSelect($setting['name'])->when('Mail to SMS');
     
@@ -128,33 +128,31 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
 
+    // SMS Username variations - these aim to simplify the setup by using the matching terminology for each gateway.
     $setting = getSettingByScope($connection2, 'Messenger', 'smsUsername', true);
     $row = $form->addRow()->addClass('smsSettingsOneWay');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
 
-    $row = $form->addRow()->addClass('smsDomain');
-        $row->addLabel($setting['name'], __('SMS Domain'))->description(__('Allows sending SMS messages via Email for supported gateways. The domain is relative to your SMS provider, and the sender ID should be an email address verified with your third-party gateway.'));
-        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
-
-    $row = $form->addRow()->addClass('smsAccountID');
-        $row->addLabel($setting['name'], __('Account ID'))->description();
-        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
-
     $row = $form->addRow()->addClass('smsAPIKey');
-        $row->addLabel($setting['name'], __('API Key'))->description();
+        $row->addLabel($setting['name'], __('API Key'));
         $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
 
+    $row = $form->addRow()->addClass('smsDomain');
+        $row->addLabel($setting['name'], __('SMS Domain'));
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
+
+    // SMS Password variations
     $setting = getSettingByScope($connection2, 'Messenger', 'smsPassword', true);
     $row = $form->addRow()->addClass('smsSettingsOneWay');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
 
-    $setting = getSettingByScope($connection2, 'Messenger', 'smsPassword', true);
     $row = $form->addRow()->addClass('smsAPIToken');
-        $row->addLabel($setting['name'], __('API Secret/Auth Token'))->description();
+        $row->addLabel($setting['name'], __('API Secret/Auth Token'));
         $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
 
+    // SMS Endpoint URLs - currently used by OneWaySMS
     $setting = getSettingByScope($connection2, 'Messenger', 'smsURL', true);
     $row = $form->addRow()->addClass('smsSettingsOneWay');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -107,23 +107,61 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     // SMS
     $form->addRow()->addHeading(__('SMS Settings'))->append(sprintf(__('Gibbon is designed to use the %1$sOne Way SMS%2$s gateway to send out SMS messages. This is a paid service, not affiliated with Gibbon, and you must create your own account with them before being able to send out SMSs using the Messenger module. It is possible that completing the fields below with details from other gateways may work.'), "<a href='http://onewaysms.com' target='_blank'>", '</a>'));
 
-    $setting = getSettingByScope($connection2, 'Messenger', 'smsUsername', true);
+    $smsGateways = ['OneWaySMS', 'Twilio', 'Nexmo', 'Clockwork', 'TextLocal', 'Mail to SMS'];
+    $setting = getSettingByScope($connection2, 'Messenger', 'smsGateway', true);
     $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addSelect($setting['name'])
+            ->fromArray(['' => __('No')])
+            ->fromArray($smsGateways)
+            ->selected($setting['value']);
+
+    $form->toggleVisibilityByClass('smsSettings')->onSelect($setting['name'])->whenNot('');
+    $form->toggleVisibilityByClass('smsSettingsOneWay')->onSelect($setting['name'])->when('OneWaySMS');
+    $form->toggleVisibilityByClass('smsAccountID')->onSelect($setting['name'])->when('Twilio');
+    $form->toggleVisibilityByClass('smsAPIKey')->onSelect($setting['name'])->when(['Nexmo', 'Clockwork', 'TextLocal']);
+    $form->toggleVisibilityByClass('smsAPIToken')->onSelect($setting['name'])->when(['Twilio', 'Nexmo']);
+    $form->toggleVisibilityByClass('smsDomain')->onSelect($setting['name'])->when('Mail to SMS');
+    
+    $setting = getSettingByScope($connection2, 'Messenger', 'smsSenderID', true);
+    $row = $form->addRow()->addClass('smsSettings');
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
+
+    $setting = getSettingByScope($connection2, 'Messenger', 'smsUsername', true);
+    $row = $form->addRow()->addClass('smsSettingsOneWay');
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
+
+    $row = $form->addRow()->addClass('smsDomain');
+        $row->addLabel($setting['name'], __('SMS Domain'))->description(__('Allows sending SMS messages via Email for supported gateways. The domain is relative to your SMS provider, and the sender ID should be an email address verified with your third-party gateway.'));
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
+
+    $row = $form->addRow()->addClass('smsAccountID');
+        $row->addLabel($setting['name'], __('Account ID'))->description();
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
+
+    $row = $form->addRow()->addClass('smsAPIKey');
+        $row->addLabel($setting['name'], __('API Key'))->description();
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
+
+    $setting = getSettingByScope($connection2, 'Messenger', 'smsPassword', true);
+    $row = $form->addRow()->addClass('smsSettingsOneWay');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
 
     $setting = getSettingByScope($connection2, 'Messenger', 'smsPassword', true);
-    $row = $form->addRow();
-        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+    $row = $form->addRow()->addClass('smsAPIToken');
+        $row->addLabel($setting['name'], __('API Secret/Auth Token'))->description();
         $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50);
 
     $setting = getSettingByScope($connection2, 'Messenger', 'smsURL', true);
-    $row = $form->addRow();
+    $row = $form->addRow()->addClass('smsSettingsOneWay');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Messenger', 'smsURLCredit', true);
-    $row = $form->addRow();
+    $row = $form->addRow()->addClass('smsSettingsOneWay');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value']);
 

--- a/modules/System Admin/thirdPartySettingsProcess.php
+++ b/modules/System Admin/thirdPartySettingsProcess.php
@@ -37,6 +37,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $googleRedirectUri = (isset($_POST['googleRedirectUri']))? $_POST['googleRedirectUri'] : '';
     $googleDeveloperKey = (isset($_POST['googleDeveloperKey']))? $_POST['googleDeveloperKey'] : '';
     $calendarFeed = (isset($_POST['calendarFeed']))? $_POST['calendarFeed'] : '';
+    $smsGateway = $_POST['smsGateway'] ?? '';
+    $smsSenderID = $_POST['smsSenderID'] ?? '';
     $smsUsername = (isset($_POST['smsUsername']))? $_POST['smsUsername'] : '';
     $smsPassword = (isset($_POST['smsPassword']))? $_POST['smsPassword'] : '';
     $smsURL = (isset($_POST['smsURL']))? $_POST['smsURL'] : '';
@@ -161,39 +163,59 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
         }
 
         try {
-            $data = array('value' => $smsUsername);
-            $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsUsername'";
+            $data = array('value' => $smsGateway);
+            $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsGateway'";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
             $fail = true;
         }
 
-        try {
-            $data = array('value' => $smsPassword);
-            $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsPassword'";
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            $fail = true;
-        }
+        if (!empty($smsGateway)) {
+            try {
+                $data = array('value' => $smsSenderID);
+                $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsSenderID'";
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+            } catch (PDOException $e) {
+                $fail = true;
+            }
 
-        try {
-            $data = array('value' => $smsURL);
-            $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsURL'";
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            $fail = true;
-        }
+            try {
+                $data = array('value' => $smsUsername);
+                $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsUsername'";
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+            } catch (PDOException $e) {
+                $fail = true;
+            }
 
-        try {
-            $data = array('value' => $smsURLCredit);
-            $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsURLCredit'";
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            $fail = true;
+            try {
+                $data = array('value' => $smsPassword);
+                $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsPassword'";
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+            } catch (PDOException $e) {
+                $fail = true;
+            }
+
+            try {
+                $data = array('value' => $smsURL);
+                $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsURL'";
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+            } catch (PDOException $e) {
+                $fail = true;
+            }
+
+            try {
+                $data = array('value' => $smsURLCredit);
+                $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='smsURLCredit'";
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+            } catch (PDOException $e) {
+                $fail = true;
+            }
         }
 
         // SMTP Mailer

--- a/src/Comms/Drivers/MailDriver.php
+++ b/src/Comms/Drivers/MailDriver.php
@@ -1,0 +1,108 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Comms\Drivers;
+
+use Gibbon\Contracts\Comms\Mailer;
+use Matthewbdaly\SMS\Contracts\Driver;
+
+/**
+ * An SMS driver which works via a gateway supporting Mail to SMS.
+ * 
+ * @version v17
+ * @since   v17
+ */
+class MailDriver implements Driver
+{
+    /**
+     * Mailer.
+     *
+     * @var
+     */
+    protected $mail;
+
+    /**
+     * Endpoint.
+     *
+     * @var
+     */
+    protected $endpoint;
+
+    /**
+     * Constructor.
+     *
+     * @param Mailer $mailer The Mailer instance.
+     * @param array  $config The configuration.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(Mailer $mail, array $config)
+    {
+        $this->mail = $mail;
+        if (! array_key_exists('domain', $config)) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->endpoint = trim($config['domain']. ' @');
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Mail';
+    }
+
+    /**
+     * Get endpoint domain.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $recipient = preg_replace('/[^0-9,]/', '', $message['to']) . "@" . $this->endpoint;
+            $content = trim(stripslashes(strip_tags($message['content'])));
+
+            $this->mail->SetFrom($message['from']);
+            $this->mail->AddAddress($recipient);
+            $this->mail->Subject = $content;
+            $this->mail->Body = $content;
+
+            return $this->mail->Send();
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}

--- a/src/Comms/Drivers/OneWaySMSDriver.php
+++ b/src/Comms/Drivers/OneWaySMSDriver.php
@@ -103,11 +103,6 @@ class OneWaySMSDriver implements Driver
     public function sendRequest(array $message) : bool
     {
         try {
-            // Collapse arrays into comma-separated batches
-            if (is_array($message['to'])) {
-                $message['to'] = implode(',', $message['to']);
-            }
-
             // Prep the url parameters by stripping out invalid characters
             $urlParams = $this->urlParams + [
                 'mobileno' => preg_replace('/[^0-9,]/', '', $message['to']),

--- a/src/Comms/Drivers/OneWaySMSDriver.php
+++ b/src/Comms/Drivers/OneWaySMSDriver.php
@@ -1,0 +1,140 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Comms\Drivers;
+
+use Matthewbdaly\SMS\Contracts\Driver;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * SMS driver for OneWaySMS: http://onewaysms.hk/
+ *
+ * @version v17
+ * @since   v17
+ */
+class OneWaySMSDriver implements Driver
+{
+    /**
+     * Message Endpoint.
+     *
+     * @var
+     */
+    protected $messageEndpoint;
+
+    /**
+     * Credit Endpoint.
+     *
+     * @var
+     */
+    protected $creditEndpoint;
+
+    /**
+     * URL Query Params.
+     *
+     * @var
+     */
+    private $urlParams = [];
+
+    /**
+     * Constructor.
+     *
+     * @param array  $config The configuration.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(array $config)
+    {
+        if (empty($config['smsURL']) || empty($config['smsUsername']) || empty($config['smsPassword'])) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->messageEndpoint = trim($config['smsURL'], ' ?');
+        $this->creditEndpoint = trim($config['smsURLCredit'] ?? '', ' ?');
+        $this->urlParams = [
+            'apiusername'  => $config['smsUsername'],
+            'apipassword'  => $config['smsPassword'],
+            'languagetype' => 1,
+        ];
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver() : string
+    {
+        return 'OneWaySMS';
+    }
+
+    /**
+     * Get endpoint domain.
+     *
+     * @return string
+     */
+    public function getEndpoint() : string
+    {
+        return $this->messageEndpoint;
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message) : bool
+    {
+        try {
+            // Collapse arrays into comma-separated batches
+            if (is_array($message['to'])) {
+                $message['to'] = implode(',', $message['to']);
+            }
+
+            // Prep the url parameters by stripping out invalid characters
+            $urlParams = $this->urlParams + [
+                'mobileno' => preg_replace('/[^0-9,]/', '', $message['to']),
+                'senderid' => preg_replace('/[^a-zA-Z0-9]/', '', $message['from']),
+                'message'  => stripslashes(strip_tags($message['content'])),
+            ];
+
+            // Fetch the result using a basic HTTP get request
+            $url = $this->messageEndpoint.'?'.http_build_query($urlParams);
+            $result = @file_get_contents($url);
+
+            return !empty($result);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Get the current credit balance using the smsURLCredit url endpoint.
+     *
+     * @return int
+     */
+    public function getCreditBalance() : float
+    {
+        $url = $this->creditEndpoint.'?'.http_build_query($this->urlParams);
+        $result = @file_get_contents($url);
+
+        return floatval($result);
+    }
+}

--- a/src/Comms/Drivers/UnknownDriver.php
+++ b/src/Comms/Drivers/UnknownDriver.php
@@ -1,0 +1,63 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Comms\Drivers;
+
+use Matthewbdaly\SMS\Contracts\Driver;
+
+/**
+ * An unknown SMS driver, which always returns a failed response when sending messages.
+ * 
+ * @version v17
+ * @since   v17
+ */
+class UnknownDriver implements Driver
+{
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Unknown';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return '';
+    }
+
+    /**
+     * Always fail to send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        return false;
+    }
+}

--- a/src/Comms/SMS.php
+++ b/src/Comms/SMS.php
@@ -19,13 +19,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Comms;
 
+use Matthewbdaly\SMS\Client;
 use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Drivers\Nexmo;
+use Matthewbdaly\SMS\Drivers\Twilio;
 use GuzzleHttp\Client as GuzzleClient;
 use Gibbon\Comms\Drivers\UnknownDriver;
 use Gibbon\Comms\Drivers\OneWaySMSDriver;
 use Gibbon\Contracts\Comms\SMS as SMSInterface;
-use Matthewbdaly\SMS\Client;
-use Matthewbdaly\SMS\Drivers\Twilio;
 use Matthewbdaly\SMS\Contracts\Client as ClientContract;
 use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
 
@@ -63,6 +64,13 @@ class SMS implements SMSInterface
                     $this->driver = new Twilio(new GuzzleClient(), new Response(), [
                         'account_id' => $config['smsUsername'],
                         'api_token' => $config['smsPassword'],
+                    ]);
+                    break;
+
+                case 'Nexmo':
+                    $this->driver = new Nexmo(new GuzzleClient(), new Response(), [
+                        'api_key' => $config['smsUsername'],
+                        'api_secret' => $config['smsPassword'],
                     ]);
                     break;
 

--- a/src/Comms/SMS.php
+++ b/src/Comms/SMS.php
@@ -19,15 +19,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Comms;
 
-use Matthewbdaly\SMS\Client;
-use GuzzleHttp\Psr7\Response;
-use Matthewbdaly\SMS\Drivers\Nexmo;
-use Matthewbdaly\SMS\Drivers\Twilio;
-use GuzzleHttp\Client as GuzzleClient;
-use Gibbon\Comms\Drivers\UnknownDriver;
+use Gibbon\Comms\Drivers\MailDriver;
 use Gibbon\Comms\Drivers\OneWaySMSDriver;
+use Gibbon\Comms\Drivers\UnknownDriver;
 use Gibbon\Contracts\Comms\SMS as SMSInterface;
-use Matthewbdaly\SMS\Contracts\Client as ClientContract;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Client;
+use Matthewbdaly\SMS\Drivers\Twilio;
+use Matthewbdaly\SMS\Drivers\Nexmo;
+use Matthewbdaly\SMS\Drivers\Clockwork;
+use Matthewbdaly\SMS\Drivers\TextLocal;
 use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
 
 
@@ -74,6 +76,24 @@ class SMS implements SMSInterface
                     ]);
                     break;
 
+                case 'Clockwork':
+                    $this->driver = new Clockwork(new GuzzleClient(), new Response(), [
+                        'api_key' => $config['smsUsername'],
+                    ]);
+                    break;
+
+                case 'TextLocal':
+                    $this->driver = new TextLocal(new GuzzleClient(), new Response(), [
+                        'api_key' => $config['smsUsername'],
+                    ]);
+                    break;
+
+                case 'Mail to SMS':
+                    $this->driver = new MailDriver($config['smsMailer'], [
+                        'domain' => $config['smsUsername'],
+                    ]);
+                    break;
+
                 default:
                     throw new DriverNotConfiguredException();
             }
@@ -84,7 +104,7 @@ class SMS implements SMSInterface
         $this->client = new Client($this->driver);
 
         $this->to = [];
-        $this->from($config['smsSender']);
+        $this->from($config['smsSenderID']);
     }
 
     /**

--- a/src/Comms/SMS.php
+++ b/src/Comms/SMS.php
@@ -1,0 +1,168 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Comms;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Client as GuzzleClient;
+use Gibbon\Comms\Drivers\UnknownDriver;
+use Gibbon\Comms\Drivers\OneWaySMSDriver;
+use Gibbon\Contracts\Comms\SMS as SMSInterface;
+use Matthewbdaly\SMS\Client;
+use Matthewbdaly\SMS\Drivers\Twilio;
+use Matthewbdaly\SMS\Contracts\Client as ClientContract;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+
+/**
+ * Factory class to create a fully configured SMS client based on the chosen gateway.
+ * 
+ * @version v17
+ * @since   v17
+ */
+class SMS implements SMSInterface
+{
+    protected $client;
+
+    protected $driver;
+
+    protected $to;
+
+    protected $from;
+
+    protected $content;
+
+    protected $batchSize;
+
+    public function __construct(array $config)
+    {
+        try {
+            switch ($config['smsGateway']) {
+                case 'OneWaySMS':
+                    $this->driver = new OneWaySMSDriver($config);
+                    $this->batchSize = 10;
+                    break;
+
+                case 'Twilio':
+                    $this->driver = new Twilio(new GuzzleClient(), new Response(), [
+                        'account_id' => $config['smsUsername'],
+                        'api_token' => $config['smsPassword'],
+                    ]);
+                    break;
+
+                default:
+                    throw new DriverNotConfiguredException();
+            }
+        } catch (DriverNotConfiguredException $e) {
+            $this->driver = new UnknownDriver();
+        }
+
+        $this->client = new Client($this->driver);
+
+        $this->to = [];
+        $this->from($config['smsSender']);
+    }
+
+    /**
+     * Get the SMS driver name.
+     *
+     * @return string
+     */
+    public function getDriver() : string
+    {
+        return $this->client->getDriver();
+    }
+
+    /**
+     * Get the SMS credit balance, if supported by the driver.
+     *
+     * @return float
+     */
+    public function getCreditBalance() : float
+    {
+        return method_exists($this->driver, 'getCreditBalance')
+            ? $this->driver->getCreditBalance()
+            : 0;
+    }
+
+    /**
+     * Set the message recipient(s).
+     *
+     * @param string|array $to
+     */
+    public function to($to)
+    {
+        $this->to = array_merge($this->to, is_array($to) ? $to : [$to]);
+
+        return $this;
+    }
+
+    /**
+     * Set the message sender name.
+     *
+     * @param string $from
+     */
+    public function from(string $from)
+    {
+        $this->from = $from;
+
+        return $this;
+    }
+
+    /**
+     * Set the message content.
+     *
+     * @param string $from
+     */
+    public function content(string $content)
+    {
+        $this->content = stripslashes(strip_tags($content));
+
+        return $this;
+    }
+
+    /**
+     * Send the message to one or more recipients.
+     *
+     * @param array $to The recipient array.
+     *
+     * @return boolean True on successful delivery.
+     */
+    public function send(array $recipients = []) : bool
+    {
+        $result = true;
+
+        $recipients += array_merge($this->to, $recipients);
+
+        // Split the messages into batches, if supported by the driver.
+        if (!empty($this->batchSize)) {
+            $recipients = array_chunk($recipients, $this->batchSize);
+        }
+
+        foreach ($recipients as $recipient) {
+            $result &= $this->client->send([
+                'to'      => $recipient,
+                'from'    => $this->from,
+                'content' => $this->content,
+            ]);
+        }
+
+        return $result;
+    }
+}

--- a/src/Comms/SMS.php
+++ b/src/Comms/SMS.php
@@ -171,12 +171,11 @@ class SMS implements SMSInterface
      *
      * @param array $to The recipient array.
      *
-     * @return boolean True on successful delivery.
+     * @return array Array of successful recipients.
      */
-    public function send(array $recipients = []) : bool
+    public function send(array $recipients = []) : array
     {
-        $result = true;
-
+        $sent = [];
         $recipients += array_merge($this->to, $recipients);
 
         // Split the messages into comma-separated batches, if supported by the driver.
@@ -187,13 +186,17 @@ class SMS implements SMSInterface
         }
 
         foreach ($recipients as $recipient) {
-            $result &= $this->client->send([
+            $message = [
                 'to'      => $recipient,
                 'from'    => $this->from,
                 'content' => $this->content,
-            ]);
+            ];
+
+            if ($this->client->send($message)) {
+                $sent[] = $recipient;
+            }
         }
 
-        return $result;
+        return $sent;
     }
 }

--- a/src/Contracts/Comms/SMS.php
+++ b/src/Contracts/Comms/SMS.php
@@ -34,5 +34,5 @@ interface SMS
 
     public function content(string $message);
 
-    public function send(array $recipients) : bool;
+    public function send(array $recipients) : array;
 }

--- a/src/Contracts/Comms/SMS.php
+++ b/src/Contracts/Comms/SMS.php
@@ -1,0 +1,38 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Contracts\Comms;
+
+/**
+ * An interface for sending SMS messages.
+ */
+interface SMS
+{
+    public function getDriver() : string;
+
+    public function getCreditBalance() : float;
+
+    public function to($to);
+
+    public function from(string $from);
+
+    public function content(string $message);
+
+    public function send(array $recipients) : bool;
+}

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -202,14 +202,16 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
 
         $container->add(SMSInterface::class, function () use ($session, $container) {
             $connection2 = $container->get('db')->getConnection();
+            $smsGateway = getSettingByScope($connection2, 'Messenger', 'smsGateway');
 
             return new SMS([
-                'smsGateway'   => 'OneWaySMS',
-                'smsSender'    => $session->get('organisationNameShort'),
+                'smsGateway'   => $smsGateway,
+                'smsSenderID'  => getSettingByScope($connection2, 'Messenger', 'smsSenderID'),
                 'smsURL'       => getSettingByScope($connection2, 'Messenger', 'smsURL'),
                 'smsURLCredit' => getSettingByScope($connection2, 'Messenger', 'smsURLCredit'),
                 'smsUsername'  => getSettingByScope($connection2, 'Messenger', 'smsUsername'),
                 'smsPassword'  => getSettingByScope($connection2, 'Messenger', 'smsPassword'),
+                'smsMailer'    => $smsGateway == 'Mail to SMS' ? $container->get(MailerInterface::class) : '',
             ]);
         });
     }

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -16,6 +16,7 @@ return array(
     'Psr\\Container\\' => array($vendorDir . '/psr/container/src'),
     'Psr\\Cache\\' => array($vendorDir . '/psr/cache/src'),
     'Monolog\\' => array($vendorDir . '/monolog/monolog/src/Monolog'),
+    'Matthewbdaly\\SMS\\' => array($vendorDir . '/matthewbdaly/sms-client/src'),
     'League\\Container\\' => array($vendorDir . '/league/container/src'),
     'Interop\\Container\\' => array($vendorDir . '/container-interop/container-interop/src/Interop/Container'),
     'GuzzleHttp\\Psr7\\' => array($vendorDir . '/guzzlehttp/psr7/src'),

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -41,6 +41,7 @@ class ComposerStaticInit3046e8c42bde92b8c2d990c2f6dd9601
         'M' => 
         array (
             'Monolog\\' => 8,
+            'Matthewbdaly\\SMS\\' => 17,
         ),
         'L' => 
         array (
@@ -109,6 +110,10 @@ class ComposerStaticInit3046e8c42bde92b8c2d990c2f6dd9601
         'Monolog\\' => 
         array (
             0 => __DIR__ . '/..' . '/monolog/monolog/src/Monolog',
+        ),
+        'Matthewbdaly\\SMS\\' => 
+        array (
+            0 => __DIR__ . '/..' . '/matthewbdaly/sms-client/src',
         ),
         'League\\Container\\' => 
         array (

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -548,6 +548,56 @@
         ]
     },
     {
+        "name": "matthewbdaly/sms-client",
+        "version": "1.0.13",
+        "version_normalized": "1.0.13.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/matthewbdaly/sms-client.git",
+            "reference": "36b22d684cc38a189afcf7b900251931843882d0"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/matthewbdaly/sms-client/zipball/36b22d684cc38a189afcf7b900251931843882d0",
+            "reference": "36b22d684cc38a189afcf7b900251931843882d0",
+            "shasum": ""
+        },
+        "require": {
+            "guzzlehttp/guzzle": "^6.2"
+        },
+        "require-dev": {
+            "aws/aws-sdk-php": "3.*",
+            "phpspec/phpspec": "^3.2",
+            "psy/psysh": "^0.8.0",
+            "squizlabs/php_codesniffer": "^2.7"
+        },
+        "suggest": {
+            "aws/aws-sdk-php": "Allows using the AWS SNS driver"
+        },
+        "time": "2018-06-16T16:42:15+00:00",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Matthewbdaly\\SMS\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Matthew Daly",
+                "email": "matthewbdaly@gmail.com"
+            }
+        ],
+        "description": "A generic SMS client library. Supports multiple swappable drivers.",
+        "keywords": [
+            "sms"
+        ]
+    },
+    {
         "name": "monolog/monolog",
         "version": "1.24.0",
         "version_normalized": "1.24.0.0",
@@ -1367,6 +1417,59 @@
         "support": {
             "source": "https://github.com/yookoala/TCPDF/tree/6.0.038"
         }
+    },
+    {
+        "name": "twbs/bootstrap",
+        "version": "v4.1.3",
+        "version_normalized": "4.1.3.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/twbs/bootstrap.git",
+            "reference": "3b558734382ce58b51e5fc676453bfd53bba9201"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/twbs/bootstrap/zipball/3b558734382ce58b51e5fc676453bfd53bba9201",
+            "reference": "3b558734382ce58b51e5fc676453bfd53bba9201",
+            "shasum": ""
+        },
+        "replace": {
+            "twitter/bootstrap": "self.version"
+        },
+        "time": "2018-07-24T15:54:34+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "3.3.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Jacob Thornton",
+                "email": "jacobthornton@gmail.com"
+            },
+            {
+                "name": "Mark Otto",
+                "email": "markdotto@gmail.com"
+            }
+        ],
+        "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
+        "homepage": "https://getbootstrap.com/",
+        "keywords": [
+            "JS",
+            "css",
+            "framework",
+            "front-end",
+            "mobile-first",
+            "responsive",
+            "sass",
+            "web"
+        ]
     },
     {
         "name": "twig/twig",

--- a/vendor/matthewbdaly/sms-client/.gitignore
+++ b/vendor/matthewbdaly/sms-client/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+.DS_Store
+vendor/
+composer.lock
+test*

--- a/vendor/matthewbdaly/sms-client/.travis.yml
+++ b/vendor/matthewbdaly/sms-client/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+
+php:
+    - 7.0
+    - 7.1
+
+before_script:
+    - travis_retry composer self-update
+    - travis_retry composer install --no-interaction --prefer-source --dev
+
+script: vendor/bin/phpspec run

--- a/vendor/matthewbdaly/sms-client/LICENSE
+++ b/vendor/matthewbdaly/sms-client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Matthew Daly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/matthewbdaly/sms-client/README.md
+++ b/vendor/matthewbdaly/sms-client/README.md
@@ -1,0 +1,247 @@
+# sms-client
+[![Build Status](https://travis-ci.org/matthewbdaly/sms-client.svg?branch=master)](https://travis-ci.org/matthewbdaly/sms-client)
+
+A generic SMS client library. Supports multiple swappable drivers, so that you're never tied to just one provider.
+
+This library is aimed squarely at sending SMS messages only, and I don't plan to add support for other functionality. The idea is to create one library that should be able to work with any provider that has a driver for the purpose of sending SMS messages.
+
+Drivers
+-------
+
+It currently ships with the following drivers:
+
+* Clockwork
+* Nexmo
+* TextLocal
+* Twilio
+* AWS SNS (requires installation of `aws/aws-sdk-php`)
+* Mail (for mail-to-SMS gateways)
+
+In addition, it also has the following drivers for test purposes:
+
+* RequestBin
+* Null
+* Log
+
+The RequestBin sends the POST request to the specified RequestBin path for debugging. The Null driver does nothing, while the Log driver accepts a PSR3 logger and uses it to log the request.
+
+Example Usage
+-----
+
+**Null**
+
+```php
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Drivers\Null;
+use Matthewbdaly\SMS\Client;
+
+$guzzle = new GuzzleClient;
+$resp = new Response;
+$driver = new Null($guzzle, $resp);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+**Log**
+
+```php
+use Matthewbdaly\SMS\Drivers\Log;
+use Matthewbdaly\SMS\Client;
+use Psr\Log\LoggerInterface;
+
+$driver = new Log($logger); // $logger should be an implementation of Psr\Log\LoggerInterface
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+
+```
+
+**RequestBin**
+
+```php
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Drivers\RequestBin;
+use Matthewbdaly\SMS\Client;
+
+$guzzle = new GuzzleClient;
+$resp = new Response;
+$driver = new RequestBin($guzzle, $resp, [
+    'path' => 'MY_REQUESTBIN_PATH',
+]);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+**Clockwork**
+
+```php
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Drivers\Clockwork;
+use Matthewbdaly\SMS\Client;
+
+$guzzle = new GuzzleClient;
+$resp = new Response;
+$driver = new Clockwork($guzzle, $resp, [
+    'api_key' => 'MY_CLOCKWORK_API_KEY',
+]);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+**Nexmo**
+
+```php
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Drivers\Nexmo;
+use Matthewbdaly\SMS\Client;
+
+$guzzle = new GuzzleClient;
+$resp = new Response;
+$driver = new Nexmo($guzzle, $resp, [
+    'api_key' => 'MY_NEXMO_API_KEY',
+    'api_secret' => 'MY_NEXMO_API_SECRET',
+]);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'from'    => 'Test User',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+**AWS SNS**
+
+```php
+use Matthewbdaly\SMS\Client;
+use Matthewbdaly\SMS\Drivers\Aws;
+
+$config = [
+    'api_key'    => 'foo',
+    'api_secret' => 'bar',
+    'api_region' => 'ap-southeast-2'
+];
+$driver = new Aws($config);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'from'    => 'Test User',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+**Mail**
+
+```php
+use Matthewbdaly\SMS\Client;
+use Matthewbdaly\SMS\Drivers\Mail;
+use Matthewbdaly\SMS\Contracts\Mailer;
+
+$config = [
+    'domain' => 'my.sms-gateway.com'
+];
+$driver = new Mail($config);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+**TextLocal**
+
+```php
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Drivers\TextLocal;
+use Matthewbdaly\SMS\Client;
+
+$guzzle = new GuzzleClient;
+$resp = new Response;
+$driver = new TextLocal($guzzle, $resp, [
+    'api_key' => 'MY_TEXTLOCAL_API_KEY',
+]);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'from'    => 'Test User',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+**Twilio**
+
+```php
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Response;
+use Matthewbdaly\SMS\Drivers\Twilio;
+use Matthewbdaly\SMS\Client;
+
+$guzzle = new GuzzleClient;
+$resp = new Response;
+$driver = new Twilio($guzzle, $resp, [
+    'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+    'api_token' => 'MY_TWILIO_API_TOKEN',
+]);
+$client = new Client($driver);
+$msg = [
+    'to'      => '+44 01234 567890',
+    'from'      => '+44 01234 567890',
+    'content' => 'Just testing',
+];
+$client->send($msg);
+```
+
+Mail driver
+-----------
+
+I have implemented a mail driver at `Matthewbdaly\SMS\Drivers\Mail`, but it's very basic and may not work with a lot of mail-to-SMS gateways out of the box. It accepts an instance of the `Matthewbdaly\SMS\Contracts\Mailer` interface as the first argument, and the config array as the second.
+
+I've included the class `Matthewbdaly\SMS\PHPMailAdapter` in the library as a very basic implementation of the mailer interface, but it's deliberately very basic - it's just a very thin wrapper around the PHP `mail()` function. You will almost certainly want to create your own implementation for your own use case - for instance, if you're using Laravel you might create a wrapper class for the `Mail` facade.
+
+The mail driver will nearly always be slower and less reliable than the HTTP-based ones, so if you have to integrate with a provider that doesn't yet have a driver, but does have a REST API, you're probably better off creating an API driver for it. If you do need to work with a mail-to-SMS gateway, you're quite likely to find that you need to extend `Matthewbdaly\SMS\Drivers\Mail` to amend the functionality.
+
+Laravel and Lumen integration
+-------------------
+
+Using Laravel or Lumen? You probably want to use [my integration package](https://packagist.org/packages/matthewbdaly/laravel-sms) rather than this one, since that includes a service provider, as well as the `SMS` facade and easier configuration.
+
+Creating your own driver
+------------------------
+
+It's easy to create your own driver - just implement the `Matthewbdaly\SMS\Contracts\Driver` interface. You can use whatever method is most appropriate for sending the SMS - for instance, if your provider has a mail-to-SMS gateway, you can happily use Swiftmailer or PHPMailer in your driver to send emails, or if they have a REST API you can use Guzzle.
+
+You can pass any configuration options required in the `config` array in the constructor of the driver. Please ensure that your driver has tests using PHPSpec (see the existing drivers for examples), and that it meets the coding standard (the package includes a PHP Codesniffer configuration for that reason).
+
+If you've created a new driver, feel free to submit a pull request and I'll consider including it.
+
+TODO
+----
+
+I have plans for a 2.0 release which include:
+
+* More drivers! If you're using an SMS provider that isn't on the list and you'd like to see support for it in this library, go ahead and create your own driver and submit a pull request for it.
+* Remove dependency on Guzzle and replace it with HTTPlug so it doesn't need a specific implementation.
+* Add a factory for resolving the drivers automatically.

--- a/vendor/matthewbdaly/sms-client/composer.json
+++ b/vendor/matthewbdaly/sms-client/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "matthewbdaly/sms-client",
+    "description": "A generic SMS client library. Supports multiple swappable drivers.",
+    "type": "library",
+    "keywords": ["sms"],
+    "require": {
+        "guzzlehttp/guzzle": "^6.2"
+    },
+    "require-dev": {
+        "psy/psysh": "^0.8.0",
+        "phpspec/phpspec": "^3.2",
+        "squizlabs/php_codesniffer": "^2.7",
+        "aws/aws-sdk-php": "3.*"
+    },
+    "suggest": {
+        "aws/aws-sdk-php": "Allows using the AWS SNS driver"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Matthew Daly",
+            "email": "matthewbdaly@gmail.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Matthewbdaly\\SMS\\": "src/"
+        }
+    }
+
+}

--- a/vendor/matthewbdaly/sms-client/phpcs.xml
+++ b/vendor/matthewbdaly/sms-client/phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+	<description>Coding standard for SMS API integration.</description>
+	<file>src</file>
+	<arg value="np"/>
+	<rule ref="PSR2"/>
+	<rule ref="Squiz.Commenting.FunctionComment" />
+	<rule ref="Squiz.Commenting.FunctionCommentThrowTag" />
+	<rule ref="Squiz.Commenting.ClassComment" />
+	<rule ref="Squiz.PHP.ForbiddenFunctions">
+		<properties>
+			<property name="forbiddenFunctions" type="array" value="eval=>NULL,dd=>NULL,die=>NULL,var_dump=>NULL,sizeof=>count,delete=>unset,print=>echo,create_function=>NULL"/>
+		</properties>
+	</rule>
+</ruleset>

--- a/vendor/matthewbdaly/sms-client/phpspec.yml
+++ b/vendor/matthewbdaly/sms-client/phpspec.yml
@@ -1,0 +1,4 @@
+suites:
+    test_suite:
+        namespace: Matthewbdaly\SMS
+        psr4_prefix: Matthewbdaly\SMS

--- a/vendor/matthewbdaly/sms-client/spec/ClientSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/ClientSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS;
+
+use Matthewbdaly\SMS\Client;
+use Matthewbdaly\SMS\Contracts\Driver;
+use PhpSpec\ObjectBehavior;
+
+class ClientSpec extends ObjectBehavior
+{
+    public function let(Driver $driver)
+    {
+        $this->beConstructedWith($driver);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Client::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Client');
+    }
+
+    public function it_returns_the_driver_name(Driver $driver)
+    {
+        $driver->getDriver()->willReturn('Test');
+        $this->getDriver()->shouldReturn('Test');
+    }
+
+    public function it_sends_a_message(Driver $driver)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $driver->sendRequest($msg)->willReturn(true);
+        $this->send($msg)->shouldReturn(true);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/AwsSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/AwsSpec.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use Matthewbdaly\SMS\Drivers\Aws;
+use PhpSpec\ObjectBehavior;
+use Aws\Sns\SnsClient;
+
+class AwsSpec extends ObjectBehavior
+{
+    public function let(SnsClient $sns)
+    {
+        $this->beConstructedWith([], $sns);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Aws::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_throws_exception_if_misconfigured()
+    {
+        $config = [
+        ];
+        $this->beConstructedWith($config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$config]);
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('Aws');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('');
+    }
+
+    public function it_can_be_constructed_with_config_only()
+    {
+        $config = [
+            'api_key'    => 'foo',
+            'api_secret' => 'bar',
+            'api_region' => 'ap-southeast-2'
+        ];
+        $this->beConstructedWith($config);
+        $this->getDriver()->shouldReturn('Aws');
+    }
+
+    public function it_sends_the_request(SnsClient $sns)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $args = [
+            "SenderID" => $msg['from'],
+            "SMSType" => "Transactional",
+            "Message" => $msg['content'],
+            "PhoneNumber" => $msg['to']
+        ];
+
+        $sns->publish($args)->shouldBeCalled();
+        $this->beConstructedWith([], $sns);
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/ClockworkSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/ClockworkSpec.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleInterface;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Drivers\Clockwork;
+use PhpSpec\ObjectBehavior;
+
+class ClockworkSpec extends ObjectBehavior
+{
+    public function let(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'api_key' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Clockwork::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_throws_exception_if_misconfigured(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$client, $response, $config]);
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('Clockwork');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('https://api.clockworksms.com/http/send.aspx');
+    }
+
+    public function it_sends_the_request(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new GuzzleResponse(201),
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key' => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+
+    public function it_throws_an_error_for_400(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ClientException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ClientException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_500(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ServerException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ServerException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_request_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\RequestException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\RequestException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_connect_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ConnectException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ConnectException')->during('sendRequest', [$msg]);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/LogSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/LogSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use Matthewbdaly\SMS\Drivers\Log;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+class LogSpec extends ObjectBehavior
+{
+    public function let(LoggerInterface $logger)
+    {
+        $this->beConstructedWith($logger);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Log::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('Log');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('');
+    }
+
+    public function it_sends_the_request(LoggerInterface $logger)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $this->beConstructedWith($logger);
+        $this->sendRequest($msg)->shouldReturn(true);
+        $logger->info('Message sent', $msg)->shouldHaveBeenCalled();
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/MailSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/MailSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use Matthewbdaly\SMS\Drivers\Mail;
+use Matthewbdaly\SMS\Contracts\Mailer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class MailSpec extends ObjectBehavior
+{
+    public function let(Mailer $mailer)
+    {
+        $config = [
+            'domain' => 'my.sms-gateway.com'
+        ];
+        $this->beConstructedWith($mailer, $config);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Mail::class);
+    }
+
+    public function it_throws_exception_if_misconfigured(Mailer $mailer)
+    {
+        $config = [
+        ];
+        $this->beConstructedWith($mailer, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$mailer, $config]);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('Mail');
+    }
+
+    public function it_returns_the_driver_endpoint(Mailer $mailer)
+    {
+        $this->getEndpoint()->shouldReturn('my.sms-gateway.com');
+    }
+
+    public function it_sends_the_request(Mailer $mailer)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $config = [
+            'domain' => 'my.sms-gateway.com'
+        ];
+        $mailer->send('+4401234567890@my.sms-gateway.com', 'Just testing')->shouldBeCalled();
+        $this->beConstructedWith($mailer, $config);
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/NexmoSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/NexmoSpec.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleInterface;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Drivers\Nexmo;
+use PhpSpec\ObjectBehavior;
+
+class NexmoSpec extends ObjectBehavior
+{
+    public function let(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'api_key'    => 'foo',
+            'api_secret' => 'bar',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Nexmo::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_throws_exception_if_no_api_key(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'api_secret' => 'bar',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$client, $response, $config]);
+    }
+
+    public function it_throws_exception_if_no_api_secret(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'api_key'    => 'foo',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$client, $response, $config]);
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('Nexmo');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('https://rest.nexmo.com/sms/json');
+    }
+
+    public function it_sends_the_request(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new GuzzleResponse(201),
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+            'api_secret' => 'MY_DUMMY_API_SECRET',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+
+    public function it_throws_an_error_for_400(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ClientException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+            'api_secret' => 'MY_DUMMY_API_SECRET',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ClientException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_500(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ServerException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+            'api_secret' => 'MY_DUMMY_API_SECRET',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ServerException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_request_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\RequestException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+            'api_secret' => 'MY_DUMMY_API_SECRET',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\RequestException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_connect_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ConnectException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key'    => 'MY_DUMMY_API_KEY',
+            'api_secret' => 'MY_DUMMY_API_SECRET',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ConnectException')->during('sendRequest', [$msg]);
+    }
+
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/NullDriverSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/NullDriverSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleInterface;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Drivers\NullDriver;
+use PhpSpec\ObjectBehavior;
+
+class NullDriverSpec extends ObjectBehavior
+{
+    public function let(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $this->beConstructedWith($client, $response);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(NullDriver::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('Null');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('');
+    }
+
+    public function it_sends_the_request()
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/RequestBinSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/RequestBinSpec.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleInterface;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Drivers\RequestBin;
+use PhpSpec\ObjectBehavior;
+
+class RequestBinSpec extends ObjectBehavior
+{
+    public function let(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'path' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(RequestBin::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_throws_exception_if_misconfigured(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$client, $response, $config]);
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('RequestBin');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('https://requestb.in/blah');
+    }
+
+    public function it_sends_the_request(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new GuzzleResponse(201),
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'path' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+
+    public function it_throws_an_error_for_400(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ClientException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'path' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ClientException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_500(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ServerException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'path' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ServerException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_request_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\RequestException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'path' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\RequestException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_connect_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ConnectException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'path' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ConnectException')->during('sendRequest', [$msg]);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/TextLocalSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/TextLocalSpec.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleInterface;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Drivers\TextLocal;
+use PhpSpec\ObjectBehavior;
+
+class TextLocalSpec extends ObjectBehavior
+{
+    public function let(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'api_key' => 'blah',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(TextLocal::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_throws_exception_if_misconfigured(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$client, $response, $config]);
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('TextLocal');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('https://api.txtlocal.com/send/');
+    }
+
+    public function it_sends_the_request(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new GuzzleResponse(201),
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key' => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+
+    public function it_throws_an_error_for_400(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ClientException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key' => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ClientException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_500(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ServerException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key' => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ServerException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_request_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\RequestException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key' => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\RequestException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_connect_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => 'Tester',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ConnectException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'api_key' => 'MY_DUMMY_API_KEY',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ConnectException')->during('sendRequest', [$msg]);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Drivers/TwilioSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Drivers/TwilioSpec.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface as GuzzleInterface;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Drivers\Twilio;
+use PhpSpec\ObjectBehavior;
+
+class TwilioSpec extends ObjectBehavior
+{
+    public function let(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+            'api_token' => 'MY_TWILIO_API_TOKEN',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(Twilio::class);
+    }
+
+    public function it_implements_interface()
+    {
+        $this->shouldImplement('Matthewbdaly\SMS\Contracts\Driver');
+    }
+
+    public function it_throws_exception_if_account_name_not_configured(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$client, $response, $config]);
+    }
+
+    public function it_throws_exception_if_api_token_not_configured(GuzzleInterface $client, ResponseInterface $response)
+    {
+        $config = [
+            'api_token' => 'MY_TWILIO_API_TOKEN',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException')->during('__construct', [$client, $response, $config]);
+    }
+
+    public function it_returns_the_driver_name()
+    {
+        $this->getDriver()->shouldReturn('Twilio');
+    }
+
+    public function it_returns_the_driver_endpoint()
+    {
+        $this->getEndpoint()->shouldReturn('https://api.twilio.com/2010-04-01/Accounts/MY_TWILIO_ACCOUNT_ID/Messages.json');
+    }
+
+    public function it_sends_the_request(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new GuzzleResponse(201),
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+            'api_token' => 'MY_TWILIO_API_TOKEN',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->sendRequest($msg)->shouldReturn(true);
+    }
+
+    public function it_throws_an_error_for_400(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ClientException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+            'api_token' => 'MY_TWILIO_API_TOKEN',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ClientException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_500(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ServerException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+            'api_token' => 'MY_TWILIO_API_TOKEN',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ServerException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_request_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\RequestException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+            'api_token' => 'MY_TWILIO_API_TOKEN',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\RequestException')->during('sendRequest', [$msg]);
+    }
+
+    public function it_throws_an_error_for_connect_exception(ResponseInterface $response)
+    {
+        $msg = [
+            'to'      => '+44 01234 567890',
+            'from'    => '+44 01234 567890',
+            'content' => 'Just testing',
+        ];
+        $mock = new MockHandler(
+            [
+            new \GuzzleHttp\Exception\ConnectException("", new Request('POST', 'test'))
+            ]
+        );
+        $handler = HandlerStack::create($mock);
+        $client = new GuzzleClient(['handler' => $handler]);
+        $config = [
+            'account_id' => 'MY_TWILIO_ACCOUNT_ID',
+            'api_token' => 'MY_TWILIO_API_TOKEN',
+        ];
+        $this->beConstructedWith($client, $response, $config);
+        $this->shouldThrow('Matthewbdaly\SMS\Exceptions\ConnectException')->during('sendRequest', [$msg]);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Exceptions/ClientExceptionSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Exceptions/ClientExceptionSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Exceptions;
+
+use Matthewbdaly\SMS\Exceptions\ClientException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ClientExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ClientException::class);
+    }
+
+    function it_is_an_exception()
+    {
+        $this->shouldHaveType(\Exception::class);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Exceptions/ConnectExceptionSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Exceptions/ConnectExceptionSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Exceptions;
+
+use Matthewbdaly\SMS\Exceptions\ConnectException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ConnectExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ConnectException::class);
+    }
+
+    function it_is_an_exception()
+    {
+        $this->shouldHaveType(\Exception::class);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Exceptions/DriverNotConfiguredExceptionSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Exceptions/DriverNotConfiguredExceptionSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Exceptions;
+
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class DriverNotConfiguredExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(DriverNotConfiguredException::class);
+    }
+
+    function it_is_an_exception()
+    {
+        $this->shouldHaveType(\Exception::class);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Exceptions/RequestExceptionSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Exceptions/RequestExceptionSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Exceptions;
+
+use Matthewbdaly\SMS\Exceptions\RequestException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RequestExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RequestException::class);
+    }
+
+    function it_is_an_exception()
+    {
+        $this->shouldHaveType(\Exception::class);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/spec/Exceptions/ServerExceptionSpec.php
+++ b/vendor/matthewbdaly/sms-client/spec/Exceptions/ServerExceptionSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\Matthewbdaly\SMS\Exceptions;
+
+use Matthewbdaly\SMS\Exceptions\ServerException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ServerExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ServerException::class);
+    }
+
+    function it_is_an_exception()
+    {
+        $this->shouldHaveType(\Exception::class);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Client.php
+++ b/vendor/matthewbdaly/sms-client/src/Client.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS;
+
+use Matthewbdaly\SMS\Contracts\Client as ClientContract;
+use Matthewbdaly\SMS\Contracts\Driver;
+
+/**
+ * SMS client.
+ */
+class Client implements ClientContract
+{
+    /**
+     * Driver to use.
+     *
+     * @var
+     */
+    private $driver;
+
+    /**
+     * Constructor.
+     *
+     * @param Driver $driver The driver to use.
+     *
+     * @return void
+     */
+    public function __construct(Driver $driver)
+    {
+        $this->driver = $driver;
+    }
+
+    /**
+     * Get the driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return $this->driver->getDriver();
+    }
+
+    /**
+     * Send the message.
+     *
+     * @param array $msg The message array.
+     *
+     * @return boolean
+     */
+    public function send(array $msg): bool
+    {
+        return $this->driver->sendRequest($msg);
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Contracts/Client.php
+++ b/vendor/matthewbdaly/sms-client/src/Contracts/Client.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Contracts;
+
+/**
+ * SMS client.
+ */
+interface Client
+{
+    /**
+     * Get the driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string;
+
+    /**
+     * Send the message.
+     *
+     * @param array $msg The message array.
+     *
+     * @return boolean
+     */
+    public function send(array $msg): bool;
+}

--- a/vendor/matthewbdaly/sms-client/src/Contracts/Driver.php
+++ b/vendor/matthewbdaly/sms-client/src/Contracts/Driver.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Contracts;
+
+interface Driver
+{
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string;
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string;
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool;
+}

--- a/vendor/matthewbdaly/sms-client/src/Contracts/Mailer.php
+++ b/vendor/matthewbdaly/sms-client/src/Contracts/Mailer.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Contracts;
+
+/**
+ * Basic mailer interface
+ */
+interface Mailer
+{
+    /**
+     * Send email
+     *
+     * @param string $recipient The recipent's email.
+     * @param string $message   The message.
+     * @return boolean
+     */
+    public function send(string $recipient, string $message);
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/Aws.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/Aws.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use Matthewbdaly\SMS\Contracts\Driver;
+use Aws\Sns\SnsClient;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * Driver for AWS SNS.
+ */
+class Aws implements Driver
+{
+    /**
+     * Guzzle response.
+     *
+     * @var
+     */
+    protected $response;
+
+    /**
+     * Endpoint.
+     *
+     * @var
+     */
+    private $endpoint = '';
+
+    /**
+     * SNS Client
+     *
+     * @var
+     */
+    protected $sns;
+
+    /**
+     * Constructor.
+     *
+     * @param array          $config The configuration array.
+     * @param SnsClient|null $sns    The Amazon SNS client.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(array $config = [], SnsClient $sns = null)
+    {
+        if (!$sns) {
+            if (! array_key_exists('api_key', $config) || ! array_key_exists('api_secret', $config) || ! array_key_exists('api_region', $config)) {
+                throw new DriverNotConfiguredException();
+            }
+            $params = array(
+                'credentials' => array(
+                    'key' => $config['api_key'],
+                    'secret' => $config['api_secret']
+                ),
+                'region' => $config['api_region'],
+                'version' => 'latest'
+            );
+            $sns = new SnsClient($params);
+        }
+        $this->sns = $sns;
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Aws';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @throws \Matthewbdaly\SMS\Exceptions\ClientException  Client exception.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $args = array(
+                "SenderID" => $message['from'],
+                "SMSType" => "Transactional",
+                "Message" => $message['content'],
+                "PhoneNumber" => $message['to']
+            );
+
+            $this->sns->publish($args);
+        } catch (\Aws\Sns\Exception\SnsException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ClientException();
+        }
+
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/Clockwork.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/Clockwork.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\ClientInterface as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Contracts\Driver;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * Driver for Clockwork.
+ */
+class Clockwork implements Driver
+{
+    /**
+     * Guzzle client.
+     *
+     * @var
+     */
+    protected $client;
+
+    /**
+     * Guzzle response.
+     *
+     * @var
+     */
+    protected $response;
+
+    /**
+     * Endpoint.
+     *
+     * @var
+     */
+    private $endpoint = 'https://api.clockworksms.com/http/send.aspx';
+
+    /**
+     * API Key.
+     *
+     * @var
+     */
+    private $apiKey;
+
+    /**
+     * Constructor.
+     *
+     * @param GuzzleClient      $client   The Guzzle Client instance.
+     * @param ResponseInterface $response The response instance.
+     * @param array             $config   The configuration array.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(GuzzleClient $client, ResponseInterface $response, array $config)
+    {
+        $this->client = $client;
+        $this->response = $response;
+        if (! array_key_exists('api_key', $config)) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->apiKey = $config['api_key'];
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Clockwork';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @throws \Matthewbdaly\SMS\Exceptions\ClientException  Client exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ServerException  Server exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\RequestException Request exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ConnectException Connect exception.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $message['key'] = $this->apiKey;
+            $response = $this->client->request('POST', $this->getEndpoint().'?'.http_build_query($message));
+        } catch (ClientException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ClientException();
+        } catch (ServerException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ServerException();
+        } catch (ConnectException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ConnectException();
+        } catch (RequestException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\RequestException();
+        }
+
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/Log.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/Log.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use Psr\Log\LoggerInterface;
+use Matthewbdaly\SMS\Contracts\Driver;
+
+/**
+ * Driver for Clockwork.
+ */
+class Log implements Driver
+{
+    /**
+     * Logger.
+     *
+     * @var
+     */
+    private $logger;
+
+    /**
+     * Constructor
+     *
+     * @param LoggerInterface $logger The logger instance.
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Log';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return '';
+    }
+
+    /**
+     * Send the request.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        $this->logger->info('Message sent', $message);
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/Mail.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/Mail.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use Matthewbdaly\SMS\Contracts\Mailer;
+use Matthewbdaly\SMS\Contracts\Driver;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * Generic mail driver
+ */
+class Mail implements Driver
+{
+    /**
+     * Mailer.
+     *
+     * @var
+     */
+    protected $mailer;
+
+    /**
+     * Endpoint.
+     *
+     * @var
+     */
+    protected $endpoint;
+
+    /**
+     * Constructor.
+     *
+     * @param Mailer $mailer The Mailer instance.
+     * @param array  $config The configuration.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(Mailer $mailer, array $config)
+    {
+        $this->mailer = $mailer;
+        if (! array_key_exists('domain', $config)) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->endpoint = $config['domain'];
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Mail';
+    }
+
+    /**
+     * Get endpoint domain.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $recipient = preg_replace('/\s+/', '', $message['to']) . "@" . $this->endpoint;
+            $this->mailer->send($recipient, $message['content']);
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/Nexmo.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/Nexmo.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\ClientInterface as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Contracts\Driver;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * Driver for Nexmo.
+ */
+class Nexmo implements Driver
+{
+    /**
+     * Guzzle client.
+     *
+     * @var
+     */
+    protected $client;
+
+    /**
+     * Guzzle response.
+     *
+     * @var
+     */
+    protected $response;
+
+    /**
+     * Endpoint.
+     *
+     * @var
+     */
+    private $endpoint = 'https://rest.nexmo.com/sms/json';
+
+    /**
+     * API Key.
+     *
+     * @var
+     */
+    private $apiKey;
+
+    /**
+     * API Secret.
+     *
+     * @var
+     */
+    private $apiSecret;
+
+    /**
+     * Constructor.
+     *
+     * @param GuzzleClient      $client   The Guzzle Client instance.
+     * @param ResponseInterface $response The response instance.
+     * @param array             $config   The configuration array.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(GuzzleClient $client, ResponseInterface $response, array $config)
+    {
+        $this->client = $client;
+        $this->response = $response;
+        if (! array_key_exists('api_key', $config) || ! array_key_exists('api_secret', $config)) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->apiKey = $config['api_key'];
+        $this->apiSecret = $config['api_secret'];
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Nexmo';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @throws \Matthewbdaly\SMS\Exceptions\ClientException  Client exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ServerException  Server exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\RequestException Request exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ConnectException Connect exception.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $message['api_key'] = $this->apiKey;
+            $message['api_secret'] = $this->apiSecret;
+            $message['text'] = $message['content'];
+            unset($message['content']);
+            $response = $this->client->request('POST', $this->getEndpoint().'?'.http_build_query($message));
+        } catch (ClientException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ClientException();
+        } catch (ServerException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ServerException();
+        } catch (ConnectException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ConnectException();
+        } catch (RequestException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\RequestException();
+        }
+
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/NullDriver.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/NullDriver.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\ClientInterface as GuzzleClient;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Contracts\Driver;
+
+/**
+ * Null driver for testing.
+ */
+class NullDriver implements Driver
+{
+    /**
+     * Guzzle client.
+     *
+     * @var
+     */
+    protected $client;
+
+    /**
+     * Guzzle response.
+     *
+     * @var
+     */
+    protected $response;
+
+    /**
+     * Constructor.
+     *
+     * @param GuzzleClient      $client   The Guzzle Client instance.
+     * @param ResponseInterface $response The response instance.
+     *
+     * @return void
+     */
+    public function __construct(GuzzleClient $client, ResponseInterface $response)
+    {
+        $this->client = $client;
+        $this->response = $response;
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Null';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return '';
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/RequestBin.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/RequestBin.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\ClientInterface as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Contracts\Driver;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * Driver for RequestBin.
+ */
+class RequestBin implements Driver
+{
+    /**
+     * Guzzle client.
+     *
+     * @var
+     */
+    protected $client;
+
+    /**
+     * Guzzle response.
+     *
+     * @var
+     */
+    protected $response;
+
+    /**
+     * Path.
+     *
+     * @var
+     */
+    private $path;
+
+    /**
+     * Endpoint.
+     *
+     * @var
+     */
+    private $endpoint = 'https://requestb.in/';
+
+    /**
+     * Constructor.
+     *
+     * @param GuzzleClient      $client   The Guzzle Client instance.
+     * @param ResponseInterface $response The response instance.
+     * @param array             $config   The configuration array.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(GuzzleClient $client, ResponseInterface $response, array $config)
+    {
+        $this->client = $client;
+        $this->response = $response;
+        if (! array_key_exists('path', $config)) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->path = $config['path'];
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'RequestBin';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint.$this->path;
+    }
+
+    /**
+     * Send the request.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @throws \Matthewbdaly\SMS\Exceptions\ClientException  Client exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ServerException  Server exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\RequestException Request exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ConnectException Connect exception.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $response = $this->client->request('POST', $this->getEndpoint(), $message);
+        } catch (ClientException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ClientException();
+        } catch (ServerException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ServerException();
+        } catch (ConnectException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ConnectException();
+        } catch (RequestException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\RequestException();
+        }
+
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/TextLocal.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/TextLocal.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\ClientInterface as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Contracts\Driver;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * Driver for TextLocal
+ */
+class TextLocal implements Driver
+{
+    /**
+     * Guzzle client.
+     *
+     * @var
+     */
+    protected $client;
+
+    /**
+     * Guzzle response.
+     *
+     * @var
+     */
+    protected $response;
+
+    /**
+     * Endpoint.
+     *
+     * @var
+     */
+    private $endpoint = 'https://api.txtlocal.com/send/';
+
+    /**
+     * API Key.
+     *
+     * @var
+     */
+    private $apiKey;
+
+    /**
+     * Constructor.
+     *
+     * @param GuzzleClient      $client   The Guzzle Client instance.
+     * @param ResponseInterface $response The response instance.
+     * @param array             $config   The configuration array.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(GuzzleClient $client, ResponseInterface $response, array $config)
+    {
+        $this->client = $client;
+        $this->response = $response;
+        if (! array_key_exists('api_key', $config)) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->apiKey = $config['api_key'];
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'TextLocal';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @throws \Matthewbdaly\SMS\Exceptions\ClientException  Client exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ServerException  Server exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\RequestException Request exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ConnectException Connect exception.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $cleanMessage = [];
+            $cleanMessage['apikey'] = urlencode($this->apiKey);
+            $cleanMessage['numbers'] = preg_replace('/[^0-9]/', '', $message['to']);
+            $cleanMessage['sender'] = urlencode($message['from']);
+            $cleanMessage['message'] = rawurlencode($message['content']);
+            $response = $this->client->request('POST', $this->getEndpoint().'?'.http_build_query($cleanMessage));
+        } catch (ClientException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ClientException();
+        } catch (ServerException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ServerException();
+        } catch (ConnectException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ConnectException();
+        } catch (RequestException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\RequestException();
+        }
+
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Drivers/TextLocal.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/TextLocal.php
@@ -102,7 +102,7 @@ class TextLocal implements Driver
         try {
             $cleanMessage = [];
             $cleanMessage['apikey'] = urlencode($this->apiKey);
-            $cleanMessage['numbers'] = preg_replace('/[^0-9]/', '', $message['to']);
+            $cleanMessage['numbers'] = preg_replace('/[^0-9,]/', '', $message['to']);
             $cleanMessage['sender'] = urlencode($message['from']);
             $cleanMessage['message'] = rawurlencode($message['content']);
             $response = $this->client->request('POST', $this->getEndpoint().'?'.http_build_query($cleanMessage));

--- a/vendor/matthewbdaly/sms-client/src/Drivers/Twilio.php
+++ b/vendor/matthewbdaly/sms-client/src/Drivers/Twilio.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Drivers;
+
+use GuzzleHttp\ClientInterface as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use Psr\Http\Message\ResponseInterface;
+use Matthewbdaly\SMS\Contracts\Driver;
+use Matthewbdaly\SMS\Exceptions\DriverNotConfiguredException;
+
+/**
+ * Driver for Twilio.
+ */
+class Twilio implements Driver
+{
+    /**
+     * Guzzle client.
+     *
+     * @var
+     */
+    protected $client;
+
+    /**
+     * Guzzle response.
+     *
+     * @var
+     */
+    protected $response;
+
+    /**
+     * Account ID.
+     *
+     * @var
+     */
+    private $accountId;
+
+    /**
+     * API Token.
+     *
+     * @var
+     */
+    private $apiToken;
+
+    /**
+     * Constructor.
+     *
+     * @param GuzzleClient      $client   The Guzzle Client instance.
+     * @param ResponseInterface $response The response instance.
+     * @param array             $config   The configuration array.
+     * @throws DriverNotConfiguredException Driver not configured correctly.
+     *
+     * @return void
+     */
+    public function __construct(GuzzleClient $client, ResponseInterface $response, array $config)
+    {
+        $this->client = $client;
+        $this->response = $response;
+        if (! array_key_exists('account_id', $config) || ! array_key_exists('api_token', $config)) {
+            throw new DriverNotConfiguredException();
+        }
+        $this->accountId = $config['account_id'];
+        $this->apiToken = $config['api_token'];
+    }
+
+    /**
+     * Get driver name.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return 'Twilio';
+    }
+
+    /**
+     * Get endpoint URL.
+     *
+     * @return string
+     */
+    public function getEndpoint(): string
+    {
+        return "https://api.twilio.com/2010-04-01/Accounts/$this->accountId/Messages.json";
+    }
+
+    /**
+     * Send the SMS.
+     *
+     * @param array $message An array containing the message.
+     *
+     * @throws \Matthewbdaly\SMS\Exceptions\ClientException  Client exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ServerException  Server exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\RequestException Request exception.
+     * @throws \Matthewbdaly\SMS\Exceptions\ConnectException Connect exception.
+     *
+     * @return boolean
+     */
+    public function sendRequest(array $message): bool
+    {
+        try {
+            $cleanMessage = [];
+            $cleanMessage['To'] = $message['to'];
+            $cleanMessage['From'] = $message['from'];
+            $cleanMessage['Body'] = $message['content'];
+            $response = $this->client->request('POST', $this->getEndpoint(), [
+                'form_params' => $cleanMessage,
+                'auth' => [
+                    $this->accountId,
+                    $this->apiToken
+                ]]);
+        } catch (ClientException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ClientException();
+        } catch (ServerException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ServerException();
+        } catch (ConnectException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\ConnectException();
+        } catch (RequestException $e) {
+            throw new \Matthewbdaly\SMS\Exceptions\RequestException();
+        }
+
+        return true;
+    }
+}

--- a/vendor/matthewbdaly/sms-client/src/Exceptions/ClientException.php
+++ b/vendor/matthewbdaly/sms-client/src/Exceptions/ClientException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Exceptions;
+
+/**
+ * Client exception
+ */
+class ClientException extends \Exception
+{
+}

--- a/vendor/matthewbdaly/sms-client/src/Exceptions/ConnectException.php
+++ b/vendor/matthewbdaly/sms-client/src/Exceptions/ConnectException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Exceptions;
+
+/**
+ * Connect exception
+ */
+class ConnectException extends \Exception
+{
+}

--- a/vendor/matthewbdaly/sms-client/src/Exceptions/DriverNotConfiguredException.php
+++ b/vendor/matthewbdaly/sms-client/src/Exceptions/DriverNotConfiguredException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Exceptions;
+
+/**
+ * Driver not configured exception
+ */
+class DriverNotConfiguredException extends \Exception
+{
+}

--- a/vendor/matthewbdaly/sms-client/src/Exceptions/RequestException.php
+++ b/vendor/matthewbdaly/sms-client/src/Exceptions/RequestException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Exceptions;
+
+/**
+ * Request exception
+ */
+class RequestException extends \Exception
+{
+}

--- a/vendor/matthewbdaly/sms-client/src/Exceptions/ServerException.php
+++ b/vendor/matthewbdaly/sms-client/src/Exceptions/ServerException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS\Exceptions;
+
+/**
+ * Server exception
+ */
+class ServerException extends \Exception
+{
+}

--- a/vendor/matthewbdaly/sms-client/src/PHPMailAdapter.php
+++ b/vendor/matthewbdaly/sms-client/src/PHPMailAdapter.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Matthewbdaly\SMS;
+
+use Matthewbdaly\SMS\Contracts\Mailer;
+
+/**
+ * Basic mailer interface implementation
+ */
+class PHPMailAdapter implements Mailer
+{
+    /**
+     * Send email
+     *
+     * @param string $recipient The recipent's email.
+     * @param string $message   The message.
+     * @return void
+     */
+    public function send(string $recipient, string $message)
+    {
+        mail($recipient, "", $message);
+    }
+}


### PR DESCRIPTION
**New Feature**

This PR adds a PHP library for handling SMS gateways: https://github.com/matthewbdaly/sms-client
It implements the library through an SMS class/interface via the DI container, which provides a fully configured SMS object ready to send. The result is a very simple, fluent interface for SMS sending with a few lines of code, and support for 6 different options by default: OneWaySMS, Twilio, Nexmo, Clockwork, TextLocal, and Mail to SMS.

## Description
- Adds the Matthewbdaly\SMS library, which is wrapped with a class & contract so the core only interacts via an interface.
- Replaces the existing SMS sending code in Messenger.
- Expands on the existing SMS options in Third Party Settings to allow a choice of gateways.
- Enables additional gateways in future versions simply by adding a new driver.
- Enables balance checking for available gateways (currently just OneWaySMS)
- Enables the configuration of a custom Sender ID (defaults to organization short name).
- Defaults to OneWaySMS if any SMS settings have already been configured.
- Hides the SMS NOT CONFIGURED error on the Messenger screen if the smsGateway option is No, which is useful for schools who do not wish to use SMS.

## Motivation and Context
Expands the capability of the core so it no longer relies on a single SMS provider: different schools globally need a variety of different options for SMS sending.

## How Has This Been Tested?
Each gateway has been tested with a trial account (except Clockwork which only sends to UK numbers, but I've tested the API request/response successfully). I've tested the Mail to SMS option with both OneWaySMS and TextLocal. Sending by mail takes longer than a basic http POST, so it should only be used if there's no other available options.