### PR TITLE
Render tables - Support to internationalization - v18

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ v18.0.00
     Tweaks & Additions
         System: updated Google login scopes to remove plus.me, based on Google API changes
         System: made disabled checkboxes more visible
+        System: method for columns that require the translation, and update the columns where this is applicable
         Students: added link from student profile to Individual Needs edit screen
 
     Bug Fixes

--- a/src/Tables/Columns/Column.php
+++ b/src/Tables/Columns/Column.php
@@ -36,6 +36,7 @@ class Column
     protected $width = 'auto';
     protected $depth = 0;
     protected $sortable = false;
+    protected $translatable = false;
     protected $formatter;
 
     protected $columns = array();
@@ -174,6 +175,28 @@ class Column
     }
 
     /**
+     * Sets that this column of table must be translated
+     *
+     * @return self
+     */
+    public function isTranslatable() 
+    {
+        $this->translatable = true;
+        
+        return $this;
+    }    
+
+    /**
+     * Gets if the column of table must be translated or not
+     *
+     * @return bool
+     */
+    public function getTranslatable()
+    {
+        return $this->translatable;
+    }    
+    
+    /**
      * Set a callable function that can modify each cell and/or row based on that row's data.
      *
      * @param callable $callable
@@ -277,7 +300,8 @@ class Column
         if ($this->hasFormatter()) {
             return call_user_func($this->formatter, $data);
         } else {
-            return isset($data[$this->getID()])? $data[$this->getID()] : '';
+            $content = isset($data[$this->getID()])? $data[$this->getID()] : '';
+            return $this->getTranslatable() ? __($content) : $content;
         }
     }
 }


### PR DESCRIPTION
## Motivation and context
Method for columns that require the translation, and update the columns where this is applicable, for example:
schoolYear_manage.php
gradeScales_manage.php
attendanceSettings.php
fileExtensions_manage.php

## How Has This Been Tested?
Local and Travis

## Example
schoolYear_manage.php - line 63
before: $table->addColumn('status', __('Status'));
after:  $table->addColumn('status', __('Status'))->isTranslatable();
