### PR TITLE
System: add the ability to set the current language with a URL parameter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,6 +48,7 @@ v17.0.00
         System: added Sri Lankan Rupee as a currency option
         System: fixed incorrect return value in Public Registration when user is below the minimum age
         System: deprecated getGibbonMailer function, replaced with Mailer wrapper
+        System: added the ability to set the current language with an i18n URL parameter
         Activities: post-OOification fix to include All Users in Staff selection for in Manage Activities
         Activities: fixed incorrect count in Registered column in Activity Enrolment Summary
         Attendance: fixed an error in the parent view of Student History for PHP 7.1+

--- a/functions.php
+++ b/functions.php
@@ -446,8 +446,17 @@ function getMinorLinks($connection2, $guid, $cacheLoad)
 {
     $return = false;
 
+    // Add a link to go back to the system/personal default language, if we're not using it
+    if (isset($_SESSION[$guid]['i18n']['default']['code']) && isset($_SESSION[$guid]['i18n']['code'])) {
+        if ($_SESSION[$guid]['i18n']['code'] != $_SESSION[$guid]['i18n']['default']['code']) {
+            $systemDefaultShortName = trim(strstr($_SESSION[$guid]['i18n']['default']['name'], '-', true));
+            $languageLink = "<a href='".$_SESSION[$guid]['absoluteURL']."?i18n=".$_SESSION[$guid]['i18n']['default']['code']."'>".$systemDefaultShortName.'</a>';
+        }
+    }
+
     if (isset($_SESSION[$guid]['username']) == false) {
         if ($_SESSION[$guid]['webLink'] != '') {
+            $return .= !empty($languageLink) ? $languageLink.' . ' : '';
             $return .= __('Return to')." <a style='margin-right: 12px' target='_blank' href='".$_SESSION[$guid]['webLink']."'>".$_SESSION[$guid]['organisationNameShort'].' '.__('Website').'</a>';
         }
     } else {
@@ -471,6 +480,8 @@ function getMinorLinks($connection2, $guid, $cacheLoad)
         if ($_SESSION[$guid]['website'] != '') {
             $return .= " . <a target='_blank' href='".$_SESSION[$guid]['website']."'>".__('My Website').'</a>';
         }
+
+        $return .= !empty($languageLink) ? ' . '.$languageLink : '';
 
         //Check for house logo (needed to get bubble, below, in right spot)
         if (isset($_SESSION[$guid]['gibbonHouseIDLogo']) and isset($_SESSION[$guid]['gibbonHouseIDName'])) {
@@ -3895,7 +3906,7 @@ function getSystemSettings($guid, $connection2)
 }
 
 //Set language session variables
-function setLanguageSession($guid, $row)
+function setLanguageSession($guid, $row, $defaultLanguage = true)
 {
     $_SESSION[$guid]['i18n']['gibboni18nID'] = $row['gibboni18nID'];
     $_SESSION[$guid]['i18n']['code'] = $row['code'];
@@ -3904,6 +3915,11 @@ function setLanguageSession($guid, $row)
     $_SESSION[$guid]['i18n']['dateFormatRegEx'] = $row['dateFormatRegEx'];
     $_SESSION[$guid]['i18n']['dateFormatPHP'] = $row['dateFormatPHP'];
     $_SESSION[$guid]['i18n']['rtl'] = $row['rtl'];
+
+    if ($defaultLanguage) {
+        $_SESSION[$guid]['i18n']['default']['code'] = $row['code'];
+        $_SESSION[$guid]['i18n']['default']['name'] = $row['name'];
+    }
 }
 
 //Gets the desired setting, specified by name and scope.

--- a/index.php
+++ b/index.php
@@ -231,6 +231,19 @@ if (is_file(sprintf($localePath, $localeCode))) {
     $datepickerLocale = $localeCodeShort;
 }
 
+// Allow the URL to override system default from the i18l param
+if (!empty($_GET['i18n']) && $gibbon->locale->getLocale() != $_GET['i18n']) {
+    $data = ['code' => $_GET['i18n']];
+    $sql = "SELECT * FROM gibboni18n WHERE code=:code LIMIT 1";
+
+    if ($result = $pdo->selectOne($sql, $data)) {
+        setLanguageSession($guid, $result, false);
+        $gibbon->locale->setLocale($_GET['i18n']);
+        $gibbon->locale->setTextDomain($pdo);
+        $cacheLoad = true;
+    }
+}
+
 /**
  * JAVASCRIPT
  *

--- a/login.php
+++ b/login.php
@@ -229,7 +229,7 @@ else {
                         }
                         if ($resultLanguage->rowCount() == 1) {
                             $rowLanguage = $resultLanguage->fetch();
-                            setLanguageSession($guid, $rowLanguage);
+                            setLanguageSession($guid, $rowLanguage, false);
                         }
                     } else {
                         //If no language specified, get user preference if it exists
@@ -243,7 +243,7 @@ else {
                             }
                             if ($resultLanguage->rowCount() == 1) {
                                 $rowLanguage = $resultLanguage->fetch();
-                                setLanguageSession($guid, $rowLanguage);
+                                setLanguageSession($guid, $rowLanguage, false);
                             }
                         }
                     }


### PR DESCRIPTION
This is a small tweak we've had at TIS for a while which may be useful for other schools. It allows you to add an `i81n=` parameter to your URL to set the current language. This is handy for sharing login links with non-english speaking users (where the login options link would be hard to use if you don't speak the language). It's also useful for linking to a school's application form to ensure it's set to a specific language (or different languages per link). It adds a language link to the top-right so users can easily return to the system default language.