### PR TITLE
System: update date and time localization in Format class

### DIFF
--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -188,6 +188,53 @@ class Format
     }
 
     /**
+     * Formats a Date or DateTime string relative to the current time. Eg: 1 hr ago, 3 mins from now.
+     *
+     * @param string $dateString
+     * @return string
+     */
+    public static function relativeTime($dateString, $tooltip = true)
+    {
+        if (strlen($dateString) == 10) $dateString .= ' 00:00:00';
+        $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateString);
+
+        $timeDifference = time() - $date->format('U');
+        $seconds = abs($timeDifference);
+
+        switch ($seconds) {
+            case ($seconds < 60):
+                $time = __('Less than 1 min');
+                break;
+            case ($seconds >= 60 && $seconds < 3600):
+                $minutes = floor($seconds / 60);
+                $time = __n('{count} min', '{count} mins', $minutes);
+                break;
+            case ($seconds >= 3600 && $seconds < 86400):
+                $hours = floor($seconds / 3600);
+                $time = __n('{count} hr', '{count} hrs', $hours);
+                break;
+            case ($seconds >= 86400 && $seconds < 2419200):
+                $days = floor($seconds / 86400);
+                $time = __n('{count} day', '{count} days', $days);
+                break;
+            default:
+                return self::tooltip($date->format(
+                    strlen($dateString) == 10
+                        ? static::$settings['dateFormatPHP']
+                        : static::$settings['dateTimeFormatPHP']
+                ));
+        }
+
+        $time = ($timeDifference >= 0)
+            ? __('{time} ago', ['time' => $time])
+            : __('{time} from now', ['time' => $time]);
+
+        return $tooltip 
+            ? self::tooltip($time, $dateString)
+            : $time;
+    }
+
+    /**
      * Converts a YYYY-MM-DD date to a Unix timestamp.
      *
      * @return string
@@ -288,6 +335,17 @@ class Format
     public static function small($value)
     {
         return '<span class="small emphasis">'.$value.'</span>';
+    }
+
+    /**
+     * Formats a string of additional details for a hover-over tooltip.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function tooltip($value, $tooltip = '')
+    {
+        return '<span title="'.$tooltip.'">'.$value.'</span>';
     }
 
     /**

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -220,18 +220,21 @@ class Format
                 $time = __n('{count} day', '{count} days', $days);
                 break;
             default:
-                return self::tooltip($date->format(
+                $timeDifference = 0;
+                $time = $date->format(
                     strlen($dateString) == 10
                         ? static::$settings['dateFormatPHP']
                         : static::$settings['dateTimeFormatPHP']
-                ));
+                );
         }
 
-        $time = ($timeDifference >= 0)
-            ? __('{time} ago', ['time' => $time])
-            : __('{time} from now', ['time' => $time]);
-
-        return $tooltip 
+        if ($timeDifference > 0) {
+            $time = __('{time} ago', ['time' => $time]);
+        } elseif ($timeDifference < 0) {
+            $time = __('{time} from now', ['time' => $time]);
+        }
+        
+        return $tooltip
             ? self::tooltip($time, static::dateTime($dateString))
             : $time;
     }

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -117,7 +117,7 @@ class Format
      */
     public static function dateReadable($dateString, $format = '%b %e, %G')
     {
-        return utf8_encode(ucfirst(strftime($format, strtotime($dateString))));
+        return mb_convert_case(strftime($format, strtotime($dateString)), MB_CASE_TITLE);
     }
 
     /**
@@ -128,7 +128,7 @@ class Format
      */
     public static function dateTimeReadable($dateString, $format = '%b %e, %G %H:%M')
     {
-        return utf8_encode(ucfirst(strftime($format, strtotime($dateString))));
+        return mb_convert_case(strftime($format, strtotime($dateString)), MB_CASE_TITLE);
     }
 
     /**
@@ -171,7 +171,7 @@ class Format
             $output = strftime('%b %e, %G', $startTime).' - '.strftime('%b %e, %G', $endTime);
         }
 
-        return utf8_encode(ucfirst($output));
+        return mb_convert_case($output, MB_CASE_TITLE);
     }  
 
     /**
@@ -230,7 +230,7 @@ class Format
             : __('{time} from now', ['time' => $time]);
 
         return $tooltip 
-            ? self::tooltip($time, $dateString)
+            ? self::tooltip($time, static::dateTime($dateString))
             : $time;
     }
 

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -115,9 +115,20 @@ class Format
      * @param string $dateString
      * @return string
      */
