### PR TITLE
Forms, Tables: rename setters that start with isXXX for code consistency

### DIFF
--- a/src/Forms/Input/TextField.php
+++ b/src/Forms/Input/TextField.php
@@ -72,7 +72,22 @@ class TextField extends Input
         return $this;
     }
 
-    public function isUnique($ajaxURL, $data = array())
+    /**
+     * @deprecated Remove setters that start with isXXX for code consistency.
+     */
+    public function isUnique($ajaxURL, $data = [])
+    {
+        return $this->uniqueField($ajaxURL, $data);
+    }
+
+    /**
+     * Add an AJAX uniqueness check to this field using the given URL.
+     *
+     * @param string $ajaxURL
+     * @param array $data
+     * @return self
+     */
+    public function uniqueField($ajaxURL, $data = [])
     {
         $label = $this->row->getElement('label'.$this->getName());
         $fieldLabel = (!empty($label))? $label->getLabelText() : ucfirst($this->getName());

--- a/src/Forms/Traits/InputAttributesTrait.php
+++ b/src/Forms/Traits/InputAttributesTrait.php
@@ -128,14 +128,22 @@ trait InputAttributesTrait
     }
 
     /**
-     * Set the input to disabled.
-     * @param   bool    $value
-     * @return  self
+     * @deprecated Remove setters that start with isXXX for code consistency.
      */
     public function isDisabled($disabled = true)
     {
         $this->setDisabled('disabled', $disabled);
         return $this;
+    }
+
+    /**
+     * Set the input to disabled.
+     * @param   bool    $value
+     * @return  self
+     */
+    public function disabled($disabled = true)
+    {
+        return $this->setDisabled('disabled', $disabled);
     }
 
     /**
@@ -159,11 +167,19 @@ trait InputAttributesTrait
     }
 
     /**
+     * @deprecated Remove setters that start with isXXX for code consistency.
+     */
+    public function isRequired($required = true)
+    {
+        return $this->setRequired($required);
+    }
+
+    /**
      * Set the input to required.
      * @param   bool    $value
      * @return  self
      */
-    public function isRequired($required = true)
+    public function required($required = true)
     {
         return $this->setRequired($required);
     }

--- a/src/Tables/Action.php
+++ b/src/Tables/Action.php
@@ -54,7 +54,7 @@ class Action extends WebLink
                             break;
             case 'edit':    $this->setIcon('config');
                             break;
-            case 'delete':  $this->setIcon('garbage')->isModal(650, 135);
+            case 'delete':  $this->setIcon('garbage')->modalWindow(650, 135);
                             break;
             case 'print':   $this->setIcon('print');
                             break;
@@ -155,12 +155,20 @@ class Action extends WebLink
     }
 
     /**
+     * @deprecated Remove setters that start with isXXX for code consistency.
+     */
+    public function isModal($width = 650, $height = 650) 
+    {
+        return $this->modalWindow($width, $height);
+    }
+
+    /**
      * Load the action URL in a modal window rather than loading a new page. Commonly used for delete actions.
      *
      * @param bool $value
      * @return self
      */
-    public function isModal($width = 650, $height = 650) 
+    public function modalWindow($width = 650, $height = 650) 
     {
         $this->modal = true;
 
@@ -172,13 +180,21 @@ class Action extends WebLink
     }
 
     /**
+     * @deprecated Remove setters that start with isXXX for code consistency.
+     */
+    public function isDirect($value = true) 
+    {
+        return $this->directLink($value);
+    }
+
+    /**
      * The action link will not prepend an index.php?q=
      *
      * @return self
      */
-    public function isDirect() 
+    public function directLink($value = true) 
     {
-        $this->direct = true;
+        $this->direct = $value;
 
         return $this;
     }


### PR DESCRIPTION
A follow-up to [a previous discussion](https://github.com/GibbonEdu/core/pull/787) about getter/setter naming consistency, this PR renames some methods currently used in the form and table classes. For backwards compatibility it leaves the current methods in place, marked with a `@deprecated` doc tag. After this is merged I'll catch all the current instances in the core, and we can aim to catch additional modules as part of our ongoing refactoring.

`isUnique` → `uniqueField`
`isDisabled` → `disabled`
`isRequired` → `required`
`isModal` → `modalWindow`
`isDirect` → `directLink`