### PR TITLE
System Admin: add import type for Timetable - Complete 

### DIFF
--- a/resources/imports/timetableComplete.yml
+++ b/resources/imports/timetableComplete.yml
@@ -80,7 +80,7 @@ fields:
     gibbonSpaceID:
         name: "Space Name"
         desc: ""
-        args: { filter: string, custom: true }
+        args: { filter: string, required: true, custom: true }
         relationship: { table: gibbonSpace, key: gibbonSpaceID, field: name }
 tables:
     gibbonCourse:
@@ -122,7 +122,10 @@ tables:
         uniqueKeys:
             - [ gibbonCourseClassID, gibbonTTDayID, gibbonTTColumnRowID ]
         fields:
+            - gibbonSchoolYearID
+            - gibbonTTID
             - gibbonCourseClassID
             - gibbonTTDayID
+            - gibbonTTColumnID
             - gibbonTTColumnRowID
             - gibbonSpaceID

--- a/resources/imports/timetableComplete.yml
+++ b/resources/imports/timetableComplete.yml
@@ -1,0 +1,128 @@
+details:
+    type: timetableComplete
+    name: Timetable - Complete
+    table: gibbonTTDayRowClass
+    modes: { update: true, insert: true, export: true }
+access:
+    module: Timetable Admin
+    action: Manage Timetables
+primaryKey:
+    gibbonTTDayRowClassID
+uniqueKeys:
+    - [ gibbonCourseClassID, gibbonTTDayID, gibbonTTColumnRowID ]
+fields:
+    gibbonSchoolYearID:
+        name: "School Year"
+        desc: "School year name, as set in School Admin. Must already exist."
+        args: { filter: schoolyear, required: true, custom: true, readonly: [gibbonCourseClass, gibbonCourseClassPerson, gibbonTTDayRowClass] }
+        relationship: { table: gibbonSchoolYear, key: gibbonSchoolYearID, field: name  }
+    gibbonTTID:
+        name: "Timetable"
+        desc: "Short Name"
+        args: { filter: string, required: true, custom: true, readonly: true }
+        relationship: { table: gibbonTT, key: gibbonTTID, field: [nameShort, gibbonSchoolYearID]  }
+    gibbonCourse.nameShort:
+        name: "Course Short Name"
+        desc: "e.g. DR10 for Year 10 Drama"
+        args: { filter: string, required: true, custom: true }
+    gibbonCourse.name:
+        name: "Course"
+        desc: "Name"
+        args: { filter: string, linked: gibbonCourse.nameShort }
+    gibbonCourseID:
+        name: "Course"
+        desc: "ID"
+        args: { filter: string, linked: gibbonCourse.nameShort, readonly: [ gibbonCourseClassPerson, gibbonTTDayRowClass ] }
+        relationship: { table: gibbonCourse, key: gibbonCourseID, field: [ nameShort, gibbonSchoolYearID ]  }
+    gibbonYearGroupIDList: 
+        name: "Year Groups"
+        desc: ""
+        args: { filter: string, linked: gibbonTTID }
+        relationship: { table: gibbonTT, key: gibbonYearGroupIDList, field: [ gibbonTTID ]  }
+    gibbonCourseClass.nameShort:
+        name: "Class Short Name"
+        desc: "e.g 1 for DR10.1"
+        args: { filter: string, required: true, custom: true }
+    gibbonCourseClass.name:
+        name: "Class"
+        desc: "Name"
+        args: { filter: string, linked: gibbonCourseClass.nameShort }
+    gibbonCourseClassID:
+        name: "Class"
+        desc: "ID"
+        args: { filter: string, linked: gibbonCourseClass.nameShort }
+        relationship: { table: gibbonCourseClass, key: gibbonCourseClassID, field: [ nameShort, gibbonCourseID ]  }
+    gibbonTTDayID:
+        name: "Day Name"
+        desc: "as used in the target timetable"
+        args: { filter: string, required: true, custom: true }
+        relationship: { table: gibbonTTDay, key: gibbonTTDayID, field: [ name, gibbonTTID ]  }
+    gibbonTTColumnID:
+        name: "Timetable Column"
+        desc: "Linked"
+        args: { filter: string, required: true, custom: true, readonly: true, linked: gibbonTTDayID }
+        relationship: { table: gibbonTTColumn, key: gibbonTTColumnID, join: gibbonTTDay, on: [gibbonTTColumnID, gibbonTTColumnID], field: [ gibbonTTDayID ] }
+    gibbonTTColumnRowID:
+        name: "Row Long Name"
+        desc: "as used in the target timetable"
+        args: { filter: string, required: true, custom: true }
+        relationship: { table: gibbonTTColumnRow, key: gibbonTTColumnRowID, field: [ name, gibbonTTColumnID ]  }
+    gibbonPersonID:
+        name: "Teacher"
+        desc: "Username"
+        args: { filter: string, required: true, custom: true }
+        relationship: { table: gibbonPerson, key: gibbonPersonID, field: username  }
+    role:
+        name: "Role"
+        desc: ""
+        value: "Teacher"
+        args: { filter: string, hidden: true }
+    gibbonSpaceID:
+        name: "Space Name"
+        desc: ""
+        args: { filter: string, custom: true }
+        relationship: { table: gibbonSpace, key: gibbonSpaceID, field: name }
+tables:
+    gibbonCourse:
+        primaryKey:
+            gibbonCourseID
+        uniqueKeys:
+            - [ gibbonSchoolYearID, gibbonCourse.name ]
+            - [ gibbonSchoolYearID, gibbonCourse.nameShort ]
+        fields:
+            - gibbonSchoolYearID
+            - gibbonTTID
+            - gibbonCourse.name
+            - gibbonCourse.nameShort
+            - gibbonYearGroupIDList
+    gibbonCourseClass:
+        primaryKey:
+            gibbonCourseClassID
+        uniqueKeys:
+            - [ gibbonCourseID, gibbonCourseClass.nameShort ]
+        fields:
+            - gibbonSchoolYearID
+            - gibbonCourseID
+            - gibbonCourseClass.name
+            - gibbonCourseClass.nameShort
+    gibbonCourseClassPerson:
+        primaryKey:
+            gibbonCourseClassPersonID
+        uniqueKeys:
+            - [ gibbonCourseClassID, gibbonPersonID ]
+        fields:
+            - gibbonSchoolYearID
+            - gibbonCourseID
+            - gibbonCourseClassID
+            - gibbonPersonID
+            - role
+    gibbonTTDayRowClass:
+        primaryKey:
+            gibbonTTDayRowClassID
+        uniqueKeys:
+            - [ gibbonCourseClassID, gibbonTTDayID, gibbonTTColumnRowID ]
+        fields:
+            - gibbonCourseClassID
+            - gibbonTTDayID
+            - gibbonTTColumnRowID
+            - gibbonSpaceID

