### PR TITLE
System: update Google login scopes to remove plus.me

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ v18.0.00
     Security
 
     Tweaks & Additions
+        System: updated Google login scopes to remove plus.me, based on Google API changes
         Students: added link from student profile to Individual Needs edit screen
 
     Bug Fixes

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -33,8 +33,8 @@ $client->setClientId($client_id);
 $client->setClientSecret($client_secret);
 $client->setRedirectUri($redirect_uri);
 $client->setAccessType('offline');
-$client->setScopes(array('https://www.googleapis.com/auth/userinfo.email',
-    'https://www.googleapis.com/auth/plus.me',
+$client->setScopes(array('email',
+    'profile',
     'https://www.googleapis.com/auth/calendar')); // set scope during user login
 
 /************************************************

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -191,7 +191,7 @@ function getCalendarEvents($connection2, $guid, $xml, $startDayStamp, $endDaySta
 
             //Re-establish $client
             $client->setApplicationName($googleClientName); // Set your application name
-            $client->setScopes(array('https://www.googleapis.com/auth/userinfo.email', 'https://www.googleapis.com/auth/plus.me', 'https://www.googleapis.com/auth/calendar')); // set scope during user login
+            $client->setScopes(array('email', 'profile', 'https://www.googleapis.com/auth/calendar')); // set scope during user login
             $client->setClientId($googleClientID); // paste the client id which you get from google API Console
             $client->setClientSecret($googleClientSecret); // set the client secret
             $client->setRedirectUri($googleRedirectUri); // paste the redirect URI where you given in APi Console. You will get the Access Token here during login success


### PR DESCRIPTION
Google is shutting down their Google+ APIs by March 7, 2019: https://developers.google.com/+/api-shutdown

This PR replaces the `plus.me` scopes with the basic `email` and `profile` scopes recommended for [Google sign-in](https://developers.google.com/identity/protocols/googlescopes#google_sign-in). It looks like the client library we use has already not been accessing the Google+ API (based on console usage data), so this change shouldn't have an effect on end users. At the most, they may be asked to re-accept the Google consent screen.