### PR TITLE
Incorrect Error Message Logic in Attendance Course Class

### DIFF
--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
 } else {
     //Proceed!
     if (isset($_GET['return'])) {
-        returnProcess($guid, $_GET['return'], null, array('error3' => __('Your request failed because the specified date is not in the future, or is not a school day.')));
+        returnProcess($guid, $_GET['return'], null, array('error3' => __('Your request failed because the specified date is in the future, or is not a school day.')));
     }
 
     $attendance = new AttendanceView($gibbon, $pdo);


### PR DESCRIPTION
The logic of the error message states that the date SHOULD BE IN THE FUTURE, but the TEST does the opposite.  The test is correct.

Bug Fix
