### PR TITLE
System: add an option to explicitly set PHPMailer SMTPSecure

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -840,4 +840,5 @@ ALTER TABLE gibbonUnitBlock DROP COLUMN gibbonOutcomeIDList;end
 ALTER TABLE gibbonUnitClassBlock DROP COLUMN gibbonOutcomeIDList;end
 ALTER TABLE `gibbonTTSpaceBooking` CHANGE `foreignKey` `foreignKey` ENUM('gibbonSpaceID','gibbonLibraryItemID') NOT NULL DEFAULT 'gibbonSpaceID';end
 UPDATE gibbonTTSpaceBooking SET foreignKey='gibbonSpaceID' WHERE foreignKey='';end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES ('System', 'mailerSMTPSecure', 'SMTP Encryption', 'Automatically sets the encryption based on the port, otherwise select one manually.', 'auto');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ v18.0.00
         System: fixed missing globals in custom index scripts
         System: fixed index_custom.php content not loading on first login
         System: fix SQL key integer length in database tables to ensure referential integrity
+        System: added an option to select SMTP encryption in Third Party Settings
         Markbook: fix column title showing term's name when the term filter is applied in View Markbook
         User Admin: fixed issue preventing action names from being translated in Manage Permissions
 

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -183,6 +183,17 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value']);
 
+    $encryptionOptions = [
+        'auto' => __('Automatic'),
+        'tls'  => 'TLS',
+        'ssl'  => 'SSL',
+        'none' => __('None'),
+    ];
+    $setting = getSettingByScope($connection2, 'System', 'mailerSMTPSecure', true);
+    $row = $form->addRow()->addClass('smtpSettings');
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addSelect($setting['name'])->fromArray($encryptionOptions)->selected($setting['value']);
+
     $setting = getSettingByScope($connection2, 'System', 'mailerSMTPUsername', true);
     $row = $form->addRow()->addClass('smtpSettings');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));

--- a/modules/System Admin/thirdPartySettingsProcess.php
+++ b/modules/System Admin/thirdPartySettingsProcess.php
@@ -48,6 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $enableMailerSMTP = (isset($_POST['enableMailerSMTP']))? $_POST['enableMailerSMTP'] : '';
     $mailerSMTPHost = (isset($_POST['mailerSMTPHost']))? $_POST['mailerSMTPHost'] : '';
     $mailerSMTPPort = (isset($_POST['mailerSMTPPort']))? $_POST['mailerSMTPPort'] : '';
+    $mailerSMTPSecure = (isset($_POST['mailerSMTPSecure']))? $_POST['mailerSMTPSecure'] : '';
     $mailerSMTPUsername = (isset($_POST['mailerSMTPUsername']))? $_POST['mailerSMTPUsername'] : '';
     $mailerSMTPPassword = (isset($_POST['mailerSMTPPassword']))? $_POST['mailerSMTPPassword'] : '';
 
@@ -241,6 +242,15 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
             try {
                 $data = array('value' => $mailerSMTPPort);
                 $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='System' AND name='mailerSMTPPort'";
+                $result = $connection2->prepare($sql);
+                $result->execute($data);
+            } catch (PDOException $e) {
+                $fail = true;
+            }
+
+            try {
+                $data = array('value' => $mailerSMTPSecure);
+                $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='System' AND name='mailerSMTPSecure'";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/src/Comms/Mailer.php
+++ b/src/Comms/Mailer.php
@@ -51,25 +51,37 @@ class Mailer extends \PHPMailer implements MailerInterface
         $host = $this->session->get('mailerSMTPHost');
         $port = $this->session->get('mailerSMTPPort');
 
-        if ( !empty($host) && !empty($port) ) {
+        if (!empty($host) && !empty($port)) {
             $username = $this->session->get('mailerSMTPUsername');
             $password = $this->session->get('mailerSMTPPassword');
-            $auth = ( !empty($username) && !empty($password) );
+            $auth = (!empty($username) && !empty($password));
 
             $this->IsSMTP();
             $this->Host       = $host;      // SMTP server example
             $this->SMTPDebug  = 0;          // enables SMTP debug information (for testing)
             $this->SMTPAuth   = $auth;      // enable SMTP authentication
-            $this->Port       = $port;      // set the SMTP port for the Gmail server
+            $this->Port       = $port;      // set the SMTP port for the server
             $this->Username   = $username;  // SMTP account username example
             $this->Password   = $password;  // SMTP account password example
             $this->Helo       = parse_url($this->session->get('absoluteURL'), PHP_URL_HOST);
 
-            // Automatically applies the required type of SMTP security for Gmail 
-            // based on the port used. https://support.google.com/a/answer/176600?hl=en
-            if ($this->Host === 'smtp.gmail.com' || $this->Host === 'smtp-relay.gmail.com') {
-                if ($port == 465) $this->SMTPSecure = 'ssl';
-                if ($port == 587) $this->SMTPSecure = 'tls';
+            $encryption = $this->session->get('mailerSMTPSecure');
+            if ($encryption == 'auto') {
+                // Automatically applies the required type of SMTP security based on the port used.
+                if ($port == 465) {
+                    $this->SMTPSecure = 'ssl';
+                } elseif ($port == 587) {
+                    $this->SMTPSecure = 'tls';
+                } else {
+                    $this->SMTPAutoTLS = true;
+                }
+            } elseif ($encryption == 'none') {
+                // Disables encryption as well as PHPMailer's opportunistic TLS setting.
+                $this->SMTPSecure = false;
+                $this->SMTPAutoTLS = false;
+            } else {
+                // Explicitly use the selected type of encryption.
+                $this->SMTPSecure = $encryption;
             }
         }
     }


### PR DESCRIPTION
Adds a new SMTP Encryption option under Third Party Settings, defaulting to the same behaviour we have currently. This allows a system admin to select the specific SSL or TLS setting they need, based on their mail server. The 'none' option is available for the rare case that a mail server requires TLS/SSL disabled.

Via the forum post:
https://ask.gibbonedu.org/discussion/2388/send-email-via-amazon-ses-service-failed-due-to-ssl-and-tsl-field

More info about the `SMTPSecure` and `SMTPAutoTLS` settings here:
https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#check-you-have-the-openssl-extension