### PR TITLE
Planner: removed Smart Block to Lesson outcome mapping

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -836,4 +836,6 @@ ALTER TABLE `gibbonTTSpaceChange` CHANGE `gibbonPersonID` `gibbonPersonID` INT(1
 ALTER TABLE `gibbonTTSpaceBooking` CHANGE `foreignKey` `foreignKey` INT(10) UNSIGNED ZEROFILL NOT NULL;end
 UPDATE gibboni18n SET active='Y' WHERE code='hr_HR';end
 ALTER TABLE gibbonUnit DROP COLUMN embeddable;end
+ALTER TABLE gibbonUnitBlock DROP COLUMN gibbonOutcomeIDList;end
+ALTER TABLE gibbonUnitClassBlock DROP COLUMN gibbonOutcomeIDList;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ v18.0.00
         System: made disabled checkboxes more visible
         System: method for columns that require the translation, and update the columns where this is applicable
         Planner: removed Unit embed feature
+        Planner: removed Smart Block to Lesson outcome mapping
         Students: added link from student profile to Individual Needs edit screen
         Timetable: update View Timetable by Person to access Expected users when All Users filter is enabled
 

--- a/modules/Planner/curriculumMapping_outcomesByCourse.php
+++ b/modules/Planner/curriculumMapping_outcomesByCourse.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/curriculumMapping_
 
 	$form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/curriculumMapping_outcomesByCourse.php');
 
-	
+
 	$data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
 	$sql = "SELECT gibbonCourse.gibbonCourseID, gibbonCourse.name, gibbonDepartment.name AS department FROM gibbonCourse LEFT JOIN gibbonDepartment ON (gibbonCourse.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND NOT gibbonYearGroupIDList='' ORDER BY department, gibbonCourse.nameShort";
 	$result = $pdo->executeQuery($data, $sql);
@@ -108,8 +108,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/curriculumMapping_
                 try {
                     $dataOutcomes = array('gibbonCourseID1' => $gibbonCourseID, 'gibbonCourseID2' => $gibbonCourseID);
                     $sqlOutcomes = "(SELECT 'Unit' AS type, gibbonCourseClass.gibbonCourseClassID, gibbonOutcome.* FROM gibbonOutcome JOIN gibbonUnitOutcome ON (gibbonUnitOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) JOIN gibbonUnit ON (gibbonUnitOutcome.gibbonUnitID=gibbonUnit.gibbonUnitID) JOIN gibbonUnitClass ON (gibbonUnitClass.gibbonUnitID=gibbonUnit.gibbonUnitID) JOIN gibbonCourseClass ON (gibbonUnitClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonCourseClass.gibbonCourseID=:gibbonCourseID1 AND gibbonOutcome.active='Y' AND running='Y')
-					UNION ALL
-					(SELECT 'Working Block' AS type, gibbonCourseClass.gibbonCourseClassID, gibbonOutcome.* FROM gibbonOutcome JOIN gibbonUnitClassBlock ON (gibbonUnitClassBlock.gibbonOutcomeIDList LIKE concat('%', gibbonOutcome.gibbonOutcomeID, '%')) JOIN gibbonUnitClass ON (gibbonUnitClassBlock.gibbonUnitClassID=gibbonUnitClass.gibbonUnitClassID) JOIN gibbonCourseClass ON (gibbonUnitClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonCourseClass.gibbonCourseID=:gibbonCourseID2 AND gibbonOutcome.active='Y' AND running='Y')
 					UNION ALL
 					(SELECT 'Planner Entry' AS type, gibbonCourseClass.gibbonCourseClassID, gibbonOutcome.* FROM gibbonOutcome JOIN gibbonPlannerEntryOutcome ON (gibbonPlannerEntryOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) JOIN gibbonPlannerEntry ON (gibbonPlannerEntryOutcome.gibbonPlannerEntryID=gibbonPlannerEntry.gibbonPlannerEntryID) JOIN gibbonCourseClass ON (gibbonPlannerEntry.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) WHERE gibbonCourseClass.gibbonCourseID=:gibbonCourseID2 AND gibbonOutcome.active='Y')";
                     $resultOutcomes = $connection2->prepare($sqlOutcomes);

--- a/modules/Planner/moduleFunctions.php
+++ b/modules/Planner/moduleFunctions.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //Make the display for a block, according to the input provided, where $i is a unique number appended to the block's field ids.
 //Mode can be masterAdd, masterEdit, workingDeploy, workingEdit, plannerEdit, embed
 //Outcomes is the result set of a mysql query of all outcomes from the unit the class belongs to
-function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $type = '', $length = '', $contents = '', $complete = 'N', $gibbonUnitBlockID = '', $gibbonUnitClassBlockID = '', $teachersNotes = '', $outerBlock = true, $unitOutcomes = null, $gibbonOutcomeIDList = null)
+function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $type = '', $length = '', $contents = '', $complete = 'N', $gibbonUnitBlockID = '', $gibbonUnitClassBlockID = '', $teachersNotes = '', $outerBlock = true)
 {
     if ($outerBlock) {
         echo "<div id='blockOuter$i' class='blockOuter'>";
@@ -192,59 +192,6 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
                     } elseif ($teachersNotes != '') {
                         echo "<div style='text-align: left; font-weight: bold; margin-top: 15px'>".__('Teacher\'s Notes').'</div>';
                         echo "<div style='max-width: 595px; margin-right: 0!important; padding: 5px!important; background-color: #F6CECB'><p>$teachersNotes</p></div>";
-                    }
-
-                    //Outcomes
-                    if ($mode == 'masterAdd') {
-                        echo "<div style='text-align: left; font-weight: bold; margin-top: 15px'>".__('Outcomes').'</div>';
-                        echo "<div class='warning'>".__('After creating this unit, you will be able to edit the unit and assign unit outcomes to individual blocks. These will then become lesson outcomes when you deploy a unit.').'</div>';
-                    } elseif ($mode == 'masterEdit' or $mode == 'workingDeploy' or $mode == 'workingEdit' or $mode == 'plannerEdit') {
-                        echo "<div style='text-align: left; font-weight: bold; margin-top: 15px'>".__('Outcomes').'</div>';
-                        if (count($unitOutcomes) < 1) {
-                            echo "<div class='warning'>".__('There are no records to display.').'</div>';
-                        } else {
-                            echo "<table cellspacing='0' style='width:100%'>";
-                            echo "<tr class='head'>";
-                            echo '<th>';
-                            echo __('Scope');
-                            echo '</th>';
-                            echo '<th>';
-                            echo __('Category');
-                            echo '</th>';
-                            echo '<th>';
-                            echo __('Name');
-                            echo '</th>';
-                            echo '<th>';
-                            echo __('Include');
-                            echo '</th>';
-                            echo '</tr>';
-
-                            foreach ($unitOutcomes as $unitOutcome) {
-                                //COLOR ROW BY STATUS!
-                                    echo '<tr>';
-                                echo "<td style='padding: 5px!important'>";
-                                echo '<b>'.$unitOutcome['scope'].'</b><br/>';
-                                if ($unitOutcome['scope'] == 'Learning Area' and $unitOutcome['department'] != '') {
-                                    echo "<span style='font-size: 75%; font-style: italic'>".$unitOutcome['department'].'</span>';
-                                }
-                                echo '</td>';
-                                echo "<td style='padding: 5px!important'>";
-                                echo $unitOutcome['category'];
-                                echo '</td>';
-                                echo "<td style='padding: 5px!important'>";
-                                echo $unitOutcome['name'];
-                                echo '</td>';
-                                echo "<td style='padding: 5px!important'>";
-                                $checked = '';
-                                if (strpos($gibbonOutcomeIDList, $unitOutcome['gibbonOutcomeID']) !== false) {
-                                    $checked = 'checked';
-                                }
-                                echo "<input $checked type='checkbox' name='outcomes".$i."[]' value='".$unitOutcome['gibbonOutcomeID']."' />";
-                                echo '</td>';
-                                echo '</tr>';
-                            }
-                            echo '</table>';
-                        }
                     }
    				 	?>
 				</td>

--- a/modules/Planner/planner_duplicateProcess.php
+++ b/modules/Planner/planner_duplicateProcess.php
@@ -236,8 +236,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.
                         }
                         while ($rowBlocks = $resultBlocks->fetch()) {
                             try {
-                                $dataBlocksInsert = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $rowBlocks['gibbonUnitBlockID'], 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber'], 'gibbonOutcomeIDList' => $rowBlocks['gibbonOutcomeIDList']);
-                                $sqlBlocksInsert = "INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList, complete='N'";
+                                $dataBlocksInsert = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $rowBlocks['gibbonUnitBlockID'], 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber']);
+                                $sqlBlocksInsert = "INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, complete='N'";
                                 $resultBlocksInsert = $connection2->prepare($sqlBlocksInsert);
                                 $resultBlocksInsert->execute($dataBlocksInsert);
                             } catch (PDOException $e) {

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -395,11 +395,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
 
                         //Lesson outcomes
                         try {
-                            $dataOutcomes = array('gibbonPlannerEntryID1' => $row['gibbonPlannerEntryID'], 'gibbonPlannerEntryID2' => $row['gibbonPlannerEntryID']);
-                            $sqlOutcomes = "(SELECT scope, name, nameShort, category, gibbonYearGroupIDList, sequenceNumber, content FROM gibbonPlannerEntryOutcome JOIN gibbonOutcome ON (gibbonPlannerEntryOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID1 AND active='Y')
-							UNION
-							(SELECT scope, name, nameShort, category, gibbonYearGroupIDList, '' AS sequenceNumber, description AS content FROM gibbonUnitClassBlock JOIN gibbonOutcome ON (gibbonUnitClassBlock.gibbonOutcomeIDList LIKE concat( '%', gibbonOutcome.gibbonOutcomeID, '%' )) WHERE gibbonUnitClassBlock.gibbonPlannerEntryID=:gibbonPlannerEntryID2 AND active='Y')
-							ORDER BY (sequenceNumber='') ASC, sequenceNumber, category, name";
+                            $dataOutcomes = array('gibbonPlannerEntryID' => $row['gibbonPlannerEntryID']);
+                            $sqlOutcomes = "SELECT scope, name, nameShort, category, gibbonYearGroupIDList, sequenceNumber, content FROM gibbonPlannerEntryOutcome JOIN gibbonOutcome ON (gibbonPlannerEntryOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID AND active='Y' ORDER BY (sequenceNumber='') ASC, sequenceNumber, category, name";
                             $resultOutcomes = $connection2->prepare($sqlOutcomes);
                             $resultOutcomes->execute($dataOutcomes);
                         } catch (PDOException $e) {
@@ -578,17 +575,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
 
 										<div class="sortable" id="sortable" style='width: 100%; padding: 5px 0px 0px 0px; border-top: 1px dotted #666; border-bottom: 1px dotted #666'>
 											<?php
-											//Get outcomes
-											try {
-												$dataOutcomes = array('gibbonUnitID' => $gibbonUnitID);
-												$sqlOutcomes = "SELECT gibbonOutcome.gibbonOutcomeID, gibbonOutcome.name, gibbonOutcome.category, scope, gibbonDepartment.name AS department FROM gibbonUnitOutcome JOIN gibbonOutcome ON (gibbonUnitOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) LEFT JOIN gibbonDepartment ON (gibbonOutcome.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonUnitID=:gibbonUnitID AND active='Y' ORDER BY sequenceNumber";
-												$resultOutcomes = $connection2->prepare($sqlOutcomes);
-												$resultOutcomes->execute($dataOutcomes);
-											} catch (PDOException $e) {
-												echo "<div class='error'>".$e->getMessage().'</div>';
-											}
-											$unitOutcomes = $resultOutcomes->fetchall();
-
 											$i = 1;
 											$minSeq = 0;
 											while ($rowBlocks = $resultBlocks->fetch()) {
@@ -596,7 +582,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
 													$minSeq = $rowBlocks['sequenceNumber'];
 												}
 												if ($hooked == false) {
-													makeBlock($guid, $connection2, $i, 'plannerEdit', $rowBlocks['title'], $rowBlocks['type'], $rowBlocks['length'], $rowBlocks['contents'], $rowBlocks['complete'], '', $rowBlocks['gibbonUnitClassBlockID'], $rowBlocks['teachersNotes'], true, $unitOutcomes, $rowBlocks['gibbonOutcomeIDList']);
+													makeBlock($guid, $connection2, $i, 'plannerEdit', $rowBlocks['title'], $rowBlocks['type'], $rowBlocks['length'], $rowBlocks['contents'], $rowBlocks['complete'], '', $rowBlocks['gibbonUnitClassBlockID'], $rowBlocks['teachersNotes'], true);
 												} else {
 													makeBlock($guid, $connection2, $i, 'plannerEdit', $rowBlocks[$hookOptions['classSmartBlockTitleField']], $rowBlocks[$hookOptions['classSmartBlockTypeField']], $rowBlocks[$hookOptions['classSmartBlockLengthField']], $rowBlocks[$hookOptions['classSmartBlockContentsField']], $rowBlocks[$hookOptions['classSmartBlockCompleteField']], '', $rowBlocks[$hookOptions['classSmartBlockIDField']], $rowBlocks[$hookOptions['classSmartBlockTeachersNotesField']]);
 												}

--- a/modules/Planner/planner_view_full_smartProcess.php
+++ b/modules/Planner/planner_view_full_smartProcess.php
@@ -141,22 +141,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                             }
                         }
 
-                        //Deal with outcomes
-                        $gibbonOutcomeIDList = '';
-                        if (isset($_POST['outcomes'.$i])) {
-                            if (is_array($_POST['outcomes'.$i])) {
-                                foreach ($_POST['outcomes'.$i] as $outcome) {
-                                    $gibbonOutcomeIDList .= $outcome.',';
-                                }
-                            }
-                            $gibbonOutcomeIDList = substr($gibbonOutcomeIDList, 0, -1);
-                        }
-
                         //Write to database
                         try {
                             if ($hooked == false) {
-                                $data = array('title' => $title, 'type' => $type, 'length' => $length, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'complete' => $complete, 'sequenceNumber' => $seq, 'gibbonOutcomeIDList' => $gibbonOutcomeIDList, 'gibbonUnitClassBlockID' => $id);
-                                $sql = 'UPDATE gibbonUnitClassBlock SET title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, complete=:complete, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList WHERE gibbonUnitClassBlockID=:gibbonUnitClassBlockID';
+                                $data = array('title' => $title, 'type' => $type, 'length' => $length, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'complete' => $complete, 'sequenceNumber' => $seq, 'gibbonUnitClassBlockID' => $id);
+                                $sql = 'UPDATE gibbonUnitClassBlock SET title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, complete=:complete, sequenceNumber=:sequenceNumber WHERE gibbonUnitClassBlockID=:gibbonUnitClassBlockID';
                             } else {
                                 $data = array('title' => $title, 'type' => $type, 'length' => $length, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'complete' => $complete, 'sequenceNumber' => $seq, 'gibbonUnitClassBlockID' => $id);
                                 $sql = 'UPDATE '.$hookOptions['classSmartBlockTable'].' SET '.$hookOptions['classSmartBlockTitleField'].'=:title, '.$hookOptions['classSmartBlockTypeField'].'=:type, '.$hookOptions['classSmartBlockLengthField'].'=:length, '.$hookOptions['classSmartBlockContentsField'].'=:contents, '.$hookOptions['classSmartBlockTeachersNotesField'].'=:teachersNotes, '.$hookOptions['classSmartBlockCompleteField'].'=:complete, '.$hookOptions['classSmartBlockSequenceNumberField'].'=:sequenceNumber WHERE '.$hookOptions['classSmartBlockIDField'].'=:gibbonUnitClassBlockID';
@@ -168,24 +157,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                         }
                         ++$seq;
                     }
-                }
 
-                $summaryBlocks = substr($summaryBlocks, 0, -2);
-                if (strlen($summaryBlocks) > 75) {
-                    $summaryBlocks = substr($summaryBlocks, 0, 72).'...';
-                }
-                if ($summaryBlocks) {
-                    $summary = $summaryBlocks;
-                }
+                    $summaryBlocks = substr($summaryBlocks, 0, -2);
+                    if (strlen($summaryBlocks) > 75) {
+                        $summaryBlocks = substr($summaryBlocks, 0, 72).'...';
+                    }
+                    if ($summaryBlocks) {
+                        $summary = $summaryBlocks;
+                    }
 
-                //Write to database
-                try {
-                    $data = array('summary' => $summary, 'gibbonPlannerEntryID' => $gibbonPlannerEntryID);
-                    $sql = 'UPDATE gibbonPlannerEntry SET summary=:summary WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID';
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    $partialFail = true;
+                    //Write to database
+                    try {
+                        $data = array('summary' => $summary, 'gibbonPlannerEntryID' => $gibbonPlannerEntryID);
+                        $sql = 'UPDATE gibbonPlannerEntry SET summary=:summary WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID';
+                        $result = $connection2->prepare($sql);
+                        $result->execute($data);
+                    } catch (PDOException $e) {
+                        $partialFail = true;
+                    }
                 }
 
                 //Return final verdict

--- a/modules/Planner/unitsProcessBulk.php
+++ b/modules/Planner/unitsProcessBulk.php
@@ -121,8 +121,8 @@ if ($gibbonCourseID == '' or $gibbonCourseIDCopyTo == '' or $gibbonSchoolYearID 
                         }
                         while ($rowBlocks = $resultBlocks->fetch()) {
                             try {
-                                $dataBlock = array('gibbonUnitID' => $AI, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber'], 'gibbonOutcomeIDList' => $rowBlocks['gibbonOutcomeIDList']);
-                                $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                                $dataBlock = array('gibbonUnitID' => $AI, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber']);
+                                $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber';
                                 $resultBlock = $connection2->prepare($sqlBlock);
                                 $resultBlock->execute($dataBlock);
                             } catch (PDOException $e) {

--- a/modules/Planner/units_duplicateProcess.php
+++ b/modules/Planner/units_duplicateProcess.php
@@ -199,8 +199,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_duplicate.ph
                                             }
                                             while ($rowBlocks = $resultBlocks->fetch()) {
                                                 try {
-                                                    $dataBlock = array('gibbonPlannerEntryID' => $gibbonPlannerEntryNew, 'gibbonUnitClassID' => $gibbonUnitClassIDNew, 'gibbonUnitBlockID' => $rowBlocks['gibbonUnitBlockID'], 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber'], 'gibbonOutcomeIDList' => $rowBlocks['gibbonOutcomeIDList']);
-                                                    $sqlBlock = 'INSERT INTO gibbonUnitClassBlock SET gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitClassID=:gibbonUnitClassID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                                                    $dataBlock = array('gibbonPlannerEntryID' => $gibbonPlannerEntryNew, 'gibbonUnitClassID' => $gibbonUnitClassIDNew, 'gibbonUnitBlockID' => $rowBlocks['gibbonUnitBlockID'], 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber']);
+                                                    $sqlBlock = 'INSERT INTO gibbonUnitClassBlock SET gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitClassID=:gibbonUnitClassID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber';
                                                     $resultBlock = $connection2->prepare($sqlBlock);
                                                     $resultBlock->execute($dataBlock);
                                                 } catch (PDOException $e) {
@@ -224,8 +224,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_duplicate.ph
                     }
                     while ($rowBlocks = $resultBlocks->fetch()) {
                         try {
-                            $dataBlock = array('gibbonUnitID' => $AI, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber'], 'gibbonOutcomeIDList' => $rowBlocks['gibbonOutcomeIDList']);
-                            $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                            $dataBlock = array('gibbonUnitID' => $AI, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'teachersNotes' => $rowBlocks['teachersNotes'], 'sequenceNumber' => $rowBlocks['sequenceNumber']);
+                            $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber';
                             $resultBlock = $connection2->prepare($sqlBlock);
                             $resultBlock->execute($dataBlock);
                         } catch (PDOException $e) {

--- a/modules/Planner/units_edit.php
+++ b/modules/Planner/units_edit.php
@@ -689,18 +689,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                                                 } catch (PDOException $e) {
                                                     echo "<div class='error'>".$e->getMessage().'</div>';
                                                 }
-												try {
-													$dataOutcomes = array('gibbonUnitID' => $gibbonUnitID);
-													$sqlOutcomes = "SELECT gibbonOutcome.gibbonOutcomeID, gibbonOutcome.name, gibbonOutcome.category, scope, gibbonDepartment.name AS department FROM gibbonUnitOutcome JOIN gibbonOutcome ON (gibbonUnitOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) LEFT JOIN gibbonDepartment ON (gibbonOutcome.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonUnitID=:gibbonUnitID AND active='Y' ORDER BY sequenceNumber";
-													$resultOutcomes = $connection2->prepare($sqlOutcomes);
-													$resultOutcomes->execute($dataOutcomes);
-												} catch (PDOException $e) {
-													echo "<div class='error'>".$e->getMessage().'</div>';
-												}
-												$unitOutcomes = $resultOutcomes->fetchall();
 												$i = 1;
 												while ($rowBlocks = $resultBlocks->fetch()) {
-													makeBlock($guid, $connection2, $i, 'masterEdit', $rowBlocks['title'], $rowBlocks['type'], $rowBlocks['length'], $rowBlocks['contents'], 'N', $rowBlocks['gibbonUnitBlockID'], '', $rowBlocks['teachersNotes'], true, $unitOutcomes, $rowBlocks['gibbonOutcomeIDList']);
+													makeBlock($guid, $connection2, $i, 'masterEdit', $rowBlocks['title'], $rowBlocks['type'], $rowBlocks['length'], $rowBlocks['contents'], 'N', $rowBlocks['gibbonUnitBlockID'], '', $rowBlocks['teachersNotes'], true);
 													++$i;
 												}
 												?>

--- a/modules/Planner/units_editProcess.php
+++ b/modules/Planner/units_editProcess.php
@@ -185,21 +185,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                                     $teachersNotes = $_POST["teachersNotes$i"];
                                     $gibbonUnitBlockID = $_POST["gibbonUnitBlockID$i"];
 
-                                    //Deal with outcomes
-                                    $gibbonOutcomeIDList = '';
-                                    if (isset($_POST['outcomes'.$i])) {
-                                        if (is_array($_POST['outcomes'.$i])) {
-                                            foreach ($_POST['outcomes'.$i] as $outcome) {
-                                                $gibbonOutcomeIDList .= $outcome.',';
-                                            }
-                                        }
-                                        $gibbonOutcomeIDList = substr($gibbonOutcomeIDList, 0, -1);
-                                    }
-
                                     if ($gibbonUnitBlockID != '') {
                                         try {
-                                            $dataBlock = array('gibbonUnitID' => $gibbonUnitID, 'title' => $title, 'type' => $type2, 'length' => $length, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber, 'gibbonOutcomeIDList' => $gibbonOutcomeIDList, 'gibbonUnitBlockID' => $gibbonUnitBlockID);
-                                            $sqlBlock = 'UPDATE gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList WHERE gibbonUnitBlockID=:gibbonUnitBlockID';
+                                            $dataBlock = array('gibbonUnitID' => $gibbonUnitID, 'title' => $title, 'type' => $type2, 'length' => $length, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber, 'gibbonUnitBlockID' => $gibbonUnitBlockID);
+                                            $sqlBlock = 'UPDATE gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber WHERE gibbonUnitBlockID=:gibbonUnitBlockID';
                                             $resultBlock = $connection2->prepare($sqlBlock);
                                             $resultBlock->execute($dataBlock);
                                         } catch (PDOException $e) {

--- a/modules/Planner/units_edit_copyBackProcess.php
+++ b/modules/Planner/units_edit_copyBackProcess.php
@@ -101,8 +101,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_copyBac
                     $partialFail = false;
                     while ($rowBlocks = $resultBlocks->fetch()) {
                         try {
-                            $dataBlock = array('gibbonUnitID' => $gibbonUnitID, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'sequenceNumber' => $rowBlocks['sequenceNumber'], 'gibbonOutcomeIDList' => $rowBlocks['gibbonOutcomeIDList']);
-                            $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                            $dataBlock = array('gibbonUnitID' => $gibbonUnitID, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'sequenceNumber' => $rowBlocks['sequenceNumber']);
+                            $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, sequenceNumber=:sequenceNumber';
                             $resultBlock = $connection2->prepare($sqlBlock);
                             $resultBlock->execute($dataBlock);
                         } catch (PDOException $e) {

--- a/modules/Planner/units_edit_copyForwardProcess.php
+++ b/modules/Planner/units_edit_copyForwardProcess.php
@@ -113,8 +113,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_copyFor
                         //Write blocks to new unit
                         while ($rowBlocks = $resultBlocks->fetch()) {
                             try {
-                                $dataBlock = array('gibbonUnitID' => $gibbinUnitIDNew, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'sequenceNumber' => $rowBlocks['sequenceNumber'], 'gibbonOutcomeIDList' => $rowBlocks['gibbonOutcomeIDList']);
-                                $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                                $dataBlock = array('gibbonUnitID' => $gibbinUnitIDNew, 'title' => $rowBlocks['title'], 'type' => $rowBlocks['type'], 'length' => $rowBlocks['length'], 'contents' => $rowBlocks['contents'], 'sequenceNumber' => $rowBlocks['sequenceNumber']);
+                                $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, sequenceNumber=:sequenceNumber';
                                 $resultBlock = $connection2->prepare($sqlBlock);
                                 $resultBlock->execute($dataBlock);
                             } catch (PDOException $e) {
@@ -153,7 +153,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_copyFor
                         header("Location: {$URL}");
                     } else {
                         $URLCopy = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address'])."/units_edit.php&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseID=$gibbonCourseIDTarget&gibbonUnitID=$gibbinUnitIDNew";
-                        $URLCopy = $URLCopy.'&copyForwardReturn=success2';
+                        $URLCopy = $URLCopy.'&return=success0';
                         header("Location: {$URLCopy}");
                     }
                 }

--- a/modules/Planner/units_edit_deploy.php
+++ b/modules/Planner/units_edit_deploy.php
@@ -523,7 +523,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
                                     $blocks[$blockCount][3] = $rowBlocks['length'];
                                     $blocks[$blockCount][4] = $rowBlocks['contents'];
                                     $blocks[$blockCount][5] = $rowBlocks['teachersNotes'];
-                                    $blocks[$blockCount][6] = $rowBlocks['gibbonOutcomeIDList'];
                                 } else {
                                     $blocks[$blockCount][0] = $rowBlocks[$hookOptions['unitSmartBlockIDField']];
                                     $blocks[$blockCount][1] = $rowBlocks[$hookOptions['unitSmartBlockTitleField']];
@@ -553,7 +552,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
                                 $blocks2[$blockCount2][3] = $rowBlocks2['length'];
                                 $blocks2[$blockCount2][4] = $rowBlocks2['contents'];
                                 $blocks2[$blockCount2][5] = $rowBlocks2['teachersNotes'];
-                                $blocks2[$blockCount2][6] = $rowBlocks2['gibbonOutcomeIDList'];
                                 ++$blockCount2;
                             }
 
@@ -651,7 +649,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
                                                     ++$deployCount;
                                                 } else {
                                                     if (($length - $blocks[$deployCount][3]) >= 0) {
-                                                        makeBlock($guid,  $connection2, $blockCount2, $mode = 'workingDeploy', $blocks[$deployCount][1], $blocks[$deployCount][2], $blocks[$deployCount][3], $blocks[$deployCount][4], 'N', $blocks[$deployCount][0], '', $blocks[$deployCount][5], true, $unitOutcomes, @$blocks[$deployCount][6]);
+                                                        makeBlock($guid,  $connection2, $blockCount2, $mode = 'workingDeploy', $blocks[$deployCount][1], $blocks[$deployCount][2], $blocks[$deployCount][3], $blocks[$deployCount][4], 'N', $blocks[$deployCount][0], '', $blocks[$deployCount][5], true);
                                                         $length = $length - $blocks[$deployCount][3];
                                                         ++$deployCount;
                                                     }

--- a/modules/Planner/units_edit_deployProcess.php
+++ b/modules/Planner/units_edit_deployProcess.php
@@ -192,21 +192,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
                             $teachersNotes = $_POST['teachersNotes'.$order];
                             $gibbonUnitBlockID = $_POST['gibbonUnitBlockID'.$order];
 
-                            //Deal with outcomes
-                            $gibbonOutcomeIDList = '';
-                            if (isset($_POST['outcomes'.$order])) {
-                                if (is_array($_POST['outcomes'.$order])) {
-                                    foreach ($_POST['outcomes'.$order] as $outcome) {
-                                        $gibbonOutcomeIDList .= $outcome.',';
-                                    }
-                                }
-                                $gibbonOutcomeIDList = substr($gibbonOutcomeIDList, 0, -1);
-                            }
-
                             try {
                                 if ($hooked == false) {
-                                    $data = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $titles, 'type' => $types, 'length' => $lengths, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber, 'gibbonOutcomeIDList' => $gibbonOutcomeIDList);
-                                    $sql = "INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList, complete='N'";
+                                    $data = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $titles, 'type' => $types, 'length' => $lengths, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber);
+                                    $sql = "INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, complete='N'";
                                 } else {
                                     $data = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $titles, 'type' => $types, 'length' => $lengths, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber);
                                     $sql = 'INSERT INTO '.$hookOptions['classSmartBlockTable'].' SET '.$hookOptions['classSmartBlockJoinField'].'=:gibbonUnitClassID, '.$hookOptions['classSmartBlockPlannerJoin'].'=:gibbonPlannerEntryID, '.$hookOptions['classSmartBlockUnitBlockJoinField'].'=:gibbonUnitBlockID, '.$hookOptions['classSmartBlockTitleField'].'=:title, '.$hookOptions['classSmartBlockTypeField'].'=:type, '.$hookOptions['classSmartBlockLengthField'].'=:length, '.$hookOptions['classSmartBlockContentsField'].'=:contents, '.$hookOptions['classSmartBlockTeachersNotesField'].'=:teachersNotes, '.$hookOptions['classSmartBlockSequenceNumberField']."=:sequenceNumber, complete='N'";

--- a/modules/Planner/units_edit_smartBlockifyProcess.php
+++ b/modules/Planner/units_edit_smartBlockifyProcess.php
@@ -98,8 +98,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_smartBl
 
                         //MAKE NEW BLOCK
                         try {
-                            $dataBlock = array('gibbonUnitID' => $gibbonUnitID, 'title' => $row['name'], 'type' => '', 'length' => $length, 'contents' => $row['description'], 'teachersNotes' => $row['teachersNotes'], 'sequenceNumber' => $sequenceNumber, 'gibbonOutcomeIDList' => '');
-                            $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                            $dataBlock = array('gibbonUnitID' => $gibbonUnitID, 'title' => $row['name'], 'type' => '', 'length' => $length, 'contents' => $row['description'], 'teachersNotes' => $row['teachersNotes'], 'sequenceNumber' => $sequenceNumber);
+                            $sqlBlock = 'INSERT INTO gibbonUnitBlock SET gibbonUnitID=:gibbonUnitID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber';
                             $resultBlock = $connection2->prepare($sqlBlock);
                             $resultBlock->execute($dataBlock);
                         } catch (PDOException $e) {
@@ -112,8 +112,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_smartBl
                             $gibbonUnitBlockID = $connection2->lastInsertID();
                             $blockFail2 = false;
                             try {
-                                $dataBlock2 = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $row['gibbonPlannerEntryID'], 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $row['name'], 'type' => '', 'length' => $length, 'contents' => $row['description'], 'teachersNotes' => $row['teachersNotes'], 'sequenceNumber' => 1, 'gibbonOutcomeIDList' => '');
-                                $sqlBlock2 = 'INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                                $dataBlock2 = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $row['gibbonPlannerEntryID'], 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $row['name'], 'type' => '', 'length' => $length, 'contents' => $row['description'], 'teachersNotes' => $row['teachersNotes'], 'sequenceNumber' => 1);
+                                $sqlBlock2 = 'INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber';
                                 $resultBlock2 = $connection2->prepare($sqlBlock2);
                                 $resultBlock2->execute($dataBlock2);
                             } catch (PDOException $e) {

--- a/modules/Planner/units_edit_working.php
+++ b/modules/Planner/units_edit_working.php
@@ -222,7 +222,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
                             $blocks2[$blockCount2][3] = $rowBlocks2['length'];
                             $blocks2[$blockCount2][4] = $rowBlocks2['contents'];
                             $blocks2[$blockCount2][5] = $rowBlocks2['teachersNotes'];
-                            $blocks2[$blockCount2][6] = $rowBlocks2['gibbonOutcomeIDList'];
                             ++$blockCount2;
                         }
 
@@ -342,7 +341,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
 
                                 while ($rowLessonBlocks = $resultLessonBlocks->fetch()) {
                                     if ($hooked == false) {
-                                        makeBlock($guid,  $connection2, $blockCount2, $mode = 'workingEdit', $rowLessonBlocks['title'], $rowLessonBlocks['type'], $rowLessonBlocks['length'], $rowLessonBlocks['contents'], $rowLessonBlocks['complete'], $rowLessonBlocks['gibbonUnitBlockID'], $rowLessonBlocks['gibbonUnitClassBlockID'], $rowLessonBlocks['teachersNotes'], true, $unitOutcomes, $rowLessonBlocks['gibbonOutcomeIDList']);
+                                        makeBlock($guid,  $connection2, $blockCount2, $mode = 'workingEdit', $rowLessonBlocks['title'], $rowLessonBlocks['type'], $rowLessonBlocks['length'], $rowLessonBlocks['contents'], $rowLessonBlocks['complete'], $rowLessonBlocks['gibbonUnitBlockID'], $rowLessonBlocks['gibbonUnitClassBlockID'], $rowLessonBlocks['teachersNotes'], true);
                                     } else {
                                         makeBlock($guid,  $connection2, $blockCount2, $mode = 'workingEdit', $rowLessonBlocks[$hookOptions['classSmartBlockTitleField']], $rowLessonBlocks[$hookOptions['classSmartBlockTypeField']], $rowLessonBlocks[$hookOptions['classSmartBlockLengthField']], $rowLessonBlocks[$hookOptions['classSmartBlockContentsField']], $rowLessonBlocks['complete'], $rowLessonBlocks['gibbonUnitBlockID'], $rowLessonBlocks['gibbonUnitClassBlockID'], $rowLessonBlocks[$hookOptions['classSmartBlockTeachersNotesField']], true);
                                     }

--- a/modules/Planner/units_edit_workingProcess.php
+++ b/modules/Planner/units_edit_workingProcess.php
@@ -170,21 +170,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
                             $teachersNotes = $_POST['teachersNotes'.$order];
                             $gibbonUnitBlockID = $_POST['gibbonUnitBlockID'.$order];
 
-                            //Deal with outcomes
-                            $gibbonOutcomeIDList = '';
-                            if (isset($_POST['outcomes'.$order])) {
-                                if (is_array($_POST['outcomes'.$order])) {
-                                    foreach ($_POST['outcomes'.$order] as $outcome) {
-                                        $gibbonOutcomeIDList .= $outcome.',';
-                                    }
-                                }
-                                $gibbonOutcomeIDList = substr($gibbonOutcomeIDList, 0, -1);
-                            }
-
                             try {
                                 if ($hooked == false) {
-                                    $data = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $titles, 'type' => $types, 'length' => $lengths, 'complete' => $completes, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber, 'gibbonOutcomeIDList' => $gibbonOutcomeIDList);
-                                    $sql = 'INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, complete=:complete, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber, gibbonOutcomeIDList=:gibbonOutcomeIDList';
+                                    $data = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $titles, 'type' => $types, 'length' => $lengths, 'complete' => $completes, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber);
+                                    $sql = 'INSERT INTO gibbonUnitClassBlock SET gibbonUnitClassID=:gibbonUnitClassID, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonUnitBlockID=:gibbonUnitBlockID, title=:title, type=:type, length=:length, complete=:complete, contents=:contents, teachersNotes=:teachersNotes, sequenceNumber=:sequenceNumber';
                                 } else {
                                     $data = array('gibbonUnitClassID' => $gibbonUnitClassID, 'gibbonPlannerEntryID' => $AI, 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'title' => $titles, 'type' => $types, 'length' => $lengths, 'complete' => $completes, 'contents' => $contents, 'teachersNotes' => $teachersNotes, 'sequenceNumber' => $sequenceNumber);
                                     $sql = 'INSERT INTO '.$hookOptions['classSmartBlockTable'].' SET '.$hookOptions['classSmartBlockJoinField'].'=:gibbonUnitClassID, '.$hookOptions['classSmartBlockPlannerJoin'].'=:gibbonPlannerEntryID, '.$hookOptions['classSmartBlockUnitBlockJoinField'].'=:gibbonUnitBlockID, '.$hookOptions['classSmartBlockTitleField'].'=:title, '.$hookOptions['classSmartBlockTypeField'].'=:type, '.$hookOptions['classSmartBlockLengthField'].'=:length, '.$hookOptions['classSmartBlockCompleteField'].'=:complete, '.$hookOptions['classSmartBlockContentsField'].'=:contents, '.$hookOptions['classSmartBlockTeachersNotesField'].'=:teachersNotes, '.$hookOptions['classSmartBlockSequenceNumberField'].'=:sequenceNumber';

--- a/modules/Planner/units_edit_working_copyback.php
+++ b/modules/Planner/units_edit_working_copyback.php
@@ -152,9 +152,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
                         ?>
 						<form method="post" action="<?php echo $_SESSION[$guid]['absoluteURL']."/modules/Planner/units_edit_working_copybackProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseID=$gibbonCourseID&gibbonCourseClassID=$gibbonCourseClassID&gibbonUnitID=$gibbonUnitID&gibbonUnitBlockID=$gibbonUnitBlockID&gibbonUnitClassBlockID=$gibbonUnitClassBlockID&gibbonUnitClassID=$gibbonUnitClassID";
                         ?>">
-							<table class='smallIntBorder fullWidth' cellspacing='0'>	
+							<table class='smallIntBorder fullWidth' cellspacing='0'>
 								<tr>
-									<td style='width: 275px'> 
+									<td style='width: 275px'>
 										<b><?php echo __('Include Working Units?') ?> *</b><br/>
 										<span class="emphasis small"></span>
 									</td>
@@ -163,7 +163,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
 											<?php
                                             echo "<option value='N'>".__('No').'</option>';
                         					echo "<option value='Y'>".__('Yes').'</option>';
-                        					?>				
+                        					?>
 										</select>
 									</td>
 								</tr>
@@ -172,7 +172,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
 										<span class="emphasis small">* <?php echo __('denotes a required field'); ?></span>
 									</td>
 									<td class="right">
-										<input name="gibbonTTID" id="gibbonTTID" value="<?php echo $_GET['gibbonTTID'] ?>" type="hidden">
 										<input name="gibbonSchoolYearID" id="gibbonSchoolYearID" value="<?php echo $_GET['gibbonSchoolYearID'] ?>" type="hidden">
 										<input type="hidden" name="address" value="<?php echo $_SESSION[$guid]['address'] ?>">
 										<input type="submit" value="<?php echo __('Submit'); ?>">

--- a/modules/Planner/units_edit_working_copybackProcess.php
+++ b/modules/Planner/units_edit_working_copybackProcess.php
@@ -85,8 +85,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
                     $partialFail = false;
 
                     try {
-                        $data = array('title' => $row['title'], 'type' => $row['type'], 'length' => $row['length'], 'contents' => $row['contents'], 'teachersNotes' => $row['teachersNotes'], 'gibbonOutcomeIDList' => $row['gibbonOutcomeIDList'], 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'gibbonUnitID' => $gibbonUnitID);
-                        $sql = 'UPDATE gibbonUnitBlock SET title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, gibbonOutcomeIDList=:gibbonOutcomeIDList WHERE gibbonUnitBlockID=:gibbonUnitBlockID AND gibbonUnitID=:gibbonUnitID';
+                        $data = array('title' => $row['title'], 'type' => $row['type'], 'length' => $row['length'], 'contents' => $row['contents'], 'teachersNotes' => $row['teachersNotes'], 'gibbonUnitBlockID' => $gibbonUnitBlockID, 'gibbonUnitID' => $gibbonUnitID);
+                        $sql = 'UPDATE gibbonUnitBlock SET title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes WHERE gibbonUnitBlockID=:gibbonUnitBlockID AND gibbonUnitID=:gibbonUnitID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
@@ -96,8 +96,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
                     $working = $_POST['working'];
                     if ($working == 'Y') {
                         try {
-                            $data = array('title' => $row['title'], 'type' => $row['type'], 'length' => $row['length'], 'contents' => $row['contents'], 'teachersNotes' => $row['teachersNotes'], 'gibbonOutcomeIDList' => $row['gibbonOutcomeIDList'], 'gibbonUnitBlockID' => $gibbonUnitBlockID);
-                            $sql = 'UPDATE gibbonUnitClassBlock SET title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes, gibbonOutcomeIDList=:gibbonOutcomeIDList WHERE gibbonUnitBlockID=:gibbonUnitBlockID';
+                            $data = array('title' => $row['title'], 'type' => $row['type'], 'length' => $row['length'], 'contents' => $row['contents'], 'teachersNotes' => $row['teachersNotes'], 'gibbonUnitBlockID' => $gibbonUnitBlockID);
+                            $sql = 'UPDATE gibbonUnitClassBlock SET title=:title, type=:type, length=:length, contents=:contents, teachersNotes=:teachersNotes WHERE gibbonUnitBlockID=:gibbonUnitBlockID';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {


### PR DESCRIPTION
The current Smart Block setup is bloated, and so to ease OOification, and to remove unneeded code, the little (never?) used feature of mapping unit outcomes to lesson outcomes via Smart Blocks is removed by this PR.

Tested locally.