-    public static function dateReadable($dateString)
+    public static function dateReadable($dateString, $format = '%b %e, %G')
     {
-        return static::date($dateString, 'F j, Y');
+        return utf8_encode(ucfirst(strftime($format, strtotime($dateString))));
+    }
+
+    /**
+     * Formats a YYYY-MM-DD date as a readable string with month names and times.
+     *
+     * @param string $dateString
+     * @return string
+     */
+    public static function dateTimeReadable($dateString, $format = '%b %e, %G %H:%M')
+    {
+        return utf8_encode(ucfirst(strftime($format, strtotime($dateString))));
     }
 
     /**
@@ -147,15 +158,20 @@ class Format
         $startDate = ($dateFrom instanceof DateTime)? $dateFrom : new DateTime($dateFrom);
         $endDate = ($dateTo instanceof DateTime)? $dateTo : new DateTime($dateTo);
 
-        if ($startDate->format('Y-m') == $endDate->format('Y-m')) {
-            $output = $startDate->format('M Y');
-        } else if ($startDate->format('Y') == $endDate->format('Y')) {
-            $output = $startDate->format('M').' - '.$endDate->format('M Y');
+        $startTime = $startDate->format('U');
+        $endTime = $endDate->format('U');
+
+        if ($startDate->format('Y-m-d') == $endDate->format('Y-m-d')) {
+            $output = strftime('%b %e, %G', $startTime);
+        } elseif ($startDate->format('Y-m') == $endDate->format('Y-m')) {
+            $output = strftime('%b %e', $startTime).' - '.strftime('%e, %G', $endTime);
+        } elseif ($startDate->format('Y') == $endDate->format('Y')) {
+            $output = strftime('%b %e', $startTime).' - '.strftime('%b %e, %G', $endTime);
         } else {
-            $output = $startDate->format('M Y').' - '.$endDate->format('M Y');
+            $output = strftime('%b %e, %G', $startTime).' - '.strftime('%b %e, %G', $endTime);
         }
 
-        return $output;
+        return utf8_encode(ucfirst($output));
     }  
 
     /**

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -74,68 +74,70 @@ class Format
     /**
      * Formats a YYYY-MM-DD date with the language-specific format. Optionally provide a format string to use instead.
      *
-     * @param string $dateString
+     * @param DateTime|string $dateString
      * @param string $format
      * @return string
      */
     public static function date($dateString, $format = false)
     {
-        $date = DateTime::createFromFormat('Y-m-d', substr($dateString, 0, 10));
+        $date = static::createDateTime($dateString);
         return $date ? $date->format($format ? $format : static::$settings['dateFormatPHP']) : $dateString;
     }
 
     /**
      * Converts a date in the language-specific format to YYYY-MM-DD.
      *
-     * @param string $dateString
+     * @param DateTime|string $dateString
      * @return string
      */
     public static function dateConvert($dateString)
     {
-        $date = DateTime::createFromFormat(static::$settings['dateFormatPHP'], $dateString);
+        $date = static::createDateTime($dateString, static::$settings['dateFormatPHP']);
         return $date ? $date->format('Y-m-d') : $dateString;
     }
 
     /**
-     * Formats a YYYY-MM-DD H:I:S MySQL timestamp as a readable string. Optionally provide a format string to use.
+     * Formats a YYYY-MM-DD H:I:S MySQL timestamp as a language-specific string. Optionally provide a format string to use.
      *
-     * @param string $dateString
+     * @param DateTime|string $dateString
      * @param string $format
      * @return string
      */
     public static function dateTime($dateString, $format = false)
     {
-        $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateString);
+        $date = static::createDateTime($dateString, 'Y-m-d H:i:s');
         return $date ? $date->format($format ? $format : static::$settings['dateTimeFormatPHP']) : $dateString;
     }
     
     /**
      * Formats a YYYY-MM-DD date as a readable string with month names.
      *
-     * @param string $dateString
+     * @param DateTime|string $dateString
      * @return string
      */
     public static function dateReadable($dateString, $format = '%b %e, %G')
     {
-        return mb_convert_case(strftime($format, strtotime($dateString)), MB_CASE_TITLE);
+        $date = static::createDateTime($dateString);
+        return mb_convert_case(strftime($format, $date->format('U')), MB_CASE_TITLE);
     }
 
     /**
      * Formats a YYYY-MM-DD date as a readable string with month names and times.
      *
-     * @param string $dateString
+     * @param DateTime|string $dateString
      * @return string
      */
     public static function dateTimeReadable($dateString, $format = '%b %e, %G %H:%M')
     {
-        return mb_convert_case(strftime($format, strtotime($dateString)), MB_CASE_TITLE);
+        $date = static::createDateTime($dateString);
+        return mb_convert_case(strftime($format, $date->format('U')), MB_CASE_TITLE);
     }
 
     /**
      * Formats two YYYY-MM-DD dates with the language-specific format. Optionally provide a format string to use instead.
      *
-     * @param string $dateFrom
-     * @param string $dateTo
+     * @param DateTime|string $dateFrom
+     * @param DateTime|string $dateTo
      * @return string
      */
     public static function dateRange($dateFrom, $dateTo, $format = false)
@@ -146,8 +148,8 @@ class Format
     /**
      * Formats two YYYY-MM-DD dates as a readable string, collapsing same months and same years.
      *
-     * @param string $dateFrom
-     * @param string $dateTo
+     * @param DateTime|string $dateFrom
+     * @param DateTime|string $dateTo
      * @return string
      */
     public static function dateRangeReadable($dateFrom, $dateTo)