--- a/src/Data/ImportType.php
+++ b/src/Data/ImportType.php
@@ -348,8 +348,10 @@ class ImportType
                 continue;
             }
 
-            if (isset($columns[$fieldName])) {
-                foreach ($columns[$fieldName] as $columnName => $columnField) {
+            $columnFieldName = stripos($fieldName, '.') !== false ? trim(strrchr($fieldName, '.'), '.') : $fieldName;
+
+            if (isset($columns[$columnFieldName])) {
+                foreach ($columns[$columnFieldName] as $columnName => $columnField) {
                     if ($columnName == 'Type') {
                         $this->parseTableValueType($fieldName, $columnField);
                     } else {


### PR DESCRIPTION
This import definition aims to replicate the same functionality as the Import option in Timetable Admin. It uses the somewhat-complex syntax for multi-table imports to allow:

- Create courses if they don't already exist
- Creates classes if they don't already exist
- Adds teachers to classes
- Adds the timetable day/row/column schedules
- Assigns the facility to the timetabled class

The only thing it doesn't have is the additional feedback messages that the current Import tool provides, although it does provide more pre-import feedback via the Dry Run step. I've tested it with demo data so far, will test it with some actual timetables for our next school year which are being made in the next month or so.

Also tweaks the ImportType and Importer class to handle dot notation for column references in the yml import syntax.

<img width="762" alt="screen shot 2019-02-22 at 2 24 37 pm" src="https://user-images.githubusercontent.com/897700/53223834-a19a5900-36ad-11e9-9a46-accc5e935d6d.png">