@@ -155,11 +157,11 @@ class Format
         $output = '';
         if (empty($dateFrom) || empty($dateTo)) return $output;
 
-        $startDate = ($dateFrom instanceof DateTime)? $dateFrom : new DateTime($dateFrom);
-        $endDate = ($dateTo instanceof DateTime)? $dateTo : new DateTime($dateTo);
+        $startDate = static::createDateTime($dateFrom);
+        $endDate = static::createDateTime($dateTo);
 
-        $startTime = $startDate->format('U');
-        $endTime = $endDate->format('U');
+        $startTime = $startDate->getTimestamp();
+        $endTime = $endDate->getTimestamp();
 
         if ($startDate->format('Y-m-d') == $endDate->format('Y-m-d')) {
             $output = strftime('%b %e, %G', $startTime);
@@ -177,26 +179,26 @@ class Format
     /**
      * Formats a Unix timestamp as the language-specific format. Optionally provide a format string to use instead.
      *
-     * @param string|int $timestamp
+     * @param DateTime|string|int $timestamp
      * @param string $format
      * @return string
      */
     public static function dateFromTimestamp($timestamp, $format = false)
     {
-        $date = DateTime::createFromFormat('U', $timestamp);
+        $date = static::createDateTime($timestamp, 'U');
         return $date ? $date->format($format ? $format : static::$settings['dateFormatPHP']) : $timestamp;
     }
 
     /**
      * Formats a Date or DateTime string relative to the current time. Eg: 1 hr ago, 3 mins from now.
      *
-     * @param string $dateString
+     * @param DateTime|string $dateString
      * @return string
      */
     public static function relativeTime($dateString, $tooltip = true)
     {
         if (strlen($dateString) == 10) $dateString .= ' 00:00:00';
-        $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateString);
+        $date = static::createDateTime($dateString, 'Y-m-d H:i:s');
 
         $timeDifference = time() - $date->format('U');
         $seconds = abs($timeDifference);
@@ -237,34 +239,36 @@ class Format
     /**
      * Converts a YYYY-MM-DD date to a Unix timestamp.
      *
-     * @return string
+     * @param DateTime|string $dateString
+     * @param string $timezone
+     * @return int
      */
-    public static function timestamp($dateString, $timeZone = null)
+    public static function timestamp($dateString, $timezone = null)
     {
         if (strlen($dateString) == 10) $dateString .= ' 00:00:00';
-        $date = DateTime::createFromFormat('Y-m-d H:i:s', $dateString, $timeZone);
+        $date = static::createDateTime($dateString, 'Y-m-d H:i:s', $timezone);
         return $date ? $date->getTimestamp() : 0;
     }
 
     /**
      * Formats a time from a given MySQL time or timestamp value.
      * 
-     * @param string $timeString
+     * @param DateTime|string $timeString
      * @param string|bool $format
      * @return string
      */
     public static function time($timeString, $format = false)
     {
         $convertFormat = strlen($timeString) == 8? 'H:i:s' : 'Y-m-d H:i:s';
-        $date = DateTime::createFromFormat($convertFormat, $timeString);
+        $date = static::createDateTime($timeString, $convertFormat);
         return $date ? $date->format($format ? $format : static::$settings['timeFormatPHP']) : $timeString;
     }
 
     /**
      * Formats a range of times from two given MySQL time or timestamp values.
      * 
-     * @param string $timeFrom
-     * @param string $timeTo
+     * @param DateTime|string $timeFrom
+     * @param DateTime|string $timeTo
      * @param string|bool $format
      * @return string
      */
@@ -552,5 +556,14 @@ class Format
     public static function alert($message, $level = 'error')
     {
         return '<div class="'.$level.'">'.$message.'</div>';
+    }
+
+    private static function createDateTime($dateOriginal, $expectedFormat = null, $timezone = null)
+    {
+        if ($dateOriginal instanceof DateTime) return $dateOriginal;
+
+        return !empty($expectedFormat)
+            ? DateTime::createFromFormat($expectedFormat, $dateOriginal, $timezone)
+            : new DateTime($dateOriginal, $timezone);
     }
 }


### PR DESCRIPTION
Updates the `dateReadable`, `dateTimeReadable` and `dateRangeReadable` methods to use `strftime`, which handles localization of date strings: http://php.net/manual/en/function.strftime.php 

Also adds a `relativeTime` method, which aims to provide an easy-to-use, translatable way to display simple time strings like 1 hr ago, 3 mins from now, etc.

@leofreitas Let me know what you think. We should be able to use something like `Format::dateReadable($date, '%b');` to properly handle the date strings in `modules/Attendence/attendence.php`. By using this class, in the future we should be able to enable more customization of preferred date formats for admins, by pulling in the system-wide preferred date formats from settings.