### PR TITLE
Forms, Tables: update all instances of renamed setter methods

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2753,7 +2753,7 @@ function sidebar($gibbon, $pdo)
             $row = $form->addRow();
                 $row->addContent(sprintf($loginIcon, 'attendance', __('Username or email')));
                 $row->addTextField('username')
-                    ->isRequired()
+                    ->required()
                     ->maxLength(50)
                     ->setClass('fullWidth')
                     ->placeholder(__('Username or email'))
@@ -2762,7 +2762,7 @@ function sidebar($gibbon, $pdo)
             $row = $form->addRow();
                 $row->addContent(sprintf($loginIcon, 'key', __('Password')));
                 $row->addPassword('password')
-                    ->isRequired()
+                    ->required()
                     ->maxLength(30)
                     ->setClass('fullWidth')
                     ->placeholder(__('Password'))

--- a/installer/install.php
+++ b/installer/install.php
@@ -229,7 +229,7 @@ $_SESSION[$guid]['stringReplacement'] = array();
 
                                 $row = $form->addRow();
                                     $row->addLabel('code', __('System Language'));
-                                    $row->addSelectSystemLanguage('code')->selected($code)->isRequired();
+                                    $row->addSelectSystemLanguage('code')->selected($code)->required();
 
                                 $row = $form->addRow();
                                     $row->addFooter();
@@ -255,23 +255,23 @@ $_SESSION[$guid]['stringReplacement'] = array();
 
                                 $row = $form->addRow();
                                     $row->addLabel('type', __('Database Type'));
-                                    $row->addTextField('type')->setValue('MySQL')->readonly()->isRequired();
+                                    $row->addTextField('type')->setValue('MySQL')->readonly()->required();
 
                                 $row = $form->addRow();
                                     $row->addLabel('databaseServer', __('Database Server'))->description(__('Localhost, IP address or domain.'));
-                                    $row->addTextField('databaseServer')->isRequired()->maxLength(255);
+                                    $row->addTextField('databaseServer')->required()->maxLength(255);
 
                                 $row = $form->addRow();
                                     $row->addLabel('databaseName', __('Database Name'))->description(__('This database will be created if it does not already exist. Collation should be utf8_general_ci.'));
-                                    $row->addTextField('databaseName')->isRequired()->maxLength(50);
+                                    $row->addTextField('databaseName')->required()->maxLength(50);
 
                                 $row = $form->addRow();
                                     $row->addLabel('databaseUsername', __('Database Username'));
-                                    $row->addTextField('databaseUsername')->isRequired()->maxLength(50);
+                                    $row->addTextField('databaseUsername')->required()->maxLength(50);
 
                                 $row = $form->addRow();
                                     $row->addLabel('databasePassword', __('Database Password'));
-                                    $row->addPassword('databasePassword')->isRequired()->maxLength(255);
+                                    $row->addPassword('databasePassword')->required()->maxLength(255);
 
                                 $row = $form->addRow();
                                     $row->addLabel('demoData', __('Install Demo Data?'));
@@ -443,15 +443,15 @@ $_SESSION[$guid]['stringReplacement'] = array();
 
                                                 $row = $form->addRow();
                                                     $row->addLabel('surname', __('Surname'))->description(__('Family name as shown in ID documents.'));
-                                                    $row->addTextField('surname')->isRequired()->maxLength(30);
+                                                    $row->addTextField('surname')->required()->maxLength(30);
 
                                                 $row = $form->addRow();
                                                     $row->addLabel('firstName', __('First Name'))->description(__('First name as shown in ID documents.'));
-                                                    $row->addTextField('firstName')->isRequired()->maxLength(30);
+                                                    $row->addTextField('firstName')->required()->maxLength(30);
 
                                                 $row = $form->addRow();
                                                     $row->addLabel('email', __('Email'));
-                                                    $row->addEmail('email')->isRequired();
+                                                    $row->addEmail('email')->required();
 
                                                 $row = $form->addRow();
                                                     $row->addLabel('support', '<b>'.__('Receive Support?').'</b>')->description(__('Join our mailing list and recieve a welcome email from the team.'));
@@ -459,7 +459,7 @@ $_SESSION[$guid]['stringReplacement'] = array();
 
                                                 $row = $form->addRow();
                                                     $row->addLabel('username', __('Username'))->description(__('Must be unique. System login name. Cannot be changed.'));
-                                                    $row->addTextField('username')->isRequired()->maxLength(20);
+                                                    $row->addTextField('username')->required()->maxLength(20);
 
                                                 $policy = getPasswordPolicy($guid, $connection2);
                                                 if ($policy != false) {
@@ -468,7 +468,7 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                 $row = $form->addRow();
                                                     $row->addLabel('passwordNew', __('Password'));
                                                     $password = $row->addPassword('passwordNew')
-                                                        ->isRequired()
+                                                        ->required()
                                                         ->maxLength(30);
 
                                                 $alpha = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha');
@@ -492,7 +492,7 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                 $row = $form->addRow();
                                                     $row->addLabel('passwordConfirm', __('Confirm Password'));
                                                     $row->addPassword('passwordConfirm')
-                                                        ->isRequired()
+                                                        ->required()
                                                         ->maxLength(30)
                                                         ->addValidation('Validate.Confirmation', "match: 'passwordNew'");
 
@@ -507,17 +507,17 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                 $setting = getSettingByScope($connection2, 'System', 'absoluteURL', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addURL($setting['name'])->setValue($pageURL.$_SERVER['SERVER_NAME'].$port.substr($uri_parts[0], 0, -22))->maxLength(100)->isRequired();
+                                                    $row->addURL($setting['name'])->setValue($pageURL.$_SERVER['SERVER_NAME'].$port.substr($uri_parts[0], 0, -22))->maxLength(100)->required();
 
                                                 $setting = getSettingByScope($connection2, 'System', 'absolutePath', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addTextField($setting['name'])->setValue(substr(__FILE__, 0, -22))->maxLength(100)->isRequired();
+                                                    $row->addTextField($setting['name'])->setValue(substr(__FILE__, 0, -22))->maxLength(100)->required();
 
                                                 $setting = getSettingByScope($connection2, 'System', 'systemName', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addTextField($setting['name'])->maxLength(50)->isRequired()->setValue('Gibbon');
+                                                    $row->addTextField($setting['name'])->maxLength(50)->required()->setValue('Gibbon');
 
                                                 $installTypes = array(
                                                     'Production'  => __('Production'),
@@ -528,7 +528,7 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                 $setting = getSettingByScope($connection2, 'System', 'installType', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addSelect($setting['name'])->fromArray($installTypes)->selected('Testing')->isRequired();
+                                                    $row->addSelect($setting['name'])->fromArray($installTypes)->selected('Testing')->required();
 
                                                 $statusInitial = "<div id='status' class='warning'><div style='width: 100%; text-align: center'><img style='margin: 10px 0 5px 0' src='../themes/Default/img/loading.gif' alt='Loading'/><br/>".__('Checking for Cutting Edge Code.')."</div></div>";
                                                 $row = $form->addRow();
@@ -567,19 +567,19 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                 $setting = getSettingByScope($connection2, 'System', 'statsCollection', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addYesNo($setting['name'])->selected('Y')->isRequired();
+                                                    $row->addYesNo($setting['name'])->selected('Y')->required();
 
                                                 $form->addRow()->addHeading(__('Organisation Settings'));
 
                                                 $setting = getSettingByScope($connection2, 'System', 'organisationName', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addTextField($setting['name'])->setValue('')->maxLength(50)->isRequired();
+                                                    $row->addTextField($setting['name'])->setValue('')->maxLength(50)->required();
 
                                                 $setting = getSettingByScope($connection2, 'System', 'organisationNameShort', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addTextField($setting['name'])->setValue('')->maxLength(50)->isRequired();
+                                                    $row->addTextField($setting['name'])->setValue('')->maxLength(50)->required();
 
                                                 $form->addRow()->addHeading(__('gibbonedu.com Value Added Services'));
 
@@ -598,12 +598,12 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                 $setting = getSettingByScope($connection2, 'System', 'country', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addSelectCountry($setting['name'])->isRequired();
+                                                    $row->addSelectCountry($setting['name'])->required();
 
                                                 $setting = getSettingByScope($connection2, 'System', 'currency', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addSelectCurrency($setting['name'])->isRequired();
+                                                    $row->addSelectCurrency($setting['name'])->required();
 
                                                 $tzlist = array_reduce(DateTimeZone::listIdentifiers(DateTimeZone::ALL), function($group, $item) {
                                                     $group[$item] = __($item);
@@ -612,7 +612,7 @@ $_SESSION[$guid]['stringReplacement'] = array();
                                                 $setting = getSettingByScope($connection2, 'System', 'timezone', true);
                                                 $row = $form->addRow();
                                                     $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-                                                    $row->addSelect($setting['name'])->fromArray($tzlist)->isRequired()->placeholder();
+                                                    $row->addSelect($setting['name'])->fromArray($tzlist)->required()->placeholder();
 
                                                 $row = $form->addRow();
                                                     $row->addFooter();

--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
 
     $row = $form->addRow();
         $row->addLabel('gibbonActivityID', __('Activity'));
-        $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->isRequired()->placeholder();
+        $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session);

--- a/modules/Activities/activities_attendance_sheet.php
+++ b/modules/Activities/activities_attendance_sheet.php
@@ -54,11 +54,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
     $sql = "SELECT gibbonActivityID AS value, name FROM gibbonActivity WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name, programStart";
     $row = $form->addRow();
         $row->addLabel('gibbonActivityID', __('Activity'));
-        $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->isRequired()->placeholder();
+        $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('numberOfColumns', __('Number of Columns'));
-        $row->addNumber('numberOfColumns')->decimalPlaces(0)->maximum(20)->maxLength(2)->setValue($numberOfColumns)->isRequired();
+        $row->addNumber('numberOfColumns')->decimalPlaces(0)->maximum(20)->maxLength(2)->setValue($numberOfColumns)->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Activities/activities_manage_add.php
+++ b/modules/Activities/activities_manage_add.php
@@ -59,11 +59,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 	$row = $form->addRow();
         $row->addLabel('name', __('Name'));
-		$row->addTextField('name')->isRequired()->maxLength(40);
+		$row->addTextField('name')->required()->maxLength(40);
 
 	$row = $form->addRow();
         $row->addLabel('provider', __('Provider'));
-        $row->addSelect('provider')->isRequired()->fromArray(array('School' => $_SESSION[$guid]['organisationNameShort'], 'External' => __('External')));
+        $row->addSelect('provider')->required()->fromArray(array('School' => $_SESSION[$guid]['organisationNameShort'], 'External' => __('External')));
 
 	$activityTypes = getSettingByScope($connection2, 'Activities', 'activityTypes');
 	if (!empty($activityTypes)) {
@@ -74,11 +74,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 	$row = $form->addRow();
         $row->addLabel('active', __('Active'));
-		$row->addYesNo('active')->isRequired();
+		$row->addYesNo('active')->required();
 
 	$row = $form->addRow();
         $row->addLabel('registration', __('Registration'))->description(__('Assuming system-wide registration is open, should this activity be open for registration?'));
-		$row->addYesNo('registration')->isRequired();
+		$row->addYesNo('registration')->required();
 
 	$dateType = getSettingByScope($connection2, 'Activities', 'dateType');
 	$form->addHiddenValue('dateType', $dateType);
@@ -106,19 +106,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 		$row = $form->addRow();
         	$row->addLabel('listingStart', __('Listing Start Date'))->description(__('Default: 2 weeks before the end of the current term.'));
-			$row->addDate('listingStart')->isRequired()->setValue($listingStart->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
+			$row->addDate('listingStart')->required()->setValue($listingStart->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
 
 		$row = $form->addRow();
         	$row->addLabel('listingEnd', __('Listing End Date'))->description(__('Default: 2 weeks after the start of next term.'));
-			$row->addDate('listingEnd')->isRequired()->setValue($listingEnd->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
+			$row->addDate('listingEnd')->required()->setValue($listingEnd->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
 
 		$row = $form->addRow();
         	$row->addLabel('programStart', __('Program Start Date'))->description(__('Default: first day of next term.'));
-			$row->addDate('programStart')->isRequired()->setValue($programStart->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
+			$row->addDate('programStart')->required()->setValue($programStart->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
 
 		$row = $form->addRow();
         	$row->addLabel('programEnd', __('Program End Date'))->description(__('Default: last day of the next term.'));
-			$row->addDate('programEnd')->isRequired()->setValue($programEnd->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
+			$row->addDate('programEnd')->required()->setValue($programEnd->format($_SESSION[$guid]['i18n']['dateFormatPHP']));
 	}
 
 	$row = $form->addRow();
@@ -127,7 +127,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 	$row = $form->addRow();
         $row->addLabel('maxParticipants', __('Max Participants'));
-		$row->addNumber('maxParticipants')->isRequired()->maxLength(4)->setValue('0');
+		$row->addNumber('maxParticipants')->required()->maxLength(4)->setValue('0');
 
 	$column = $form->addRow()->addColumn();
         $column->addLabel('description', __('Description'));
@@ -139,7 +139,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 		$row = $form->addRow();
         	$row->addLabel('payment', __('Cost'));
-			$row->addCurrency('payment')->isRequired()->maxLength(9)->setValue('0.00');
+			$row->addCurrency('payment')->required()->maxLength(9)->setValue('0.00');
 
 		$costTypes = array(
 			'Entire Programme' => __('Entire Programme'),
@@ -150,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 		$row = $form->addRow();
         	$row->addLabel('paymentType', __('Cost Type'));
-			$row->addSelect('paymentType')->isRequired()->fromArray($costTypes);
+			$row->addSelect('paymentType')->required()->fromArray($costTypes);
 
 		$costStatuses = array(
             'Finalised' => __('Finalised'),
@@ -159,7 +159,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 		$row = $form->addRow();
         	$row->addLabel('paymentFirmness', __('Cost Status'));
-        	$row->addSelect('paymentFirmness')->isRequired()->fromArray($costStatuses);
+        	$row->addSelect('paymentFirmness')->required()->fromArray($costStatuses);
 	}
 
 	$form->addRow()->addHeading(__('Time Slots'));

--- a/modules/Activities/activities_manage_edit.php
+++ b/modules/Activities/activities_manage_edit.php
@@ -80,11 +80,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'));
-				$row->addTextField('name')->isRequired()->maxLength(40);
+				$row->addTextField('name')->required()->maxLength(40);
 
 			$row = $form->addRow();
 				$row->addLabel('provider', __('Provider'));
-				$row->addSelect('provider')->isRequired()->fromArray(array('School' => $_SESSION[$guid]['organisationNameShort'], 'External' => __('External')));
+				$row->addSelect('provider')->required()->fromArray(array('School' => $_SESSION[$guid]['organisationNameShort'], 'External' => __('External')));
 
 			$activityTypes = getSettingByScope($connection2, 'Activities', 'activityTypes');
 			if (!empty($activityTypes)) {
@@ -95,11 +95,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 			$row = $form->addRow();
 				$row->addLabel('active', __('Active'));
-				$row->addYesNo('active')->isRequired();
+				$row->addYesNo('active')->required();
 
 			$row = $form->addRow();
 				$row->addLabel('registration', __('Registration'))->description(__('Assuming system-wide registration is open, should this activity be open for registration?'));
-				$row->addYesNo('registration')->isRequired();
+				$row->addYesNo('registration')->required();
 
 			$dateType = getSettingByScope($connection2, 'Activities', 'dateType');
 			$form->addHiddenValue('dateType', $dateType);
@@ -110,19 +110,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 			} else {
 				$row = $form->addRow();
 					$row->addLabel('listingStart', __('Listing Start Date'))->description(__('Default: 2 weeks before the end of the current term.'));
-					$row->addDate('listingStart')->isRequired()->setValue(dateConvertBack($guid, $values['listingStart']));
+					$row->addDate('listingStart')->required()->setValue(dateConvertBack($guid, $values['listingStart']));
 
 				$row = $form->addRow();
 					$row->addLabel('listingEnd', __('Listing End Date'))->description(__('Default: 2 weeks after the start of next term.'));
-					$row->addDate('listingEnd')->isRequired()->setValue(dateConvertBack($guid, $values['listingEnd']));
+					$row->addDate('listingEnd')->required()->setValue(dateConvertBack($guid, $values['listingEnd']));
 
 				$row = $form->addRow();
 					$row->addLabel('programStart', __('Program Start Date'))->description(__('Default: first day of next term.'));
-					$row->addDate('programStart')->isRequired()->setValue(dateConvertBack($guid, $values['programStart']));
+					$row->addDate('programStart')->required()->setValue(dateConvertBack($guid, $values['programStart']));
 
 				$row = $form->addRow();
 					$row->addLabel('programEnd', __('Program End Date'))->description(__('Default: last day of the next term.'));
-					$row->addDate('programEnd')->isRequired()->setValue(dateConvertBack($guid, $values['programEnd']));
+					$row->addDate('programEnd')->required()->setValue(dateConvertBack($guid, $values['programEnd']));
 			}
 
 			$row = $form->addRow();
@@ -131,7 +131,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 			$row = $form->addRow();
 				$row->addLabel('maxParticipants', __('Max Participants'));
-				$row->addNumber('maxParticipants')->isRequired()->maxLength(4);
+				$row->addNumber('maxParticipants')->required()->maxLength(4);
 
 			$column = $form->addRow()->addColumn();
 				$column->addLabel('description', __('Description'));
@@ -143,7 +143,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 				$row = $form->addRow();
 					$row->addLabel('payment', __('Cost'));
-					$row->addCurrency('payment')->isRequired()->maxLength(9);
+					$row->addCurrency('payment')->required()->maxLength(9);
 
 				$costTypes = array(
 					'Entire Programme' => __('Entire Programme'),
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 				$row = $form->addRow();
 					$row->addLabel('paymentType', __('Cost Type'));
-					$row->addSelect('paymentType')->isRequired()->fromArray($costTypes);
+					$row->addSelect('paymentType')->required()->fromArray($costTypes);
 
 				$costStatuses = array(
 					'Finalised' => __('Finalised'),
@@ -163,7 +163,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 				$row = $form->addRow();
 					$row->addLabel('paymentFirmness', __('Cost Status'));
-					$row->addSelect('paymentFirmness')->isRequired()->fromArray($costStatuses);
+					$row->addSelect('paymentFirmness')->required()->fromArray($costStatuses);
 			}
 
 			$form->addRow()->addHeading(__('Current Time Slots'));

--- a/modules/Activities/activities_manage_enrolment_add.php
+++ b/modules/Activities/activities_manage_enrolment_add.php
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 			$row = $form->addRow();
                 $row->addLabel('Members[]', __('Students'));
-				$row->addSelect('Members[]')->fromArray($students)->selectMultiple()->isRequired();
+				$row->addSelect('Members[]')->fromArray($students)->selectMultiple()->required();
 				
 			$statuses = array('Accepted' => __('Accepted'));
 			$enrolment = getSettingByScope($connection2, 'Activities', 'enrolmentType');
@@ -166,7 +166,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
 			$row = $form->addRow();
                 $row->addLabel('status', __('Status'));
-                $row->addSelect('status')->fromArray($statuses)->isRequired();
+                $row->addSelect('status')->fromArray($statuses)->required();
 			
 			$row = $form->addRow();
                 $row->addFooter();

--- a/modules/Activities/activities_manage_enrolment_edit.php
+++ b/modules/Activities/activities_manage_enrolment_edit.php
@@ -140,7 +140,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
             $row = $form->addRow();
             $row->addLabel('status', __('Status'));
-            $row->addSelect('status')->fromArray($statuses)->isRequired();
+            $row->addSelect('status')->fromArray($statuses)->required();
 			
             $row = $form->addRow();
             $row->addFooter();

--- a/modules/Activities/activities_payment.php
+++ b/modules/Activities/activities_payment.php
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_paym
             $bulkAction->addSelect('action')
                 ->fromArray($billingSchedules)
                 ->fromArray($defaultActions)
-                ->isRequired()
+                ->required()
                 ->setClass('mediumWidth floatNone')
                 ->placeholder(__('Select action'));
             $bulkAction->addSubmit(__('Go'));
@@ -102,7 +102,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_paym
             $row->addContent($student['rollGroup']);
             $row->addContent(formatName('', $student['preferredName'], $student['surname'], 'Student', true));
             $row->addContent($student['name']);
-            $row->addCurrency("payment[$gibbonActivityStudentID]")->isRequired()->setValue($student['payment']);
+            $row->addCurrency("payment[$gibbonActivityStudentID]")->required()->setValue($student['payment']);
             $row->addCheckbox("gibbonActivityStudentID[$gibbonActivityStudentID]")->setValue($student['gibbonActivityStudentID'])->setClass('');
         }
         

--- a/modules/Activities/activities_view_register.php
+++ b/modules/Activities/activities_view_register.php
@@ -276,7 +276,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
                                                     ->description(sprintf(__('Incase %1$s is full.'), $values['name']));
                                                 $row->addSelect('gibbonActivityIDBackup')
                                                     ->fromResults($result)
-                                                    ->isRequired($result->rowCount() > 0)
+                                                    ->required($result->rowCount() > 0)
                                                     ->placeholder();
                                         }
 

--- a/modules/Activities/report_activityChoices_byRollGroup.php
+++ b/modules/Activities/report_activityChoices_byRollGroup.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
 
     $row = $form->addRow();
         $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->isRequired();
+        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Activities/report_activityChoices_byStudent.php
+++ b/modules/Activities/report_activityChoices_byStudent.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Student'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->isRequired()->placeholder()->selected($gibbonPersonID);
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->required()->placeholder()->selected($gibbonPersonID);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Activities/report_activitySpread_rollGroup.php
+++ b/modules/Activities/report_activitySpread_rollGroup.php
@@ -56,11 +56,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
 
         $row = $form->addRow();
             $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->isRequired();
+            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->required();
 
         $row = $form->addRow();
             $row->addLabel('status', __('Status'));
-            $row->addSelect('status')->fromArray(array('Accepted' => __('Accepted'), 'Registered' => __('Registered')))->selected($status)->isRequired();
+            $row->addSelect('status')->fromArray(array('Accepted' => __('Accepted'), 'Registered' => __('Registered')))->selected($status)->required();
 
         $row = $form->addRow();
             $row->addFooter();

--- a/modules/Activities/report_activityType_rollGroup.php
+++ b/modules/Activities/report_activityType_rollGroup.php
@@ -53,11 +53,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_activity
 
         $row = $form->addRow();
             $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->isRequired();
+            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->required();
 
         $row = $form->addRow();
             $row->addLabel('status', __('Status'));
-            $row->addSelect('status')->fromArray(array('Accepted' => __('Accepted'), 'Registered' => __('Registered')))->selected($status)->isRequired();
+            $row->addSelect('status')->fromArray(array('Accepted' => __('Accepted'), 'Registered' => __('Registered')))->selected($status)->required();
 
         $row = $form->addRow();
             $row->addFooter();

--- a/modules/Activities/report_attendance.php
+++ b/modules/Activities/report_attendance.php
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
     $sql = "SELECT gibbonActivityID AS value, name FROM gibbonActivity WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name, programStart";
     $row = $form->addRow();
         $row->addLabel('gibbonActivityID', __('Activity'));
-        $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->isRequired()->placeholder();
+        $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('allColumns', __('All Columns'))->description('Include empty columns with unrecorded attendance.');

--- a/modules/Activities/report_attendance_byDate.php
+++ b/modules/Activities/report_attendance_byDate.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
 
         $row = $form->addRow();
             $row->addLabel('date', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-            $row->addDate('date')->setValue(dateConvertBack($guid, $date))->isRequired();
+            $row->addDate('date')->setValue(dateConvertBack($guid, $date))->required();
 
         $sortOptions = array('absent' => __('Absent'), 'surname' => __('Surname'), 'preferredName' => __('Given Name'), 'rollGroup' => __('Roll Group'));
         $row = $form->addRow();

--- a/modules/Activities/report_participants.php
+++ b/modules/Activities/report_participants.php
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_particip
         $sql = "SELECT gibbonActivityID AS value, name FROM gibbonActivity WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name, programStart";
         $row = $form->addRow();
             $row->addLabel('gibbonActivityID', __('Activity'));
-            $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->isRequired()->placeholder();
+            $row->addSelect('gibbonActivityID')->fromQuery($pdo, $sql, $data)->selected($gibbonActivityID)->required()->placeholder();
 
         $row = $form->addRow();
             $row->addFooter();

--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -58,12 +58,12 @@ $form->addHiddenValue('q', '/modules/' . $session->get('module') . '/attendance.
 
 $row = $form->addRow();
 $row->addLabel('currentDate', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-$row->addDate('currentDate')->setValue(Format::date($currentDate))->isRequired();
+$row->addDate('currentDate')->setValue(Format::date($currentDate))->required();
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_rollGroupsNotRegistered_byDate.php')) {
     $row = $form->addRow();
     $row->addLabel('gibbonPersonID', __('Staff'));
-    $row->addSelectStaff('gibbonPersonID')->selected($gibbonPersonID)->placeholder()->isRequired();
+    $row->addSelectStaff('gibbonPersonID')->selected($gibbonPersonID)->placeholder()->required();
 } else {
     $form->addHiddenValue('gibbonPersonID', $session->get('gibbonPersonID'));
 }

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Student'));
-        $row->addSelectStudent('gibbonPersonID',$_SESSION[$guid]['gibbonSchoolYearID'])->isRequired()->placeholder()->selected($gibbonPersonID);
+        $row->addSelectStudent('gibbonPersonID',$_SESSION[$guid]['gibbonSchoolYearID'])->required()->placeholder()->selected($gibbonPersonID);
 
     if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byCourseClass.php')) {
         $availableAbsenceTypes = array(
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
         $form->toggleVisibilityByClass('partialDateRow')->onSelect('absenceType')->when('partial');
         $row = $form->addRow()->addClass('partialDateRow');
             $row->addLabel('date', __('Date'));
-            $row->addDate('date')->isRequired()->setValue($date);
+            $row->addDate('date')->required()->setValue($date);
     }
 
     $form->addRow()->addSearchSubmit($gibbon->session);
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
         if ($absenceType == 'full') {
             $row = $form->addRow();
                 $row->addLabel('dateStart', __('Start Date'));
-                $row->addDate('dateStart')->isRequired();
+                $row->addDate('dateStart')->required();
 
             $row = $form->addRow();
                 $row->addLabel('dateEnd', __('End Date'));
@@ -207,7 +207,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
 
         $row = $form->addRow();
             $row->addLabel('type', __('Type'));
-            $row->addSelect('type')->fromArray($attendanceTypes)->isRequired()->selected('Absent');
+            $row->addSelect('type')->fromArray($attendanceTypes)->required()->selected('Absent');
 
         $row = $form->addRow();
             $row->addLabel('reason', __('Reason'));

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -78,13 +78,13 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
     $row = $form->addRow();
     $row->addLabel('gibbonCourseClassID', __('Class'));
     $row->addSelectClass('gibbonCourseClassID', $_SESSION[$guid]['gibbonSchoolYearID'], $_SESSION[$guid]['gibbonPersonID'], array('attendance' => 'Y'))
-        ->isRequired()
+        ->required()
         ->selected($gibbonCourseClassID)
         ->placeholder();
 
     $row = $form->addRow();
     $row->addLabel('currentDate', __('Date'));
-    $row->addDate('currentDate')->isRequired()->setValue(dateConvertBack($guid, $currentDate));
+    $row->addDate('currentDate')->required()->setValue(dateConvertBack($guid, $currentDate));
 
     $row = $form->addRow();
     $row->addSearchSubmit($gibbon->session);

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -55,11 +55,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Student'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->isRequired()->selected($gibbonPersonID)->placeholder();
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->required()->selected($gibbonPersonID)->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('currentDate', __('Date'));
-        $row->addDate('currentDate')->isRequired()->setValue(dateConvertBack($guid, $currentDate));
+        $row->addDate('currentDate')->required()->setValue(dateConvertBack($guid, $currentDate));
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session);

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -78,11 +78,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
         $row = $form->addRow();
             $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->isRequired()->selected($gibbonRollGroupID)->placeholder();
+            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->required()->selected($gibbonRollGroupID)->placeholder();
 
         $row = $form->addRow();
             $row->addLabel('currentDate', __('Date'));
-            $row->addDate('currentDate')->isRequired()->setValue(dateConvertBack($guid, $currentDate));
+            $row->addDate('currentDate')->required()->setValue(dateConvertBack($guid, $currentDate));
 
         $row = $form->addRow();
             $row->addSearchSubmit($gibbon->session);

--- a/modules/Attendance/report_courseClassesNotRegistered_byDate.php
+++ b/modules/Attendance/report_courseClassesNotRegistered_byDate.php
@@ -77,11 +77,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_courseCl
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Start Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->isRequired();
+        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->required();
 
     $row = $form->addRow();
         $row->addLabel('dateEnd', __('End Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->isRequired();
+        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -103,11 +103,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_graph_by
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Start Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->isRequired();
+        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->required();
 
     $row = $form->addRow();
         $row->addLabel('dateEnd', __('End Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->isRequired();
+        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->required();
 
     $typeOptions = array_column($attendance->getAttendanceTypes(), 'name');
     $typeOptions = array_map('__', $typeOptions);

--- a/modules/Attendance/report_rollGroupsNotRegistered_byDate.php
+++ b/modules/Attendance/report_rollGroupsNotRegistered_byDate.php
@@ -77,11 +77,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_rollGrou
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Start Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->isRequired();
+        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->required();
 
     $row = $form->addRow();
         $row->addLabel('dateEnd', __('End Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->isRequired();
+        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Attendance/report_studentHistory.php
+++ b/modules/Attendance/report_studentHistory.php
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentH
 
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonID', __('Student'));
-                $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonPersonID)->placeholder()->isRequired();
+                $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonPersonID)->placeholder()->required();
 
             $row = $form->addRow();
                 $row->addFooter();
@@ -158,10 +158,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_studentH
                         $row = $form->addRow();
                             $row->addLabel('gibbonPersonID', __('Child'));
                             if ($countChild > 1) {
-                                $row->addSelect('gibbonPersonID')->fromArray($options)->selected($gibbonPersonID)->placeholder()->isRequired();
+                                $row->addSelect('gibbonPersonID')->fromArray($options)->selected($gibbonPersonID)->placeholder()->required();
                             }
                             else {
-                                $row->addSelect('gibbonPersonID')->fromArray($options)->selected($gibbonPersonID)->isRequired();
+                                $row->addSelect('gibbonPersonID')->fromArray($options)->selected($gibbonPersonID)->required();
                             }
                     }
 

--- a/modules/Attendance/report_studentsNotOnsite_byDate.php
+++ b/modules/Attendance/report_studentsNotOnsite_byDate.php
@@ -60,11 +60,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
 
     $row = $form->addRow();
         $row->addLabel('currentDate', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('currentDate')->setValue(dateConvertBack($guid, $currentDate))->isRequired();
+        $row->addDate('currentDate')->setValue(dateConvertBack($guid, $currentDate))->required();
 
     $row = $form->addRow();
         $row->addLabel('sort', __('Sort By'));
-        $row->addSelect('sort')->fromArray(array('surname' => __('Surname'), 'preferredName' => __('Preferred Name'), 'rollGroup' => __('Roll Group')))->selected($sort)->isRequired();
+        $row->addSelect('sort')->fromArray(array('surname' => __('Surname'), 'preferredName' => __('Preferred Name'), 'rollGroup' => __('Roll Group')))->selected($sort)->required();
 
     $row = $form->addRow();
         $row->addLabel('allStudents', __('All Students'))->description('Include all students, even those where attendance has not yet been recorded.');

--- a/modules/Attendance/report_studentsNotPresent_byDate.php
+++ b/modules/Attendance/report_studentsNotPresent_byDate.php
@@ -60,11 +60,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
 
     $row = $form->addRow();
         $row->addLabel('currentDate', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('currentDate')->setValue(dateConvertBack($guid, $currentDate))->isRequired();
+        $row->addDate('currentDate')->setValue(dateConvertBack($guid, $currentDate))->required();
 
     $row = $form->addRow();
         $row->addLabel('sort', __('Sort By'));
-        $row->addSelect('sort')->fromArray(array('surname' => __('Surname'), 'preferredName' => __('Preferred Name'), 'rollGroup' => __('Roll Group')))->selected($sort)->isRequired();
+        $row->addSelect('sort')->fromArray(array('surname' => __('Surname'), 'preferredName' => __('Preferred Name'), 'rollGroup' => __('Roll Group')))->selected($sort)->required();
 
     $row = $form->addRow();
         $row->addLabel('allStudents', __('All Students'))->description('Include all students, even those where attendance has not yet been recorded.');

--- a/modules/Attendance/report_summary_byDate.php
+++ b/modules/Attendance/report_summary_byDate.php
@@ -76,11 +76,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_summary_
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Start Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->isRequired();
+        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->required();
 
     $row = $form->addRow();
         $row->addLabel('dateEnd', __('End Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->isRequired();
+        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->required();
 
     $options = array("all" => __('All Students'));
     if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take_byCourseClass.php")) {
@@ -91,21 +91,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_summary_
     }
     $row = $form->addRow();
         $row->addLabel('group', __('Group By'));
-        $row->addSelect('group')->fromArray($options)->selected($group)->isRequired();
+        $row->addSelect('group')->fromArray($options)->selected($group)->required();
 
     $form->toggleVisibilityByClass('class')->onSelect('group')->when('class');
     $row = $form->addRow()->addClass('class');
         $row->addLabel('gibbonCourseClassID', __('Class'));
-        $row->addSelectClass('gibbonCourseClassID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonCourseClassID)->placeholder()->isRequired();
+        $row->addSelectClass('gibbonCourseClassID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonCourseClassID)->placeholder()->required();
 
     $form->toggleVisibilityByClass('rollGroup')->onSelect('group')->when('rollGroup');
     $row = $form->addRow()->addClass('rollGroup');
         $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->placeholder()->isRequired();
+        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->placeholder()->required();
 
     $row = $form->addRow();
         $row->addLabel('sort', __('Sort By'));
-        $row->addSelect('sort')->fromArray(array('surname' => __('Surname'), 'preferredName' => __('Preferred Name'), 'rollGroup' => __('Roll Group')))->selected($sort)->isRequired();
+        $row->addSelect('sort')->fromArray(array('surname' => __('Surname'), 'preferredName' => __('Preferred Name'), 'rollGroup' => __('Roll Group')))->selected($sort)->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Behaviour/behaviour_manage_add.php
+++ b/modules/Behaviour/behaviour_manage_add.php
@@ -91,17 +91,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             //Student
             $row = $form->addRow();
             	$row->addLabel('gibbonPersonID', __('Student'));
-            	$row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->placeholder(__('Please select...'))->selected($gibbonPersonID)->isRequired();
+            	$row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->placeholder(__('Please select...'))->selected($gibbonPersonID)->required();
 
             //Date
             $row = $form->addRow();
             	$row->addLabel('date', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-            	$row->addDate('date')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']))->isRequired();
+            	$row->addDate('date')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']))->required();
 
             //Type
             $row = $form->addRow();
             	$row->addLabel('type', __('Type'));
-            	$row->addSelect('type')->fromArray(array('Positive' => __('Positive'), 'Negative' => __('Negative')))->selected($type)->isRequired();
+            	$row->addSelect('type')->fromArray(array('Positive' => __('Positive'), 'Negative' => __('Negative')))->selected($type)->required();
 
             //Descriptor
             if ($enableDescriptors == 'Y') {
@@ -120,7 +120,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                         ->fromArray($positiveDescriptors)
                         ->fromArray($negativeDescriptors)
                         ->chainedTo('type', $chainedTo)
-                        ->isRequired()
+                        ->required()
                         ->placeholder();
             }
 

--- a/modules/Behaviour/behaviour_manage_addMulti.php
+++ b/modules/Behaviour/behaviour_manage_addMulti.php
@@ -64,17 +64,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
     //Student
     $row = $form->addRow();
         $row->addLabel('gibbonPersonIDMulti', __('Students'));
-        $row->addSelectStudent('gibbonPersonIDMulti', $_SESSION[$guid]['gibbonSchoolYearID'], array('byName' => true, 'byRoll' => true))->selectMultiple()->isRequired();
+        $row->addSelectStudent('gibbonPersonIDMulti', $_SESSION[$guid]['gibbonSchoolYearID'], array('byName' => true, 'byRoll' => true))->selectMultiple()->required();
 
     //Date
     $row = $form->addRow();
         $row->addLabel('date', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('date')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']))->isRequired();
+        $row->addDate('date')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']))->required();
 
     //Type
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addSelect('type')->fromArray(array('Positive' => __('Positive'), 'Negative' => __('Negative')))->isRequired();
+        $row->addSelect('type')->fromArray(array('Positive' => __('Positive'), 'Negative' => __('Negative')))->required();
 
     //Descriptor
     if ($enableDescriptors == 'Y') {
@@ -93,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 ->fromArray($positiveDescriptors)
                 ->fromArray($negativeDescriptors)
                 ->chainedTo('type', $chainedTo)
-                ->isRequired()
+                ->required()
                 ->placeholder();
     }
 

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -104,12 +104,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 //Date
                 $row = $form->addRow();
                 	$row->addLabel('date', __('Date'));
-                	$row->addDate('date')->setValue(dateConvertBack($guid, $values['date']))->isRequired()->readonly();
+                	$row->addDate('date')->setValue(dateConvertBack($guid, $values['date']))->required()->readonly();
 
                 //Date
                 $row = $form->addRow();
                     $row->addLabel('type', __('Type'));
-                    $row->addTextField('type')->setValue($values['type'])->isRequired()->readonly();
+                    $row->addTextField('type')->setValue($values['type'])->required()->readonly();
 
                 //Descriptor
                 if ($enableDescriptors == 'Y') {
@@ -126,7 +126,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                         $row->addSelect('descriptor')
                             ->fromArray($descriptors)
                             ->selected($values['descriptor'])
-                            ->isRequired()
+                            ->required()
                             ->placeholder();
                 }
 

--- a/modules/Crowd Assessment/crowdAssess_view_discuss_post.php
+++ b/modules/Crowd Assessment/crowdAssess_view_discuss_post.php
@@ -95,7 +95,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Crowd Assessment/crowdAsse
 
                     $column = $form->addRow()->addColumn();
                         $column->addLabel('commentLabel', __('Write your comment below:'));
-                        $column->addEditor('comment', $guid)->setRows(10)->isRequired();
+                        $column->addEditor('comment', $guid)->setRows(10)->required();
 
                     $form->addRow()->addSubmit();
 

--- a/modules/Data Updater/data_family.php
+++ b/modules/Data Updater/data_family.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
             $row->addLabel('gibbonFamilyID', __('Family'));
             $row->addSelect('gibbonFamilyID')
                 ->fromQuery($pdo, $sql, $data)
-                ->isRequired()
+                ->required()
                 ->selected($gibbonFamilyID)
                 ->placeholder();
         

--- a/modules/Data Updater/data_finance.php
+++ b/modules/Data Updater/data_finance.php
@@ -105,7 +105,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
             $row->addLabel('gibbonFinanceInvoiceeID', __('Invoicee'))->description(__('Individual for whom invoices are generated.'));
             $row->addSelect('gibbonFinanceInvoiceeID')
                 ->fromArray($invoicees)
-                ->isRequired()
+                ->required()
                 ->selected($gibbonFinanceInvoiceeID)
                 ->placeholder();
         

--- a/modules/Data Updater/data_medical.php
+++ b/modules/Data Updater/data_medical.php
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 			$row->addLabel('gibbonPersonID', __('Person'));
 			$row->addSelect('gibbonPersonID')
                 ->fromArray($people)
-                ->isRequired()
+                ->required()
                 ->selected($gibbonPersonID)
 				->placeholder();
 
@@ -266,11 +266,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 								$sql = "SELECT name AS value, name FROM gibbonMedicalCondition ORDER BY name";
 								$row = $form->addRow();
 									$row->addLabel('name'.$count, __('Condition Name'));
-									$row->addSelect('name'.$count)->fromQuery($pdo, $sql)->isRequired()->placeholder()->selected($rowCond['name']);
+									$row->addSelect('name'.$count)->fromQuery($pdo, $sql)->required()->placeholder()->selected($rowCond['name']);
 
 								$row = $form->addRow();
 									$row->addLabel('gibbonAlertLevelID'.$count, __('Risk'));
-									$row->addSelectAlert('gibbonAlertLevelID'.$count)->isRequired()->selected($rowCond['gibbonAlertLevelID']);
+									$row->addSelectAlert('gibbonAlertLevelID'.$count)->required()->selected($rowCond['gibbonAlertLevelID']);
 
 								$row = $form->addRow();
 									$row->addLabel('triggers'.$count, __('Triggers'));
@@ -317,11 +317,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 						$sql = "SELECT name AS value, name FROM gibbonMedicalCondition ORDER BY name";
 						$row = $form->addRow()->addClass('addConditionRow');
 							$row->addLabel('name', __('Condition Name'));
-							$row->addSelect('name')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+							$row->addSelect('name')->fromQuery($pdo, $sql)->required()->placeholder();
 
 						$row = $form->addRow()->addClass('addConditionRow');
 							$row->addLabel('gibbonAlertLevelID', __('Risk'));
-							$row->addSelectAlert('gibbonAlertLevelID')->isRequired();
+							$row->addSelectAlert('gibbonAlertLevelID')->required();
 
 						$row = $form->addRow()->addClass('addConditionRow');
 							$row->addLabel('triggers', __('Triggers'));

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -354,7 +354,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
 					$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
 					if ($uniqueEmailAddress == 'Y') {
-						$email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('gibbonPersonID' => $gibbonPersonID));
+						$email->uniqueField('./modules/User Admin/user_manage_emailAjax.php', array('gibbonPersonID' => $gibbonPersonID));
 					}
 
 					$row = $form->addRow();

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -118,7 +118,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
             $row->addLabel('gibbonPersonID', __('Person'));
             $row->addSelect('gibbonPersonID')
                 ->fromArray($people)
-                ->isRequired()
+                ->required()
                 ->selected($gibbonPersonID)
                 ->placeholder();
         

--- a/modules/Data Updater/report_family_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_family_dataUpdaterHistory.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_family
 
     $row = $form->addRow();
         $row->addLabel('date', __('Date'))->description(__('Earliest acceptable update'));
-        $row->addDate('date')->setValue($date)->isRequired();
+        $row->addDate('date')->setValue($date)->required();
 
     $row = $form->addRow();
         $row->addLabel('nonCompliant', __('Show Only Non-Compliant?'))->description(__('If not checked, show all. If checked, show only non-compliant students.'));

--- a/modules/Data Updater/report_student_dataUpdaterHistory.php
+++ b/modules/Data Updater/report_student_dataUpdaterHistory.php
@@ -58,12 +58,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/report_studen
         $row->addLabel('members', __('Students'));
         $row->addSelectStudent('members', $_SESSION[$guid]['gibbonSchoolYearID'], array('byRoll' => true, 'byName' => true))
             ->selectMultiple()
-            ->isRequired()
+            ->required()
             ->selected($choices);
 
     $row = $form->addRow();
         $row->addLabel('date', __('Date'))->description(__('Earliest acceptable update'));
-        $row->addDate('date')->setValue($date)->isRequired();
+        $row->addDate('date')->setValue($date)->required();
 
     $row = $form->addRow();
         $row->addLabel('nonCompliant', __('Show Only Non-Compliant?'))->description(__('If not checked, show all. If checked, show only non-compliant students.'));

--- a/modules/Finance/billingSchedule_manage_add.php
+++ b/modules/Finance/billingSchedule_manage_add.php
@@ -62,15 +62,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/billingSchedule_ma
 
         $row = $form->addRow();
         	$row->addLabel("yearName", __("School Year"))->description(__("This value cannot be changed."));
-        	$row->addTextField("yearName")->setValue($_SESSION[$guid]['gibbonSchoolYearName'])->readonly(true)->isRequired();
+        	$row->addTextField("yearName")->setValue($_SESSION[$guid]['gibbonSchoolYearName'])->readonly(true)->required();
 
         $row = $form->addRow();
         	$row->addLabel("name", __("Name"));
-        	$row->addTextField("name")->maxLength(100)->isRequired();
+        	$row->addTextField("name")->maxLength(100)->required();
 
         $row = $form->addRow();
         	$row->addLabel("active", __("Active"));
-        	$row->addYesNo("active")->isRequired();
+        	$row->addYesNo("active")->required();
 
         $row = $form->addRow();
         	$row->addLabel("description", __("Description"));
@@ -78,11 +78,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/billingSchedule_ma
 
         $row = $form->addRow();
         	$row->addLabel("invoiceIssueDate", __('Invoice Issue Date'))->description(__('Intended issue date.').'<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-        	$row->addDate('invoiceIssueDate')->isRequired();
+        	$row->addDate('invoiceIssueDate')->required();
 
         $row = $form->addRow();
 			$row->addLabel('invoiceDueDate', __('Invoice Due Date'))->description(__('Final payment date.').'<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-			$row->addDate('invoiceDueDate')->isRequired();
+			$row->addDate('invoiceDueDate')->required();
 
         $row = $form->addRow();
         	$row->addFooter();

--- a/modules/Finance/billingSchedule_manage_edit.php
+++ b/modules/Finance/billingSchedule_manage_edit.php
@@ -90,15 +90,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/billingSchedule_ma
 
             $row = $form->addRow();
                 $row->addLabel("yearName", __("School Year"))->description(__("This value cannot be changed."));
-                $row->addTextField("yearName")->setValue($yearName)->readonly(true)->isRequired();
+                $row->addTextField("yearName")->setValue($yearName)->readonly(true)->required();
 
             $row = $form->addRow();
                 $row->addLabel("name", __("Name"));
-                $row->addTextField("name")->setValue(htmlprep($resultRow['name']))->maxLength(100)->isRequired();
+                $row->addTextField("name")->setValue(htmlprep($resultRow['name']))->maxLength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel("active", __("Active"));
-                $row->addYesNo("active")->selected($resultRow['active'])->isRequired();
+                $row->addYesNo("active")->selected($resultRow['active'])->required();
 
             $row = $form->addRow();
                 $row->addLabel("description", __("Description"));
@@ -106,11 +106,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/billingSchedule_ma
 
             $row = $form->addRow();
                 $row->addLabel("invoiceIssueDate", __('Invoice Issue Date'))->description(__('Intended issue date.').'<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-                $row->addDate('invoiceIssueDate')->setValue(dateConvertBack($guid, $resultRow['invoiceIssueDate']))->isRequired();
+                $row->addDate('invoiceIssueDate')->setValue(dateConvertBack($guid, $resultRow['invoiceIssueDate']))->required();
 
             $row = $form->addRow();
                 $row->addLabel('invoiceDueDate', __('Invoice Due Date'))->description(__('Final payment date.').'<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-                $row->addDate('invoiceDueDate')->setValue(dateConvertBack($guid, $resultRow['invoiceDueDate']))->isRequired();
+                $row->addDate('invoiceDueDate')->setValue(dateConvertBack($guid, $resultRow['invoiceDueDate']))->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Finance/budgetCycles_manage_add.php
+++ b/modules/Finance/budgetCycles_manage_add.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
 
     $row = $form->addRow();
         $row->addLabel("name", __("Name"))->description(__("Must be unique."));
-	$row->addTextField("name")->isRequired()->maxLength(7);
+	$row->addTextField("name")->required()->maxLength(7);
 
     $statusTypes = array(
         'Upcoming' => __("Upcoming"),
@@ -63,15 +63,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
 
     $row = $form->addRow();
         $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-        $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceBudgetCycle')->isRequired()->maxLength(3);
+        $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceBudgetCycle')->required()->maxLength(3);
 
     $row = $form->addRow();
         $row->addLabel("dateStart", __("Start Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-        $row->addDate("dateStart")->isRequired();
+        $row->addDate("dateStart")->required();
 
     $row = $form->addRow();
         $row->addLabel("dateEnd", __("End Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-        $row->addDate("dateEnd")->isRequired();
+        $row->addDate("dateEnd")->required();
 
     $row = $form->addRow();
         $row->addHeading(__("Budget Allocations"));

--- a/modules/Finance/budgetCycles_manage_edit.php
+++ b/modules/Finance/budgetCycles_manage_edit.php
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
 
             $row = $form->addRow();
                 $row->addLabel("name", __("Name"))->description(__("Must be unique."));
-                $row->addTextField("name")->isRequired()->maxLength(7);
+                $row->addTextField("name")->required()->maxLength(7);
 
             $statusTypes = array(
                 'Upcoming' => __("Upcoming"),
@@ -83,15 +83,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
 
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-                $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceBudgetCycle', $values['sequenceNumber'])->isRequired()->maxLength(3);
+                $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceBudgetCycle', $values['sequenceNumber'])->required()->maxLength(3);
 
             $row = $form->addRow();
                 $row->addLabel("dateStart", __("Start Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-                $row->addDate("dateStart")->isRequired();
+                $row->addDate("dateStart")->required();
 
             $row = $form->addRow();
                 $row->addLabel("dateEnd", __("End Date"))->description(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-                $row->addDate("dateEnd")->isRequired();
+                $row->addDate("dateEnd")->required();
             
             $row = $form->addRow();
                 $row->addHeading(__("Budget Allocations"));
@@ -110,7 +110,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
                 while ($rowBudget = $resultBudget->fetch()) {
                     $row = $form->addRow();
                         $row->addLabel($rowBudget['gibbonFinanceBudgetID'], $rowBudget['name']);
-                        $row->addCurrency($rowBudget['gibbonFinanceBudgetID'])->setName('values[]')->isRequired()->maxLength(15)->setValue((is_null($rowBudget['value'])) ? '0.00' : $rowBudget['value']);
+                        $row->addCurrency($rowBudget['gibbonFinanceBudgetID'])->setName('values[]')->required()->maxLength(15)->setValue((is_null($rowBudget['value'])) ? '0.00' : $rowBudget['value']);
                     $form->addHiddenValue('gibbonFinanceBudgetIDs[]', $rowBudget['gibbonFinanceBudgetID']);
                 }
             }

--- a/modules/Finance/budgets_manage_add.php
+++ b/modules/Finance/budgets_manage_add.php
@@ -53,15 +53,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_add
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->maxLength(100)->isRequired();
+        $row->addTextField('name')->maxLength(100)->required();
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-        $row->addTextField('nameShort')->maxLength(14)->isRequired();
+        $row->addTextField('nameShort')->maxLength(14)->required();
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $categories = getSettingByScope($connection2, 'Finance', 'budgetCategories');
     if (empty($categories)) {
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_add
     }
     $row = $form->addRow();
         $row->addLabel('category', __('Category'));
-        $row->addSelect('category')->fromString($categories)->placeholder()->isRequired();
+        $row->addSelect('category')->fromString($categories)->placeholder()->required();
 
     $form->addRow()->addHeading(__('Staff'));
 

--- a/modules/Finance/budgets_manage_edit.php
+++ b/modules/Finance/budgets_manage_edit.php
@@ -73,15 +73,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->maxLength(100)->isRequired();
+                $row->addTextField('name')->maxLength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-                $row->addTextField('nameShort')->maxLength(14)->isRequired();
+                $row->addTextField('nameShort')->maxLength(14)->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $categories = getSettingByScope($connection2, 'Finance', 'budgetCategories');
             if (empty($categories)) {
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
             }
             $row = $form->addRow();
                 $row->addLabel('category', __('Category'));
-                $row->addSelect('category')->fromString($categories)->placeholder()->isRequired();
+                $row->addSelect('category')->fromString($categories)->placeholder()->required();
 
             $form->addRow()->addHeading(__('Current Staff'));
 

--- a/modules/Finance/expenseApprovers_manage_add.php
+++ b/modules/Finance/expenseApprovers_manage_add.php
@@ -48,13 +48,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Staff'));
-        $row->addSelectStaff('gibbonPersonID')->isRequired()->placeholder();
+        $row->addSelectStaff('gibbonPersonID')->required()->placeholder();
 
     $expenseApprovalType = getSettingByScope($connection2, 'Finance', 'expenseApprovalType');
     if ($expenseApprovalType == 'Chain Of All') {
         $row = $form->addRow();
             $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique.'));
-            $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceExpenseApprover')->isRequired()->maxLength(3);
+            $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceExpenseApprover')->required()->maxLength(3);
     }
 
     $row = $form->addRow();

--- a/modules/Finance/expenseApprovers_manage_edit.php
+++ b/modules/Finance/expenseApprovers_manage_edit.php
@@ -68,13 +68,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
 
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonID', __('Staff'));
-                $row->addSelectStaff('gibbonPersonID')->isRequired()->placeholder();
+                $row->addSelectStaff('gibbonPersonID')->required()->placeholder();
 
             $expenseApprovalType = getSettingByScope($connection2, 'Finance', 'expenseApprovalType');
             if ($expenseApprovalType == 'Chain Of All') {
                 $row = $form->addRow();
                     $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique.'));
-                    $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceExpenseApprover', $values['sequenceNumber'])->isRequired()->maxLength(3);
+                    $row->addSequenceNumber('sequenceNumber', 'gibbonFinanceExpenseApprover', $values['sequenceNumber'])->required()->maxLength(3);
             }
 
             $form->loadAllValuesFrom($values);

--- a/modules/Finance/expenseRequest_manage_add.php
+++ b/modules/Finance/expenseRequest_manage_add.php
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                     $cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
                     $row = $form->addRow();
                         $row->addLabel('name', __('Budget Cycle'));
-                        $row->addTextField('name')->setValue($cycleName)->maxLength(20)->isRequired()->readonly();
+                        $row->addTextField('name')->setValue($cycleName)->maxLength(20)->required()->readonly();
 
                     $budgetsProcessed = array() ;
                     foreach ($budgets as $budget) {
@@ -117,15 +117,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                     }
                     $row = $form->addRow();
                         $row->addLabel('gibbonFinanceBudgetID', __('Budget'));
-                        $row->addSelect('gibbonFinanceBudgetID')->fromArray($budgetsProcessed)->isRequired()->placeholder();
+                        $row->addSelect('gibbonFinanceBudgetID')->fromArray($budgetsProcessed)->required()->placeholder();
 
                     $row = $form->addRow();
                         $row->addLabel('title', __('Title'));
-                        $row->addTextField('title')->maxLength(60)->isRequired();
+                        $row->addTextField('title')->maxLength(60)->required();
 
                     $row = $form->addRow();
                         $row->addLabel('status', __('Status'));
-                        $row->addTextField('status')->setValue('Requested')->isRequired()->readonly();
+                        $row->addTextField('status')->setValue('Requested')->required()->readonly();
 
                     $expenseRequestTemplate = getSettingByScope($connection2, 'Finance', 'expenseRequestTemplate');
                     $row = $form->addRow();
@@ -135,15 +135,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                     $row = $form->addRow();
                     	$row->addLabel('cost', __('Total Cost'));
-            			$row->addCurrency('cost')->isRequired()->maxLength(15);
+            			$row->addCurrency('cost')->required()->maxLength(15);
 
                     $row = $form->addRow();
                         $row->addLabel('countAgainstBudget', __('Count Against Budget'))->description(__('For tracking purposes, should the item be counted against the budget? If immediately offset by some revenue, perhaps not.'));
-                        $row->addYesNo('countAgainstBudget')->isRequired();
+                        $row->addYesNo('countAgainstBudget')->required();
 
                     $row = $form->addRow();
                         $row->addLabel('purchaseBy', __('Purchase By'));
-                        $row->addSelect('purchaseBy')->fromArray(array('School' => __('School'), 'Self' => __('Self')))->isRequired();
+                        $row->addSelect('purchaseBy')->fromArray(array('School' => __('School'), 'Self' => __('Self')))->required();
 
                     $row = $form->addRow();
                         $column = $row->addColumn();

--- a/modules/Finance/expenseRequest_manage_reimburse.php
+++ b/modules/Finance/expenseRequest_manage_reimburse.php
@@ -121,16 +121,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                     $cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
                     $row = $form->addRow();
                         $row->addLabel('nameBudget', __('Budget Cycle'));
-                        $row->addTextField('nameBudget')->setValue($cycleName)->maxLength(20)->isRequired()->readonly();
+                        $row->addTextField('nameBudget')->setValue($cycleName)->maxLength(20)->required()->readonly();
 
                     $form->addHiddenValue('gibbonFinanceBudgetID', $values['gibbonFinanceBudgetID']);
                     $row = $form->addRow();
                         $row->addLabel('budget', __('Budget'));
-                        $row->addTextField('budget')->setValue($values['budget'])->maxLength(20)->isRequired()->readonly();
+                        $row->addTextField('budget')->setValue($values['budget'])->maxLength(20)->required()->readonly();
 
                     $row = $form->addRow();
                         $row->addLabel('title', __('Title'));
-                        $row->addTextField('title')->maxLength(60)->isRequired()->readonly()->setValue($values['title']);
+                        $row->addTextField('title')->maxLength(60)->required()->readonly()->setValue($values['title']);
 
                     $row = $form->addRow();
                         $row->addLabel('status', __('Status'));
@@ -139,9 +139,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                             if ($values['status'] == 'Approved') {
                                 $statuses['Paid'] = __('Paid');
                             }
-                            $row->addSelect('status')->fromArray($statuses)->selected('Paid')->isRequired();
+                            $row->addSelect('status')->fromArray($statuses)->selected('Paid')->required();
                         } else {
-                            $row->addTextField('status')->maxLength(60)->isRequired()->readonly()->setValue($values['status']);
+                            $row->addTextField('status')->maxLength(60)->required()->readonly()->setValue($values['status']);
                         }
 
                     $row = $form->addRow();
@@ -151,15 +151,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                     $row = $form->addRow();
                         $row->addLabel('cost', __('Total Cost'));
-                        $row->addCurrency('cost')->isRequired()->maxLength(15)->readonly()->setValue($values['cost']);
+                        $row->addCurrency('cost')->required()->maxLength(15)->readonly()->setValue($values['cost']);
 
                     $row = $form->addRow();
                         $row->addLabel('countAgainstBudget', __('Count Against Budget'));
-                        $row->addTextField('countAgainstBudget')->maxLength(3)->isRequired()->readonly()->setValue(ynExpander($guid, $values['countAgainstBudget']));
+                        $row->addTextField('countAgainstBudget')->maxLength(3)->required()->readonly()->setValue(ynExpander($guid, $values['countAgainstBudget']));
 
                     $row = $form->addRow();
                         $row->addLabel('purchaseBy', __('Purchase By'));
-                        $row->addTextField('purchaseBy')->isRequired()->readonly()->setValue($values['purchaseBy']);
+                        $row->addTextField('purchaseBy')->required()->readonly()->setValue($values['purchaseBy']);
 
                     $row = $form->addRow();
                         $column = $row->addColumn();
@@ -183,16 +183,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                     $row = $form->addRow()->addClass('payment');
                         $row->addLabel('paymentDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));
-                        $row->addDate('paymentDate')->isRequired();
+                        $row->addDate('paymentDate')->required();
 
                     $row = $form->addRow()->addClass('payment');
                     	$row->addLabel('paymentAmount', __('Amount paid'))->description(__('Final amount paid.'));
-            			$row->addCurrency('paymentAmount')->isRequired()->maxLength(15);
+            			$row->addCurrency('paymentAmount')->required()->maxLength(15);
 
                     $form->addHiddenValue('gibbonPersonIDPayment', $_SESSION[$guid]['gibbonPersonID']);
                     $row = $form->addRow()->addClass('payment');
                         $row->addLabel('name', __('Payee'))->description(__('Staff who made, or arranged, the payment.'));
-                        $row->addTextField('name')->isRequired()->readonly()->setValue(formatName('', ($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Staff', true, true));
+                        $row->addTextField('name')->required()->readonly()->setValue(formatName('', ($_SESSION[$guid]['preferredName']), htmlPrep($_SESSION[$guid]['surname']), 'Staff', true, true));
 
                     $methods = array(
                         'Bank Transfer' => __('Bank Transfer'),
@@ -203,13 +203,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                     );
                     $row = $form->addRow()->addClass('payment');
                         $row->addLabel('paymentMethod', __('Payment Method'));
-                        $row->addSelect('paymentMethod')->fromArray($methods)->placeholder()->isRequired();
+                        $row->addSelect('paymentMethod')->fromArray($methods)->placeholder()->required();
 
                     $row = $form->addRow()->addClass('payment');;
                         $row->addLabel('file', __('Payment Receipt'))->description(__('Digital copy of the receipt for this payment.'));
                         $row->addFileUpload('file')
                             ->accepts('.jpg,.jpeg,.gif,.png,.pdf')
-                            ->isRequired();
+                            ->required();
 
                     $row = $form->addRow();
                         $row->addFooter();

--- a/modules/Finance/expenseRequest_manage_view.php
+++ b/modules/Finance/expenseRequest_manage_view.php
@@ -131,20 +131,20 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                         $cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
                         $row = $form->addRow();
                             $row->addLabel('name', __('Budget Cycle'));
-                            $row->addTextField('name')->setValue($cycleName)->maxLength(20)->isRequired()->readonly();
+                            $row->addTextField('name')->setValue($cycleName)->maxLength(20)->required()->readonly();
 
                         $form->addHiddenValue('gibbonFinanceBudgetID', $values['gibbonFinanceBudgetID']);
                         $row = $form->addRow();
                             $row->addLabel('budget', __('Budget'));
-                            $row->addTextField('budget')->setValue($cycleName)->maxLength(20)->isRequired()->readonly()->setValue($values['budget']);
+                            $row->addTextField('budget')->setValue($cycleName)->maxLength(20)->required()->readonly()->setValue($values['budget']);
 
                         $row = $form->addRow();
                             $row->addLabel('title', __('Title'));
-                            $row->addTextField('title')->maxLength(60)->isRequired()->readonly()->setValue($values['title']);
+                            $row->addTextField('title')->maxLength(60)->required()->readonly()->setValue($values['title']);
 
                         $row = $form->addRow();
                             $row->addLabel('status', __('Status'));
-                            $row->addTextField('status')->maxLength(60)->isRequired()->readonly()->setValue($values['status']);
+                            $row->addTextField('status')->maxLength(60)->required()->readonly()->setValue($values['status']);
 
                         $row = $form->addRow();
                             $column = $row->addColumn();
@@ -153,15 +153,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                         $row = $form->addRow();
                         	$row->addLabel('cost', __('Total Cost'));
-                			$row->addCurrency('cost')->isRequired()->maxLength(15)->readonly()->setValue($values['cost']);
+                			$row->addCurrency('cost')->required()->maxLength(15)->readonly()->setValue($values['cost']);
 
                         $row = $form->addRow();
                             $row->addLabel('countAgainstBudget', __('Count Against Budget'));
-                            $row->addTextField('countAgainstBudget')->maxLength(3)->isRequired()->readonly()->setValue(ynExpander($guid, $values['countAgainstBudget']));
+                            $row->addTextField('countAgainstBudget')->maxLength(3)->required()->readonly()->setValue(ynExpander($guid, $values['countAgainstBudget']));
 
                         $row = $form->addRow();
                             $row->addLabel('purchaseBy', __('Purchase By'));
-                            $row->addTextField('purchaseBy')->isRequired()->readonly()->setValue($values['purchaseBy']);
+                            $row->addTextField('purchaseBy')->required()->readonly()->setValue($values['purchaseBy']);
 
                         $row = $form->addRow();
                             $column = $row->addColumn();

--- a/modules/Finance/expenses_manage_add.php
+++ b/modules/Finance/expenses_manage_add.php
@@ -83,16 +83,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
 			$cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
 			$row = $form->addRow();
 				$row->addLabel('name', __('Budget Cycle'));
-				$row->addTextField('name')->setValue($cycleName)->maxLength(20)->isRequired()->readonly();
+				$row->addTextField('name')->setValue($cycleName)->maxLength(20)->required()->readonly();
 
 			$sql = "SELECT gibbonFinanceBudgetID as value, name FROM gibbonFinanceBudget WHERE active='Y' ORDER BY name";
 			$row = $form->addRow();
 				$row->addLabel('gibbonFinanceBudgetID', __('Budget'));
-				$row->addSelect('gibbonFinanceBudgetID')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+				$row->addSelect('gibbonFinanceBudgetID')->fromQuery($pdo, $sql)->required()->placeholder();
 
 			$row = $form->addRow();
 				$row->addLabel('title', __('Title'));
-				$row->addTextField('title')->maxLength(60)->isRequired();
+				$row->addTextField('title')->maxLength(60)->required();
 
 			$statuses = array(
 				'Approved' => __('Approved'),
@@ -101,7 +101,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
 			);
 			$row = $form->addRow();
 				$row->addLabel('status', __('Status'));
-				$row->addSelect('status')->fromArray($statuses)->isRequired()->placeholder();
+				$row->addSelect('status')->fromArray($statuses)->required()->placeholder();
 
 			$expenseRequestTemplate = getSettingByScope($connection2, 'Finance', 'expenseRequestTemplate');
 			$row = $form->addRow();
@@ -111,15 +111,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
 
 			$row = $form->addRow();
 				$row->addLabel('cost', __('Total Cost'));
-				$row->addCurrency('cost')->isRequired()->maxLength(15);
+				$row->addCurrency('cost')->required()->maxLength(15);
 
 			$row = $form->addRow();
 				$row->addLabel('countAgainstBudget', __('Count Against Budget'))->description(__('For tracking purposes, should the item be counted against the budget? If immediately offset by some revenue, perhaps not.'));
-				$row->addYesNo('countAgainstBudget')->isRequired();
+				$row->addYesNo('countAgainstBudget')->required();
 
 			$row = $form->addRow();
 				$row->addLabel('purchaseBy', __('Purchase By'));
-				$row->addSelect('purchaseBy')->fromArray(array('School' => __('School'), 'Self' => __('Self')))->isRequired();
+				$row->addSelect('purchaseBy')->fromArray(array('School' => __('School'), 'Self' => __('Self')))->required();
 
 			$row = $form->addRow();
 				$column = $row->addColumn();
@@ -132,15 +132,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
 
 			$row = $form->addRow()->addClass('paymentInfo');
 				$row->addLabel('paymentDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));
-				$row->addDate('paymentDate')->isRequired();
+				$row->addDate('paymentDate')->required();
 
 			$row = $form->addRow()->addClass('paymentInfo');
 				$row->addLabel('paymentAmount', __('Amount Paid'))->description(__('Final amount paid.'));
-				$row->addCurrency('paymentAmount')->isRequired()->maxLength(15);
+				$row->addCurrency('paymentAmount')->required()->maxLength(15);
 
 			$row = $form->addRow()->addClass('paymentInfo');
 				$row->addLabel('gibbonPersonIDPayment', __('Payee'))->description(__('Staff who made, or arranged, the payment.'));
-				$row->addSelectStaff('gibbonPersonIDPayment')->isRequired()->placeholder();
+				$row->addSelectStaff('gibbonPersonIDPayment')->required()->placeholder();
 
 			$methods = array(
 				'Bank Transfer' => __('Bank Transfer'),
@@ -151,7 +151,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
 			);
 			$row = $form->addRow()->addClass('paymentInfo');
 				$row->addLabel('paymentMethod', __('Payment Method'));
-				$row->addSelect('paymentMethod')->fromArray($methods)->placeholder()->isRequired();
+				$row->addSelect('paymentMethod')->fromArray($methods)->placeholder()->required();
 
 			$row = $form->addRow()->addClass('paymentInfo');
 				$row->addLabel('paymentID', __('Payment ID'))->description(__('Transaction ID to identify this payment.'));

--- a/modules/Finance/expenses_manage_approve.php
+++ b/modules/Finance/expenses_manage_approve.php
@@ -161,7 +161,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
 							$cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
 							$row = $form->addRow();
 								$row->addLabel('name', __('Budget Cycle'));
-								$row->addTextField('name')->setValue($cycleName)->maxLength(20)->isRequired()->readonly();
+								$row->addTextField('name')->setValue($cycleName)->maxLength(20)->required()->readonly();
 
                             //Can change budgets only if budget level approval is passed (e.g. you are a school approver.
                             if ($highestAction == 'Manage Expenses_all' and $values['statusApprovalBudgetCleared'] == 'Y') 
@@ -169,22 +169,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
                                 $sql = "SELECT gibbonFinanceBudgetID as value, name FROM gibbonFinanceBudget WHERE active='Y' ORDER BY name";
                                 $row = $form->addRow();
                                     $row->addLabel('gibbonFinanceBudgetID', __('Budget'));
-                                    $row->addSelect('gibbonFinanceBudgetID')->fromQuery($pdo, $sql)->isRequired()->placeholder()->selected($values['gibbonFinanceBudgetID']);
+                                    $row->addSelect('gibbonFinanceBudgetID')->fromQuery($pdo, $sql)->required()->placeholder()->selected($values['gibbonFinanceBudgetID']);
                             } else {
                                 $form->addHiddenValue('gibbonFinanceBudgetID', $values['gibbonFinanceBudgetID']);
 
                                 $row = $form->addRow();
 								    $row->addLabel('budgetName', __('Budget'));
-								    $row->addTextField('budgetName')->setValue($values['budget'])->isRequired()->readonly();
+								    $row->addTextField('budgetName')->setValue($values['budget'])->required()->readonly();
                             }
 
 							$row = $form->addRow();
 								$row->addLabel('title', __('Title'));
-								$row->addTextField('title')->isRequired()->readonly();
+								$row->addTextField('title')->required()->readonly();
 
 							$row = $form->addRow();
 								$row->addLabel('status', __('Status'));
-								$row->addTextField('status')->isRequired()->readonly();
+								$row->addTextField('status')->required()->readonly();
 
 							$row = $form->addRow();
 								$col = $row->addColumn();
@@ -193,7 +193,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
 
 							$row = $form->addRow();
 								$row->addLabel('purchaseBy', __('Purchase By'));
-								$row->addTextField('purchaseBy')->isRequired()->readonly();
+								$row->addTextField('purchaseBy')->required()->readonly();
 
 							$row = $form->addRow();
 								$col = $row->addColumn();
@@ -204,28 +204,28 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
                             
                             $row = $form->addRow();
                                 $row->addLabel('costLabel', __('Total Cost'));
-                                $row->addTextField('costLabel')->isRequired()->readonly()->setValue(number_format($values['cost'], 2, '.', ','));
+                                $row->addTextField('costLabel')->required()->readonly()->setValue(number_format($values['cost'], 2, '.', ','));
 
 							$row = $form->addRow();
 								$row->addLabel('countAgainstBudgetLabel', __('Count Against Budget'));
-                                $row->addTextField('countAgainstBudgetLabel')->setValue(ynExpander($guid, $values['countAgainstBudget']))->isRequired()->readonly();
+                                $row->addTextField('countAgainstBudgetLabel')->setValue(ynExpander($guid, $values['countAgainstBudget']))->required()->readonly();
                                 
                             if ($values['countAgainstBudget'] == 'Y') {
                                 $budgetAllocationLabel = (is_numeric($budgetAllocation))? number_format($budgetAllocation, 2, '.', ',') : $budgetAllocation;
                                 $row = $form->addRow();
                                     $row->addLabel('budgetAllocation', __('Budget For Cycle'))->description(__('Numeric value of the fee.'));
-                                    $row->addTextField('budgetAllocation')->isRequired()->readonly()->setValue($budgetAllocationLabel);
+                                    $row->addTextField('budgetAllocation')->required()->readonly()->setValue($budgetAllocationLabel);
                                 
                                 $budgetAllocatedLabel = (is_numeric($budgetAllocated))? number_format($budgetAllocated, 2, '.', ',') : $budgetAllocated;
                                 $row = $form->addRow();
                                     $row->addLabel('budgetForCycle', __('Amount already approved or spent'))->description(__('Numeric value of the fee.'));
-                                    $row->addTextField('budgetForCycle')->isRequired()->readonly()->setValue($budgetAllocatedLabel);
+                                    $row->addTextField('budgetForCycle')->required()->readonly()->setValue($budgetAllocatedLabel);
                                     
                                 $budgetRemainingLabel = (is_numeric($budgetRemaining))? number_format($budgetRemaining, 2, '.', ',') : $budgetRemaining;
                                 $row = $form->addRow();
                                     $row->addLabel('budgetRemaining', __('Budget Remaining For Cycle'))->description(__('Numeric value of the fee.'));
                                     $row->addTextField('budgetRemaining')
-                                        ->isRequired()
+                                        ->required()
                                         ->readonly()
                                         ->setValue($budgetRemainingLabel)
                                         ->addClass( (is_numeric($budgetRemaining) && $budgetRemaining - $values['cost'] > 0)? 'textUnderBudget' : 'textOverBudget' );
@@ -248,7 +248,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
                                 );
                                 $row = $form->addRow();
                                     $row->addLabel('approval', __('Approval'));
-                                    $row->addSelect('approval')->fromArray($approvalStatuses)->isRequired()->placeholder();
+                                    $row->addSelect('approval')->fromArray($approvalStatuses)->required()->placeholder();
 
                                 $col = $form->addRow()->addColumn();
                                     $col->addLabel('comment', __('Comment'));

--- a/modules/Finance/expenses_manage_edit.php
+++ b/modules/Finance/expenses_manage_edit.php
@@ -151,15 +151,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 							$cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
 							$row = $form->addRow();
 								$row->addLabel('name', __('Budget Cycle'));
-								$row->addTextField('name')->setValue($cycleName)->maxLength(20)->isRequired()->readonly();
+								$row->addTextField('name')->setValue($cycleName)->maxLength(20)->required()->readonly();
 
 							$row = $form->addRow();
 								$row->addLabel('budgetName', __('Budget'));
-								$row->addTextField('budgetName')->setValue($values['budget'])->isRequired()->readonly();
+								$row->addTextField('budgetName')->setValue($values['budget'])->required()->readonly();
 
 							$row = $form->addRow();
 								$row->addLabel('title', __('Title'));
-								$row->addTextField('title')->isRequired()->readonly();
+								$row->addTextField('title')->required()->readonly();
 
 							$row = $form->addRow();
 								$row->addLabel('status', __('Status'));
@@ -180,9 +180,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 									$statuses = array('Approved' => __('Approved')) + $statuses;
 								}
 
-								$row->addSelect('status')->fromArray($statuses)->isRequired()->placeholder();
+								$row->addSelect('status')->fromArray($statuses)->required()->placeholder();
 							} else {
-								$row->addTextField('status')->isRequired()->readonly();
+								$row->addTextField('status')->required()->readonly();
 							}
 
 							$row = $form->addRow();
@@ -192,7 +192,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 
 							$row = $form->addRow();
 								$row->addLabel('purchaseBy', __('Purchase By'));
-								$row->addTextField('purchaseBy')->isRequired()->readonly();
+								$row->addTextField('purchaseBy')->required()->readonly();
 
 							$row = $form->addRow();
 								$col = $row->addColumn();
@@ -203,29 +203,29 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
                             
                             $row = $form->addRow();
                                 $row->addLabel('cost', __('Total Cost'));
-                                $row->addCurrency('cost')->isRequired()->readonly()->setValue(number_format($values['cost'], 2, '.', ','));
+                                $row->addCurrency('cost')->required()->readonly()->setValue(number_format($values['cost'], 2, '.', ','));
 
 							$row = $form->addRow();
 								$row->addLabel('countAgainstBudget', __('Count Against Budget'))->description(__('For tracking purposes, should the item be counted against the budget? If immediately offset by some revenue, perhaps not.'));
-                                $row->addYesNo('countAgainstBudget')->isRequired();
+                                $row->addYesNo('countAgainstBudget')->required();
                                 
                             $form->toggleVisibilityByClass('budgetInfo')->onSelect('countAgainstBudget')->when('Y');
 
                             $budgetAllocationLabel = (is_numeric($budgetAllocation))? number_format($budgetAllocation, 2, '.', ',') : $budgetAllocation;
                             $row = $form->addRow()->addClass('budgetInfo');
 								$row->addLabel('budgetAllocation', __('Budget For Cycle'))->description(__('Numeric value of the fee.'));
-                                $row->addCurrency('budgetAllocation')->isRequired()->readonly()->setValue($budgetAllocationLabel);
+                                $row->addCurrency('budgetAllocation')->required()->readonly()->setValue($budgetAllocationLabel);
                               
                             $budgetAllocatedLabel = (is_numeric($budgetAllocated))? number_format($budgetAllocated, 2, '.', ',') : $budgetAllocated;
 							$row = $form->addRow()->addClass('budgetInfo');
 								$row->addLabel('budgetForCycle', __('Amount already approved or spent'))->description(__('Numeric value of the fee.'));
-                                $row->addCurrency('budgetForCycle')->isRequired()->readonly()->setValue($budgetAllocatedLabel);
+                                $row->addCurrency('budgetForCycle')->required()->readonly()->setValue($budgetAllocatedLabel);
                                 
                             $budgetRemainingLabel = (is_numeric($budgetRemaining))? number_format($budgetRemaining, 2, '.', ',') : $budgetRemaining;
 							$row = $form->addRow()->addClass('budgetInfo');
 								$row->addLabel('budgetRemaining', __('Budget Remaining For Cycle'))->description(__('Numeric value of the fee.'));
                                 $row->addCurrency('budgetRemaining')
-                                    ->isRequired()
+                                    ->required()
                                     ->readonly()
                                     ->setValue($budgetRemainingLabel)
                                     ->addClass( (is_numeric($budgetRemaining) && $budgetRemaining - $values['cost'] > 0)? 'textUnderBudget' : 'textOverBudget' );
@@ -243,11 +243,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 
 							$row = $form->addRow()->addClass('paymentInfo');
 								$row->addLabel('paymentDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));
-								$row->addDate('paymentDate')->isRequired()->setValue(dateConvertBack($guid, $values['paymentDate']))->readonly($isPaid);
+								$row->addDate('paymentDate')->required()->setValue(dateConvertBack($guid, $values['paymentDate']))->readonly($isPaid);
 
 							$row = $form->addRow()->addClass('paymentInfo');
 								$row->addLabel('paymentAmount', __('Amount Paid'))->description(__('Final amount paid.'));
-								$row->addCurrency('paymentAmount')->isRequired()->maxLength(15)->readonly($isPaid);
+								$row->addCurrency('paymentAmount')->required()->maxLength(15)->readonly($isPaid);
 
 							$row = $form->addRow()->addClass('paymentInfo');
                                 $row->addLabel('gibbonPersonIDPayment', __('Payee'))->description(__('Staff who made, or arranged, the payment.'));
@@ -257,10 +257,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
                                     $result = $pdo->executeQuery($data, $sql);
                                     $payee = $result->rowCount() == 1? $result->fetch() : null;
                                     $payeeName = !empty($payee)? formatName($payee['title'], $payee['preferredName'], $payee['surname'], 'Staff', true, true) : '';
-                                    $row->addTextField('payee')->isRequired()->readonly()->setValue($payeeName);
+                                    $row->addTextField('payee')->required()->readonly()->setValue($payeeName);
                                     $form->addHiddenValue('gibbonPersonIDPayment', $values['gibbonPersonIDPayment']);
                                 } else {
-                                    $row->addSelectStaff('gibbonPersonIDPayment')->isRequired()->placeholder();
+                                    $row->addSelectStaff('gibbonPersonIDPayment')->required()->placeholder();
                                 }
 								
 
@@ -274,9 +274,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 							$row = $form->addRow()->addClass('paymentInfo');
                                 $row->addLabel('paymentMethod', __('Payment Method'));
                                 if ($isPaid) {
-                                    $row->addTextField('paymentMethod')->isRequired()->readonly()->setValue($values['paymentMethod']);
+                                    $row->addTextField('paymentMethod')->required()->readonly()->setValue($values['paymentMethod']);
                                 } else {
-                                    $row->addSelect('paymentMethod')->fromArray($methods)->placeholder()->isRequired()->readonly($isPaid);
+                                    $row->addSelect('paymentMethod')->fromArray($methods)->placeholder()->required()->readonly($isPaid);
                                 }
 
 							$row = $form->addRow()->addClass('paymentInfo');

--- a/modules/Finance/feeCategories_manage_add.php
+++ b/modules/Finance/feeCategories_manage_add.php
@@ -49,15 +49,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->maxLength(100)->isRequired();
+        $row->addTextField('name')->maxLength(100)->required();
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'));
-        $row->addTextField('nameShort')->maxLength(14)->isRequired();
+        $row->addTextField('nameShort')->maxLength(14)->required();
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $row = $form->addRow();
         $row->addLabel('description', __('Description'));

--- a/modules/Finance/feeCategories_manage_edit.php
+++ b/modules/Finance/feeCategories_manage_edit.php
@@ -69,15 +69,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->maxLength(100)->isRequired();
+                $row->addTextField('name')->maxLength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'));
-                $row->addTextField('nameShort')->maxLength(14)->isRequired();
+                $row->addTextField('nameShort')->maxLength(14)->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));

--- a/modules/Finance/fees_manage_add.php
+++ b/modules/Finance/fees_manage_add.php
@@ -73,20 +73,20 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/fees_manage_add.ph
             $values = $resultYear->fetch();
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-                $row->addTextField('schoolYear')->maxLength(20)->isRequired()->readonly()->setValue($values['schoolYear']);
+                $row->addTextField('schoolYear')->maxLength(20)->required()->readonly()->setValue($values['schoolYear']);
         }
 
         $row = $form->addRow();
             $row->addLabel('name', __('Name'));
-            $row->addTextField('name')->maxLength(100)->isRequired();
+            $row->addTextField('name')->maxLength(100)->required();
 
         $row = $form->addRow();
             $row->addLabel('nameShort', __('Short Name'));
-            $row->addTextField('nameShort')->maxLength(6)->isRequired();
+            $row->addTextField('nameShort')->maxLength(6)->required();
 
         $row = $form->addRow();
             $row->addLabel('active', __('Active'));
-            $row->addYesNo('active')->isRequired();
+            $row->addYesNo('active')->required();
 
         $row = $form->addRow();
             $row->addLabel('description', __('Description'));
@@ -96,12 +96,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/fees_manage_add.ph
         $sql = "SELECT gibbonFinanceFeeCategoryID AS value, name FROM gibbonFinanceFeeCategory WHERE active='Y' AND NOT gibbonFinanceFeeCategoryID=1 ORDER BY name";
         $row = $form->addRow();
             $row->addLabel('gibbonFinanceFeeCategoryID', __('Category'));
-            $row->addSelect('gibbonFinanceFeeCategoryID')->fromQuery($pdo, $sql, $data)->fromArray(array('1' => __('Other')))->isRequired()->placeholder();
+            $row->addSelect('gibbonFinanceFeeCategoryID')->fromQuery($pdo, $sql, $data)->fromArray(array('1' => __('Other')))->required()->placeholder();
 
         $row = $form->addRow();
             $row->addLabel('fee', __('Fee'))
                 ->description(__('Numeric value of the fee.'));
-            $row->addCurrency('fee')->isRequired();
+            $row->addCurrency('fee')->required();
 
         $row = $form->addRow();
         $row->addFooter();

--- a/modules/Finance/fees_manage_edit.php
+++ b/modules/Finance/fees_manage_edit.php
@@ -82,19 +82,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/fees_manage_edit.p
 
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-                $row->addTextField('schoolYear')->maxLength(20)->isRequired()->readonly()->setValue($values['schoolYear']);
+                $row->addTextField('schoolYear')->maxLength(20)->required()->readonly()->setValue($values['schoolYear']);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->maxLength(100)->isRequired();
+                $row->addTextField('name')->maxLength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'));
-                $row->addTextField('nameShort')->maxLength(6)->isRequired();
+                $row->addTextField('nameShort')->maxLength(6)->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));
@@ -104,12 +104,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/fees_manage_edit.p
             $sql = "SELECT gibbonFinanceFeeCategoryID AS value, name FROM gibbonFinanceFeeCategory WHERE active='Y' AND NOT gibbonFinanceFeeCategoryID=1 ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('gibbonFinanceFeeCategoryID', __('Category'));
-                $row->addSelect('gibbonFinanceFeeCategoryID')->fromQuery($pdo, $sql, $data)->fromArray(array('1' => __('Other')))->isRequired()->placeholder();
+                $row->addSelect('gibbonFinanceFeeCategoryID')->fromQuery($pdo, $sql, $data)->fromArray(array('1' => __('Other')))->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('fee', __('Fee'))
                     ->description(__('Numeric value of the fee.'));
-                $row->addCurrency('fee')->isRequired();
+                $row->addCurrency('fee')->required();
 
             $row = $form->addRow();
             $row->addFooter();

--- a/modules/Finance/invoicees_manage_edit.php
+++ b/modules/Finance/invoicees_manage_edit.php
@@ -103,19 +103,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoicees_manage_e
             // COMPANY DETAILS
             $row = $form->addRow()->addClass('paymentCompany');
                 $row->addLabel('companyName', __('Company Name'));
-                $row->addTextField('companyName')->isRequired()->maxLength(100);
+                $row->addTextField('companyName')->required()->maxLength(100);
 
             $row = $form->addRow()->addClass('paymentCompany');
                 $row->addLabel('companyContact', __('Company Contact Person'));
-                $row->addTextField('companyContact')->isRequired()->maxLength(100);
+                $row->addTextField('companyContact')->required()->maxLength(100);
 
             $row = $form->addRow()->addClass('paymentCompany');
                 $row->addLabel('companyAddress', __('Company Address'));
-                $row->addTextField('companyAddress')->isRequired()->maxLength(255);
+                $row->addTextField('companyAddress')->required()->maxLength(255);
 
             $row = $form->addRow()->addClass('paymentCompany');
                 $row->addLabel('companyEmail', __('Company Emails'))->description(__('Comma-separated list of email address'));
-                $row->addTextField('companyEmail')->isRequired();
+                $row->addTextField('companyEmail')->required();
 
             $row = $form->addRow()->addClass('paymentCompany');
                 $row->addLabel('companyCCFamily', __('CC Family?'))->description(__('Should the family be sent a copy of billing emails?'));

--- a/modules/Finance/invoices_manage.php
+++ b/modules/Finance/invoices_manage.php
@@ -188,12 +188,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
         $col = $form->createBulkActionColumn($bulkActions);
             $col->addSelectPaymentMethod('paymentType')
                 ->setClass('bulkPaid shortWidth displayNone')
-                ->isRequired()
+                ->required()
                 ->addValidationOption('onlyOnSubmit: true')
                 ->placeholder(__('Payment Type').'...');
             $col->addDate('paidDate')
                 ->setClass('bulkPaid shortWidth displayNone')
-                ->isRequired()
+                ->required()
                 ->addValidationOption('onlyOnSubmit: true')
                 ->placeholder(__('Date Paid'));
             $col->addSubmit(__('Go'));

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -89,27 +89,27 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
         $row = $form->addRow();
             $row->addLabel('schoolYear', __('School Year'));
-            $row->addTextField('schoolYear')->isRequired()->readonly()->setValue($schoolYearName);
+            $row->addTextField('schoolYear')->required()->readonly()->setValue($schoolYearName);
 
         $row = $form->addRow();
             $row->addLabel('gibbonFinanceInvoiceeIDs', __('Invoicees'))->append(sprintf(__('Visit %1$sManage Invoicees%2$s to automatically generate missing students.'), "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Finance/invoicees_manage.php'>", '</a>'));
-            $row->addSelectInvoicee('gibbonFinanceInvoiceeIDs', $gibbonSchoolYearID)->isRequired()->selectMultiple();
+            $row->addSelectInvoicee('gibbonFinanceInvoiceeIDs', $gibbonSchoolYearID)->required()->selectMultiple();
 
         $scheduling = array('Scheduled' => __('Scheduled'), 'Ad Hoc' => __('Ad Hoc'));
         $row = $form->addRow();
             $row->addLabel('scheduling', __('Scheduling'))->description(__('When using scheduled, invoice due date is linked to and determined by the schedule.'));
-            $row->addRadio('scheduling')->fromArray($scheduling)->isRequired()->inline()->checked('Scheduled');
+            $row->addRadio('scheduling')->fromArray($scheduling)->required()->inline()->checked('Scheduled');
 
         $form->toggleVisibilityByClass('schedulingScheduled')->onRadio('scheduling')->when('Scheduled');
         $form->toggleVisibilityByClass('schedulingAdHoc')->onRadio('scheduling')->when('Ad Hoc');
 
         $row = $form->addRow()->addClass('schedulingScheduled');
             $row->addLabel('gibbonFinanceBillingScheduleID', __('Billing Schedule'));
-            $row->addSelectBillingSchedule('gibbonFinanceBillingScheduleID', $gibbonSchoolYearID)->isRequired()->selected($gibbonFinanceBillingScheduleID);
+            $row->addSelectBillingSchedule('gibbonFinanceBillingScheduleID', $gibbonSchoolYearID)->required()->selected($gibbonFinanceBillingScheduleID);
 
         $row = $form->addRow()->addClass('schedulingAdHoc');
             $row->addLabel('invoiceDueDate', __('Invoice Due Date'))->description(__('For fees added to existing invoice, specified date will override existing due date.'));
-            $row->addDate('invoiceDueDate')->isRequired();
+            $row->addDate('invoiceDueDate')->required();
 
         $row = $form->addRow();
             $row->addLabel('notes', __('Notes'))->description(__('Notes will be displayed on the final invoice and receipt.'));
@@ -125,7 +125,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
         // Block template
         $blockTemplate = $form->getFactory()->createTable()->setClass('blank');
             $row = $blockTemplate->addRow();
-                $row->addTextField('name')->setClass('standardWidth floatLeft noMargin title')->isRequired()->placeholder(__('Fee Name'))
+                $row->addTextField('name')->setClass('standardWidth floatLeft noMargin title')->required()->placeholder(__('Fee Name'))
                     ->append('<input type="hidden" id="gibbonFinanceFeeID" name="gibbonFinanceFeeID" value="">')
                     ->append('<input type="hidden" id="feeType" name="feeType" value="">');
                 
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
                 $col->addCurrency('fee')
                     ->setClass('shortWidth floatLeft')
-                    ->isRequired()
+                    ->required()
                     ->placeholder(__('Value').(!empty($_SESSION[$guid]['currency'])? ' ('.$_SESSION[$guid]['currency'].')' : ''));
                 
             $col = $blockTemplate->addRow()->addClass('showHide fullWidth')->addColumn();

--- a/modules/Finance/invoices_manage_edit.php
+++ b/modules/Finance/invoices_manage_edit.php
@@ -94,29 +94,29 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
 
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-                $row->addTextField('schoolYear')->isRequired()->readonly();
+                $row->addTextField('schoolYear')->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('personName', __('Invoicee'));
-                $row->addTextField('personName')->isRequired()->readonly()->setValue(formatName('', $values['preferredName'], $values['surname'], 'Student', true));
+                $row->addTextField('personName')->required()->readonly()->setValue(formatName('', $values['preferredName'], $values['surname'], 'Student', true));
 
             $row = $form->addRow();
                 $row->addLabel('billingScheduleType', __('Scheduling'));
-                $row->addTextField('billingScheduleType')->isRequired()->readonly();
+                $row->addTextField('billingScheduleType')->required()->readonly();
 
             if ($values['billingScheduleType'] == 'Scheduled') {
                 $row = $form->addRow();
                     $row->addLabel('billingScheduleName', __('Billing Schedule'));
-                    $row->addTextField('billingScheduleName')->isRequired()->readonly();
+                    $row->addTextField('billingScheduleName')->required()->readonly();
             } else {
                 if ($values['status'] == 'Pending' || $values['status'] == 'Issued') {
                     $row = $form->addRow();
                         $row->addLabel('invoiceDueDate', __('Invoice Due Date'));
-                        $row->addDate('invoiceDueDate')->isRequired();
+                        $row->addDate('invoiceDueDate')->required();
                 } else {
                     $row = $form->addRow();
                         $row->addLabel('invoiceDueDate', __('Invoice Due Date'));
-                        $row->addDate('invoiceDueDate')->isRequired()->readonly();
+                        $row->addDate('invoiceDueDate')->required()->readonly();
                 }
             }
 
@@ -124,7 +124,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
                 $row->addLabel('status', __('Status'))->description($values['status'] == 'Pending'
                     ? __('This value cannot be changed. Use the Issue function to change the status from "Pending" to "Issued".') 
                     : __('Available options are limited according to current status.'));
-                $row->addSelectInvoiceStatus('status', $values['status'])->isRequired();
+                $row->addSelectInvoiceStatus('status', $values['status'])->required();
 
             // PAYMENT INFO
             if ($values['status'] == 'Issued' or $values['status'] == 'Paid - Partial') {
@@ -132,7 +132,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
                 
                 $row = $form->addRow()->addClass('paymentInfo');
                     $row->addLabel('paymentType', __('Payment Type'));
-                    $row->addSelectPaymentMethod('paymentType')->isRequired();       
+                    $row->addSelectPaymentMethod('paymentType')->required();       
 
                 $row = $form->addRow()->addClass('paymentInfo');
                     $row->addLabel('paymentTransactionID', __('Transaction ID'))->description(__('Transaction ID to identify this payment.'));
@@ -140,7 +140,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
 
                 $row = $form->addRow()->addClass('paymentInfo');
                     $row->addLabel('paidDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));
-                    $row->addDate('paidDate')->isRequired();
+                    $row->addDate('paidDate')->required();
 
                 $remainingFee = getInvoiceTotalFee($pdo, $gibbonFinanceInvoiceID, $values['status']);
                 if ($values['status'] == 'Paid - Partial') {
@@ -150,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
 
                 $row = $form->addRow()->addClass('paymentInfo');
                     $row->addLabel('paidAmount', __('Amount Paid'))->description(__('Amount in current payment.'));
-                    $row->addCurrency('paidAmount')->maxLength(14)->isRequired()->setValue(number_format($remainingFee, 2, '.', ''));
+                    $row->addCurrency('paidAmount')->maxLength(14)->required()->setValue(number_format($remainingFee, 2, '.', ''));
 
                 unset($values['paidDate']);
                 unset($values['paidAmount']);
@@ -185,7 +185,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
                 // Block template
                 $blockTemplate = $form->getFactory()->createTable()->setClass('blank');
                 $row = $blockTemplate->addRow();
-                    $row->addTextField('name')->setClass('standardWidth floatLeft noMargin title')->isRequired()->placeholder(__('Fee Name'))
+                    $row->addTextField('name')->setClass('standardWidth floatLeft noMargin title')->required()->placeholder(__('Fee Name'))
                         ->append('<input type="hidden" id="gibbonFinanceFeeID" name="gibbonFinanceFeeID" value="">')
                         ->append('<input type="hidden" id="feeType" name="feeType" value="">');
                     
@@ -195,7 +195,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
 
                     $col->addCurrency('fee')
                         ->setClass('shortWidth floatLeft')
-                        ->isRequired()
+                        ->required()
                         ->placeholder(__('Value').(!empty($_SESSION[$guid]['currency'])? ' ('.$_SESSION[$guid]['currency'].')' : ''));
                     
                 $col = $blockTemplate->addRow()->addClass('showHide fullWidth')->addColumn();

--- a/modules/Finance/invoices_manage_issue.php
+++ b/modules/Finance/invoices_manage_issue.php
@@ -99,30 +99,30 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
 
 			$row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-				$row->addTextField('schoolYear')->isRequired()->readonly();
+				$row->addTextField('schoolYear')->required()->readonly();
 				
 			$row = $form->addRow();
                 $row->addLabel('personName', __('Invoicee'));
-                $row->addTextField('personName')->isRequired()->readonly()->setValue(formatName('', $values['preferredName'], $values['surname'], 'Student', true));
+                $row->addTextField('personName')->required()->readonly()->setValue(formatName('', $values['preferredName'], $values['surname'], 'Student', true));
 
             $row = $form->addRow();
                 $row->addLabel('billingScheduleType', __('Scheduling'));
-				$row->addTextField('billingScheduleType')->isRequired()->readonly();
+				$row->addTextField('billingScheduleType')->required()->readonly();
 				
 			if ($values['billingScheduleType'] == 'Scheduled') {
 				$row = $form->addRow();
 					$row->addLabel('billingScheduleName', __('Billing Schedule'));
-					$row->addTextField('billingScheduleName')->isRequired()->readonly();
+					$row->addTextField('billingScheduleName')->required()->readonly();
 					$form->addHiddenValue('invoiceDueDate', dateConvertBack($guid, $values['billingScheduleInvoiceDueDate']));
 			} else {
 				$row = $form->addRow();
 					$row->addLabel('invoiceDueDate', __('Invoice Due Date'));
-					$row->addDate('invoiceDueDate')->isRequired()->readonly();
+					$row->addDate('invoiceDueDate')->required()->readonly();
 			}
 
 			$row = $form->addRow();
 				$row->addLabel('status', __('Status'));
-				$row->addTextField('status')->isRequired()->readonly();
+				$row->addTextField('status')->required()->readonly();
 
 			$row = $form->addRow();
                 $row->addLabel('notes', __('Notes'))->description(__('Notes will be displayed on the final invoice and receipt.'));
@@ -133,11 +133,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
 			$totalFee = getInvoiceTotalFee($pdo, $gibbonFinanceInvoiceID, $values['status']);
 			$row = $form->addRow();
 				$row->addLabel('totalFee', __('Total'))->description('<small><i>('.$_SESSION[$guid]['currency'].')</i></small>');
-				$row->addTextField('totalFee')->isRequired()->readonly()->setValue(number_format($totalFee, 2));
+				$row->addTextField('totalFee')->required()->readonly()->setValue(number_format($totalFee, 2));
 
 			$row = $form->addRow();
 				$row->addLabel('invoiceTo', __('Invoice To'));
-				$row->addTextField('invoiceTo')->isRequired()->readonly();
+				$row->addTextField('invoiceTo')->required()->readonly();
 
 			$form->addRow()->addHeading(__('Email Invoice'));
 

--- a/modules/Formal Assessment/externalAssessment_manage_details_add.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_add.php
@@ -114,7 +114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
                 $sql = "SELECT gibbonExternalAssessmentID as value, name FROM gibbonExternalAssessment WHERE active='Y' ORDER BY name";
                 $row = $form->addRow();
                     $row->addLabel('gibbonExternalAssessmentID', __('Choose Assessment'));
-                    $row->addSelect('gibbonExternalAssessmentID')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+                    $row->addSelect('gibbonExternalAssessmentID')->fromQuery($pdo, $sql)->required()->placeholder();
 
                 $form->toggleVisibilityByClass('copyToGCSE')->onSelect('gibbonExternalAssessmentID')->when('0002');
                 $row = $form->addRow()->addClass('copyToGCSE');
@@ -358,11 +358,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
 
                     $row = $form->addRow();
                     $row->addLabel('name', __('Assessment Type'));
-                    $row->addTextField('name')->isRequired()->readOnly()->setValue(__($rowSelect['name']));
+                    $row->addTextField('name')->required()->readOnly()->setValue(__($rowSelect['name']));
 
                     $row = $form->addRow();
                     $row->addLabel('date', __('Date'));
-                    $row->addDate('date')->isRequired();
+                    $row->addDate('date')->required();
 
                     if ($rowSelect['allowFileUpload'] == 'Y') {
                         $row = $form->addRow();

--- a/modules/Formal Assessment/externalAssessment_manage_details_edit.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_edit.php
@@ -109,11 +109,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
             
             $row = $form->addRow();
                 $row->addLabel('name', __('Assessment Type'));
-                $row->addTextField('name')->isRequired()->readOnly()->setValue(__($values['assessment']));
+                $row->addTextField('name')->required()->readOnly()->setValue(__($values['assessment']));
 
             $row = $form->addRow();
                 $row->addLabel('date', __('Date'));
-                $row->addDate('date')->isRequired()->loadFrom($values);
+                $row->addDate('date')->required()->loadFrom($values);
 
             if ($values['allowFileUpload'] == 'Y') {
                 $row = $form->addRow();

--- a/modules/Formal Assessment/internalAssessment_manage_add.php
+++ b/modules/Formal Assessment/internalAssessment_manage_add.php
@@ -77,22 +77,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $row->addSelect('gibbonCourseClassIDMulti')
                     ->fromQuery($pdo, $sql, $data, 'groupBy')
                     ->selectMultiple()
-                    ->isRequired()
+                    ->required()
                     ->selected($gibbonCourseClassID);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(20);
+                $row->addTextField('name')->required()->maxLength(20);
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));
-                $row->addTextField('description')->isRequired()->maxLength(1000);
+                $row->addTextField('description')->required()->maxLength(1000);
 
             $types = getSettingByScope($connection2, 'Formal Assessment', 'internalAssessmentTypes');
             if (!empty($types)) {
                 $row = $form->addRow();
                     $row->addLabel('type', __('Type'));
-                    $row->addSelect('type')->fromString($types)->isRequired()->placeholder();
+                    $row->addSelect('type')->fromString($types)->required()->placeholder();
             }
 
             $row = $form->addRow();
@@ -104,44 +104,44 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
             $attainmentLabel = !empty($attainmentAlternativeName)? sprintf(__('Assess %1$s?'), $attainmentAlternativeName) : __('Assess Attainment?');
             $row = $form->addRow();
                 $row->addLabel('attainment', $attainmentLabel);
-                $row->addYesNoRadio('attainment')->isRequired();
+                $row->addYesNoRadio('attainment')->required();
 
             $form->toggleVisibilityByClass('attainmentRow')->onRadio('attainment')->when('Y');
 
             $attainmentScaleLabel = !empty($attainmentAlternativeName)? $attainmentAlternativeName.' '.__('Scale') : __('Attainment Scale');
             $row = $form->addRow()->addClass('attainmentRow');
                 $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
-                $row->addSelectGradeScale('gibbonScaleIDAttainment')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                $row->addSelectGradeScale('gibbonScaleIDAttainment')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
 
             $effortLabel = !empty($effortAlternativeName)? sprintf(__('Assess %1$s?'), $effortAlternativeName) : __('Assess Effort?');
             $row = $form->addRow();
                 $row->addLabel('effort', $effortLabel);
-                $row->addYesNoRadio('effort')->isRequired();
+                $row->addYesNoRadio('effort')->required();
 
             $form->toggleVisibilityByClass('effortRow')->onRadio('effort')->when('Y');
 
             $effortScaleLabel = !empty($effortAlternativeName)? $effortAlternativeName.' '.__('Scale') : __('Effort Scale');
             $row = $form->addRow()->addClass('effortRow');
                 $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
-                $row->addSelectGradeScale('gibbonScaleIDEffort')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                $row->addSelectGradeScale('gibbonScaleIDEffort')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
 
             $row = $form->addRow();
                 $row->addLabel('comment', __('Include Comment?'));
-                $row->addYesNoRadio('comment')->isRequired();
+                $row->addYesNoRadio('comment')->required();
 
             $row = $form->addRow();
                 $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
-                $row->addYesNoRadio('uploadedResponse')->isRequired();
+                $row->addYesNoRadio('uploadedResponse')->required();
 
             $form->addRow()->addHeading(__('Access'));
 
             $row = $form->addRow();
                 $row->addLabel('viewableStudents', __('Viewable to Students'));
-                $row->addYesNo('viewableStudents')->isRequired();
+                $row->addYesNo('viewableStudents')->required();
 
             $row = $form->addRow();
                 $row->addLabel('viewableParents', __('Viewable to Parents'));
-                $row->addYesNo('viewableParents')->isRequired();
+                $row->addYesNo('viewableParents')->required();
 
             $row = $form->addRow();
                 $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));

--- a/modules/Formal Assessment/internalAssessment_manage_edit.php
+++ b/modules/Formal Assessment/internalAssessment_manage_edit.php
@@ -94,21 +94,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
         
                     $row = $form->addRow();
                         $row->addLabel('className', __('Class'));
-                        $row->addTextField('className')->isRequired()->readonly()->setValue(htmlPrep($class['course'].'.'.$class['class']));
+                        $row->addTextField('className')->required()->readonly()->setValue(htmlPrep($class['course'].'.'.$class['class']));
         
                     $row = $form->addRow();
                         $row->addLabel('name', __('Name'));
-                        $row->addTextField('name')->isRequired()->maxLength(20);
+                        $row->addTextField('name')->required()->maxLength(20);
         
                     $row = $form->addRow();
                         $row->addLabel('description', __('Description'));
-                        $row->addTextField('description')->isRequired()->maxLength(1000);
+                        $row->addTextField('description')->required()->maxLength(1000);
         
                     $types = getSettingByScope($connection2, 'Formal Assessment', 'internalAssessmentTypes');
                     if (!empty($types)) {
                         $row = $form->addRow();
                             $row->addLabel('type', __('Type'));
-                            $row->addSelect('type')->fromString($types)->isRequired()->placeholder();
+                            $row->addSelect('type')->fromString($types)->required()->placeholder();
                     }
         
                     $row = $form->addRow();
@@ -120,44 +120,44 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     $attainmentLabel = !empty($attainmentAlternativeName)? sprintf(__('Assess %1$s?'), $attainmentAlternativeName) : __('Assess Attainment?');
                     $row = $form->addRow();
                         $row->addLabel('attainment', $attainmentLabel);
-                        $row->addYesNoRadio('attainment')->isRequired();
+                        $row->addYesNoRadio('attainment')->required();
         
                     $form->toggleVisibilityByClass('attainmentRow')->onRadio('attainment')->when('Y');
         
                     $attainmentScaleLabel = !empty($attainmentAlternativeName)? $attainmentAlternativeName.' '.__('Scale') : __('Attainment Scale');
                     $row = $form->addRow()->addClass('attainmentRow');
                         $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
-                        $row->addSelectGradeScale('gibbonScaleIDAttainment')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                        $row->addSelectGradeScale('gibbonScaleIDAttainment')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
         
                     $effortLabel = !empty($effortAlternativeName)? sprintf(__('Assess %1$s?'), $effortAlternativeName) : __('Assess Effort?');
                     $row = $form->addRow();
                         $row->addLabel('effort', $effortLabel);
-                        $row->addYesNoRadio('effort')->isRequired();
+                        $row->addYesNoRadio('effort')->required();
         
                     $form->toggleVisibilityByClass('effortRow')->onRadio('effort')->when('Y');
         
                     $effortScaleLabel = !empty($effortAlternativeName)? $effortAlternativeName.' '.__('Scale') : __('Effort Scale');
                     $row = $form->addRow()->addClass('effortRow');
                         $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
-                        $row->addSelectGradeScale('gibbonScaleIDEffort')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                        $row->addSelectGradeScale('gibbonScaleIDEffort')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
         
                     $row = $form->addRow();
                         $row->addLabel('comment', __('Include Comment?'));
-                        $row->addYesNoRadio('comment')->isRequired();
+                        $row->addYesNoRadio('comment')->required();
         
                     $row = $form->addRow();
                         $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
-                        $row->addYesNoRadio('uploadedResponse')->isRequired();
+                        $row->addYesNoRadio('uploadedResponse')->required();
         
                     $form->addRow()->addHeading(__('Access'));
         
                     $row = $form->addRow();
                         $row->addLabel('viewableStudents', __('Viewable to Students'));
-                        $row->addYesNo('viewableStudents')->isRequired();
+                        $row->addYesNo('viewableStudents')->required();
         
                     $row = $form->addRow();
                         $row->addLabel('viewableParents', __('Viewable to Parents'));
-                        $row->addYesNo('viewableParents')->isRequired();
+                        $row->addYesNo('viewableParents')->required();
         
                     $row = $form->addRow();
                         $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));

--- a/modules/Formal Assessment/internalAssessment_write_data.php
+++ b/modules/Formal Assessment/internalAssessment_write_data.php
@@ -133,7 +133,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
 
                     $row = $form->addRow();
                         $row->addLabel('description', __('Description'));
-                        $row->addTextField('description')->isRequired()->maxLength(1000);
+                        $row->addTextField('description')->required()->maxLength(1000);
 
                     $row = $form->addRow();
                         $row->addLabel('file', __('Attachment'));

--- a/modules/Individual Needs/in_archive.php
+++ b/modules/Individual Needs/in_archive.php
@@ -60,11 +60,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_archiv
 
     $row = $form->addRow();
         $row->addLabel('deleteCurrentPlans', __('Delete Current Plans?'))->description(__('Deletes Individual Education Plan fields only, not Individual Needs Status fields.'));
-        $row->addYesNo('deleteCurrentPlans')->isRequired()->selected('N');
+        $row->addYesNo('deleteCurrentPlans')->required()->selected('N');
 
     $row = $form->addRow();
         $row->addLabel('title', __('Archive Title'));
-        $row->addTextField('title')->isRequired()->maxLength(50);
+        $row->addTextField('title')->required()->maxLength(50);
                         
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Students'));

--- a/modules/Library/library_lending_item_edit.php
+++ b/modules/Library/library_lending_item_edit.php
@@ -83,15 +83,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $row = $form->addRow();
                 $row->addLabel('id', __('ID'));
-                $row->addTextField('id')->setValue($values['id'])->readonly()->isRequired();
+                $row->addTextField('id')->setValue($values['id'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->setValue($values['name'])->readonly()->isRequired();
+                $row->addTextField('name')->setValue($values['name'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('statusCurrent', __('Current Status'));
-                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->isRequired();
+                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->required();
 
             $form->addRow()->addHeading(__('This Event'));
 
@@ -104,16 +104,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             );
             $row = $form->addRow();
                 $row->addLabel('status', __('New Status'));
-                $row->addSelect('status')->fromArray($statuses)->isRequired()->selected($values['status'])->placeholder();
+                $row->addSelect('status')->fromArray($statuses)->required()->selected($values['status'])->placeholder();
 
             $form->addHiddenValue('gibbonPersonIDStatusResponsible', $values['gibbonPersonIDStatusResponsible']);
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonIDStatusResponsiblename', __('Responsible User'));
-                $row->addTextField('gibbonPersonIDStatusResponsiblename')->setValue(formatName('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student', true))->readonly()->isRequired();
+                $row->addTextField('gibbonPersonIDStatusResponsiblename')->setValue(formatName('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student', true))->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('returnExpected', __('Expected Return Date'));
-                $row->addDate('returnExpected')->setValue(dateConvertBack($guid, $values['returnExpected']))->isRequired();
+                $row->addDate('returnExpected')->setValue(dateConvertBack($guid, $values['returnExpected']))->required();
 
 
             $row = $form->addRow()->addHeading(__('On Return'));

--- a/modules/Library/library_lending_item_renew.php
+++ b/modules/Library/library_lending_item_renew.php
@@ -84,15 +84,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $row = $form->addRow();
                 $row->addLabel('id', __('ID'));
-                $row->addTextField('id')->setValue($values['id'])->readonly()->isRequired();
+                $row->addTextField('id')->setValue($values['id'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->setValue($values['name'])->readonly()->isRequired();
+                $row->addTextField('name')->setValue($values['name'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('statusCurrent', __('Current Status'));
-                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->isRequired();
+                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->required();
 
             $row = $form->addRow()->addHeading(__('On Return'));
                 $row->append(__('The new status will be set to "Returned" unless the fields below are completed:'));
@@ -100,13 +100,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             $form->addHiddenValue('gibbonPersonIDStatusResponsible', $values['gibbonPersonIDStatusResponsible']);
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonIDStatusResponsiblename', __('Responsible User'));
-                $row->addTextField('gibbonPersonIDStatusResponsiblename')->setValue(formatName('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student', true))->readonly()->isRequired();
+                $row->addTextField('gibbonPersonIDStatusResponsiblename')->setValue(formatName('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student', true))->readonly()->required();
 
             $loanLength = getSettingByScope($connection2, 'Library', 'defaultLoanLength');
             $loanLength = (is_numeric($loanLength) == false or $loanLength < 0) ? 7 : $loanLength ;
             $row = $form->addRow();
                 $row->addLabel('returnExpected', __('Expected Return Date'))->description(sprintf(__('Default renew length is today plus %1$s day(s)'), $loanLength));
-                $row->addDate('returnExpected')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP'], time() + ($loanLength * 60 * 60 * 24)))->isRequired();
+                $row->addDate('returnExpected')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP'], time() + ($loanLength * 60 * 60 * 24)))->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Library/library_lending_item_return.php
+++ b/modules/Library/library_lending_item_return.php
@@ -78,15 +78,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $row = $form->addRow();
                 $row->addLabel('id', __('ID'));
-                $row->addTextField('id')->setValue($values['id'])->readonly()->isRequired();
+                $row->addTextField('id')->setValue($values['id'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->setValue($values['name'])->readonly()->isRequired();
+                $row->addTextField('name')->setValue($values['name'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('statusCurrent', __('Current Status'));
-                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->isRequired();
+                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->required();
 
             $row = $form->addRow()->addHeading(__('On Return'));
                 $row->append(__('The new status will be set to "Returned" unless the fields below are completed:'));

--- a/modules/Library/library_lending_item_signout.php
+++ b/modules/Library/library_lending_item_signout.php
@@ -111,15 +111,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $row = $form->addRow();
                 $row->addLabel('idLabel', __('ID'));
-                $row->addTextField('idLabel')->setValue($values['id'])->readonly()->isRequired();
+                $row->addTextField('idLabel')->setValue($values['id'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->setValue($values['name'])->readonly()->isRequired();
+                $row->addTextField('name')->setValue($values['name'])->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('statusCurrent', __('Current Status'));
-                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->isRequired();
+                $row->addTextField('statusCurrent')->setValue($values['status'])->readonly()->required();
 
             $form->addRow()->addHeading(__('This Event'));
 
@@ -132,7 +132,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             );
             $row = $form->addRow();
                 $row->addLabel('status', __('New Status'));
-                $row->addSelect('status')->fromArray($statuses)->isRequired()->selected('On Loan')->placeholder();
+                $row->addSelect('status')->fromArray($statuses)->required()->selected('On Loan')->placeholder();
 
             $people = array();
 
@@ -168,13 +168,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonIDStatusResponsible', __('Responsible User'))->description(__('Who is responsible for this new status?'));
-                $row->addSelect('gibbonPersonIDStatusResponsible')->fromArray($people)->placeholder()->isRequired();
+                $row->addSelect('gibbonPersonIDStatusResponsible')->fromArray($people)->placeholder()->required();
 
             $loanLength = getSettingByScope($connection2, 'Library', 'defaultLoanLength');
             $loanLength = (is_numeric($loanLength) == false or $loanLength < 0) ? 7 : $loanLength ;
             $row = $form->addRow();
                 $row->addLabel('returnExpected', __('Expected Return Date'))->description(sprintf(__('Default renew length is today plus %1$s day(s)'), $loanLength));
-                $row->addDate('returnExpected')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP'], time() + ($loanLength * 60 * 60 * 24)))->isRequired();
+                $row->addDate('returnExpected')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP'], time() + ($loanLength * 60 * 60 * 24)))->required();
 
             $row = $form->addRow()->addHeading(__('On Return'));
 

--- a/modules/Library/library_manage_catalog_add.php
+++ b/modules/Library/library_manage_catalog_add.php
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
         $row->addSelect('gibbonLibraryTypeID')
             ->fromQuery($pdo, $sql, array())
             ->placeholder()
-            ->isRequired()
+            ->required()
             ->selected($urlParams['gibbonLibraryTypeID']);
 
     $form->toggleVisibilityByClass('general')->onSelect('gibbonLibraryTypeID')->whenNot('Please select...');
@@ -75,18 +75,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('name', __('Name'))->description(__('Volume or product name.'));
-        $row->addTextField('name')->isRequired()->maxLength(255);
+        $row->addTextField('name')->required()->maxLength(255);
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('idCheck', __('ID'));
         $row->addTextField('idCheck')
             ->uniqueField('./modules/Library/library_manage_catalog_idCheckAjax.php')
-            ->isRequired()
+            ->required()
             ->maxLength(255);
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('producer', __('Author/Brand'))->description(__('Who created the item?'));
-        $row->addTextField('producer')->isRequired()->maxLength(255);
+        $row->addTextField('producer')->required()->maxLength(255);
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('vendor', __('Vendor'))->description(__('Who supplied the item?'));
@@ -112,14 +112,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
         $row->addFileUpload('imageFile')
             ->accepts('.jpg,.jpeg,.gif,.png')
             ->setMaxUpload(false)
-            ->isRequired();
+            ->required();
 
     $form->toggleVisibilityByClass('imageLink')->onSelect('imageType')->when('Link');
 
     $row = $form->addRow()->addClass('general imageLink');
         $row->addLabel('imageLink', __('Image Link'))
             ->description(__('240px x 240px or smaller.'));
-        $row->addURL('imageLink')->maxLength(255)->isRequired();
+        $row->addURL('imageLink')->maxLength(255)->required();
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('gibbonSpaceID', __('Location'));
@@ -168,11 +168,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
     );
     $row = $form->addRow()->addClass('general');
         $row->addLabel('status', __('Status?'))->description(__('Initial availability.'));
-        $row->addSelect('status')->fromArray($statuses)->isRequired();
+        $row->addSelect('status')->fromArray($statuses)->required();
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('replacement', __('Plan Replacement?'));
-        $row->addYesNo('replacement')->isRequired()->selected('N');
+        $row->addYesNo('replacement')->required()->selected('N');
 
     $form->toggleVisibilityByClass('replacement')->onSelect('replacement')->when('Y');
 

--- a/modules/Library/library_manage_catalog_add.php
+++ b/modules/Library/library_manage_catalog_add.php
@@ -80,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
     $row = $form->addRow()->addClass('general');
         $row->addLabel('idCheck', __('ID'));
         $row->addTextField('idCheck')
-            ->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php')
+            ->uniqueField('./modules/Library/library_manage_catalog_idCheckAjax.php')
             ->isRequired()
             ->maxLength(255);
 

--- a/modules/Library/library_manage_catalog_duplicate.php
+++ b/modules/Library/library_manage_catalog_duplicate.php
@@ -86,19 +86,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
                 $form->addHiddenValue('gibbonLibraryTypeID', $values['gibbonLibraryTypeID']);
                 $row = $form->addRow();
                     $row->addLabel('type', __('Type'));
-                    $row->addTextField('type')->setValue($values['type'])->readonly()->isRequired();
+                    $row->addTextField('type')->setValue($values['type'])->readonly()->required();
 
                 $row = $form->addRow();
                     $row->addLabel('name', __('Name'));
-                    $row->addTextField('name')->setValue($values['name'])->readonly()->isRequired();
+                    $row->addTextField('name')->setValue($values['name'])->readonly()->required();
 
                 $row = $form->addRow();
                     $row->addLabel('id', __('ID'));
-                    $row->addTextField('id')->setValue($values['id'])->readonly()->isRequired();
+                    $row->addTextField('id')->setValue($values['id'])->readonly()->required();
 
                 $row = $form->addRow();
                     $row->addLabel('producer', __('Author/Brand'));
-                    $row->addTextField('producer')->setValue($values['producer'])->readonly()->isRequired();
+                    $row->addTextField('producer')->setValue($values['producer'])->readonly()->required();
 
                 $options = array();
                 for ($i = 1; $i < 21; ++$i) {
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
                 }
                 $row = $form->addRow();
                     $row->addLabel('number', __('Number of Copies'))->description('How many copies do you want to make of this item?');
-                    $row->addSelect('number')->fromArray($options)->isRequired();
+                    $row->addSelect('number')->fromArray($options)->required();
 
                 $row = $form->addRow();
                     $row->addFooter();
@@ -138,7 +138,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
                         $row->addLabel('id'.$i, sprintf(__('Copy %1$s ID'), $i));
                         $row->addTextField('id'.$i)
                             ->uniqueField('./modules/Library/library_manage_catalog_idCheckAjax.php', array('fieldName' => 'id'))
-                            ->isRequired()
+                            ->required()
                             ->maxLength(255);
                 }
 

--- a/modules/Library/library_manage_catalog_duplicate.php
+++ b/modules/Library/library_manage_catalog_duplicate.php
@@ -137,7 +137,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
                     $row = $form->addRow();
                         $row->addLabel('id'.$i, sprintf(__('Copy %1$s ID'), $i));
                         $row->addTextField('id'.$i)
-                            ->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php', array('fieldName' => 'id'))
+                            ->uniqueField('./modules/Library/library_manage_catalog_idCheckAjax.php', array('fieldName' => 'id'))
                             ->isRequired()
                             ->maxLength(255);
                 }

--- a/modules/Library/library_manage_catalog_edit.php
+++ b/modules/Library/library_manage_catalog_edit.php
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 			$sql = "SELECT gibbonLibraryTypeID AS value, name FROM gibbonLibraryType WHERE active='Y' ORDER BY name";
 			$row = $form->addRow();
 				$row->addLabel('type', __('Type'));
-				$row->addTextField('type')->isRequired()->readOnly();
+				$row->addTextField('type')->required()->readOnly();
 
 			$form->toggleVisibilityByClass('general')->onSelect('gibbonLibraryTypeID')->whenNot('Please select...');
 
@@ -93,18 +93,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'))->description(__('Volume or product name.'));
-				$row->addTextField('name')->isRequired()->maxLength(255);
+				$row->addTextField('name')->required()->maxLength(255);
 
 			$row = $form->addRow();
 				$row->addLabel('id', __('ID'));
 				$row->addTextField('id')
 					->uniqueField('./modules/Library/library_manage_catalog_idCheckAjax.php', array('gibbonLibraryItemID' => $gibbonLibraryItemID))
-					->isRequired()
+					->required()
 					->maxLength(255);
 
 			$row = $form->addRow();
 				$row->addLabel('producer', __('Author/Brand'))->description(__('Who created the item?'));
-				$row->addTextField('producer')->isRequired()->maxLength(255);
+				$row->addTextField('producer')->required()->maxLength(255);
 
 			$row = $form->addRow();
 				$row->addLabel('vendor', __('Vendor'))->description(__('Who supplied the item?'));
@@ -130,14 +130,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 				$row->addFileUpload('imageFile')
 					->accepts('.jpg,.jpeg,.gif,.png')
 					->setMaxUpload(false)
-					->isRequired();
+					->required();
 
 			$form->toggleVisibilityByClass('imageLink')->onSelect('imageType')->when('Link');
 
 			$row = $form->addRow()->addClass('general imageLink');
 				$row->addLabel('imageLink', __('Image Link'))
 					->description(__('240px x 240px or smaller.'));
-				$row->addURL('imageLink')->maxLength(255)->isRequired()->setValue($values['imageLocation']);
+				$row->addURL('imageLink')->maxLength(255)->required()->setValue($values['imageLocation']);
 
 			$row = $form->addRow();
 				$row->addLabel('gibbonSpaceID', __('Location'));
@@ -190,15 +190,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 			);
 			$row = $form->addRow()->addClass('statusBorrowable');
 				$row->addLabel('statusBorrowable', __('Status?'));
-				$row->addTextField('statusBorrowable')->isRequired()->readOnly()->setValue(__('Available'));
+				$row->addTextField('statusBorrowable')->required()->readOnly()->setValue(__('Available'));
 
 			$row = $form->addRow()->addClass('statusNotBorrowable');
 				$row->addLabel('statusNotBorrowable', __('Status?'));
-				$row->addSelect('statusNotBorrowable')->fromArray($statuses)->isRequired();
+				$row->addSelect('statusNotBorrowable')->fromArray($statuses)->required();
 
 			$row = $form->addRow();
 				$row->addLabel('replacement', __('Plan Replacement?'));
-				$row->addYesNo('replacement')->isRequired()->selected('N');
+				$row->addYesNo('replacement')->required()->selected('N');
 
 			$form->toggleVisibilityByClass('replacement')->onSelect('replacement')->when('Y');
 

--- a/modules/Library/library_manage_catalog_edit.php
+++ b/modules/Library/library_manage_catalog_edit.php
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 			$row = $form->addRow();
 				$row->addLabel('id', __('ID'));
 				$row->addTextField('id')
-					->isUnique('./modules/Library/library_manage_catalog_idCheckAjax.php', array('gibbonLibraryItemID' => $gibbonLibraryItemID))
+					->uniqueField('./modules/Library/library_manage_catalog_idCheckAjax.php', array('gibbonLibraryItemID' => $gibbonLibraryItemID))
 					->isRequired()
 					->maxLength(255);
 

--- a/modules/Library/report_studentBorrowingRecord.php
+++ b/modules/Library/report_studentBorrowingRecord.php
@@ -52,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/report_studentBorr
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Student'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonPersonID)->placeholder()->isRequired();
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonPersonID)->placeholder()->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Markbook/markbook_edit_add.php
+++ b/modules/Markbook/markbook_edit_add.php
@@ -111,7 +111,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                 $row = $form->addRow();
                     $row->addLabel('courseName', __('Class'));
-                    $row->addTextField('courseName')->isRequired()->readOnly()->setValue($course['course'].'.'.$course['class']);
+                    $row->addTextField('courseName')->required()->readOnly()->setValue($course['course'].'.'.$course['class']);
 
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
                 $sql = "SELECT gibbonUnit.gibbonUnitID as value, gibbonUnit.name FROM gibbonUnit JOIN gibbonUnitClass ON (gibbonUnit.gibbonUnitID=gibbonUnitClass.gibbonUnitID) WHERE running='Y' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY name";
@@ -129,18 +129,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                 $row = $form->addRow();
                     $row->addLabel('name', __('Name'));
-                    $row->addTextField('name')->isRequired()->maxLength(20)->setValue($name);
+                    $row->addTextField('name')->required()->maxLength(20)->setValue($name);
 
                 $row = $form->addRow();
                     $row->addLabel('description', __('Description'));
-                    $row->addTextField('description')->isRequired()->maxLength(1000)->setValue($summary);
+                    $row->addTextField('description')->required()->maxLength(1000)->setValue($summary);
 
                 // TYPE
                 $types = getSettingByScope($connection2, 'Markbook', 'markbookType');
                 if (!empty($types)) {
                     $row = $form->addRow();
                         $row->addLabel('type', __('Type'));
-                        $typesSelect = $row->addSelect('type')->isRequired()->placeholder();
+                        $typesSelect = $row->addSelect('type')->required()->placeholder();
 
                     if ($enableColumnWeighting == 'Y') {
                         $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'perTerm' => __('Per Term'), 'wholeYear' => __('Whole Year'));
@@ -172,7 +172,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                     $row = $form->addRow();
                         $row->addLabel('date', __('Date'));
-                        $row->addDate('date')->setValue(dateConvertBack($guid, $date))->isRequired();
+                        $row->addDate('date')->setValue(dateConvertBack($guid, $date))->required();
                 } else {
                     $form->addHiddenValue('date', dateConvertBack($guid, $date));
                 }
@@ -188,13 +188,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                 $row = $form->addRow();
                     $row->addLabel('attainment', $attainmentLabel);
-                    $row->addYesNoRadio('attainment')->isRequired();
+                    $row->addYesNoRadio('attainment')->required();
 
                 $form->toggleVisibilityByClass('attainmentRow')->onRadio('attainment')->when('Y');
 
                 $row = $form->addRow()->addClass('attainmentRow');
                     $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
-                    $row->addSelectGradeScale('gibbonScaleIDAttainment')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                    $row->addSelectGradeScale('gibbonScaleIDAttainment')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
                     
                 if ($enableRawAttainment == 'Y') {
                     $row = $form->addRow()->addClass('attainmentRow');
@@ -222,13 +222,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                     $row = $form->addRow();
                         $row->addLabel('effort', $effortLabel);
-                        $row->addYesNoRadio('effort')->isRequired();
+                        $row->addYesNoRadio('effort')->required();
 
                     $form->toggleVisibilityByClass('effortRow')->onRadio('effort')->when('Y');
 
                     $row = $form->addRow()->addClass('effortRow');
                         $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
-                        $row->addSelectGradeScale('gibbonScaleIDEffort')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                        $row->addSelectGradeScale('gibbonScaleIDEffort')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
 
                     if ($enableRubrics == 'Y') {
                         $row = $form->addRow()->addClass('effortRow');
@@ -239,21 +239,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                 $row = $form->addRow();
                     $row->addLabel('comment', __('Include Comment?'));
-                    $row->addYesNoRadio('comment')->isRequired();
+                    $row->addYesNoRadio('comment')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
-                    $row->addYesNoRadio('uploadedResponse')->isRequired();
+                    $row->addYesNoRadio('uploadedResponse')->required();
 
                 $form->addRow()->addHeading(__('Access'));
 
                 $row = $form->addRow();
                     $row->addLabel('viewableStudents', __('Viewable to Students'));
-                    $row->addYesNo('viewableStudents')->isRequired();
+                    $row->addYesNo('viewableStudents')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('viewableParents', __('Viewable to Parents'));
-                    $row->addYesNo('viewableParents')->isRequired();
+                    $row->addYesNo('viewableParents')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));

--- a/modules/Markbook/markbook_edit_addMulti.php
+++ b/modules/Markbook/markbook_edit_addMulti.php
@@ -123,24 +123,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                     $row->addLabel('gibbonCourseClassIDMulti', __('Class'))->append(sprintf(__('The current class (%1$s.%2$s) has already been selected.'), $course['course'], $course['class']));
                     $row->addSelect('gibbonCourseClassIDMulti')
                         ->fromQuery($pdo, $sql, $data)
-                        ->isRequired()
+                        ->required()
                         ->selectMultiple()
                         ->selected($course['gibbonCourseClassID']);
 
                 $row = $form->addRow();
                     $row->addLabel('name', __('Name'));
-                    $row->addTextField('name')->isRequired()->maxLength(20);
+                    $row->addTextField('name')->required()->maxLength(20);
 
                 $row = $form->addRow();
                     $row->addLabel('description', __('Description'));
-                    $row->addTextField('description')->isRequired()->maxLength(1000);
+                    $row->addTextField('description')->required()->maxLength(1000);
 
                 // TYPE
                 $types = getSettingByScope($connection2, 'Markbook', 'markbookType');
                 if (!empty($types)) {
                     $row = $form->addRow();
                         $row->addLabel('type', __('Type'));
-                        $typesSelect = $row->addSelect('type')->isRequired()->placeholder();
+                        $typesSelect = $row->addSelect('type')->required()->placeholder();
 
                     if ($enableColumnWeighting == 'Y') {
                         $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'perTerm' => __('Per Term'), 'wholeYear' => __('Whole Year'));
@@ -172,7 +172,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                     $row = $form->addRow();
                         $row->addLabel('date', __('Date'));
-                        $row->addDate('date')->setValue(dateConvertBack($guid, $date))->isRequired();
+                        $row->addDate('date')->setValue(dateConvertBack($guid, $date))->required();
                 } else {
                     $form->addHiddenValue('date', dateConvertBack($guid, $date));
                 }
@@ -188,13 +188,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                 $row = $form->addRow();
                     $row->addLabel('attainment', $attainmentLabel);
-                    $row->addYesNoRadio('attainment')->isRequired();
+                    $row->addYesNoRadio('attainment')->required();
 
                 $form->toggleVisibilityByClass('attainmentRow')->onRadio('attainment')->when('Y');
 
                 $row = $form->addRow()->addClass('attainmentRow');
                     $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
-                    $row->addSelectGradeScale('gibbonScaleIDAttainment')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                    $row->addSelectGradeScale('gibbonScaleIDAttainment')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
 
                 if ($enableRawAttainment == 'Y') {
                     $row = $form->addRow()->addClass('attainmentRow');
@@ -222,13 +222,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                     $row = $form->addRow();
                         $row->addLabel('effort', $effortLabel);
-                        $row->addYesNoRadio('effort')->isRequired();
+                        $row->addYesNoRadio('effort')->required();
 
                     $form->toggleVisibilityByClass('effortRow')->onRadio('effort')->when('Y');
 
                     $row = $form->addRow()->addClass('effortRow');
                         $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
-                        $row->addSelectGradeScale('gibbonScaleIDEffort')->isRequired()->selected($_SESSION[$guid]['defaultAssessmentScale']);
+                        $row->addSelectGradeScale('gibbonScaleIDEffort')->required()->selected($_SESSION[$guid]['defaultAssessmentScale']);
 
                     if ($enableRubrics == 'Y') {
                         $row = $form->addRow()->addClass('effortRow');
@@ -239,21 +239,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
 
                 $row = $form->addRow();
                     $row->addLabel('comment', __('Include Comment?'));
-                    $row->addYesNoRadio('comment')->isRequired();
+                    $row->addYesNoRadio('comment')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
-                    $row->addYesNoRadio('uploadedResponse')->isRequired();
+                    $row->addYesNoRadio('uploadedResponse')->required();
 
                 $form->addRow()->addHeading(__('Access'));
 
                 $row = $form->addRow();
                     $row->addLabel('viewableStudents', __('Viewable to Students'));
-                    $row->addYesNo('viewableStudents')->isRequired();
+                    $row->addYesNo('viewableStudents')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('viewableParents', __('Viewable to Parents'));
-                    $row->addYesNo('viewableParents')->isRequired();
+                    $row->addYesNo('viewableParents')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));

--- a/modules/Markbook/markbook_edit_edit.php
+++ b/modules/Markbook/markbook_edit_edit.php
@@ -134,7 +134,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
 
                         $row = $form->addRow();
                             $row->addLabel('courseName', __('Class'));
-                            $row->addTextField('courseName')->isRequired()->readOnly()->setValue($course['course'].'.'.$course['class']);
+                            $row->addTextField('courseName')->required()->readOnly()->setValue($course['course'].'.'.$course['class']);
 
                         $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
                         $sql = "SELECT gibbonUnit.gibbonUnitID as value, gibbonUnit.name FROM gibbonUnit JOIN gibbonUnitClass ON (gibbonUnit.gibbonUnitID=gibbonUnitClass.gibbonUnitID) WHERE running='Y' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY name";
@@ -152,18 +152,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
 
                         $row = $form->addRow();
                             $row->addLabel('name', __('Name'));
-                            $row->addTextField('name')->isRequired()->maxLength(20);
+                            $row->addTextField('name')->required()->maxLength(20);
 
                         $row = $form->addRow();
                             $row->addLabel('description', __('Description'));
-                            $row->addTextField('description')->isRequired()->maxLength(1000);
+                            $row->addTextField('description')->required()->maxLength(1000);
 
                         // TYPE
                         $types = getSettingByScope($connection2, 'Markbook', 'markbookType');
                         if (!empty($types)) {
                             $row = $form->addRow();
                                 $row->addLabel('type', __('Type'));
-                                $typesSelect = $row->addSelect('type')->isRequired()->placeholder();
+                                $typesSelect = $row->addSelect('type')->required()->placeholder();
 
                             if ($enableColumnWeighting == 'Y') {
                                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'perTerm' => __('Per Term'), 'wholeYear' => __('Whole Year'));
@@ -190,7 +190,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
         
                             $row = $form->addRow();
                                 $row->addLabel('date', __('Date'));
-                                $row->addDate('date')->setValue(dateConvertBack($guid, $values['date']))->isRequired();
+                                $row->addDate('date')->setValue(dateConvertBack($guid, $values['date']))->required();
                         } else {
                             $form->addHiddenValue('gibbonSchoolYearTermID',$values['gibbonSchoolYearTermID']);
                             $form->addHiddenValue('date', dateConvertBack($guid, $values['date']));
@@ -207,13 +207,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
 
                         $row = $form->addRow();
                             $row->addLabel('attainment', $attainmentLabel);
-                            $row->addYesNoRadio('attainment')->isRequired();
+                            $row->addYesNoRadio('attainment')->required();
 
                         $form->toggleVisibilityByClass('attainmentRow')->onRadio('attainment')->when('Y');
 
                         $row = $form->addRow()->addClass('attainmentRow');
                             $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
-                            $row->addSelectGradeScale('gibbonScaleIDAttainment')->isRequired();
+                            $row->addSelectGradeScale('gibbonScaleIDAttainment')->required();
                             
                         if ($enableRawAttainment == 'Y') {
                             $row = $form->addRow()->addClass('attainmentRow');
@@ -241,13 +241,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
 
                             $row = $form->addRow();
                                 $row->addLabel('effort', $effortLabel);
-                                $row->addYesNoRadio('effort')->isRequired();
+                                $row->addYesNoRadio('effort')->required();
 
                             $form->toggleVisibilityByClass('effortRow')->onRadio('effort')->when('Y');
 
                             $row = $form->addRow()->addClass('effortRow');
                                 $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
-                                $row->addSelectGradeScale('gibbonScaleIDEffort')->isRequired();
+                                $row->addSelectGradeScale('gibbonScaleIDEffort')->required();
 
                             if ($enableRubrics == 'Y') {
                                 $row = $form->addRow()->addClass('effortRow');
@@ -258,21 +258,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
 
                         $row = $form->addRow();
                             $row->addLabel('comment', __('Include Comment?'));
-                            $row->addYesNoRadio('comment')->isRequired();
+                            $row->addYesNoRadio('comment')->required();
 
                         $row = $form->addRow();
                             $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
-                            $row->addYesNoRadio('uploadedResponse')->isRequired();
+                            $row->addYesNoRadio('uploadedResponse')->required();
 
                         $form->addRow()->addHeading(__('Access'));
 
                         $row = $form->addRow();
                             $row->addLabel('viewableStudents', __('Viewable to Students'));
-                            $row->addYesNo('viewableStudents')->isRequired();
+                            $row->addYesNo('viewableStudents')->required();
 
                         $row = $form->addRow();
                             $row->addLabel('viewableParents', __('Viewable to Parents'));
-                            $row->addYesNo('viewableParents')->isRequired();
+                            $row->addYesNo('viewableParents')->required();
 
                         $row = $form->addRow();
                             $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));

--- a/modules/Markbook/weighting_manage_add.php
+++ b/modules/Markbook/weighting_manage_add.php
@@ -116,15 +116,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
 
                 $row = $form->addRow();
                     $row->addLabel('type', __('Type'));
-                    $row->addSelect('type')->fromArray(array_values($types))->isRequired()->placeholder();
+                    $row->addSelect('type')->fromArray(array_values($types))->required()->placeholder();
 
                 $row = $form->addRow();
                     $row->addLabel('description', __('Description'));
-                    $row->addTextField('description')->isRequired()->maxLength(50);
+                    $row->addTextField('description')->required()->maxLength(50);
 
                 $row = $form->addRow();
                     $row->addLabel('weighting', __('Weighting'))->description(__('Percent: 0 to 100'));
-                    $row->addNumber('weighting')->isRequired()->maxLength(6)->minimum(0)->maximum(100);
+                    $row->addNumber('weighting')->required()->maxLength(6)->minimum(0)->maximum(100);
 
                 $percentOptions = array(
                     'term' => __('Cumulative Average'),

--- a/modules/Markbook/weighting_manage_edit.php
+++ b/modules/Markbook/weighting_manage_edit.php
@@ -128,11 +128,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
 
                     $row = $form->addRow();
                         $row->addLabel('description', __('Description'));
-                        $row->addTextField('description')->isRequired()->maxLength(50);
+                        $row->addTextField('description')->required()->maxLength(50);
 
                     $row = $form->addRow();
                         $row->addLabel('weighting', __('Weighting'))->description(__('Percent: 0 to 100'));
-                        $row->addNumber('weighting')->isRequired()->maxLength(6)->minimum(0)->maximum(100)->onlyInteger(false);
+                        $row->addNumber('weighting')->required()->maxLength(6)->minimum(0)->maximum(100)->onlyInteger(false);
 
                     $percentOptions = array(
                         'term' => __('Cumulative Average'),

--- a/modules/Messenger/cannedResponse_manage_add.php
+++ b/modules/Messenger/cannedResponse_manage_add.php
@@ -44,12 +44,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_m
 
 	$row = $form->addRow();
 		$row->addLabel('subject', __('Subject'))->description(__('Must be unique.'));
-		$row->addTextField('subject')->isRequired()->maxLength(20);
+		$row->addTextField('subject')->required()->maxLength(20);
 
 	$row = $form->addRow();
 		$col = $row->addColumn('body');
 		$col->addLabel('body', __('Body'));
-		$col->addEditor('body', $guid)->isRequired()->setRows(20)->showMedia(true);
+		$col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true);
 
 	$row = $form->addRow();
 		$row->addFooter();

--- a/modules/Messenger/cannedResponse_manage_edit.php
+++ b/modules/Messenger/cannedResponse_manage_edit.php
@@ -64,12 +64,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_m
 
             $row = $form->addRow();
                 $row->addLabel('subject', __('Subject'))->description(__('Must be unique.'));
-                $row->addTextField('subject')->isRequired()->maxLength(20);
+                $row->addTextField('subject')->required()->maxLength(20);
 
             $row = $form->addRow();
                 $col = $row->addColumn('body');
                 $col->addLabel('body', __('Body'));
-                $col->addEditor('body', $guid)->isRequired()->setRows(20)->showMedia(true);
+                $col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Messenger/groups_manage_add.php
+++ b/modules/Messenger/groups_manage_add.php
@@ -45,13 +45,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_ad
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->isRequired()->setValue();
+        $row->addTextField('name')->required()->setValue();
 
     $row = $form->addRow();
         $row->addLabel('members', __('Members'));
         $row->addSelectUsers('members', $_SESSION[$guid]['gibbonSchoolYearID'], ['includeStudents' => true])
             ->selectMultiple()
-            ->isRequired();
+            ->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Messenger/groups_manage_edit.php
+++ b/modules/Messenger/groups_manage_edit.php
@@ -70,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_ed
 			
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired();
+                $row->addTextField('name')->required();
 
             $row = $form->addRow();
                 $row->addLabel('members', __('Add Members'));

--- a/modules/Messenger/messenger_manage_edit.php
+++ b/modules/Messenger/messenger_manage_edit.php
@@ -127,14 +127,14 @@ else {
 				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byMessageWall")) {
 					$row = $form->addRow();
 						$row->addLabel('messageWall', __('Message Wall'))->description(__('Place this message on user\'s message wall?'));
-						$row->addYesNoRadio('messageWall')->checked('N')->isRequired();
+						$row->addYesNoRadio('messageWall')->checked('N')->required();
 
 					$form->toggleVisibilityByClass('messageWall')->onRadio('messageWall')->when('Y');
 
 					$row = $form->addRow()->addClass('messageWall');
 				        $row->addLabel('date1', __('Publication Dates'))->description(__('Select up to three individual dates.'));
 						$col = $row->addColumn('date1')->addClass('stacked');
-						$col->addDate('date1')->setValue(dateConvertBack($guid, $values['messageWall_date1']))->isRequired();
+						$col->addDate('date1')->setValue(dateConvertBack($guid, $values['messageWall_date1']))->required();
 						$col->addDate('date2')->setValue(dateConvertBack($guid, $values['messageWall_date2']));
 						$col->addDate('date3')->setValue(dateConvertBack($guid, $values['messageWall_date3']));
 				}
@@ -165,12 +165,12 @@ else {
 
 				$row = $form->addRow();
 					$row->addLabel('subject', __('Subject'));
-					$row->addTextField('subject')->maxLength(60)->isRequired();
+					$row->addTextField('subject')->maxLength(60)->required();
 
 				$row = $form->addRow();
 			        $col = $row->addColumn('body');
 			        $col->addLabel('body', __('Body'));
-			        $col->addEditor('body', $guid)->isRequired()->setRows(20)->showMedia(true);
+			        $col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true);
 
 				//READ RECEIPTS
 				if (!isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_readReceipts")) {
@@ -190,7 +190,7 @@ else {
 
 					$row = $form->addRow()->addClass('emailReceipt');
 						$row->addLabel('emailReceiptText', __('Link Text'))->description(__('Confirmation link text to display to recipient.'));
-						$row->addTextArea('emailReceiptText')->setRows(3)->isRequired()->setValue(__('By clicking on this link I confirm that I have read, and agree to, the text contained within this email, and give consent for my child to participate.'))->readonly();
+						$row->addTextArea('emailReceiptText')->setRows(3)->required()->setValue(__('By clicking on this link I confirm that I have read, and agree to, the text contained within this email, and give consent for my child to participate.'))->readonly();
 				}
 
 				//TARGETS
@@ -219,7 +219,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('role', __('Role'))->description(__('Users of a certain type.'));
-						$row->addYesNoRadio('role')->checked($checked)->isRequired();
+						$row->addYesNoRadio('role')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('role')->onRadio('role')->when('Y');
 
@@ -227,7 +227,7 @@ else {
 					$sql = 'SELECT gibbonRoleID AS value, CONCAT(name," (",category,")") AS name FROM gibbonRole ORDER BY name';
 					$row = $form->addRow()->addClass('role hiddenReveal');
 						$row->addLabel('roles[]', __('Select Roles'));
-						$row->addSelect('roles[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->placeholder()->selected($selected);
+						$row->addSelect('roles[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
 
 					//Role Category
 					$selected = array_reduce($targets, function($group, $item) {
@@ -237,7 +237,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('roleCategory', __('Role Category'))->description(__('Users of a certain type.'));
-						$row->addYesNoRadio('roleCategory')->checked($checked)->isRequired();
+						$row->addYesNoRadio('roleCategory')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('roleCategory')->onRadio('roleCategory')->when('Y');
 
@@ -245,7 +245,7 @@ else {
 					$sql = 'SELECT DISTINCT category AS value, category AS name FROM gibbonRole ORDER BY category';
 					$row = $form->addRow()->addClass('roleCategory hiddenReveal');
 						$row->addLabel('roleCategories[]', __('Select Role Categories'));
-						$row->addSelect('roleCategories[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(4)->isRequired()->placeholder()->selected($selected);
+						$row->addSelect('roleCategories[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(4)->required()->placeholder()->selected($selected);
 				} else if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_postQuickWall.php")) {
                     // Handle the edge case where a user can post a Quick Wall message but doesn't have access to the Role target
                     $row = $form->addRow();
@@ -276,7 +276,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('yearGroup', __('Year Group'))->description(__('Students in year; staff by tutors and courses taught.'));
-						$row->addYesNoRadio('yearGroup')->checked($checked)->isRequired();
+						$row->addYesNoRadio('yearGroup')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('yearGroup')->onRadio('yearGroup')->when('Y');
 
@@ -284,7 +284,7 @@ else {
 					$sql = 'SELECT gibbonYearGroupID AS value, name FROM gibbonYearGroup ORDER BY sequenceNumber';
 					$row = $form->addRow()->addClass('yearGroup hiddenReveal');
 						$row->addLabel('yearGroups[]', __('Select Year Groups'));
-						$row->addSelect('yearGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->placeholder()->selected($selected);
+						$row->addSelect('yearGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
 
 					$row = $form->addRow()->addClass('yearGroup hiddenReveal');
 						$row->addLabel('yearGroupsStaff', __('Include Staff?'));
@@ -316,7 +316,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('rollGroup', __('Roll Group'))->description(__('Tutees and tutors.'));
-						$row->addYesNoRadio('rollGroup')->checked($checked)->isRequired();
+						$row->addYesNoRadio('rollGroup')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('rollGroup')->onRadio('rollGroup')->when('Y');
 
@@ -336,7 +336,7 @@ else {
 					}
 					$row = $form->addRow()->addClass('rollGroup hiddenReveal');
 						$row->addLabel('rollGroups[]', __('Select Roll Groups'));
-						$row->addSelect('rollGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->placeholder()->selected($selected);
+						$row->addSelect('rollGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
 
 					$row = $form->addRow()->addClass('rollGroup hiddenReveal');
 						$row->addLabel('rollGroupsStaff', __('Include Staff?'));
@@ -368,7 +368,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('course', __('Course'))->description(__('Members of a course of study.'));
-						$row->addYesNoRadio('course')->checked($checked)->isRequired();
+						$row->addYesNoRadio('course')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('course')->onRadio('course')->when('Y');
 
@@ -386,7 +386,7 @@ else {
 
 					$row = $form->addRow()->addClass('course hiddenReveal');
 						$row->addLabel('courses[]', __('Select Courses'));
-						$row->addSelect('courses[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('courses[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
 
 					$row = $form->addRow()->addClass('course hiddenReveal');
 						$row->addLabel('coursesStaff', __('Include Staff?'));
@@ -418,7 +418,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('class', __('Class'))->description(__('Members of a class within a course.'));
-						$row->addYesNoRadio('class')->checked($checked)->isRequired();
+						$row->addYesNoRadio('class')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('class')->onRadio('class')->when('Y');
 
@@ -436,7 +436,7 @@ else {
 
 					$row = $form->addRow()->addClass('class hiddenReveal');
 						$row->addLabel('classes[]', __('Select Classes'));
-						$row->addSelect('classes[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('classes[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
 
 					$row = $form->addRow()->addClass('class hiddenReveal');
 						$row->addLabel('classesStaff', __('Include Staff?'));
@@ -468,7 +468,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('activity', __('Activity'))->description(__('Members of an activity.'));
-						$row->addYesNoRadio('activity')->checked($checked)->isRequired();
+						$row->addYesNoRadio('activity')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('activity')->onRadio('activity')->when('Y');
 
@@ -485,7 +485,7 @@ else {
 					}
 					$row = $form->addRow()->addClass('activity hiddenReveal');
 						$row->addLabel('activities[]', __('Select Activities'));
-						$row->addSelect('activities[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('activities[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
 
 					$row = $form->addRow()->addClass('activity hiddenReveal');
 						$row->addLabel('activitiesStaff', __('Include Staff?'));
@@ -511,14 +511,14 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('applicants', __('Applicants'))->description(__('Applicants from a given year.'))->description(__('Does not apply to the message wall.'));
-						$row->addYesNoRadio('applicants')->checked($checked)->isRequired();
+						$row->addYesNoRadio('applicants')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('applicants')->onRadio('applicants')->when('Y');
 
 					$sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear ORDER BY sequenceNumber DESC";
 					$row = $form->addRow()->addClass('applicants hiddenReveal');
 						$row->addLabel('applicantList[]', __('Select Years'));
-						$row->addSelect('applicantList[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('applicantList[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required()->selected($selected);
 				}
 
 				// Houses
@@ -530,7 +530,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('houses', __('Houses'))->description(__('Houses for competitions, etc.'));
-						$row->addYesNoRadio('houses')->checked($checked)->isRequired();
+						$row->addYesNoRadio('houses')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('houses')->onRadio('houses')->when('Y');
 
@@ -543,7 +543,7 @@ else {
 					}
 					$row = $form->addRow()->addClass('houses hiddenReveal');
 						$row->addLabel('houseList[]', __('Select Houses'));
-						$row->addSelect('houseList[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('houseList[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
 				}
 
 				// Transport
@@ -561,14 +561,14 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('transport', __('Transport'))->description(__('Applies to all staff and students who have transport set.'));
-						$row->addYesNoRadio('transport')->checked($checked)->isRequired();
+						$row->addYesNoRadio('transport')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('transport')->onRadio('transport')->when('Y');
 
 					$sql = "SELECT DISTINCT transport as value, transport as name FROM gibbonPerson WHERE status='Full' AND NOT transport='' ORDER BY transport";
 					$row = $form->addRow()->addClass('transport hiddenReveal');
 						$row->addLabel('transports[]', __('Select Transport'));
-						$row->addSelect('transports[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('transports[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required()->selected($selected);
 
 					$row = $form->addRow()->addClass('transport hiddenReveal');
 						$row->addLabel('transportStaff', __('Include Staff?'));
@@ -598,7 +598,7 @@ else {
 					}, array());
 					$checked = !empty($selected)? 'Y' : 'N';$row = $form->addRow();
 						$row->addLabel('attendance', __('Attendance Status'))->description(__('Students matching the given attendance status.'));
-						$row->addYesNoRadio('attendance')->checked($checked)->isRequired();
+						$row->addYesNoRadio('attendance')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('attendance')->onRadio('attendance')->when('Y');
 
@@ -620,7 +620,7 @@ else {
 
 					$row = $form->addRow()->addClass('attendance hiddenReveal');
 						$row->addLabel('attendanceStatus[]', __('Select Attendance Status'));
-						$row->addSelect('attendanceStatus[]')->fromArray($attendanceCodes)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('attendanceStatus[]')->fromArray($attendanceCodes)->selectMultiple()->setSize(6)->required()->selected($selected);
 
 					$row = $form->addRow()->addClass('attendance hiddenReveal');
 						$row->addLabel('attendanceStudents', __('Include Students?'));
@@ -646,7 +646,7 @@ else {
 					$checked = !empty($selected)? 'Y' : 'N';
 					$row = $form->addRow();
 						$row->addLabel('group', __('Group'))->description(__('Members of a Messenger module group.'));
-						$row->addYesNoRadio('group')->checked($checked)->isRequired();
+						$row->addYesNoRadio('group')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('group')->onRadio('group')->when('Y');
 
@@ -664,7 +664,7 @@ else {
 
 					$row = $form->addRow()->addClass('group hiddenReveal');
 						$row->addLabel('groups[]', __('Select Groups'));
-						$row->addSelect('groups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->selected($selected);;
+						$row->addSelect('groups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);;
 
 					$row = $form->addRow()->addClass('group hiddenReveal');
 						$row->addLabel('groupsStaff', __('Include Staff?'));
@@ -689,7 +689,7 @@ else {
 					}, array());
 					$checked = !empty($selected)? 'Y' : 'N';$row = $form->addRow();
 						$row->addLabel('individuals', __('Individuals'))->description(__('Individuals from the whole school.'));
-						$row->addYesNoRadio('individuals')->checked($checked)->isRequired();
+						$row->addYesNoRadio('individuals')->checked($checked)->required();
 
 					$form->toggleVisibilityByClass('individuals')->onRadio('individuals')->when('Y');
 
@@ -705,7 +705,7 @@ else {
 
 					$row = $form->addRow()->addClass('individuals hiddenReveal');
 						$row->addLabel('individualList[]', __('Select Individuals'));
-						$row->addSelect('individualList[]')->fromArray($individuals)->selectMultiple()->setSize(6)->isRequired()->selected($selected);
+						$row->addSelect('individualList[]')->fromArray($individuals)->selectMultiple()->setSize(6)->required()->selected($selected);
 				}
 
 				$form->loadAllValuesFrom($values);

--- a/modules/Messenger/messenger_manage_edit.php
+++ b/modules/Messenger/messenger_manage_edit.php
@@ -250,7 +250,7 @@ else {
                     // Handle the edge case where a user can post a Quick Wall message but doesn't have access to the Role target
                     $row = $form->addRow();
 						$row->addLabel('roleCategoryLabel', __('Role Category'))->description(__('Users of a certain type.'));
-                        $row->addYesNoRadio('roleCategoryLabel')->checked('Y')->readonly()->isDisabled();
+                        $row->addYesNoRadio('roleCategoryLabel')->checked('Y')->readonly()->disabled();
 
                     $form->addHiddenValue('role', 'N');
                     $form->addHiddenValue('roleCategory', 'Y');

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -87,7 +87,7 @@ else {
 		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byEmail")) {
 			$row = $form->addRow();
 				$row->addLabel('email', __('Email'))->description(__('Deliver this message to user\'s primary email account?'));
-				$row->addYesNoRadio('email')->checked('Y')->isRequired();
+				$row->addYesNoRadio('email')->checked('Y')->required();
 
 			$form->toggleVisibilityByClass('email')->onRadio('email')->when('Y');
 
@@ -100,7 +100,7 @@ else {
 			}
 			$row = $form->addRow()->addClass('email');
 				$row->addLabel('from', __('Email From'));
-				$row->addSelect('from')->fromArray($from)->isRequired();
+				$row->addSelect('from')->fromArray($from)->required();
 
 			if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_fromSchool")) {
 				$row = $form->addRow()->addClass('email');
@@ -113,14 +113,14 @@ else {
 		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byMessageWall")) {
 			$row = $form->addRow();
 				$row->addLabel('messageWall', __('Message Wall'))->description(__('Place this message on user\'s message wall?'));
-				$row->addYesNoRadio('messageWall')->checked('N')->isRequired();
+				$row->addYesNoRadio('messageWall')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('messageWall')->onRadio('messageWall')->when('Y');
 
 			$row = $form->addRow()->addClass('messageWall');
 		        $row->addLabel('date1', __('Publication Dates'))->description(__('Select up to three individual dates.'));
 				$col = $row->addColumn('date1')->addClass('stacked');
-				$col->addDate('date1')->setValue(dateConvertBack($guid, date('Y-m-d')))->isRequired();
+				$col->addDate('date1')->setValue(dateConvertBack($guid, date('Y-m-d')))->required();
 				$col->addDate('date2');
 				$col->addDate('date3');
 		}
@@ -138,7 +138,7 @@ else {
 			else {
 				$row = $form->addRow();
 					$row->addLabel('sms', __('SMS'))->description(__('Deliver this message to user\'s mobile phone?'));
-					$row->addYesNoRadio('sms')->checked('N')->isRequired();
+					$row->addYesNoRadio('sms')->checked('N')->required();
 
 				$form->toggleVisibilityByClass('sms')->onRadio('sms')->when('Y');
 
@@ -216,12 +216,12 @@ else {
 
 		$row = $form->addRow();
 			$row->addLabel('subject', __('Subject'));
-			$row->addTextField('subject')->maxLength(60)->isRequired();
+			$row->addTextField('subject')->maxLength(60)->required();
 
 		$row = $form->addRow();
 	        $col = $row->addColumn('body');
 	        $col->addLabel('body', __('Body'));
-	        $col->addEditor('body', $guid)->isRequired()->setRows(20)->showMedia(true)->setValue($signature);
+	        $col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true)->setValue($signature);
 
 
 		//READ RECEIPTS
@@ -234,13 +234,13 @@ else {
 
 			$row = $form->addRow();
 				$row->addLabel('emailReceipt', __('Enable Read Receipts'))->description(__('Each email recipient will receive a personalised confirmation link.'));
-				$row->addYesNoRadio('emailReceipt')->checked('N')->isRequired();
+				$row->addYesNoRadio('emailReceipt')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('emailReceipt')->onRadio('emailReceipt')->when('Y');
 
 			$row = $form->addRow()->addClass('emailReceipt');
 				$row->addLabel('emailReceiptText', __('Link Text'))->description(__('Confirmation link text to display to recipient.'));
-				$row->addTextArea('emailReceiptText')->setRows(4)->isRequired()->setValue(__('By clicking on this link I confirm that I have read, and agree to, the text contained within this email, and give consent for my child to participate.'));
+				$row->addTextArea('emailReceiptText')->setRows(4)->required()->setValue(__('By clicking on this link I confirm that I have read, and agree to, the text contained within this email, and give consent for my child to participate.'));
 
 		}
 
@@ -252,7 +252,7 @@ else {
 		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_role")) {
 			$row = $form->addRow();
 				$row->addLabel('role', __('Role'))->description(__('Users of a certain type.'));
-				$row->addYesNoRadio('role')->checked('N')->isRequired();
+				$row->addYesNoRadio('role')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('role')->onRadio('role')->when('Y');
 
@@ -260,12 +260,12 @@ else {
 			$sql = 'SELECT gibbonRoleID AS value, CONCAT(name," (",category,")") AS name FROM gibbonRole ORDER BY name';
 			$row = $form->addRow()->addClass('role hiddenReveal');
 		        $row->addLabel('roles[]', __('Select Roles'));
-		        $row->addSelect('roles[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->placeholder();
+		        $row->addSelect('roles[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder();
 
 			//Role Category
 			$row = $form->addRow();
 				$row->addLabel('roleCategory', __('Role Category'))->description(__('Users of a certain type.'));
-				$row->addYesNoRadio('roleCategory')->checked('N')->isRequired();
+				$row->addYesNoRadio('roleCategory')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('roleCategory')->onRadio('roleCategory')->when('Y');
 
@@ -273,14 +273,14 @@ else {
 			$sql = 'SELECT DISTINCT category AS value, category AS name FROM gibbonRole ORDER BY category';
 			$row = $form->addRow()->addClass('roleCategory hiddenReveal');
 		        $row->addLabel('roleCategories[]', __('Select Role Categories'));
-		        $row->addSelect('roleCategories[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(4)->isRequired()->placeholder();
+		        $row->addSelect('roleCategories[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(4)->required()->placeholder();
 		}
 
 		//Year group
 		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_yearGroups_any")) {
 			$row = $form->addRow();
 				$row->addLabel('yearGroup', __('Year Group'))->description(__('Students in year; staff by tutors and courses taught.'));
-				$row->addYesNoRadio('yearGroup')->checked('N')->isRequired();
+				$row->addYesNoRadio('yearGroup')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('yearGroup')->onRadio('yearGroup')->when('Y');
 
@@ -288,7 +288,7 @@ else {
 			$sql = 'SELECT gibbonYearGroupID AS value, name FROM gibbonYearGroup ORDER BY sequenceNumber';
 			$row = $form->addRow()->addClass('yearGroup hiddenReveal');
 				$row->addLabel('yearGroups[]', __('Select Year Groups'));
-				$row->addSelect('yearGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->placeholder();
+				$row->addSelect('yearGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder();
 
 			$row = $form->addRow()->addClass('yearGroup hiddenReveal');
 		        $row->addLabel('yearGroupsStaff', __('Include Staff?'));
@@ -309,7 +309,7 @@ else {
 		if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_rollGroups_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_rollGroups_any")) {
 			$row = $form->addRow();
 				$row->addLabel('rollGroup', __('Roll Group'))->description(__('Tutees and tutors.'));
-				$row->addYesNoRadio('rollGroup')->checked('N')->isRequired();
+				$row->addYesNoRadio('rollGroup')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('rollGroup')->onRadio('rollGroup')->when('Y');
 
@@ -329,7 +329,7 @@ else {
 			}
 			$row = $form->addRow()->addClass('rollGroup hiddenReveal');
 				$row->addLabel('rollGroups[]', __('Select Roll Groups'));
-				$row->addSelect('rollGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired()->placeholder();
+				$row->addSelect('rollGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder();
 
 			$row = $form->addRow()->addClass('rollGroup hiddenReveal');
 		        $row->addLabel('rollGroupsStaff', __('Include Staff?'));
@@ -350,7 +350,7 @@ else {
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_any")) {
             $row = $form->addRow();
 				$row->addLabel('course', __('Course'))->description(__('Members of a course of study.'));
-				$row->addYesNoRadio('course')->checked('N')->isRequired();
+				$row->addYesNoRadio('course')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('course')->onRadio('course')->when('Y');
 
@@ -364,7 +364,7 @@ else {
 
 			$row = $form->addRow()->addClass('course hiddenReveal');
 				$row->addLabel('courses[]', __('Select Courses'));
-				$row->addSelect('courses[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('courses[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required();
 
 			$row = $form->addRow()->addClass('course hiddenReveal');
 		        $row->addLabel('coursesStaff', __('Include Staff?'));
@@ -385,7 +385,7 @@ else {
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_any")) {
             $row = $form->addRow();
 				$row->addLabel('class', __('Class'))->description(__('Members of a class within a course.'));
-				$row->addYesNoRadio('class')->checked('N')->isRequired();
+				$row->addYesNoRadio('class')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('class')->onRadio('class')->when('Y');
 
@@ -399,7 +399,7 @@ else {
 
 			$row = $form->addRow()->addClass('class hiddenReveal');
 				$row->addLabel('classes[]', __('Select Classes'));
-				$row->addSelect('classes[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('classes[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required();
 
 			$row = $form->addRow()->addClass('class hiddenReveal');
 		        $row->addLabel('classesStaff', __('Include Staff?'));
@@ -421,7 +421,7 @@ else {
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_any")) {
             $row = $form->addRow();
 				$row->addLabel('activity', __('Activity'))->description(__('Members of an activity.'));
-				$row->addYesNoRadio('activity')->checked('N')->isRequired();
+				$row->addYesNoRadio('activity')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('activity')->onRadio('activity')->when('Y');
 
@@ -438,7 +438,7 @@ else {
             }
 			$row = $form->addRow()->addClass('activity hiddenReveal');
 				$row->addLabel('activities[]', __('Select Activities'));
-				$row->addSelect('activities[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('activities[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required();
 
 			$row = $form->addRow()->addClass('activity hiddenReveal');
 		        $row->addLabel('activitiesStaff', __('Include Staff?'));
@@ -459,21 +459,21 @@ else {
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_applicants")) {
             $row = $form->addRow();
 				$row->addLabel('applicants', __('Applicants'))->description(__('Applicants from a given year.'))->description(__('Does not apply to the message wall.'));
-				$row->addYesNoRadio('applicants')->checked('N')->isRequired();
+				$row->addYesNoRadio('applicants')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('applicants')->onRadio('applicants')->when('Y');
 
 			$sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear ORDER BY sequenceNumber DESC";
 			$row = $form->addRow()->addClass('applicants hiddenReveal');
 				$row->addLabel('applicantList[]', __('Select Years'));
-				$row->addSelect('applicantList[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('applicantList[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required();
         }
 
         // Houses
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_all") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_my")) {
             $row = $form->addRow();
 				$row->addLabel('houses', __('Houses'))->description(__('Houses for competitions, etc.'));
-				$row->addYesNoRadio('houses')->checked('N')->isRequired();
+				$row->addYesNoRadio('houses')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('houses')->onRadio('houses')->when('Y');
 
@@ -486,21 +486,21 @@ else {
             }
 			$row = $form->addRow()->addClass('houses hiddenReveal');
 				$row->addLabel('houseList[]', __('Select Houses'));
-				$row->addSelect('houseList[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('houseList[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required();
         }
 
         // Transport
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_transport_any")) {
             $row = $form->addRow();
 				$row->addLabel('transport', __('Transport'))->description(__('Applies to all staff and students who have transport set.'));
-				$row->addYesNoRadio('transport')->checked('N')->isRequired();
+				$row->addYesNoRadio('transport')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('transport')->onRadio('transport')->when('Y');
 
 			$sql = "SELECT DISTINCT transport as value, transport as name FROM gibbonPerson WHERE status='Full' AND NOT transport='' ORDER BY transport";
 			$row = $form->addRow()->addClass('transport hiddenReveal');
 				$row->addLabel('transports[]', __('Select Transport'));
-				$row->addSelect('transports[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('transports[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required();
 
 			$row = $form->addRow()->addClass('transport hiddenReveal');
 		        $row->addLabel('transportStaff', __('Include Staff?'));
@@ -521,7 +521,7 @@ else {
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_attendance")) {
             $row = $form->addRow();
 				$row->addLabel('attendance', __('Attendance Status'))->description(__('Students matching the given attendance status.'));
-				$row->addYesNoRadio('attendance')->checked('N')->isRequired();
+				$row->addYesNoRadio('attendance')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('attendance')->onRadio('attendance')->when('Y');
 
@@ -543,11 +543,11 @@ else {
 
 			$row = $form->addRow()->addClass('attendance hiddenReveal');
 				$row->addLabel('attendanceStatus[]', __('Select Attendance Status'));
-                $row->addSelect('attendanceStatus[]')->fromArray($attendanceCodes)->selectMultiple()->setSize(6)->isRequired()->selected('Absent');
+                $row->addSelect('attendanceStatus[]')->fromArray($attendanceCodes)->selectMultiple()->setSize(6)->required()->selected('Absent');
 
             $row = $form->addRow()->addClass('attendance hiddenReveal');
                 $row->addLabel('attendanceDate', __('Date'));
-                $row->addDate('attendanceDate')->isRequired()->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']));
+                $row->addDate('attendanceDate')->required()->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']));
 
 			$row = $form->addRow()->addClass('attendance hiddenReveal');
 		        $row->addLabel('attendanceStudents', __('Include Students?'));
@@ -562,7 +562,7 @@ else {
 		 if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_any")) {
             $row = $form->addRow();
 				$row->addLabel('group', __('Group'))->description(__('Members of a Messenger module group.'));
-				$row->addYesNoRadio('group')->checked('N')->isRequired();
+				$row->addYesNoRadio('group')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('group')->onRadio('group')->when('Y');
 
@@ -580,7 +580,7 @@ else {
 
 			$row = $form->addRow()->addClass('group hiddenReveal');
 				$row->addLabel('groups[]', __('Select Groups'));
-				$row->addSelect('groups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('groups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required();
 
 			$row = $form->addRow()->addClass('group hiddenReveal');
 		        $row->addLabel('groupsStaff', __('Include Staff?'));
@@ -601,7 +601,7 @@ else {
         if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_individuals")) {
             $row = $form->addRow();
 				$row->addLabel('individuals', __('Individuals'))->description(__('Individuals from the whole school.'));
-				$row->addYesNoRadio('individuals')->checked('N')->isRequired();
+				$row->addYesNoRadio('individuals')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('individuals')->onRadio('individuals')->when('Y');
 
@@ -617,7 +617,7 @@ else {
 
 			$row = $form->addRow()->addClass('individuals hiddenReveal');
 				$row->addLabel('individualList[]', __('Select Individuals'));
-				$row->addSelect('individualList[]')->fromArray($individuals)->selectMultiple()->setSize(6)->isRequired();
+				$row->addSelect('individualList[]')->fromArray($individuals)->selectMultiple()->setSize(6)->required();
         }
 
 		$row = $form->addRow();

--- a/modules/Messenger/messenger_postQuickWall.php
+++ b/modules/Messenger/messenger_postQuickWall.php
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_postQu
 	$row = $form->addRow();
         $row->addLabel('date1', __('Publication Dates'))->description(__('Select up to three individual dates.'));
 		$col = $row->addColumn('date1')->addClass('stacked');
-		$col->addDate('date1')->setValue(dateConvertBack($guid, date('Y-m-d')))->isRequired();
+		$col->addDate('date1')->setValue(dateConvertBack($guid, date('Y-m-d')))->required();
 		$col->addDate('date2');
 		$col->addDate('date3');
 
@@ -70,12 +70,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_postQu
 
     $row = $form->addRow();
         $row->addLabel('subject', __('Subject'));
-        $row->addTextField('subject')->isRequired()->maxLength(60);
+        $row->addTextField('subject')->required()->maxLength(60);
 
     $row = $form->addRow();
         $col = $row->addColumn('body');
         $col->addLabel('body', __('Body'));
-        $col->addEditor('body', $guid)->isRequired()->setRows(20)->showMedia(true);
+        $col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Planner/conceptExplorer.php
+++ b/modules/Planner/conceptExplorer.php
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/conceptExplorer.ph
 
     $row = $form->addRow();
         $row->addLabel('tags', __('Concepts & Keywords'));
-        $row->addSelect('tags')->fromArray(array_column($tagsAll, 1))->selectMultiple()->isRequired()->selected($tags);
+        $row->addSelect('tags')->fromArray(array_column($tagsAll, 1))->selectMultiple()->required()->selected($tags);
 
     $row = $form->addRow();
         $row->addLabel('gibbonYearGroupID', __('Year Group'));

--- a/modules/Planner/curriculumMapping_outcomesByCourse.php
+++ b/modules/Planner/curriculumMapping_outcomesByCourse.php
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/curriculumMapping_
 
 	$row = $form->addRow();
 		$row->addLabel('gibbonCourseID', __('Course'));
-		$row->addSelect('gibbonCourseID')->fromArray($courses)->isRequired()->selected($gibbonCourseID)->placeholder();
+		$row->addSelect('gibbonCourseID')->fromArray($courses)->required()->selected($gibbonCourseID)->placeholder();
 
 	$row = $form->addRow();
 		$row->addSearchSubmit($gibbon->session, __('Clear Filters'));

--- a/modules/Planner/outcomes_add.php
+++ b/modules/Planner/outcomes_add.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_add.php')
 			$row = $form->addRow();
                 $row->addLabel('scope', 'Scope');
             if ($highestAction == 'Manage Outcomes_viewEditAll') {
-                $row->addSelect('scope')->fromArray($scopes)->isRequired()->placeholder();
+                $row->addSelect('scope')->fromArray($scopes)->required()->placeholder();
             } elseif ($highestAction == 'Manage Outcomes_viewAllEditLearningArea') {
                 $row->addTextField('scope')->readOnly()->setValue('Learning Area');
 			}
@@ -97,19 +97,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_add.php')
             }
             $row = $form->addRow()->addClass('learningAreaRow');
                 $row->addLabel('gibbonDepartmentID', __('Learning Area'));
-                $row->addSelect('gibbonDepartmentID')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder();
+                $row->addSelect('gibbonDepartmentID')->fromQuery($pdo, $sql, $data)->required()->placeholder();
 
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'));
-				$row->addTextField('name')->isRequired()->maxLength(100);
+				$row->addTextField('name')->required()->maxLength(100);
 
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'));
-				$row->addTextField('nameShort')->isRequired()->maxLength(14);
+				$row->addTextField('nameShort')->required()->maxLength(14);
 
 			$row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-				$row->addYesNo('active')->isRequired();
+				$row->addYesNo('active')->required();
 
 			$sql = "SELECT DISTINCT category FROM gibbonOutcome ORDER BY category";
             $result = $pdo->executeQuery(array(), $sql);

--- a/modules/Planner/outcomes_edit.php
+++ b/modules/Planner/outcomes_edit.php
@@ -97,7 +97,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_edit.php'
 
 					$row = $form->addRow();
                         $row->addLabel('scope', 'Scope');
-                        $row->addTextField('scope')->isRequired()->readOnly();
+                        $row->addTextField('scope')->required()->readOnly();
 
                     if ($values['scope'] == 'Learning Area') {
                         $sql = "SELECT name FROM gibbonDepartment WHERE gibbonDepartmentID=:gibbonDepartmentID";
@@ -107,20 +107,20 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_edit.php'
                         $form->addHiddenValue('gibbonDepartmentID', $values['gibbonDepartmentID']);
                         $row = $form->addRow();
                             $row->addLabel('departmentName', __('Learning Area'));
-                            $row->addTextField('departmentName')->isRequired()->readOnly()->setValue($learningArea);
+                            $row->addTextField('departmentName')->required()->readOnly()->setValue($learningArea);
 					}
 					
 					$row = $form->addRow();
 						$row->addLabel('name', __('Name'));
-						$row->addTextField('name')->isRequired()->maxLength(100);
+						$row->addTextField('name')->required()->maxLength(100);
 
 					$row = $form->addRow();
 						$row->addLabel('nameShort', __('Short Name'));
-						$row->addTextField('nameShort')->isRequired()->maxLength(14);
+						$row->addTextField('nameShort')->required()->maxLength(14);
 
 					$row = $form->addRow();
 						$row->addLabel('active', __('Active'));
-						$row->addYesNo('active')->isRequired();
+						$row->addYesNo('active')->required();
 
 					$sql = "SELECT DISTINCT category FROM gibbonOutcome ORDER BY category";
 					$result = $pdo->executeQuery(array(), $sql);

--- a/modules/Planner/report_parentWeeklyEmailSummaryConfirmation.php
+++ b/modules/Planner/report_parentWeeklyEmailSummaryConfirmation.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/report_parentWeekl
 
     $row = $form->addRow();
         $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->isRequired()->selected($gibbonRollGroupID);
+        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->required()->selected($gibbonRollGroupID);
 
     $begin = new DateTime($_SESSION[$guid]['gibbonSchoolYearFirstDay']);
     $end = new DateTime();

--- a/modules/Planner/report_workSummary_byRollGroup.php
+++ b/modules/Planner/report_workSummary_byRollGroup.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/report_workSummary
 
     $row = $form->addRow();
         $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->isRequired()->selected($gibbonRollGroupID);
+        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->required()->selected($gibbonRollGroupID);
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session, __('Clear Filters'));

--- a/modules/Planner/resources_addQuick_ajax.php
+++ b/modules/Planner/resources_addQuick_ajax.php
@@ -69,7 +69,7 @@ for ($i = 1; $i < 5; ++$i) {
 
 $row = $form->addRow();
     $row->addLabel('imagesAsLinks', __('Insert Images As'));
-    $row->addSelect('imagesAsLinks')->fromArray(array('N' => __('Image'), 'Y' => __('Link')))->isRequired();
+    $row->addSelect('imagesAsLinks')->fromArray(array('N' => __('Image'), 'Y' => __('Link')))->required();
 
 $row = $form->addRow();
     $row->addContent(getMaxUpload($guid, true));

--- a/modules/Planner/resources_add_ajax.php
+++ b/modules/Planner/resources_add_ajax.php
@@ -110,30 +110,30 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_a
         $types = array('File' => __('File'), 'Link' => __('Link'));
         $row = $form->addRow();
             $row->addLabel($id.'type', __('Type'));
-            $row->addSelect($id.'type')->fromArray($types)->isRequired()->placeholder();
+            $row->addSelect($id.'type')->fromArray($types)->required()->placeholder();
 
         // File
         $form->toggleVisibilityByClass('resourceFile')->onSelect($id.'type')->when('File');
         $row = $form->addRow()->addClass('resourceFile');
             $row->addLabel($id.'file', __('File'));
-            $row->addFileUpload($id.'file')->isRequired();
+            $row->addFileUpload($id.'file')->required();
 
         // Link
         $form->toggleVisibilityByClass('resourceLink')->onSelect($id.'type')->when('Link');
         $row = $form->addRow()->addClass('resourceLink');
             $row->addLabel($id.'link', __('Link'));
-            $row->addURL($id.'link')->maxLength(255)->isRequired();
+            $row->addURL($id.'link')->maxLength(255)->required();
 
         $form->addRow()->addSubheading(__('Resource Details'));
 
         $row = $form->addRow();
             $row->addLabel($id.'name', __('Name'));
-            $row->addTextField($id.'name')->isRequired()->maxLength(60);
+            $row->addTextField($id.'name')->required()->maxLength(60);
 
         $categories = getSettingByScope($connection2, 'Resources', 'categories');
         $row = $form->addRow();
             $row->addLabel($id.'category', __('Category'));
-            $row->addSelect($id.'category')->fromString($categories)->isRequired()->placeholder();
+            $row->addSelect($id.'category')->fromString($categories)->required()->placeholder();
 
         $purposesGeneral = getSettingByScope($connection2, 'Resources', 'purposesGeneral');
         $purposesRestricted = ($highestAction == 'Manage Resources_all')? getSettingByScope($connection2, 'Resources', 'purposesRestricted') : '';
@@ -146,7 +146,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_a
             $row->addLabel($id.'tags', __('Tags'))->description(__('Use lots of tags!'));
             $row->addFinder($id.'tags')
                 ->fromQuery($pdo, $sql)
-                ->isRequired()
+                ->required()
                 ->setParameter('hintText', __('Type a tag...'))
                 ->setParameter('allowCreation', true);
 

--- a/modules/Planner/resources_manage_add.php
+++ b/modules/Planner/resources_manage_add.php
@@ -65,37 +65,37 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_a
         $types = array('File' => __('File'), 'HTML' => __('HTML'), 'Link' => __('Link'));
         $row = $form->addRow();
             $row->addLabel('type', __('Type'));
-            $row->addSelect('type')->fromArray($types)->isRequired()->placeholder();
+            $row->addSelect('type')->fromArray($types)->required()->placeholder();
 
         // File
         $form->toggleVisibilityByClass('resourceFile')->onSelect('type')->when('File');
         $row = $form->addRow()->addClass('resourceFile');
             $row->addLabel('file', __('File'));
-            $row->addFileUpload('file')->isRequired();
+            $row->addFileUpload('file')->required();
 
         // HTML
         $form->toggleVisibilityByClass('resourceHTML')->onSelect('type')->when('HTML');
         $row = $form->addRow()->addClass('resourceHTML');
             $column = $row->addColumn()->setClass('');
             $column->addLabel('html', __('HTML'));
-            $column->addEditor('html', $guid)->isRequired();
+            $column->addEditor('html', $guid)->required();
 
         // Link
         $form->toggleVisibilityByClass('resourceLink')->onSelect('type')->when('Link');
         $row = $form->addRow()->addClass('resourceLink');
             $row->addLabel('link', __('Link'));
-            $row->addURL('link')->maxLength(255)->isRequired();
+            $row->addURL('link')->maxLength(255)->required();
 
         $form->addRow()->addHeading(__('Resource Details'));
 
         $row = $form->addRow();
             $row->addLabel('name', __('Name'));
-            $row->addTextField('name')->isRequired()->maxLength(60);
+            $row->addTextField('name')->required()->maxLength(60);
 
         $categories = getSettingByScope($connection2, 'Resources', 'categories');
         $row = $form->addRow();
             $row->addLabel('category', __('Category'));
-            $row->addSelect('category')->fromString($categories)->isRequired()->placeholder();
+            $row->addSelect('category')->fromString($categories)->required()->placeholder();
 
         $purposesGeneral = getSettingByScope($connection2, 'Resources', 'purposesGeneral');
         $purposesRestricted = ($highestAction == 'Manage Resources_all')? getSettingByScope($connection2, 'Resources', 'purposesRestricted') : '';
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_a
             $column->addLabel('tags', __('Tags'))->description(__('Use lots of tags!'));
             $column->addFinder('tags')
                 ->fromQuery($pdo, $sql)
-                ->isRequired()
+                ->required()
                 ->setParameter('hintText', __('Type a tag...'))
                 ->setParameter('allowCreation', true);
 

--- a/modules/Planner/resources_manage_edit.php
+++ b/modules/Planner/resources_manage_edit.php
@@ -96,31 +96,31 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_e
                     $row = $form->addRow()->addClass('resourceFile');
                         $row->addLabel('file', __('File'));
                         $row->addFileUpload('file')
-                            ->isRequired()
+                            ->required()
                             ->setAttachment('content', $_SESSION[$guid]['absoluteURL'], $values['content']);
                 } else if ($values['type'] == 'HTML') {
                     // HTML
                     $row = $form->addRow()->addClass('resourceHTML');
                         $column = $row->addColumn()->setClass('');
                         $column->addLabel('html', __('HTML'));
-                        $column->addEditor('html', $guid)->isRequired()->setValue($values['content']);
+                        $column->addEditor('html', $guid)->required()->setValue($values['content']);
                 } else if ($values['type'] == 'Link') {
                     // Link
                     $row = $form->addRow()->addClass('resourceLink');
                         $row->addLabel('link', __('Link'));
-                        $row->addURL('link')->maxLength(255)->isRequired()->setValue($values['content']);
+                        $row->addURL('link')->maxLength(255)->required()->setValue($values['content']);
                 }
 
                 $form->addRow()->addHeading(__('Resource Details'));
 
                 $row = $form->addRow();
                     $row->addLabel('name', __('Name'));
-                    $row->addTextField('name')->isRequired()->maxLength(60);
+                    $row->addTextField('name')->required()->maxLength(60);
 
                 $categories = getSettingByScope($connection2, 'Resources', 'categories');
                 $row = $form->addRow();
                     $row->addLabel('category', __('Category'));
-                    $row->addSelect('category')->fromString($categories)->isRequired()->placeholder();
+                    $row->addSelect('category')->fromString($categories)->required()->placeholder();
 
                 $purposesGeneral = getSettingByScope($connection2, 'Resources', 'purposesGeneral');
                 $purposesRestricted = getSettingByScope($connection2, 'Resources', 'purposesRestricted');
@@ -134,7 +134,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_e
                     $column->addLabel('tags', __('Tags'))->description(__('Use lots of tags!'));
                     $column->addFinder('tags')
                         ->fromQuery($pdo, $sql)
-                        ->isRequired()
+                        ->required()
                         ->setParameter('hintText', __('Type a tag...'))
                         ->setParameter('allowCreation', true);
 

--- a/modules/Roll Groups/rollGroups_details.php
+++ b/modules/Roll Groups/rollGroups_details.php
@@ -143,7 +143,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Roll Groups/rollGroups_det
 
             $row = $form->addRow();
                 $row->addLabel('sortBy', __('Sort By'));
-                $row->addSelect('sortBy')->fromArray(array('normal' => __('Roll Order'), 'surname' => __('Surname'), 'preferredName' => __('Preferred Name')))->selected($sortBy)->isRequired();
+                $row->addSelect('sortBy')->fromArray(array('normal' => __('Roll Order'), 'surname' => __('Surname'), 'preferredName' => __('Preferred Name')))->selected($sortBy)->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Rubrics/rubrics.php
+++ b/modules/Rubrics/rubrics.php
@@ -145,7 +145,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics.php') == f
                 if ($rubric['active'] == 'Y') {
                     $actions->addAction('view', __('View'))
                         ->setURL('/modules/Rubrics/rubrics_view_full.php')
-                        ->isModal(1100, 550);
+                        ->modalWindow(1100, 550);
                     }
             });
 

--- a/modules/Rubrics/rubrics_add.php
+++ b/modules/Rubrics/rubrics_add.php
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_add.php') 
             $row = $form->addRow();
                 $row->addLabel('scope', 'Scope');
             if ($highestAction == 'Manage Rubrics_viewEditAll') {
-                $row->addSelect('scope')->fromArray($scopes)->isRequired()->placeholder();
+                $row->addSelect('scope')->fromArray($scopes)->required()->placeholder();
                 $form->toggleVisibilityByClass('learningAreaRow')->onSelect('scope')->when('Learning Area');
             } else if ($highestAction == 'Manage Rubrics_viewAllEditLearningArea') {
                 $row->addTextField('scope')->readOnly()->setValue('Learning Area');
@@ -97,15 +97,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_add.php') 
 
             $row = $form->addRow()->addClass('learningAreaRow');
                 $row->addLabel('gibbonDepartmentID', __('Learning Area'));
-                $row->addSelect('gibbonDepartmentID')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder();
+                $row->addSelect('gibbonDepartmentID')->fromQuery($pdo, $sql, $data)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->maxLength(50)->isRequired();
+                $row->addTextField('name')->maxLength(50)->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $sql = "SELECT DISTINCT category FROM gibbonRubric ORDER BY category";
             $result = $pdo->executeQuery(array(), $sql);
@@ -132,11 +132,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_add.php') 
 
             $row = $form->addRow();
                 $row->addLabel('rows', __('Initial Rows'))->description(__('Rows store assessment strands.'));
-                $row->addSelect('rows')->fromArray(range(1, 10))->isRequired();
+                $row->addSelect('rows')->fromArray(range(1, 10))->required();
 
             $row = $form->addRow();
                 $row->addLabel('columns', __('Initial Columns'))->description(__('Columns store assessment levels.'));
-                $row->addSelect('columns')->fromArray(range(1, 10))->isRequired();
+                $row->addSelect('columns')->fromArray(range(1, 10))->required();
             
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Rubrics/rubrics_duplicate.php
+++ b/modules/Rubrics/rubrics_duplicate.php
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_duplicate.
                         $row->addLabel('scope', 'Scope');
                         
 					if ($highestAction == 'Manage Rubrics_viewEditAll') {
-                        $row->addSelect('scope')->fromArray($scopes)->isRequired()->placeholder();
+                        $row->addSelect('scope')->fromArray($scopes)->required()->placeholder();
                         $form->toggleVisibilityByClass('learningAreaRow')->onSelect('scope')->when('Learning Area');
 					} else if ($highestAction == 'Manage Rubrics_viewAllEditLearningArea') {
 						$row->addTextField('scope')->readOnly()->setValue('Learning Area');
@@ -120,11 +120,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_duplicate.
 					
 					$row = $form->addRow()->addClass('learningAreaRow');
 						$row->addLabel('gibbonDepartmentID', __('Learning Area'));
-						$row->addSelect('gibbonDepartmentID')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder();
+						$row->addSelect('gibbonDepartmentID')->fromQuery($pdo, $sql, $data)->required()->placeholder();
 
 					$row = $form->addRow();
 						$row->addLabel('name', __('Name'));
-						$row->addTextField('name')->maxLength(50)->isRequired();
+						$row->addTextField('name')->maxLength(50)->required();
 						
 					$row = $form->addRow();
 						$row->addFooter();

--- a/modules/Rubrics/rubrics_edit.php
+++ b/modules/Rubrics/rubrics_edit.php
@@ -193,7 +193,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
 
                     $row = $form->addRow();
                         $row->addLabel('scope', 'Scope');
-                        $row->addTextField('scope')->isRequired()->readOnly();
+                        $row->addTextField('scope')->required()->readOnly();
 
                     if ($values['scope'] == 'Learning Area') {
                         $sql = "SELECT name FROM gibbonDepartment WHERE gibbonDepartmentID=:gibbonDepartmentID";
@@ -203,16 +203,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
                         $form->addHiddenValue('gibbonDepartmentID', $values['gibbonDepartmentID']);
                         $row = $form->addRow();
                             $row->addLabel('departmentName', __('Learning Area'));
-                            $row->addTextField('departmentName')->isRequired()->readOnly()->setValue($learningArea);
+                            $row->addTextField('departmentName')->required()->readOnly()->setValue($learningArea);
                     }
 
                     $row = $form->addRow();
                         $row->addLabel('name', __('Name'));
-                        $row->addTextField('name')->maxLength(50)->isRequired();
+                        $row->addTextField('name')->maxLength(50)->required();
 
                     $row = $form->addRow();
                         $row->addLabel('active', __('Active'));
-                        $row->addYesNo('active')->isRequired();
+                        $row->addYesNo('active')->required();
 
                     $sql = "SELECT DISTINCT category FROM gibbonRubric ORDER BY category";
                     $result = $pdo->executeQuery(array(), $sql);

--- a/modules/Rubrics/rubrics_edit_editRowsColumns.php
+++ b/modules/Rubrics/rubrics_edit_editRowsColumns.php
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
 
                     $row = $form->addRow();
                         $row->addLabel('scope', 'Scope');
-                        $row->addTextField('scope')->isRequired()->readOnly();
+                        $row->addTextField('scope')->required()->readOnly();
 
                     if ($values['scope'] == 'Learning Area') {
                         $sql = "SELECT name FROM gibbonDepartment WHERE gibbonDepartmentID=:gibbonDepartmentID";
@@ -108,12 +108,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
                         $form->addHiddenValue('gibbonDepartmentID', $values['gibbonDepartmentID']);
                         $row = $form->addRow();
                             $row->addLabel('departmentName', __('Learning Area'));
-                            $row->addTextField('departmentName')->isRequired()->readOnly()->setValue($learningArea);
+                            $row->addTextField('departmentName')->required()->readOnly()->setValue($learningArea);
 					}
 
 					$row = $form->addRow();
                         $row->addLabel('name', __('Name'));
-						$row->addTextField('name')->maxLength(50)->isRequired()->readOnly();
+						$row->addTextField('name')->maxLength(50)->required()->readOnly();
 						
 					$form->addRow()->addHeading(__('Rows'));
 
@@ -157,13 +157,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
 									->setID('rowTitle'.$count)
 									->addClass('rowTitle'.$count)
 									->maxLength(40)
-									->isRequired()
+									->required()
 									->setValue($rubricRow['title']);
 								$column->addSelect('gibbonOutcomeID['.$count.']')
 									->setID('gibbonOutcomeID'.$count)
 									->addClass('gibbonOutcomeID'.$count)
 									->fromArray($outcomes)
-									->isRequired()
+									->required()
 									->placeholder()
 									->selected($rubricRow['gibbonOutcomeID']);
 
@@ -202,7 +202,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
 								$row->addTextField('columnTitle['.$count.']')
 									->setID('columnTitle'.$count)
 									->maxLength(20)
-									->isRequired()
+									->required()
 									->setValue($rubricColumn['title']);
 							} else {
 								$data = array('gibbonScaleID' => $values['gibbonScaleID']);
@@ -210,7 +210,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
 								$row->addSelect('gibbonScaleGradeID['.$count.']')
 									->setID('gibbonScaleGradeID'.$count)
 									->fromQuery($pdo, $sql, $data)
-									->isRequired()
+									->required()
 									->selected($rubricColumn['gibbonScaleGradeID']);
 							}
 							$form->addHiddenValue('gibbonRubricColumnID['.$count.']', $rubricColumn['gibbonRubricColumnID']);

--- a/modules/Rubrics/rubrics_view.php
+++ b/modules/Rubrics/rubrics_view.php
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_view.php')
         ->format(function ($rubric, $actions) {
             $actions->addAction('view', __('View'))
                 ->setURL('/modules/Rubrics/rubrics_view_full.php')
-                ->isModal(1100, 550);
+                ->modalWindow(1100, 550);
         });
 
     echo $table->render($rubrics);

--- a/modules/School Admin/activitySettings.php
+++ b/modules/School Admin/activitySettings.php
@@ -43,14 +43,14 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/activitySetti
     $setting = getSettingByScope($connection2, 'Activities', 'dateType', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addSelect($setting['name'])->fromArray($dateTypes)->selected($setting['value'])->isRequired();    
+        $row->addSelect($setting['name'])->fromArray($dateTypes)->selected($setting['value'])->required();    
 
     $form->toggleVisibilityByClass('perTerm')->onSelect($setting['name'])->when('Term');
 
     $setting = getSettingByScope($connection2, 'Activities', 'maxPerTerm', true);
     $row = $form->addRow()->addClass('perTerm');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addSelect($setting['name'])->fromString('0,1,2,3,4,5')->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromString('0,1,2,3,4,5')->selected($setting['value'])->required();
 
     $accessTypes = array(
         'None' => __('None'),
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/activitySetti
     $setting = getSettingByScope($connection2, 'Activities', 'access', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addSelect($setting['name'])->fromArray($accessTypes)->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray($accessTypes)->selected($setting['value'])->required();
 
     $paymentTypes = array(
         'None' => __('None'),
@@ -71,7 +71,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/activitySetti
     $setting = getSettingByScope($connection2, 'Activities', 'payment', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addSelect($setting['name'])->fromArray($paymentTypes)->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray($paymentTypes)->selected($setting['value'])->required();
 
     $enrolmentTypes = array(
         'Competitive' => __('Competitive'),
@@ -80,12 +80,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/activitySetti
     $setting = getSettingByScope($connection2, 'Activities', 'enrolmentType', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addSelect($setting['name'])->fromArray($enrolmentTypes)->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray($enrolmentTypes)->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Activities', 'backupChoice', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
 
     $setting = getSettingByScope($connection2, 'Activities', 'activityTypes', true);
@@ -96,12 +96,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/activitySetti
     $setting = getSettingByScope($connection2, 'Activities', 'disableExternalProviderSignup', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Activities', 'hideExternalProviderCost', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/alertLevelSettings.php
+++ b/modules/School Admin/alertLevelSettings.php
@@ -57,28 +57,28 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
     		$row->addTextField('name'.$count)
             ->setValue($rowSQL['name'])
             ->maxLength(50)
-            ->isRequired();
+            ->required();
 
         $row = $form->addRow();
         	$row->addLabel('nameShort'.$count, __('Short Name'));
     		$row->addTextField('nameShort'.$count)
             ->setValue($rowSQL['nameShort'])
             ->maxLength(4)
-            ->isRequired();
+            ->required();
 
         $row = $form->addRow();
         	$row->addLabel('color'.$count, __('Font/Border Color'))->description(__('RGB Hex value, without leading #.'));
     		$row->addTextField('color'.$count)
                 ->setValue($rowSQL['color'])
                 ->maxLength(6)
-                ->isRequired();
+                ->required();
 
         $row = $form->addRow();
         	$row->addLabel('colorBG'.$count, __('Background Color'))->description(__('RGB Hex value, without leading #.'));
     		$row->addTextField('colorBG'.$count)
                 ->setValue($rowSQL['colorBG'])
                 ->maxLength(6)
-                ->isRequired();
+                ->required();
 
         $row = $form->addRow();
         	$row->addLabel('sequenceNumber'.$count, __('Sequence Number'));
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
             ->setValue($rowSQL['sequenceNumber'])
             ->maxLength(4)
             ->readonly()
-            ->isRequired();
+            ->required();
 
         $row = $form->addRow();
         	$row->addLabel('description'.$count, __('Description'));

--- a/modules/School Admin/attendanceSettings.php
+++ b/modules/School Admin/attendanceSettings.php
@@ -97,24 +97,24 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
     $setting = getSettingByScope($connection2, 'Attendance', 'attendanceReasons', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Pre-Fills & Defaults'))->append(__('The pre-fill settings below determine which Attendance contexts are preset by data available from other contexts. This allows, for example, for attendance taken in a class to be preset by attendance already taken in a Roll Group. The contexts for attendance include Roll Group, Class, Person, Future and Self Registration.'));
 
     $setting = getSettingByScope($connection2, 'Attendance', 'prefillRollGroup', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Attendance', 'prefillClass', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Attendance', 'prefillPerson', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $sql = "SELECT name AS value, name FROM gibbonAttendanceCode WHERE active='Y' ORDER BY sequenceNumber ASC, name";
     $setting = getSettingByScope($connection2, 'Attendance', 'defaultRollGroupAttendanceType', true);
@@ -123,7 +123,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         $row->addSelect($setting['name'])
             ->fromQuery($pdo, $sql)
             ->selected($setting['value'])
-            ->isRequired();
+            ->required();
 
     $setting = getSettingByScope($connection2, 'Attendance', 'defaultClassAttendanceType', true);
     $row = $form->addRow();
@@ -131,7 +131,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         $row->addSelect($setting['name'])
             ->fromQuery($pdo, $sql)
             ->selected($setting['value'])
-            ->isRequired();
+            ->required();
 
 
     $row = $form->addRow()->addHeading(__('Student Self Registration'));
@@ -159,7 +159,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
     $setting = getSettingByScope($connection2, 'Attendance', 'selfRegistrationRedirect', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
 
     $row = $form->addRow()->addHeading(__('Attendance CLI'));
@@ -167,12 +167,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
     $setting = getSettingByScope($connection2, 'Attendance', 'attendanceCLINotifyByRollGroup', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Attendance', 'attendanceCLINotifyByClass', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
 
     $setting = getSettingByScope($connection2, 'Attendance', 'attendanceCLIAdditionalUsers', true);

--- a/modules/School Admin/attendanceSettings_manage_add.php
+++ b/modules/School Admin/attendanceSettings_manage_add.php
@@ -49,11 +49,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(30);
+        $row->addTextField('name')->required()->maxLength(30);
     
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(4);
+        $row->addTextField('nameShort')->required()->maxLength(4);
 
     $directions = array(
         'In'     => __('In Class'),
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
     );
     $row = $form->addRow();
         $row->addLabel('direction', __('Direction'));
-        $row->addSelect('direction')->isRequired()->fromArray($directions);
+        $row->addSelect('direction')->required()->fromArray($directions);
 
     $scopes = array(
         'Onsite'         => __('Onsite'),
@@ -71,23 +71,23 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
     );
     $row = $form->addRow();
         $row->addLabel('scope', __('Scope'));
-        $row->addSelect('scope')->isRequired()->fromArray($scopes);
+        $row->addSelect('scope')->required()->fromArray($scopes);
 
     $row = $form->addRow();
         $row->addLabel('sequenceNumber', __('Sequence Number'));
-        $row->addSequenceNumber('sequenceNumber', 'gibbonAttendanceCode')->isRequired()->maxLength(3);
+        $row->addSequenceNumber('sequenceNumber', 'gibbonAttendanceCode')->required()->maxLength(3);
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $row = $form->addRow();
         $row->addLabel('reportable', __('Reportable'));
-        $row->addYesNo('reportable')->isRequired();
+        $row->addYesNo('reportable')->required();
 
     $row = $form->addRow();
         $row->addLabel('future', __('Allow Future Use'))->description(__('Can this code be used in Set Future Absence?'));
-        $row->addYesNo('future')->isRequired();
+        $row->addYesNo('future')->required();
 
     $row = $form->addRow();
         $row->addLabel('gibbonRoleIDAll', __('Available to Roles'))->description(__('Controls who can use this code.'));

--- a/modules/School Admin/attendanceSettings_manage_edit.php
+++ b/modules/School Admin/attendanceSettings_manage_edit.php
@@ -69,11 +69,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(30);
+                $row->addTextField('name')->required()->maxLength(30);
             
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(4);
+                $row->addTextField('nameShort')->required()->maxLength(4);
         
             $directions = array(
                 'In'     => __('In Class'),
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
             );
             $row = $form->addRow();
                 $row->addLabel('direction', __('Direction'));
-                $row->addSelect('direction')->isRequired()->fromArray($directions);
+                $row->addSelect('direction')->required()->fromArray($directions);
         
             $scopes = array(
                 'Onsite'         => __('Onsite'),
@@ -91,23 +91,23 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
             );
             $row = $form->addRow();
                 $row->addLabel('scope', __('Scope'));
-                $row->addSelect('scope')->isRequired()->fromArray($scopes);
+                $row->addSelect('scope')->required()->fromArray($scopes);
         
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'));
-                $row->addSequenceNumber('sequenceNumber', 'gibbonAttendanceCode', $values['sequenceNumber'])->isRequired()->maxLength(3);
+                $row->addSequenceNumber('sequenceNumber', 'gibbonAttendanceCode', $values['sequenceNumber'])->required()->maxLength(3);
         
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
         
             $row = $form->addRow();
                 $row->addLabel('reportable', __('Reportable'));
-                $row->addYesNo('reportable')->isRequired();
+                $row->addYesNo('reportable')->required();
         
             $row = $form->addRow();
                 $row->addLabel('future', __('Allow Future Use'))->description(__('Can this code be used in Set Future Absence?'));
-                $row->addYesNo('future')->isRequired();
+                $row->addYesNo('future')->required();
         
             $row = $form->addRow();
                 $row->addLabel('gibbonRoleIDAll', __('Available to Roles'))->description(__('Controls who can use this code.'));

--- a/modules/School Admin/behaviourSettings.php
+++ b/modules/School Admin/behaviourSettings.php
@@ -45,40 +45,40 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/behaviourSett
     $setting = getSettingByScope($connection2, 'Behaviour', 'enableDescriptors', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('descriptors')->onSelect($setting['name'])->when('Y');
 
     $setting = getSettingByScope($connection2, 'Behaviour', 'positiveDescriptors', true);
     $row = $form->addRow()->addClass('descriptors');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Behaviour', 'negativeDescriptors', true);
     $row = $form->addRow()->addClass('descriptors');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Levels'));
 
     $setting = getSettingByScope($connection2, 'Behaviour', 'enableLevels', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('levels')->onSelect($setting['name'])->when('Y');
 
     $setting = getSettingByScope($connection2, 'Behaviour', 'levels', true);
     $row = $form->addRow()->addClass('levels');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Behaviour Letters'))->append(sprintf(__('By using an %1$sincluded CLI script%2$s, %3$s can be configured to automatically generate and email behaviour letters to parents and tutors, once certain negative behaviour threshold levels have been reached. In your letter text you may use the following fields: %4$s'), "<a target='_blank' href='https://gibbonedu.org/support/administrators/command-line-tools/'>", '</a>', $_SESSION[$guid]['systemName'], '[studentName], [rollGroup], [behaviourCount], [behaviourRecord]'));
 
     $setting = getSettingByScope($connection2, 'Behaviour', 'enableBehaviourLetters', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('behaviourLetters')->onSelect($setting['name'])->when('Y');
 
@@ -86,12 +86,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/behaviourSett
         $setting = getSettingByScope($connection2, 'Behaviour', 'behaviourLettersLetter'.$i.'Count', true);
         $row = $form->addRow()->addClass('behaviourLetters');
             $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-            $row->addSelect($setting['name'])->fromString('1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20')->selected($setting['value'])->isRequired();
+            $row->addSelect($setting['name'])->fromString('1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20')->selected($setting['value'])->required();
 
         $setting = getSettingByScope($connection2, 'Behaviour', 'behaviourLettersLetter'.$i.'Text', true);
         $row = $form->addRow()->addClass('behaviourLetters');
             $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-            $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+            $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
     }
 
     $row = $form->addRow()->addHeading(__('Miscellaneous'));

--- a/modules/School Admin/daysOfWeek_manage.php
+++ b/modules/School Admin/daysOfWeek_manage.php
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
 
             $row = $form->addRow();
                 $row->addLabel($day['name'].'schoolDay', __('School Day'));
-                $row->addYesNo($day['name'].'schoolDay')->isRequired()->selected($day['schoolDay']);
+                $row->addYesNo($day['name'].'schoolDay')->required()->selected($day['schoolDay']);
 
             $form->toggleVisibilityByClass($day['name'])->onSelect($day['name'].'schoolDay')->when('Y');
 
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                 $col = $row->addColumn()->addClass('right inline');
                 $col->addSelect($day['name'].'schoolOpenH')
                     ->fromString($hours)
-                    ->isRequired()
+                    ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
                     ->selected(substr($day['schoolOpen'], 0, 2));
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                 $col = $row->addColumn()->addClass('right inline');
                 $col->addSelect($day['name'].'schoolStartH')
                     ->fromString($hours)
-                    ->isRequired()
+                    ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
                     ->selected(substr($day['schoolStart'], 0, 2));
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                 $col = $row->addColumn()->addClass('right inline');
                 $col->addSelect($day['name'].'schoolEndH')
                     ->fromString($hours)
-                    ->isRequired()
+                    ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
                     ->selected(substr($day['schoolEnd'], 0, 2));
@@ -119,7 +119,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                 $col = $row->addColumn()->addClass('right inline');
                 $col->addSelect($day['name'].'schoolCloseH')
                     ->fromString($hours)
-                    ->isRequired()
+                    ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
                     ->selected(substr($day['schoolClose'], 0, 2));

--- a/modules/School Admin/department_manage.php
+++ b/modules/School Admin/department_manage.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
     $setting = getSettingByScope($connection2, 'Departments', 'makeDepartmentsPublic', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/department_manage_add.php
+++ b/modules/School Admin/department_manage_add.php
@@ -68,15 +68,15 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
 
     $row = $form->addRow();
         $row->addLabel('type', 'Type');
-        $row->addSelect('type')->fromArray($types)->isRequired();
+        $row->addSelect('type')->fromArray($types)->required();
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->maxLength(40)->isRequired();
+        $row->addTextField('name')->maxLength(40)->required();
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'));
-        $row->addTextField('nameShort')->maxLength(4)->isRequired();
+        $row->addTextField('nameShort')->maxLength(4)->required();
 
     $row = $form->addRow();
         $row->addLabel('subjectListing', __('Subject Listing'));

--- a/modules/School Admin/department_manage_edit.php
+++ b/modules/School Admin/department_manage_edit.php
@@ -93,11 +93,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
 
             $row = $form->addRow();
                 $row->addLabel('name', 'Name');
-                $row->addTextField('name')->maxLength(40)->isRequired();
+                $row->addTextField('name')->maxLength(40)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', 'Short Name');
-                $row->addTextField('nameShort')->maxLength(4)->isRequired();
+                $row->addTextField('nameShort')->maxLength(4)->required();
 
             $row = $form->addRow();
                 $row->addLabel('subjectListing', 'Subject Listing');

--- a/modules/School Admin/externalAssessments_manage_add.php
+++ b/modules/School Admin/externalAssessments_manage_add.php
@@ -47,23 +47,23 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(50);
+        $row->addTextField('name')->required()->maxLength(50);
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(10);
+        $row->addTextField('nameShort')->required()->maxLength(10);
 
     $row = $form->addRow();
         $row->addLabel('description', __('Description'))->description(__('Brief description of assessment and how it is used.'));
-        $row->addTextField('description')->isRequired()->maxLength(255);
+        $row->addTextField('description')->required()->maxLength(255);
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $row = $form->addRow();
         $row->addLabel('allowFileUpload', __('Allow File Upload'))->description(__('Should the student record include the option of a file upload?'));
-        $row->addYesNo('allowFileUpload')->isRequired()->selected('N');
+        $row->addYesNo('allowFileUpload')->required()->selected('N');
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/externalAssessments_manage_edit.php
+++ b/modules/School Admin/externalAssessments_manage_edit.php
@@ -71,23 +71,23 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(50);
+                $row->addTextField('name')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(10);
+                $row->addTextField('nameShort')->required()->maxLength(10);
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'))->description(__('Brief description of assessment and how it is used.'));
-                $row->addTextField('description')->isRequired()->maxLength(255);
+                $row->addTextField('description')->required()->maxLength(255);
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $row = $form->addRow();
                 $row->addLabel('allowFileUpload', __('Allow File Upload'))->description(__('Should the student record include the option of a file upload?'));
-                $row->addYesNo('allowFileUpload')->isRequired()->selected('N');
+                $row->addYesNo('allowFileUpload')->required()->selected('N');
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/School Admin/externalAssessments_manage_edit_field_add.php
+++ b/modules/School Admin/externalAssessments_manage_edit_field_add.php
@@ -75,20 +75,20 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(50);
+                $row->addTextField('name')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('category', __('Category'));
-                $row->addTextField('category')->isRequired()->maxLength(50);
+                $row->addTextField('category')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('order', __('Order'))->description(__('Order in which fields appear within category<br/>Should be unique for this category.'));
-                $row->addNumber('order')->isRequired()->maxLength(4);
+                $row->addNumber('order')->required()->maxLength(4);
 
             $sql = "SELECT gibbonScaleID as value, name FROM gibbonScale WHERE (active='Y') ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('gibbonScaleID', __('Grade Scale'))->description(__('Grade scale used to control values that can be assigned.'));
-                $row->addSelect('gibbonScaleID')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+                $row->addSelect('gibbonScaleID')->fromQuery($pdo, $sql)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('yearGroups', __('Year Groups'))->description(__('Year groups to which this field is relevant.'));

--- a/modules/School Admin/externalAssessments_manage_edit_field_edit.php
+++ b/modules/School Admin/externalAssessments_manage_edit_field_edit.php
@@ -73,20 +73,20 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(50);
+                $row->addTextField('name')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('category', __('Category'));
-                $row->addTextField('category')->isRequired()->maxLength(50);
+                $row->addTextField('category')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('order', __('Order'))->description(__('Order in which fields appear within category<br/>Should be unique for this category.'));
-                $row->addNumber('order')->isRequired()->maxLength(4);
+                $row->addNumber('order')->required()->maxLength(4);
 
             $sql = "SELECT gibbonScaleID as value, name FROM gibbonScale WHERE (active='Y') ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('gibbonScaleID', __('Grade Scale'))->description(__('Grade scale used to control values that can be assigned.'));
-                $row->addSelect('gibbonScaleID')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+                $row->addSelect('gibbonScaleID')->fromQuery($pdo, $sql)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('yearGroups', __('Year Groups'))->description(__('Year groups to which this field is relevant.'));

--- a/modules/School Admin/fileExtensions_manage_add.php
+++ b/modules/School Admin/fileExtensions_manage_add.php
@@ -57,18 +57,18 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
 
     $row = $form->addRow();
         $row->addLabel('extension', __('Extension'))->description(__('Must be unique.'));
-        $ext = $row->addTextField('extension')->isRequired()->maxLength(7);
+        $ext = $row->addTextField('extension')->required()->maxLength(7);
 
         $within = implode(',', array_map(function ($str) { return sprintf("'%s'", $str); }, $illegalTypes));
         $ext->addValidation('Validate.Exclusion', 'within: ['.$within.'], failureMessage: "Illegal file type!", partialMatch: true, caseSensitive: false');
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->isRequired()->maxLength(50);
+        $row->addTextField('name')->required()->maxLength(50);
 
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addSelect('type')->fromArray($categories)->isRequired()->placeholder();
+        $row->addSelect('type')->fromArray($categories)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/fileExtensions_manage_edit.php
+++ b/modules/School Admin/fileExtensions_manage_edit.php
@@ -77,18 +77,18 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
 
             $row = $form->addRow();
                 $row->addLabel('extension', __('Extension'))->description(__('Must be unique.'));
-                $ext = $row->addTextField('extension')->isRequired()->maxLength(7)->setValue($values['extension']);
+                $ext = $row->addTextField('extension')->required()->maxLength(7)->setValue($values['extension']);
 
                 $within = implode(',', array_map(function ($str) { return sprintf("'%s'", $str); }, $illegalTypes));
                 $ext->addValidation('Validate.Exclusion', 'within: ['.$within.'], failureMessage: "Illegal file type!", partialMatch: true, caseSensitive: false');
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(50)->setValue($values['name']);
+                $row->addTextField('name')->required()->maxLength(50)->setValue($values['name']);
 
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromArray($categories)->isRequired()->placeholder()->selected($values['type']);
+                $row->addSelect('type')->fromArray($categories)->required()->placeholder()->selected($values['type']);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/School Admin/financeSettings.php
+++ b/modules/School Admin/financeSettings.php
@@ -43,12 +43,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
     $setting = getSettingByScope($connection2, 'Finance', 'email', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addEmail($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addEmail($setting['name'])->setValue($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Finance', 'financeOnlinePaymentEnabled', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('onlinePayment')->onSelect($setting['name'])->when('Y');
 
@@ -76,12 +76,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
     $setting = getSettingByScope($connection2, 'Finance', 'invoiceeNameStyle', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromString('"Surname, Preferred Name", Official Name')->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromString('"Surname, Preferred Name", Official Name')->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Finance', 'invoiceNumber', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromString('Invoice ID, Person ID + Invoice ID, Student ID + Invoice ID')->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromString('Invoice ID, Person ID + Invoice ID, Student ID + Invoice ID')->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Receipts'));
 
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
     $setting = getSettingByScope($connection2, 'Finance', 'hideItemisation', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Reminders'));
 
@@ -122,17 +122,17 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
     $setting = getSettingByScope($connection2, 'Finance', 'budgetCategories', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Finance', 'expenseApprovalType', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromString('One Of, Two Of, Chain Of All')->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromString('One Of, Two Of, Chain Of All')->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Finance', 'budgetLevelExpenseApproval', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Finance', 'expenseRequestTemplate', true);
     $row = $form->addRow();
@@ -142,7 +142,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
     $setting = getSettingByScope($connection2, 'Finance', 'allowExpenseAdd', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Finance', 'purchasingOfficer', true);
     $row = $form->addRow();

--- a/modules/School Admin/formalAssessmentSettings.php
+++ b/modules/School Admin/formalAssessmentSettings.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/formalAssessm
     $setting = getSettingByScope($connection2, 'Formal Assessment', 'internalAssessmentTypes', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $form->addRow()->addHeading(__('Primary External Assessement'))->append(__('These settings allow a particular type of external assessment to be associated with each year group. The selected assessment will be used as the primary assessment to be used as a baseline for comparison (for example, within the Markbook). You are required to select a particular field category can be chosen from which to draw data (if no category is chosen, the data will not be saved).'));
 

--- a/modules/School Admin/gradeScales_manage_add.php
+++ b/modules/School Admin/gradeScales_manage_add.php
@@ -47,23 +47,23 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(40);
+        $row->addTextField('name')->required()->maxLength(40);
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(5);
+        $row->addTextField('nameShort')->required()->maxLength(5);
 
     $row = $form->addRow();
         $row->addLabel('usage', __('Usage'))->description(__('Brief description of how scale is used.'));
-        $row->addTextField('usage')->isRequired()->maxLength(50);
+        $row->addTextField('usage')->required()->maxLength(50);
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $row = $form->addRow();
         $row->addLabel('numeric', __('Numeric'))->description(__('Does this scale use only numeric grades? Note, grade "Incomplete" is exempt.'));
-        $row->addYesNo('numeric')->isRequired();
+        $row->addYesNo('numeric')->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/gradeScales_manage_edit.php
+++ b/modules/School Admin/gradeScales_manage_edit.php
@@ -71,23 +71,23 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(40);
+                $row->addTextField('name')->required()->maxLength(40);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(5);
+                $row->addTextField('nameShort')->required()->maxLength(5);
 
             $row = $form->addRow();
                 $row->addLabel('usage', __('Usage'))->description(__('Brief description of how scale is used.'));
-                $row->addTextField('usage')->isRequired()->maxLength(50);
+                $row->addTextField('usage')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $row = $form->addRow();
                 $row->addLabel('numeric', __('Numeric'))->description(__('Does this scale use only numeric grades? Note, grade "Incomplete" is exempt.'));
-                $row->addYesNo('numeric')->isRequired();
+                $row->addYesNo('numeric')->required();
 
             $data = array('gibbonScaleID' => $gibbonScaleID);
             $sql = "SELECT sequenceNumber as value, gibbonScaleGrade.value as name FROM gibbonScaleGrade WHERE gibbonScaleID=:gibbonScaleID ORDER BY sequenceNumber";

--- a/modules/School Admin/gradeScales_manage_edit_grade_add.php
+++ b/modules/School Admin/gradeScales_manage_edit_grade_add.php
@@ -73,19 +73,19 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
 
             $row = $form->addRow();
                 $row->addLabel('value', __('Value'))->description(__('Must be unique for this grade scale.'));
-                $row->addTextField('value')->isRequired()->maxLength(10);
+                $row->addTextField('value')->required()->maxLength(10);
 
             $row = $form->addRow();
                 $row->addLabel('descriptor', __('Descriptor'));
-                $row->addTextField('descriptor')->isRequired()->maxLength(50);
+                $row->addTextField('descriptor')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique for this grade scale.'));
-                $row->addNumber('sequenceNumber')->isRequired()->maxLength(5);
+                $row->addNumber('sequenceNumber')->required()->maxLength(5);
 
             $row = $form->addRow();
                 $row->addLabel('isDefault', __('Is Default?'))->description(__('Preselects this option when using this grade scale in appropriate contexts.'));
-                $row->addYesNo('isDefault')->isRequired()->selected('N');
+                $row->addYesNo('isDefault')->required()->selected('N');
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/School Admin/gradeScales_manage_edit_grade_edit.php
+++ b/modules/School Admin/gradeScales_manage_edit_grade_edit.php
@@ -70,19 +70,19 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
 
             $row = $form->addRow();
                 $row->addLabel('value', __('Value'))->description(__('Must be unique for this grade scale.'));
-                $row->addTextField('value')->isRequired()->maxLength(10);
+                $row->addTextField('value')->required()->maxLength(10);
 
             $row = $form->addRow();
                 $row->addLabel('descriptor', __('Descriptor'));
-                $row->addTextField('descriptor')->isRequired()->maxLength(50);
+                $row->addTextField('descriptor')->required()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique for this grade scale.'));
-                $row->addNumber('sequenceNumber')->isRequired()->maxLength(5);
+                $row->addNumber('sequenceNumber')->required()->maxLength(5);
 
             $row = $form->addRow();
                 $row->addLabel('isDefault', __('Is Default?'))->description(__('Preselects this option when using this grade scale in appropriate contexts.'));
-                $row->addYesNo('isDefault')->isRequired();
+                $row->addYesNo('isDefault')->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/School Admin/house_manage_add.php
+++ b/modules/School Admin/house_manage_add.php
@@ -45,11 +45,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(30);
+        $row->addTextField('name')->required()->maxLength(30);
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(10);
+        $row->addTextField('nameShort')->required()->maxLength(10);
 
     $fileUploader = new FileUploader($pdo, $gibbon->session);
 

--- a/modules/School Admin/house_manage_assign.php
+++ b/modules/School Admin/house_manage_assign.php
@@ -42,12 +42,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
 
     $row = $form->addRow();
         $row->addLabel('gibbonYearGroupIDList', __('Year Groups'));
-        $row->addSelectYearGroup('gibbonYearGroupIDList')->selectMultiple()->isRequired();
+        $row->addSelectYearGroup('gibbonYearGroupIDList')->selectMultiple()->required();
 
     $sql = "SELECT gibbonHouseID as value, name FROM gibbonHouse ORDER BY name";
     $row = $form->addRow();
         $row->addLabel('gibbonHouseIDList', __('Houses'));
-        $row->addSelect('gibbonHouseIDList')->fromQuery($pdo, $sql)->isRequired()->selectMultiple()->selectAll();
+        $row->addSelect('gibbonHouseIDList')->fromQuery($pdo, $sql)->required()->selectMultiple()->selectAll();
 
     $row = $form->addRow();
         $row->addLabel('balanceGender', __('Balance by Gender?'));

--- a/modules/School Admin/house_manage_edit.php
+++ b/modules/School Admin/house_manage_edit.php
@@ -66,11 +66,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(30)->setValue($values['name']);
+                $row->addTextField('name')->required()->maxLength(30)->setValue($values['name']);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(10)->setValue($values['nameShort']);
+                $row->addTextField('nameShort')->required()->maxLength(10)->setValue($values['nameShort']);
 
             $fileUploader = new FileUploader($pdo, $gibbon->session);
 

--- a/modules/School Admin/inSettings_add.php
+++ b/modules/School Admin/inSettings_add.php
@@ -46,15 +46,15 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/inSettings_ad
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(50);
+        $row->addTextField('name')->required()->maxLength(50);
     
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(5);
+        $row->addTextField('nameShort')->required()->maxLength(5);
 
     $row = $form->addRow();
         $row->addLabel('sequenceNumber', __('Sequence Number'));
-        $row->addSequenceNumber('sequenceNumber', 'gibbonINDescriptor')->isRequired()->maxLength(5);
+        $row->addSequenceNumber('sequenceNumber', 'gibbonINDescriptor')->required()->maxLength(5);
 
     $row = $form->addRow();
         $row->addLabel('description', __('Description'));

--- a/modules/School Admin/inSettings_edit.php
+++ b/modules/School Admin/inSettings_edit.php
@@ -66,15 +66,15 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/inSettings_ed
         
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(50);
+                $row->addTextField('name')->required()->maxLength(50);
             
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(5);
+                $row->addTextField('nameShort')->required()->maxLength(5);
         
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'));
-                $row->addSequenceNumber('sequenceNumber', 'gibbonINDescriptor', $values['sequenceNumber'])->isRequired()->maxLength(5);
+                $row->addSequenceNumber('sequenceNumber', 'gibbonINDescriptor', $values['sequenceNumber'])->required()->maxLength(5);
         
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));

--- a/modules/School Admin/librarySettings.php
+++ b/modules/School Admin/librarySettings.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/activitySetti
     $setting = getSettingByScope($connection2, 'Library', 'defaultLoanLength', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromString('0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31')->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromString('0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31')->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Library', 'browseBGColor', true);
 	$row = $form->addRow();

--- a/modules/School Admin/markbookSettings.php
+++ b/modules/School Admin/markbookSettings.php
@@ -41,17 +41,17 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/markbookSetti
     $setting = getSettingByScope($connection2, 'Markbook', 'enableEffort', true);
 	$row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-		$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+		$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'enableRubrics', true);
     $row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'enableColumnWeighting', true);
 	$row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-		$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+		$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('columnWeighting')->onSelect('enableColumnWeighting')->when('Y');
 
@@ -69,24 +69,24 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/markbookSetti
     $setting = getSettingByScope($connection2, 'Markbook', 'enableRawAttainment', true);
 	$row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
     
     $setting = getSettingByScope($connection2, 'Markbook', 'enableModifiedAssessment', true);
     $row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Interface'));
 
     $setting = getSettingByScope($connection2, 'Markbook', 'markbookType', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'enableGroupByTerm', true);
 	$row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-		$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+		$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'attainmentAlternativeName', true);
 	$row = $form->addRow();
@@ -113,27 +113,27 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/markbookSetti
     $setting = getSettingByScope($connection2, 'Markbook', 'showStudentAttainmentWarning', true);
     $row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'showStudentEffortWarning', true);
     $row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'showParentAttainmentWarning', true);
     $row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'showParentEffortWarning', true);
     $row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Markbook', 'personalisedWarnings', true);
     $row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
 	$row = $form->addRow();
 		$row->addFooter();

--- a/modules/School Admin/messengerSettings.php
+++ b/modules/School Admin/messengerSettings.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/messengerSett
 	$setting = getSettingByScope($connection2, 'Messenger', 'messageBubbleWidthType', true);
 	$row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-    	$row->addSelect($setting['name'])->fromString('Regular, Wide')->selected($setting['value'])->isRequired();
+    	$row->addSelect($setting['name'])->fromString('Regular, Wide')->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Messenger', 'messageBubbleBGColor', true);
 	$row = $form->addRow();
@@ -56,12 +56,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/messengerSett
 	$setting = getSettingByScope($connection2, 'Messenger', 'messageBubbleAutoHide', true);
 	$row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-		$row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+		$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
 	$setting = getSettingByScope($connection2, 'Messenger', 'enableHomeScreenWidget', true);
 	$row = $form->addRow();
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Miscellaneous'));
 

--- a/modules/School Admin/plannerSettings.php
+++ b/modules/School Admin/plannerSettings.php
@@ -63,39 +63,39 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/plannerSettin
     $setting = getSettingByScope($connection2, 'Planner', 'makeUnitsPublic', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Planner', 'shareUnitOutline', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Planner', 'allowOutcomeEditing', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Planner', 'sharingDefaultParents', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Planner', 'sharingDefaultStudents', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $form->addRow()->addHeading(__('Miscellaneous'));
 
     $setting = getSettingByScope($connection2, 'Planner', 'parentWeeklyEmailSummaryIncludeBehaviour', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Planner', 'parentWeeklyEmailSummaryIncludeMarkbook', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->isRequired()->selected($setting['value']);
+        $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/resourceSettings.php
+++ b/modules/School Admin/resourceSettings.php
@@ -39,12 +39,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/resourceSetti
     $setting = getSettingByScope($connection2, 'Resources', 'categories', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->isRequired()->setValue($setting['value']);
+        $row->addTextArea($setting['name'])->required()->setValue($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Resources', 'purposesGeneral', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->isRequired()->setValue($setting['value']);
+        $row->addTextArea($setting['name'])->required()->setValue($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Resources', 'purposesRestricted', true);
     $row = $form->addRow();

--- a/modules/School Admin/rollGroup_manage.php
+++ b/modules/School Admin/rollGroup_manage.php
@@ -91,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/rollGroup_man
             ->setIcon('copy')
             ->onClick('return confirm("'.__('Are you sure you want to continue?').' '.__('This operation cannot be undone.').'");')
             ->displayLabel()
-            ->isDirect()
+            ->directLink()
             ->append('&nbsp;|&nbsp;');
     }
 

--- a/modules/School Admin/rollGroup_manage_add.php
+++ b/modules/School Admin/rollGroup_manage_add.php
@@ -76,11 +76,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/rollGroup_man
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('name')->isRequired()->maxLength(10);
+                $row->addTextField('name')->required()->maxLength(10);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(5);
+                $row->addTextField('nameShort')->required()->maxLength(5);
 
             $row = $form->addRow();
                 $row->addLabel('tutors', __('Tutors'))->description(__('Up to 3 per roll group. The first-listed will be marked as "Main Tutor".'));

--- a/modules/School Admin/rollGroup_manage_edit.php
+++ b/modules/School Admin/rollGroup_manage_edit.php
@@ -73,11 +73,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/rollGroup_man
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('name')->isRequired()->maxLength(10);
+                $row->addTextField('name')->required()->maxLength(10);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(5);
+                $row->addTextField('nameShort')->required()->maxLength(5);
 
             $row = $form->addRow();
                 $row->addLabel('tutors', __('Tutors'))->description(__('Up to 3 per roll group. The first-listed will be marked as "Main Tutor".'));

--- a/modules/School Admin/schoolYearSpecialDay_manage_add.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_add.php
@@ -80,11 +80,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromArray($types)->isRequired()->placeholder();
+                $row->addSelect('type')->fromArray($types)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(20);
+                $row->addTextField('name')->required()->maxLength(20);
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));

--- a/modules/School Admin/schoolYearSpecialDay_manage_edit.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_edit.php
@@ -78,11 +78,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromArray($types)->isRequired()->placeholder();
+                $row->addSelect('type')->fromArray($types)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(20);
+                $row->addTextField('name')->required()->maxLength(20);
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));

--- a/modules/School Admin/schoolYearTerm_manage_add.php
+++ b/modules/School Admin/schoolYearTerm_manage_add.php
@@ -46,27 +46,27 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
 
     $row = $form->addRow();
         $row->addLabel('gibbonSchoolYearID', __('School Year'));
-        $row->addSelectSchoolYear('gibbonSchoolYearID')->isRequired();
+        $row->addSelectSchoolYear('gibbonSchoolYearID')->required();
 
     $row = $form->addRow();
         $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-        $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYearTerm')->isRequired()->maxLength(3);
+        $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYearTerm')->required()->maxLength(3);
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->isRequired()->maxLength(20);
+        $row->addTextField('name')->required()->maxLength(20);
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(4);
+        $row->addTextField('nameShort')->required()->maxLength(4);
 
     $row = $form->addRow();
         $row->addLabel('firstDay', __('First Day'));
-        $row->addDate('firstDay')->isRequired();
+        $row->addDate('firstDay')->required();
 
     $row = $form->addRow();
         $row->addLabel('lastDay', __('Last Day'));
-        $row->addDate('lastDay')->isRequired();
+        $row->addDate('lastDay')->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/schoolYearTerm_manage_edit.php
+++ b/modules/School Admin/schoolYearTerm_manage_edit.php
@@ -65,30 +65,30 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
 
 		    $row = $form->addRow();
 		        $row->addLabel('gibbonSchoolYearID', __('School Year'));
-		        $row->addSelectSchoolYear('gibbonSchoolYearID')->isRequired()->selected($values['gibbonSchoolYearID']);
+		        $row->addSelectSchoolYear('gibbonSchoolYearID')->required()->selected($values['gibbonSchoolYearID']);
 
 		    $row = $form->addRow();
 		        $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
 		        $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYearTerm', $values['sequenceNumber'])
-		        	->isRequired()
+		        	->required()
 		        	->maxLength(3)
 		        	->setValue($values['sequenceNumber']);
 
 		    $row = $form->addRow();
 		        $row->addLabel('name', __('Name'));
-		        $row->addTextField('name')->isRequired()->maxLength(20)->setValue($values['name']);
+		        $row->addTextField('name')->required()->maxLength(20)->setValue($values['name']);
 
 		    $row = $form->addRow();
 		        $row->addLabel('nameShort', __('Short Name'));
-		        $row->addTextField('nameShort')->isRequired()->maxLength(4)->setValue($values['nameShort']);
+		        $row->addTextField('nameShort')->required()->maxLength(4)->setValue($values['nameShort']);
 
 		    $row = $form->addRow();
 		        $row->addLabel('firstDay', __('First Day'));
-		        $row->addDate('firstDay')->isRequired()->setValue(dateConvertBack($guid, $values['firstDay']));
+		        $row->addDate('firstDay')->required()->setValue(dateConvertBack($guid, $values['firstDay']));
 
 		    $row = $form->addRow();
 		        $row->addLabel('lastDay', __('Last Day'));
-		        $row->addDate('lastDay')->isRequired()->setValue(dateConvertBack($guid, $values['lastDay']));
+		        $row->addDate('lastDay')->required()->setValue(dateConvertBack($guid, $values['lastDay']));
 
 		    $row = $form->addRow();
 		        $row->addFooter();

--- a/modules/School Admin/schoolYear_manage_add.php
+++ b/modules/School Admin/schoolYear_manage_add.php
@@ -52,11 +52,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->isRequired()->maxLength(9);
+        $row->addTextField('name')->required()->maxLength(9);
 
     $row = $form->addRow();
         $row->addLabel('status', __('Status'));
-        $row->addSelect('status')->fromArray($statuses)->isRequired()->selected('Upcoming');
+        $row->addSelect('status')->fromArray($statuses)->required()->selected('Upcoming');
 
     $form->toggleVisibilityByClass('statusChange')->onSelect('status')->when('Current');
     $direction = __('Past');
@@ -67,15 +67,15 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
 
     $row = $form->addRow();
         $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-        $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYear')->isRequired()->maxLength(3);
+        $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYear')->required()->maxLength(3);
 
     $row = $form->addRow();
         $row->addLabel('firstDay', __('First Day'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('firstDay')->isRequired();
+        $row->addDate('firstDay')->required();
 
     $row = $form->addRow();
         $row->addLabel('lastDay', __('Last Day'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('lastDay')->isRequired();
+        $row->addDate('lastDay')->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/School Admin/schoolYear_manage_edit.php
+++ b/modules/School Admin/schoolYear_manage_edit.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(9)->setValue($values['name']);
+                $row->addTextField('name')->required()->maxLength(9)->setValue($values['name']);
 
             if ($values['status'] == 'Current') {
                 $form->addHiddenValue('status', $values['status']);
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
             } else {
                 $row = $form->addRow();
                     $row->addLabel('status', __('Status'));
-                    $row->addSelect('status')->fromArray($statuses)->isRequired()->selected($values['status']);
+                    $row->addSelect('status')->fromArray($statuses)->required()->selected($values['status']);
 
                     $form->toggleVisibilityByClass('statusChange')->onSelect('status')->when('Current');
                     $direction = ($values['sequenceNumber'] < $_SESSION[$guid]['gibbonSchoolYearSequenceNumberCurrent'])? __('Upcoming') : __('Past');
@@ -94,15 +94,15 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYear_ma
 
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-                $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYear', $values['sequenceNumber'])->isRequired()->maxLength(3)->setValue($values['sequenceNumber']);
+                $row->addSequenceNumber('sequenceNumber', 'gibbonSchoolYear', $values['sequenceNumber'])->required()->maxLength(3)->setValue($values['sequenceNumber']);
 
             $row = $form->addRow();
                 $row->addLabel('firstDay', __('First Day'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                $row->addDate('firstDay')->isRequired()->setValue(dateConvertBack($guid, $values['firstDay']));
+                $row->addDate('firstDay')->required()->setValue(dateConvertBack($guid, $values['firstDay']));
 
             $row = $form->addRow();
                 $row->addLabel('lastDay', __('Last Day'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                $row->addDate('lastDay')->isRequired()->setValue(dateConvertBack($guid, $values['lastDay']));
+                $row->addDate('lastDay')->required()->setValue(dateConvertBack($guid, $values['lastDay']));
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/School Admin/spaceSettings.php
+++ b/modules/School Admin/spaceSettings.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/spaceSettings
     $setting = getSettingByScope($connection2, 'School Admin', 'facilityTypes', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
     $row = $form->addRow();
 		$row->addFooter();

--- a/modules/School Admin/space_manage_add.php
+++ b/modules/School Admin/space_manage_add.php
@@ -44,13 +44,13 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(30);
+        $row->addTextField('name')->required()->maxLength(30);
 
     $types = getSettingByScope($connection2, 'School Admin', 'facilityTypes');
 
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addSelect('type')->fromString($types)->isRequired()->placeholder();
+        $row->addSelect('type')->fromString($types)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('capacity', __('Capacity'));

--- a/modules/School Admin/space_manage_edit.php
+++ b/modules/School Admin/space_manage_edit.php
@@ -64,13 +64,13 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(30);
+                $row->addTextField('name')->required()->maxLength(30);
 
             $types = getSettingByScope($connection2, 'School Admin', 'facilityTypes');
 
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromString($types)->isRequired()->placeholder();
+                $row->addSelect('type')->fromString($types)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('capacity', __('Capacity'));

--- a/modules/School Admin/studentsSettings.php
+++ b/modules/School Admin/studentsSettings.php
@@ -93,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
     $setting = getSettingByScope($connection2, 'Students', 'enableStudentNotes', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Students', 'noteCreationNotification', true);
     $noteCreationNotificationRoles = array(
@@ -102,7 +102,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
     );
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromArray($noteCreationNotificationRoles)->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray($noteCreationNotificationRoles)->selected($setting['value'])->required();
 
     $form->addRow()->addHeading(__('Alerts'));
 
@@ -115,7 +115,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
             ->decimalPlaces(0)
             ->minimum(0)
             ->maximum(50)
-            ->isRequired();
+            ->required();
 
     $setting = getSettingByScope($connection2, 'Students', 'academicAlertMediumThreshold', true);
     $row = $form->addRow();
@@ -126,7 +126,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
             ->decimalPlaces(0)
             ->minimum(0)
             ->maximum(50)
-            ->isRequired();
+            ->required();
 
     $setting = getSettingByScope($connection2, 'Students', 'academicAlertHighThreshold', true);
     $row = $form->addRow();
@@ -137,7 +137,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
             ->decimalPlaces(0)
             ->minimum(0)
             ->maximum(50)
-            ->isRequired();
+            ->required();
 
         $setting = getSettingByScope($connection2, 'Students', 'behaviourAlertLowThreshold', true);
         $row = $form->addRow();
@@ -148,7 +148,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
                 ->decimalPlaces(0)
                 ->minimum(0)
                 ->maximum(50)
-                ->isRequired();
+                ->required();
 
         $setting = getSettingByScope($connection2, 'Students', 'behaviourAlertMediumThreshold', true);
         $row = $form->addRow();
@@ -159,7 +159,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
                 ->decimalPlaces(0)
                 ->minimum(0)
                 ->maximum(50)
-                ->isRequired();
+                ->required();
 
         $setting = getSettingByScope($connection2, 'Students', 'behaviourAlertHighThreshold', true);
         $row = $form->addRow();
@@ -170,14 +170,14 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
                 ->decimalPlaces(0)
                 ->minimum(0)
                 ->maximum(50)
-                ->isRequired();
+                ->required();
 
     $form->addRow()->addHeading(__('Miscellaneous'));
 
     $setting = getSettingByScope($connection2, 'Students', 'extendedBriefProfile', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'School Admin', 'studentAgreementOptions', true);
     $row = $form->addRow();

--- a/modules/School Admin/studentsSettings_noteCategory_add.php
+++ b/modules/School Admin/studentsSettings_noteCategory_add.php
@@ -44,11 +44,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(30);
+        $row->addTextField('name')->required()->maxLength(30);
     
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $row = $form->addRow();
         $row->addLabel('template', __('Template'))->description(__('HTML code to be inserted into blank note.'));

--- a/modules/School Admin/studentsSettings_noteCategory_edit.php
+++ b/modules/School Admin/studentsSettings_noteCategory_edit.php
@@ -63,11 +63,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/studentsSetti
         
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(30);
+                $row->addTextField('name')->required()->maxLength(30);
             
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
         
             $row = $form->addRow();
                 $row->addLabel('template', __('Template'))->description(__('HTML code to be inserted into blank note.'));

--- a/modules/School Admin/yearGroup_manage_add.php
+++ b/modules/School Admin/yearGroup_manage_add.php
@@ -46,15 +46,15 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->isRequired()->maxLength(15);
+        $row->addTextField('name')->required()->maxLength(15);
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(4);
+        $row->addTextField('nameShort')->required()->maxLength(4);
 
     $row = $form->addRow();
         $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-        $row->addSequenceNumber('sequenceNumber', 'gibbonYearGroup')->isRequired()->maxLength(3);
+        $row->addSequenceNumber('sequenceNumber', 'gibbonYearGroup')->required()->maxLength(3);
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonIDHOY', __('Head of Year'));

--- a/modules/School Admin/yearGroup_manage_edit.php
+++ b/modules/School Admin/yearGroup_manage_edit.php
@@ -66,16 +66,16 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->isRequired()->maxLength(15)->setValue($values['name']);
+                $row->addTextField('name')->required()->maxLength(15)->setValue($values['name']);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique.'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(4)->setValue($values['nameShort']);
+                $row->addTextField('nameShort')->required()->maxLength(4)->setValue($values['nameShort']);
 
             $row = $form->addRow();
                 $row->addLabel('sequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
                 $row->addSequenceNumber('sequenceNumber', 'gibbonYearGroup', $values['sequenceNumber'])
-                    ->isRequired()
+                    ->required()
                     ->maxLength(3)
                     ->setValue($values['sequenceNumber']);
             

--- a/modules/Staff/applicationForm.php
+++ b/modules/Staff/applicationForm.php
@@ -120,14 +120,14 @@ if ($proceed == false) {
         }
         $row = $form->addRow();
             $row->addLabel('gibbonStaffJobOpeningID[]', __('Job Openings'))->description(__('Please select one or more jobs to apply for.'));
-            $row->addCheckbox('gibbonStaffJobOpeningID[]')->fromArray($jobOpeningsProcessed)->isRequired();
+            $row->addCheckbox('gibbonStaffJobOpeningID[]')->fromArray($jobOpeningsProcessed)->required();
 
         $staffApplicationFormQuestions = getSettingByScope($connection2, 'Staff', 'staffApplicationFormQuestions');
         if ($staffApplicationFormQuestions != '') {
             $row = $form->addRow();
                 $column = $row->addColumn();
                 $column->addLabel('questions', __('Application Questions'))->description(__('Please answer the following questions in relation to your application.'));
-                $column->addEditor('questions', $guid)->setRows(10)->setValue($staffApplicationFormQuestions)->isRequired();
+                $column->addEditor('questions', $guid)->setRows(10)->setValue($staffApplicationFormQuestions)->required();
         }
 
         $form->addRow()->addHeading(__('Personal Data'));
@@ -136,28 +136,28 @@ if ($proceed == false) {
             $form->addHiddenValue('gibbonPersonID', $gibbonPersonID);
             $row = $form->addRow();
                 $row->addLabel('surname', __('Surname'));
-                $row->addTextField('surname')->isRequired()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['surname']);
+                $row->addTextField('surname')->required()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['surname']);
 
             $row = $form->addRow();
                 $row->addLabel('preferredName', __('Preferred Name'));
-                $row->addTextField('preferredName')->isRequired()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['preferredName']);
+                $row->addTextField('preferredName')->required()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['preferredName']);
         }
         else { //Not logged in
             $row = $form->addRow();
                 $row->addLabel('surname', __('Surname'))->description(__('Family name as shown in ID documents.'));
-                $row->addTextField('surname')->isRequired()->maxLength(30);
+                $row->addTextField('surname')->required()->maxLength(30);
 
             $row = $form->addRow();
                 $row->addLabel('firstName', __('First Name'))->description(__('First name as shown in ID documents.'));
-                $row->addTextField('firstName')->isRequired()->maxLength(30);
+                $row->addTextField('firstName')->required()->maxLength(30);
 
             $row = $form->addRow();
                 $row->addLabel('preferredName', __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-                $row->addTextField('preferredName')->isRequired()->maxLength(30);
+                $row->addTextField('preferredName')->required()->maxLength(30);
 
             $row = $form->addRow();
                 $row->addLabel('officialName', __('Official Name'))->description(__('Full name as shown in ID documents.'));
-                $row->addTextField('officialName')->isRequired()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
+                $row->addTextField('officialName')->required()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
 
             $row = $form->addRow();
                 $row->addLabel('nameInCharacters', __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -165,17 +165,17 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('gender', __('Gender'));
-                $row->addSelectGender('gender')->isRequired();
+                $row->addSelectGender('gender')->required();
 
             $row = $form->addRow();
                 $row->addLabel('dob', __('Date of Birth'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                $row->addDate('dob')->isRequired();
+                $row->addDate('dob')->required();
 
             $form->addRow()->addHeading(__('Background Data'));
 
             $row = $form->addRow();
                 $row->addLabel('languageFirst', __('First Language'))->description(__('Student\'s native/first/mother language.'));
-                $row->addSelectLanguage('languageFirst')->isRequired();
+                $row->addSelectLanguage('languageFirst')->required();
 
             $row = $form->addRow();
                 $row->addLabel('languageSecond', __('Second Language'));
@@ -187,15 +187,15 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('countryOfBirth', __('Country of Birth'));
-                $row->addSelectCountry('countryOfBirth')->isRequired();
+                $row->addSelectCountry('countryOfBirth')->required();
 
             $row = $form->addRow();
                 $row->addLabel('citizenship1', __('Citizenship'));
                 $nationalityList = getSettingByScope($connection2, 'User Admin', 'nationality');
                 if (!empty($nationalityList)) {
-                    $row->addSelect('citizenship1')->isRequired()->fromString($nationalityList)->placeholder(__('Please select...'));
+                    $row->addSelect('citizenship1')->required()->fromString($nationalityList)->placeholder(__('Please select...'));
                 } else {
-                    $row->addSelectCountry('citizenship1')->isRequired();
+                    $row->addSelectCountry('citizenship1')->required();
                 }
 
             $countryName = (isset($_SESSION[$guid]['country']))? $_SESSION[$guid]['country'].' ' : '';
@@ -224,23 +224,23 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('email', __('Email'));
-                $email = $row->addEmail('email')->isRequired();
+                $email = $row->addEmail('email')->required();
 
             $row = $form->addRow();
                 $row->addLabel('phone1', __('Phone'))->description(__('Type, country code, number.'));
-                $row->addPhoneNumber('phone1')->isRequired();
+                $row->addPhoneNumber('phone1')->required();
 
             $row = $form->addRow();
                 $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-                $row->addTextField('homeAddress')->isRequired()->maxLength(255);
+                $row->addTextField('homeAddress')->required()->maxLength(255);
 
             $row = $form->addRow();
                 $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));
-                $row->addTextFieldDistrict('homeAddressDistrict')->isRequired();
+                $row->addTextFieldDistrict('homeAddressDistrict')->required();
 
             $row = $form->addRow();
                 $row->addLabel('homeAddressCountry', __('Home Address (Country)'));
-                $row->addSelectCountry('homeAddressCountry')->isRequired();
+                $row->addSelectCountry('homeAddressCountry')->required();
         }
 
         // CUSTOM FIELDS FOR STAFF
@@ -303,11 +303,11 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('referenceEmail1', __('Referee 1'))->description(__('An email address for a referee at the applicant\'s current school.'));
-                $row->addEmail('referenceEmail1')->isRequired();
+                $row->addEmail('referenceEmail1')->required();
 
             $row = $form->addRow();
                 $row->addLabel('referenceEmail2', __('Referee 2'))->description(__('An email address for a second referee.'));
-                $row->addEmail('referenceEmail2')->isRequired();
+                $row->addEmail('referenceEmail2')->required();
         }
 
         //AGREEMENT
@@ -317,7 +317,7 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('agreement', '<b>'.__('Do you agree to the above?').'</b>');
-                $row->addCheckbox('agreement')->description(__('Yes'))->setValue('on')->isRequired();
+                $row->addCheckbox('agreement')->description(__('Yes'))->setValue('on')->required();
         }
 
         $row = $form->addRow();

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -85,11 +85,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
             $row = $form->addRow();
                 $row->addLabel('gibbonStaffApplicationFormID', __('Application ID'));
-                $row->addTextField('gibbonStaffApplicationFormID')->readOnly()->isRequired();
+                $row->addTextField('gibbonStaffApplicationFormID')->readOnly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('priority', __('Priority'))->description(__('Higher priority applicants appear first in list of applications.'));
-                $row->addSelect('priority')->fromArray(range(-9, 9))->isRequired();
+                $row->addSelect('priority')->fromArray(range(-9, 9))->required();
 
             // STATUS
             if ($values['status'] != 'Accepted') {
@@ -100,11 +100,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 );
                 $row = $form->addRow();
                         $row->addLabel('status', __('Status'))->description(__('Manually set status. "Approved" not permitted.'));
-                        $row->addSelect('status')->isRequired()->fromArray($statuses)->selected($values['status']);
+                        $row->addSelect('status')->required()->fromArray($statuses)->selected($values['status']);
             } else {
                 $row = $form->addRow();
                     $row->addLabel('status', __('Status'))->description(__('Manually set status. "Approved" not permitted.'));
-                    $row->addTextField('status')->isRequired()->readOnly()->setValue($values['status']);
+                    $row->addTextField('status')->required()->readOnly()->setValue($values['status']);
             }
 
             // MILESTONES
@@ -138,12 +138,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
             $row = $form->addRow();
                 $row->addLabel('type', __('Job Type'));
-                $row->addTextField('type')->readOnly()->isRequired();
+                $row->addTextField('type')->readOnly()->required();
 
             $form->addHiddenValue('gibbonStaffJobOpeningID', $values['gibbonStaffJobOpeningID']);
             $row = $form->addRow();
                 $row->addLabel('jobTitle', __('Job Opening'));
-                $row->addTextField('jobTitle')->readOnly()->isRequired();
+                $row->addTextField('jobTitle')->readOnly()->required();
 
             $staffApplicationFormQuestions = getSettingByScope($connection2, 'Staff', 'staffApplicationFormQuestions');
             if ($staffApplicationFormQuestions != '') {
@@ -159,28 +159,28 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 $form->addHiddenValue('gibbonPersonID', $values['gibbonPersonID']);
                 $row = $form->addRow();
                     $row->addLabel('surname', __('Surname'));
-                    $row->addTextField('surname')->isRequired()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['surname']);
+                    $row->addTextField('surname')->required()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['surname']);
 
                 $row = $form->addRow();
                     $row->addLabel('preferredName', __('Preferred Name'));
-                    $row->addTextField('preferredName')->isRequired()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['preferredName']);
+                    $row->addTextField('preferredName')->required()->maxLength(30)->readonly()->setValue($_SESSION[$guid]['preferredName']);
             }
             else { //Not logged in
                 $row = $form->addRow();
                     $row->addLabel('surname', __('Surname'))->description(__('Family name as shown in ID documents.'));
-                    $row->addTextField('surname')->isRequired()->maxLength(30);
+                    $row->addTextField('surname')->required()->maxLength(30);
 
                 $row = $form->addRow();
                     $row->addLabel('firstName', __('First Name'))->description(__('First name as shown in ID documents.'));
-                    $row->addTextField('firstName')->isRequired()->maxLength(30);
+                    $row->addTextField('firstName')->required()->maxLength(30);
 
                 $row = $form->addRow();
                     $row->addLabel('preferredName', __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-                    $row->addTextField('preferredName')->isRequired()->maxLength(30);
+                    $row->addTextField('preferredName')->required()->maxLength(30);
 
                 $row = $form->addRow();
                     $row->addLabel('officialName', __('Official Name'))->description(__('Full name as shown in ID documents.'));
-                    $row->addTextField('officialName')->isRequired()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
+                    $row->addTextField('officialName')->required()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
 
                 $row = $form->addRow();
                     $row->addLabel('nameInCharacters', __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -188,17 +188,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                 $row = $form->addRow();
                     $row->addLabel('gender', __('Gender'));
-                    $row->addSelectGender('gender')->isRequired();
+                    $row->addSelectGender('gender')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('dob', __('Date of Birth'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                    $row->addDate('dob')->isRequired();
+                    $row->addDate('dob')->required();
 
                 $form->addRow()->addHeading(__('Background Data'));
 
                 $row = $form->addRow();
                     $row->addLabel('languageFirst', __('First Language'))->description(__('Student\'s native/first/mother language.'));
-                    $row->addSelectLanguage('languageFirst')->isRequired();
+                    $row->addSelectLanguage('languageFirst')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('languageSecond', __('Second Language'));
@@ -210,15 +210,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                 $row = $form->addRow();
                     $row->addLabel('countryOfBirth', __('Country of Birth'));
-                    $row->addSelectCountry('countryOfBirth')->isRequired();
+                    $row->addSelectCountry('countryOfBirth')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('citizenship1', __('Citizenship'));
                     $nationalityList = getSettingByScope($connection2, 'User Admin', 'nationality');
                     if (!empty($nationalityList)) {
-                        $row->addSelect('citizenship1')->isRequired()->fromString($nationalityList)->placeholder(__('Please select...'));
+                        $row->addSelect('citizenship1')->required()->fromString($nationalityList)->placeholder(__('Please select...'));
                     } else {
-                        $row->addSelectCountry('citizenship1')->isRequired();
+                        $row->addSelectCountry('citizenship1')->required();
                     }
 
                 $countryName = (isset($_SESSION[$guid]['country']))? $_SESSION[$guid]['country'].' ' : '';
@@ -247,7 +247,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                 $row = $form->addRow();
                     $row->addLabel('email', __('Email'));
-                    $email = $row->addEmail('email')->isRequired();
+                    $email = $row->addEmail('email')->required();
 
                     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
                     if ($uniqueEmailAddress == 'Y') {
@@ -256,19 +256,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                 $row = $form->addRow();
                     $row->addLabel('phone1', __('Phone'))->description(__('Type, country code, number.'));
-                    $row->addPhoneNumber('phone1')->isRequired();
+                    $row->addPhoneNumber('phone1')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-                    $row->addTextField('homeAddress')->isRequired()->maxLength(255);
+                    $row->addTextField('homeAddress')->required()->maxLength(255);
 
                 $row = $form->addRow();
                     $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));
-                    $row->addTextFieldDistrict('homeAddressDistrict')->isRequired();
+                    $row->addTextFieldDistrict('homeAddressDistrict')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('homeAddressCountry', __('Home Address (Country)'));
-                    $row->addSelectCountry('homeAddressCountry')->isRequired();
+                    $row->addSelectCountry('homeAddressCountry')->required();
             }
 
             // CUSTOM FIELDS FOR STAFF
@@ -337,11 +337,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                 $row = $form->addRow();
                     $row->addLabel('referenceEmail1', __('Referee 1'))->description(__('An email address for a referee at the applicant\'s current school.'));
-                    $row->addEmail('referenceEmail1')->isRequired();
+                    $row->addEmail('referenceEmail1')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('referenceEmail2', __('Referee 2'))->description(__('An email address for a second referee.'));
-                    $row->addEmail('referenceEmail2')->isRequired();
+                    $row->addEmail('referenceEmail2')->required();
 
             }
 

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -251,7 +251,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
                     if ($uniqueEmailAddress == 'Y') {
-                        $email->isUnique('./modules/User Admin/user_manage_emailAjax.php');
+                        $email->uniqueField('./modules/User Admin/user_manage_emailAjax.php');
                     }
 
                 $row = $form->addRow();

--- a/modules/Staff/jobOpenings_manage_add.php
+++ b/modules/Staff/jobOpenings_manage_add.php
@@ -50,25 +50,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage_a
     $types[__('System Roles')] = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addSelect('type')->fromArray($types)->placeholder()->isRequired();
+        $row->addSelect('type')->fromArray($types)->placeholder()->required();
 
     $row = $form->addRow();
         $row->addLabel('jobTitle', __('Job Title'));
-        $row->addTextField('jobTitle')->maxlength(100)->isRequired();
+        $row->addTextField('jobTitle')->maxlength(100)->required();
 
     $row = $form->addRow();
         $row->addLabel('dateOpen', __('Opening Date'));
-        $row->addDate('dateOpen')->isRequired();
+        $row->addDate('dateOpen')->required();
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $jobOpeningDescriptionTemplate = getSettingByScope($connection2, 'Staff', 'jobOpeningDescriptionTemplate');
     $row = $form->addRow();
         $column = $row->addColumn();
         $column->addLabel('description', __('Description'));
-        $column->addEditor('description', $guid)->setRows(20)->showMedia()->setValue($jobOpeningDescriptionTemplate)->isRequired();
+        $column->addEditor('description', $guid)->setRows(20)->showMedia()->setValue($jobOpeningDescriptionTemplate)->required();
 
     $row = $form->addRow();
     $row->addFooter();

--- a/modules/Staff/jobOpenings_manage_edit.php
+++ b/modules/Staff/jobOpenings_manage_edit.php
@@ -70,24 +70,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage_e
             $types[__('System Roles')] = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromArray($types)->placeholder()->isRequired();
+                $row->addSelect('type')->fromArray($types)->placeholder()->required();
 
             $row = $form->addRow();
                 $row->addLabel('jobTitle', __('Job Title'));
-                $row->addTextField('jobTitle')->maxlength(100)->isRequired();
+                $row->addTextField('jobTitle')->maxlength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel('dateOpen', __('Opening Date'));
-                $row->addDate('dateOpen')->isRequired();
+                $row->addDate('dateOpen')->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $row = $form->addRow();
                 $column = $row->addColumn();
                 $column->addLabel('description', __('Description'));
-                $column->addEditor('description', $guid)->setRows(20)->showMedia()->isRequired();
+                $column->addEditor('description', $guid)->setRows(20)->showMedia()->required();
 
             $form->loadAllValuesFrom($values);
 

--- a/modules/Staff/staff_manage.php
+++ b/modules/Staff/staff_manage.php
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage.php') =
 
     $col = $form->createBulkActionColumn($bulkActions);
         $col->addDate('dateEnd')
-            ->isRequired()
+            ->required()
             ->placeholder(__('Date End'))
             ->setClass('shortWidth dateEnd');
         $col->addSubmit(__('Go'));

--- a/modules/Staff/staff_manage_add.php
+++ b/modules/Staff/staff_manage_add.php
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_add.php
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Person'))->description(__('Must be unique.'));
-        $row->addSelectUsers('gibbonPersonID')->placeholder()->isRequired();
+        $row->addSelectUsers('gibbonPersonID')->placeholder()->required();
 
     $row = $form->addRow();
         $row->addLabel('initials', __('Initials'))->description(__('Must be unique if set.'));
@@ -71,7 +71,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_add.php
     $types[__('System Roles')] = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addSelect('type')->fromArray($types)->placeholder()->isRequired();
+        $row->addSelect('type')->fromArray($types)->placeholder()->required();
 
     $row = $form->addRow();
         $row->addLabel('jobTitle', __('Job Title'));

--- a/modules/Staff/staff_manage_edit.php
+++ b/modules/Staff/staff_manage_edit.php
@@ -102,7 +102,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
                 $types[__('System Roles')] = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
                 $row = $form->addRow();
                     $row->addLabel('type', __('Type'));
-                    $row->addSelect('type')->fromArray($types)->placeholder()->isRequired();
+                    $row->addSelect('type')->fromArray($types)->placeholder()->required();
 
                 $row = $form->addRow();
                     $row->addLabel('jobTitle', __('Job Title'));

--- a/modules/Staff/staff_manage_edit_contract_add.php
+++ b/modules/Staff/staff_manage_edit_contract_add.php
@@ -82,19 +82,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_co
 
             $row = $form->addRow();
                 $row->addLabel('person', __('Person'));
-                $row->addTextField('person')->setValue(Format::name('', $values['preferredName'], $values['surname'], 'Student'))->readonly()->isRequired();
+                $row->addTextField('person')->setValue(Format::name('', $values['preferredName'], $values['surname'], 'Student'))->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('title', __('Title'))->description(__('A name to identify this contract.'));
-                $row->addTextField('title')->maxlength(100)->isRequired();
+                $row->addTextField('title')->maxlength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel('status', __('Status'));
-                $row->addSelect('status')->fromArray(array('Pending' => __('Pending'), 'Active' => __('Active'), 'Expired' => __('Expired')))->isRequired()->placeholder();
+                $row->addSelect('status')->fromArray(array('Pending' => __('Pending'), 'Active' => __('Active'), 'Expired' => __('Expired')))->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('dateStart', __('Start Date'));
-                $row->addDate('dateStart')->isRequired();
+                $row->addDate('dateStart')->required();
 
             $row = $form->addRow();
                 $row->addLabel('dateEnd', __('End Date'));

--- a/modules/Staff/staff_manage_edit_contract_edit.php
+++ b/modules/Staff/staff_manage_edit_contract_edit.php
@@ -79,19 +79,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_co
 
             $row = $form->addRow();
                 $row->addLabel('person', __('Person'));
-                $row->addTextField('person')->setValue(Format::name('', $values['preferredName'], $values['surname'], 'Student'))->readonly()->isRequired();
+                $row->addTextField('person')->setValue(Format::name('', $values['preferredName'], $values['surname'], 'Student'))->readonly()->required();
 
             $row = $form->addRow();
                 $row->addLabel('title', __('Title'))->description(__('A name to identify this contract.'));
-                $row->addTextField('title')->maxlength(100)->isRequired();
+                $row->addTextField('title')->maxlength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel('status', __('Status'));
-                $row->addSelect('status')->fromArray(array('Pending' => __('Pending'), 'Active' => __('Active'), 'Expired' => __('Expired')))->isRequired()->placeholder();
+                $row->addSelect('status')->fromArray(array('Pending' => __('Pending'), 'Active' => __('Active'), 'Expired' => __('Expired')))->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('dateStart', __('Start Date'));
-                $row->addDate('dateStart')->isRequired();
+                $row->addDate('dateStart')->required();
 
             $row = $form->addRow();
                 $row->addLabel('dateEnd', __('End Date'));

--- a/modules/Staff/staff_manage_edit_facility_add.php
+++ b/modules/Staff/staff_manage_edit_facility_add.php
@@ -79,7 +79,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_fa
 
             $row = $form->addRow();
                 $row->addLabel('person', __('Person'));
-                $row->addTextField('person')->setValue(Format::name('', $values['preferredName'], $values['surname'], 'Student'))->readonly()->isRequired();
+                $row->addTextField('person')->setValue(Format::name('', $values['preferredName'], $values['surname'], 'Student'))->readonly()->required();
 
             $data = array('gibbonPersonID' => $gibbonPersonID);
             $sql = "SELECT gibbonSpace.gibbonSpaceID AS value, name
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_fa
                 ORDER BY gibbonSpace.name";
             $row = $form->addRow();
                 $row->addLabel('gibbonSpaceID', __('Facility'));
-                $row->addSelect('gibbonSpaceID')->fromQuery($pdo, $sql, $data)->placeholder()->isRequired();
+                $row->addSelect('gibbonSpaceID')->fromQuery($pdo, $sql, $data)->placeholder()->required();
 
             $row = $form->addRow();
                 $row->addLabel('usageType', __('Usage Type'));

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -197,19 +197,19 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('surname', __('Surname'))->description(__('Family name as shown in ID documents.'));
-        $row->addTextField('surname')->isRequired()->maxLength(60);
+        $row->addTextField('surname')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('firstName', __('First Name'))->description(__('First name as shown in ID documents.'));
-        $row->addTextField('firstName')->isRequired()->maxLength(60);
+        $row->addTextField('firstName')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('preferredName', __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-        $row->addTextField('preferredName')->isRequired()->maxLength(60);
+        $row->addTextField('preferredName')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('officialName', __('Official Name'))->description(__('Full name as shown in ID documents.'));
-        $row->addTextField('officialName')->isRequired()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
+        $row->addTextField('officialName')->required()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
 
     $row = $form->addRow();
         $row->addLabel('nameInCharacters', __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -217,18 +217,18 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('gender', __('Gender'));
-        $row->addSelectGender('gender')->isRequired();
+        $row->addSelectGender('gender')->required();
 
     $row = $form->addRow();
         $row->addLabel('dob', __('Date of Birth'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dob')->isRequired();
+        $row->addDate('dob')->required();
 
     // STUDENT BACKGROUND
     $form->addRow()->addSubheading(__('Student Background'));
 
     $row = $form->addRow();
         $row->addLabel('languageHomePrimary', __('Home Language - Primary'))->description(__('The primary language used in the student\'s home.'));
-        $row->addSelectLanguage('languageHomePrimary')->isRequired();
+        $row->addSelectLanguage('languageHomePrimary')->required();
 
     $row = $form->addRow();
         $row->addLabel('languageHomeSecondary', __('Home Language - Secondary'));
@@ -236,7 +236,7 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('languageFirst', __('First Language'))->description(__('Student\'s native/first/mother language.'));
-        $row->addSelectLanguage('languageFirst')->isRequired();
+        $row->addSelectLanguage('languageFirst')->required();
 
     $row = $form->addRow();
         $row->addLabel('languageSecond', __('Second Language'));
@@ -248,15 +248,15 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('countryOfBirth', __('Country of Birth'));
-        $row->addSelectCountry('countryOfBirth')->isRequired();
+        $row->addSelectCountry('countryOfBirth')->required();
 
     $row = $form->addRow();
         $row->addLabel('citizenship1', __('Citizenship'));
         $nationalityList = getSettingByScope($connection2, 'User Admin', 'nationality');
         if (!empty($nationalityList)) {
-            $row->addSelect('citizenship1')->isRequired()->fromString($nationalityList)->placeholder(__('Please select...'));
+            $row->addSelect('citizenship1')->required()->fromString($nationalityList)->placeholder(__('Please select...'));
         } else {
-            $row->addSelectCountry('citizenship1')->isRequired();
+            $row->addSelectCountry('citizenship1')->required();
         }
 
     $countryName = (isset($_SESSION[$guid]['country']))? $_SESSION[$guid]['country'].' ' : '';
@@ -310,7 +310,7 @@ if ($proceed == false) {
 
         $row = $form->addRow();
             $row->addLabel('sen', __('Special Educational Needs (SEN)'))->description(__('Are there any known or suspected SEN concerns, or previous SEN assessments?'));
-            $row->addYesNo('sen')->isRequired()->placeholder(__('Please select...'));
+            $row->addYesNo('sen')->required()->placeholder(__('Please select...'));
 
         $form->toggleVisibilityByClass('senDetailsRow')->onSelect('sen')->when('Y');
 
@@ -344,16 +344,16 @@ if ($proceed == false) {
             $data = array();
             $sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear WHERE (status='Current' OR status='Upcoming') ORDER BY sequenceNumber";
         }
-        $row->addSelect('gibbonSchoolYearIDEntry')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder(__('Please select...'));
+        $row->addSelect('gibbonSchoolYearIDEntry')->fromQuery($pdo, $sql, $data)->required()->placeholder(__('Please select...'));
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Intended Start Date'))->description(__('Student\'s intended first day at school.'))->append('<br/>'.__('Format:'))->append(' '.$_SESSION[$guid]['i18n']['dateFormat']);
-        $row->addDate('dateStart')->isRequired();
+        $row->addDate('dateStart')->required();
 
     $row = $form->addRow();
         $row->addLabel('gibbonYearGroupIDEntry', __('Year Group at Entry'))->description('Which year level will student enter.');
         $sql = "SELECT gibbonYearGroupID as value, name FROM gibbonYearGroup ORDER BY sequenceNumber";
-        $row->addSelect('gibbonYearGroupIDEntry')->fromQuery($pdo, $sql)->isRequired()->placeholder(__('Please select...'));
+        $row->addSelect('gibbonYearGroupIDEntry')->fromQuery($pdo, $sql)->required()->placeholder(__('Please select...'));
 
     // DAY TYPE
     $dayTypeOptions = getSettingByScope($connection2, 'User Admin', 'dayTypeOptions');
@@ -368,7 +368,7 @@ if ($proceed == false) {
     if (!empty($applicationFormRefereeLink)) {
         $row = $form->addRow();
             $row->addLabel('referenceEmail', __('Current School Reference Email'))->description(__('An email address for a referee at the applicant\'s current school.'));
-            $row->addEmail('referenceEmail')->isRequired();
+            $row->addEmail('referenceEmail')->required();
     }
 
     $row = $form->addRow();
@@ -435,15 +435,15 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-                $row->addTextArea('homeAddress')->isRequired()->maxLength(255)->setRows(2);
+                $row->addTextArea('homeAddress')->required()->maxLength(255)->setRows(2);
 
             $row = $form->addRow();
                 $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));
-                $row->addTextFieldDistrict('homeAddressDistrict')->isRequired();
+                $row->addTextFieldDistrict('homeAddressDistrict')->required();
 
             $row = $form->addRow();
                 $row->addLabel('homeAddressCountry', __('Home Address (Country)'));
-                $row->addSelectCountry('homeAddressCountry')->isRequired();
+                $row->addSelectCountry('homeAddressCountry')->required();
         }
 
         // PARENT 1 - IF EXISTS
@@ -492,7 +492,7 @@ if ($proceed == false) {
 
             $row = $form->addRow();
                 $row->addLabel('parent1relationship', __('Relationship'));
-                $row->addSelectRelationship('parent1relationship')->isRequired();
+                $row->addSelectRelationship('parent1relationship')->required();
 
             // CUSTOM FIELDS FOR PARENT 1 WITH FAMILY
             $existingFields = (!empty($parent1fields))? unserialize($parent1fields) : null;
@@ -539,23 +539,23 @@ if ($proceed == false) {
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}title", __('Title'));
-                $row->addSelectTitle("parent{$i}title")->isRequired()->loadFrom($application);
+                $row->addSelectTitle("parent{$i}title")->required()->loadFrom($application);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}surname", __('Surname'))->description(__('Family name as shown in ID documents.'));
-                $row->addTextField("parent{$i}surname")->isRequired()->maxLength(30)->loadFrom($application);
+                $row->addTextField("parent{$i}surname")->required()->maxLength(30)->loadFrom($application);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}firstName", __('First Name'))->description(__('First name as shown in ID documents.'));
-                $row->addTextField("parent{$i}firstName")->isRequired()->maxLength(30)->loadFrom($application);
+                $row->addTextField("parent{$i}firstName")->required()->maxLength(30)->loadFrom($application);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}preferredName", __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-                $row->addTextField("parent{$i}preferredName")->isRequired()->maxLength(30)->loadFrom($application);
+                $row->addTextField("parent{$i}preferredName")->required()->maxLength(30)->loadFrom($application);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}officialName", __('Official Name'))->description(__('Full name as shown in ID documents.'));
-                $row->addTextField("parent{$i}officialName")->isRequired()->maxLength(150)->loadFrom($application);
+                $row->addTextField("parent{$i}officialName")->required()->maxLength(150)->loadFrom($application);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}nameInCharacters", __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -563,11 +563,11 @@ if ($proceed == false) {
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}gender", __('Gender'));
-                $row->addSelectGender("parent{$i}gender")->isRequired()->loadFrom($application);
+                $row->addSelectGender("parent{$i}gender")->required()->loadFrom($application);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}relationship", __('Relationship'));
-                $row->addSelectRelationship("parent{$i}relationship")->isRequired();
+                $row->addSelectRelationship("parent{$i}relationship")->required();
 
             // PARENT PERSONAL BACKGROUND
             $row = $form->addRow()->setClass("parentSection{$i}");
@@ -611,7 +611,7 @@ if ($proceed == false) {
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}email", __('Email'));
-                $email = $row->addEmail("parent{$i}email")->isRequired($i == 1)->loadFrom($application);
+                $email = $row->addEmail("parent{$i}email")->required($i == 1)->loadFrom($application);
                 if ($uniqueEmailAddress == 'Y') {
                     $email->uniqueField('./publicRegistrationCheck.php', array('fieldName' => 'email'));
                 }
@@ -628,7 +628,7 @@ if ($proceed == false) {
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}profession", __('Profession'));
-                $row->addTextField("parent{$i}profession")->isRequired($i == 1)->maxLength(90)->loadFrom($application);
+                $row->addTextField("parent{$i}profession")->required($i == 1)->maxLength(90)->loadFrom($application);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}employer", __('Employer'));
@@ -774,12 +774,12 @@ if ($proceed == false) {
 
         $row = $form->addRow();
             $row->addLabel('languageChoice', __('Language Choice'))->description(__('Please choose preferred additional language to study.'));
-            $row->addSelect('languageChoice')->fromArray($languages)->isRequired()->placeholder();
+            $row->addSelect('languageChoice')->fromArray($languages)->required()->placeholder();
 
         $row = $form->addRow();
             $column = $row->addColumn();
             $column->addLabel('languageChoiceExperience', __('Language Choice Experience'))->description(__('Has the applicant studied the selected language before? If so, please describe the level and type of experience.'));
-            $column->addTextArea('languageChoiceExperience')->isRequired()->setRows(5)->setClass('fullWidth');
+            $column->addTextArea('languageChoiceExperience')->required()->setRows(5)->setClass('fullWidth');
     }
 
     // SCHOLARSHIPS
@@ -824,19 +824,19 @@ if ($proceed == false) {
         // COMPANY DETAILS
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyName', __('Company Name'));
-            $row->addTextField('companyName')->isRequired()->maxLength(100)->loadFrom($application);
+            $row->addTextField('companyName')->required()->maxLength(100)->loadFrom($application);
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyContact', __('Company Contact Person'));
-            $row->addTextField('companyContact')->isRequired()->maxLength(100)->loadFrom($application);
+            $row->addTextField('companyContact')->required()->maxLength(100)->loadFrom($application);
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyAddress', __('Company Address'));
-            $row->addTextField('companyAddress')->isRequired()->maxLength(255)->loadFrom($application);
+            $row->addTextField('companyAddress')->required()->maxLength(255)->loadFrom($application);
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyEmail', __('Company Emails'))->description(__('Comma-separated list of email address'));
-            $row->addTextField('companyEmail')->isRequired()->loadFrom($application);
+            $row->addTextField('companyEmail')->required()->loadFrom($application);
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyCCFamily', __('CC Family?'))->description(__('Should the family be sent a copy of billing emails?'));
@@ -923,9 +923,9 @@ if ($proceed == false) {
         $row->addLabel('howDidYouHear', __('How Did You Hear About Us?'));
 
     if (empty($howDidYouHear)) {
-        $row->addTextField('howDidYouHear')->isRequired()->maxLength(30)->loadFrom($application);
+        $row->addTextField('howDidYouHear')->required()->maxLength(30)->loadFrom($application);
     } else {
-        $row->addSelect('howDidYouHear')->fromArray($howDidYouHearList)->isRequired()->placeholder()->loadFrom($application);
+        $row->addSelect('howDidYouHear')->fromArray($howDidYouHearList)->required()->placeholder()->loadFrom($application);
 
         $form->toggleVisibilityByClass('tellUsMore')->onSelect('howDidYouHear')->whenNot(__('Please select...'));
 
@@ -957,7 +957,7 @@ if ($proceed == false) {
 
         $row = $form->addRow();
             $row->addLabel('agreement', '<b>'.__('Do you agree to the above?').'</b>');
-            $row->addCheckbox('agreement')->description(__('Yes'))->setValue('on')->isRequired();
+            $row->addCheckbox('agreement')->description(__('Yes'))->setValue('on')->required();
     }
 
     // OFFICE ONLY

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -288,7 +288,7 @@ if ($proceed == false) {
         $row->addLabel('email', __('Email'));
         $email = $row->addEmail('email');
         if ($uniqueEmailAddress == 'Y') {
-            $email->isUnique('./publicRegistrationCheck.php');
+            $email->uniqueField('./publicRegistrationCheck.php');
         }
 
     for ($i = 1; $i < 3; ++$i) {
@@ -613,7 +613,7 @@ if ($proceed == false) {
                 $row->addLabel("parent{$i}email", __('Email'));
                 $email = $row->addEmail("parent{$i}email")->isRequired($i == 1)->loadFrom($application);
                 if ($uniqueEmailAddress == 'Y') {
-                    $email->isUnique('./publicRegistrationCheck.php', array('fieldName' => 'email'));
+                    $email->uniqueField('./publicRegistrationCheck.php', array('fieldName' => 'email'));
                 }
 
             for ($y = 1; $y < 3; ++$y) {

--- a/modules/Students/applicationForm_manage_add.php
+++ b/modules/Students/applicationForm_manage_add.php
@@ -51,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('applicationType', __('Type'));
-        $row->addSelect('applicationType')->fromArray($types)->isRequired();
+        $row->addSelect('applicationType')->fromArray($types)->required();
 
     $sql = "SELECT gibbonFamily.gibbonFamilyID as value, CONCAT(gibbonFamily.name, ' (', GROUP_CONCAT(DISTINCT CONCAT(gibbonPerson.preferredName, ' ', gibbonPerson.surname) SEPARATOR ', '), ')') as name FROM gibbonFamily
         JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID)
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow()->addClass('typeFamily');
         $row->addLabel('gibbonFamilyID', __('Family'));
-        $row->addSelect('gibbonFamilyID')->fromQuery($pdo, $sql)->isRequired();
+        $row->addSelect('gibbonFamilyID')->fromQuery($pdo, $sql)->required();
 
     $sql = "SELECT gibbonPersonID as value, CONCAT(gibbonPerson.surname, ', ', gibbonPerson.preferredName, ' (', gibbonRole.category, ': ', gibbonPerson.username, ')') as name
             FROM gibbonPerson
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow()->addClass('typePerson');
         $row->addLabel('gibbonPersonID', __('Person'));
-        $row->addSelect('gibbonPersonID')->fromQuery($pdo, $sql)->isRequired();
+        $row->addSelect('gibbonPersonID')->fromQuery($pdo, $sql)->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('priority', __('Priority'))->description(__('Higher priority applicants appear first in list of applications.'));
-        $row->addSelect('priority')->fromArray(range(-9, 9))->isRequired();
+        $row->addSelect('priority')->fromArray(range(-9, 9))->required();
 
     // STATUS
     if ($application['applicationStatus'] != 'Accepted') {
@@ -111,11 +111,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         );
         $row = $form->addRow();
                 $row->addLabel('status', __('Status'))->description(__('Manually set status. "Approved" not permitted.'));
-                $row->addSelect('status')->isRequired()->fromArray($statuses)->selected($application['applicationStatus']);
+                $row->addSelect('status')->required()->fromArray($statuses)->selected($application['applicationStatus']);
     } else {
         $row = $form->addRow();
             $row->addLabel('status', __('Status'))->description(__('Manually set status. "Approved" not permitted.'));
-            $row->addTextField('status')->isRequired()->readOnly()->setValue($application['applicationStatus']);
+            $row->addTextField('status')->required()->readOnly()->setValue($application['applicationStatus']);
     }
 
     // MILESTONES
@@ -138,16 +138,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Start Date'))->description(__('Student\'s intended first day at school.'))->append(__('Format:').' '.$_SESSION[$guid]['i18n']['dateFormat']);
-        $row->addDate('dateStart')->isRequired();
+        $row->addDate('dateStart')->required();
 
     $row = $form->addRow();
         $row->addLabel('gibbonSchoolYearIDEntry', __('Year of Entry'))->description(__('When will the student join?'));
-        $row->addSelectSchoolYear('gibbonSchoolYearIDEntry', 'Active')->isRequired();
+        $row->addSelectSchoolYear('gibbonSchoolYearIDEntry', 'Active')->required();
 
     // YEAR GROUP
     $row = $form->addRow();
         $row->addLabel('gibbonYearGroupIDEntry', __('Year Group at Entry'))->description(__('Which year level will student enter.'));
-        $row->addSelectYearGroup('gibbonYearGroupIDEntry')->isRequired();
+        $row->addSelectYearGroup('gibbonYearGroupIDEntry')->required();
 
     // ROLL GROUP
     $sqlSelect = "SELECT gibbonRollGroupID as value, name, gibbonSchoolYearID FROM gibbonRollGroup ORDER BY gibbonSchoolYearID, name";
@@ -192,7 +192,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         // PAYMENT MADE
         $row = $form->addRow();
             $row->addLabel('paymentMade', __('Payment'))->description(sprintf(__('Has payment (%1$s %2$s) been made for this application.'), $currency, $applicationFee));
-            $row->addSelect('paymentMade')->fromArray($paymentMadeOptions)->isRequired();
+            $row->addSelect('paymentMade')->fromArray($paymentMadeOptions)->required();
 
         // PAYMENT DETAILS
         if (!empty($application['paymentToken']) || !empty($application['paymentPayerID']) || !empty($application['paymentTransactionID']) || !empty($application['paymentReceiptID'])) {
@@ -298,19 +298,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('surname', __('Surname'))->description(__('Family name as shown in ID documents.'));
-        $row->addTextField('surname')->isRequired()->maxLength(60);
+        $row->addTextField('surname')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('firstName', __('First Name'))->description(__('First name as shown in ID documents.'));
-        $row->addTextField('firstName')->isRequired()->maxLength(60);
+        $row->addTextField('firstName')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('preferredName', __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-        $row->addTextField('preferredName')->isRequired()->maxLength(60);
+        $row->addTextField('preferredName')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('officialName', __('Official Name'))->description(__('Full name as shown in ID documents.'));
-        $row->addTextField('officialName')->isRequired()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
+        $row->addTextField('officialName')->required()->maxLength(150)->setTitle('Please enter full name as shown in ID documents');
 
     $row = $form->addRow();
         $row->addLabel('nameInCharacters', __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -318,18 +318,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('gender', __('Gender'));
-        $row->addSelectGender('gender')->isRequired();
+        $row->addSelectGender('gender')->required();
 
     $row = $form->addRow();
         $row->addLabel('dob', __('Date of Birth'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dob')->isRequired();
+        $row->addDate('dob')->required();
 
     // STUDENT BACKGROUND
     $form->addRow()->addSubheading(__('Student Background'));
 
     $row = $form->addRow();
         $row->addLabel('languageHomePrimary', __('Home Language - Primary'))->description(__('The primary language used in the student\'s home.'));
-        $row->addSelectLanguage('languageHomePrimary')->isRequired();
+        $row->addSelectLanguage('languageHomePrimary')->required();
 
     $row = $form->addRow();
         $row->addLabel('languageHomeSecondary', __('Home Language - Secondary'));
@@ -337,7 +337,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('languageFirst', __('First Language'))->description(__('Student\'s native/first/mother language.'));
-        $row->addSelectLanguage('languageFirst')->isRequired();
+        $row->addSelectLanguage('languageFirst')->required();
 
     $row = $form->addRow();
         $row->addLabel('languageSecond', __('Second Language'));
@@ -349,15 +349,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     $row = $form->addRow();
         $row->addLabel('countryOfBirth', __('Country of Birth'));
-        $row->addSelectCountry('countryOfBirth')->isRequired();
+        $row->addSelectCountry('countryOfBirth')->required();
 
     $row = $form->addRow();
         $row->addLabel('citizenship1', __('Citizenship'));
         $nationalityList = getSettingByScope($connection2, 'User Admin', 'nationality');
         if (!empty($nationalityList)) {
-            $row->addSelect('citizenship1')->isRequired()->fromString($nationalityList)->placeholder(__('Please select...'));
+            $row->addSelect('citizenship1')->required()->fromString($nationalityList)->placeholder(__('Please select...'));
         } else {
-            $row->addSelectCountry('citizenship1')->isRequired();
+            $row->addSelectCountry('citizenship1')->required();
         }
 
     $countryName = (isset($_SESSION[$guid]['country']))? $_SESSION[$guid]['country'].' ' : '';
@@ -411,7 +411,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
         $row = $form->addRow();
             $row->addLabel('sen', __('Special Educational Needs (SEN)'))->description(__('Are there any known or suspected SEN concerns, or previous SEN assessments?'));
-            $row->addYesNo('sen')->isRequired()->placeholder(__('Please select...'));
+            $row->addYesNo('sen')->required()->placeholder(__('Please select...'));
 
         $form->toggleVisibilityByClass('senDetailsRow')->onSelect('sen')->when('Y');
 
@@ -438,7 +438,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     if (!empty($applicationFormRefereeLink)) {
         $row = $form->addRow();
             $row->addLabel('referenceEmail', __('Current School Reference Email'))->description(__('An email address for a referee at the applicant\'s current school.'));
-            $row->addEmail('referenceEmail')->isRequired();
+            $row->addEmail('referenceEmail')->required();
     }
 
     // PREVIOUS SCHOOLS TABLE
@@ -490,15 +490,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
         $row = $form->addRow();
             $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
-            $row->addTextArea('homeAddress')->isRequired()->maxLength(255)->setRows(2);
+            $row->addTextArea('homeAddress')->required()->maxLength(255)->setRows(2);
 
         $row = $form->addRow();
             $row->addLabel('homeAddressDistrict', __('Home Address (District)'))->description(__('County, State, District'));
-            $row->addTextFieldDistrict('homeAddressDistrict')->isRequired();
+            $row->addTextFieldDistrict('homeAddressDistrict')->required();
 
         $row = $form->addRow();
             $row->addLabel('homeAddressCountry', __('Home Address (Country)'));
-            $row->addSelectCountry('homeAddressCountry')->isRequired();
+            $row->addSelectCountry('homeAddressCountry')->required();
 
 
         // PARENT 1 - IF EXISTS
@@ -519,7 +519,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow();
                 $row->addLabel('parent1relationship', __('Relationship'));
-                $row->addSelectRelationship('parent1relationship')->isRequired();
+                $row->addSelectRelationship('parent1relationship')->required();
 
             // CUSTOM FIELDS FOR PARENT 1 WITH FAMILY
             $existingFields = (isset($application["parent1fields"]))? unserialize($application["parent1fields"]) : null;
@@ -566,23 +566,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}title", __('Title'));
-                $row->addSelectTitle("parent{$i}title")->isRequired();
+                $row->addSelectTitle("parent{$i}title")->required();
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}surname", __('Surname'))->description(__('Family name as shown in ID documents.'));
-                $row->addTextField("parent{$i}surname")->isRequired()->maxLength(30);
+                $row->addTextField("parent{$i}surname")->required()->maxLength(30);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}firstName", __('First Name'))->description(__('First name as shown in ID documents.'));
-                $row->addTextField("parent{$i}firstName")->isRequired()->maxLength(30);
+                $row->addTextField("parent{$i}firstName")->required()->maxLength(30);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}preferredName", __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-                $row->addTextField("parent{$i}preferredName")->isRequired()->maxLength(30);
+                $row->addTextField("parent{$i}preferredName")->required()->maxLength(30);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}officialName", __('Official Name'))->description(__('Full name as shown in ID documents.'));
-                $row->addTextField("parent{$i}officialName")->isRequired()->maxLength(150);
+                $row->addTextField("parent{$i}officialName")->required()->maxLength(150);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}nameInCharacters", __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -590,11 +590,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}gender", __('Gender'));
-                $row->addSelectGender("parent{$i}gender")->isRequired();
+                $row->addSelectGender("parent{$i}gender")->required();
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}relationship", __('Relationship'));
-                $row->addSelectRelationship("parent{$i}relationship")->isRequired();
+                $row->addSelectRelationship("parent{$i}relationship")->required();
 
             // PARENT PERSONAL BACKGROUND
             $row = $form->addRow()->setClass("parentSection{$i}");
@@ -638,7 +638,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}email", __('Email'));
-                $email = $row->addEmail("parent{$i}email")->isRequired($i == 1);
+                $email = $row->addEmail("parent{$i}email")->required($i == 1);
 
                 if ($uniqueEmailAddress == 'Y') {
                     $email->uniqueField('./modules/User Admin/user_manage_emailAjax.php', array('fieldName' => 'email'));
@@ -656,7 +656,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}profession", __('Profession'));
-                $row->addTextField("parent{$i}profession")->isRequired($i == 1)->maxLength(90);
+                $row->addTextField("parent{$i}profession")->required($i == 1)->maxLength(90);
 
             $row = $form->addRow()->setClass("parentSection{$i}");
                 $row->addLabel("parent{$i}employer", __('Employer'));
@@ -760,12 +760,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
         $row = $form->addRow();
             $row->addLabel('languageChoice', __('Language Choice'))->description(__('Please choose preferred additional language to study.'));
-            $row->addSelect('languageChoice')->fromArray($languages)->isRequired()->placeholder();
+            $row->addSelect('languageChoice')->fromArray($languages)->required()->placeholder();
 
         $row = $form->addRow();
             $column = $row->addColumn();
             $column->addLabel('languageChoiceExperience', __('Language Choice Experience'))->description(__('Has the applicant studied the selected language before? If so, please describe the level and type of experience.'));
-            $column->addTextArea('languageChoiceExperience')->isRequired()->setRows(5)->setClass('fullWidth');
+            $column->addTextArea('languageChoiceExperience')->required()->setRows(5)->setClass('fullWidth');
     }
 
     // SCHOLARSHIPS
@@ -810,19 +810,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         // COMPANY DETAILS
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyName', __('Company Name'));
-            $row->addTextField('companyName')->isRequired()->maxLength(100);
+            $row->addTextField('companyName')->required()->maxLength(100);
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyContact', __('Company Contact Person'));
-            $row->addTextField('companyContact')->isRequired()->maxLength(100);
+            $row->addTextField('companyContact')->required()->maxLength(100);
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyAddress', __('Company Address'));
-            $row->addTextField('companyAddress')->isRequired()->maxLength(255);
+            $row->addTextField('companyAddress')->required()->maxLength(255);
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyEmail', __('Company Emails'))->description(__('Comma-separated list of email address'));
-            $row->addTextField('companyEmail')->isRequired();
+            $row->addTextField('companyEmail')->required();
 
         $row = $form->addRow()->addClass('paymentCompany');
             $row->addLabel('companyCCFamily', __('CC Family?'))->description(__('Should the family be sent a copy of billing emails?'));
@@ -921,9 +921,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $row->addLabel('howDidYouHear', __('How Did You Hear About Us?'));
 
     if (empty($howDidYouHear)) {
-        $row->addTextField('howDidYouHear')->isRequired()->maxLength(30);
+        $row->addTextField('howDidYouHear')->required()->maxLength(30);
     } else {
-        $row->addSelect('howDidYouHear')->fromArray($howDidYouHearList)->isRequired()->placeholder();
+        $row->addSelect('howDidYouHear')->fromArray($howDidYouHearList)->required()->placeholder();
 
         $form->toggleVisibilityByClass('tellUsMore')->onSelect('howDidYouHear')->whenNot(__('Please select...'));
 

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -389,7 +389,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $row->addLabel('email', __('Email'));
         $email = $row->addEmail('email');
         if ($uniqueEmailAddress == 'Y') {
-            $email->isUnique('./modules/User Admin/user_manage_emailAjax.php');
+            $email->uniqueField('./modules/User Admin/user_manage_emailAjax.php');
         }
 
     for ($i = 1; $i < 3; ++$i) {
@@ -641,7 +641,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                 $email = $row->addEmail("parent{$i}email")->isRequired($i == 1);
 
                 if ($uniqueEmailAddress == 'Y') {
-                    $email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('fieldName' => 'email'));
+                    $email->uniqueField('./modules/User Admin/user_manage_emailAjax.php', array('fieldName' => 'email'));
                 }
 
             for ($y = 1; $y < 3; ++$y) {

--- a/modules/Students/firstAidRecord_add.php
+++ b/modules/Students/firstAidRecord_add.php
@@ -62,19 +62,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ad
 
         $row = $form->addRow();
             $row->addLabel('gibbonPersonID', __('Patient'));
-            $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->placeholder()->isRequired();
+            $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->placeholder()->required();
 
         $row = $form->addRow();
             $row->addLabel('name', __('First Aider'));
-            $row->addTextField('name')->setValue(Format::name('', $_SESSION[$guid]['preferredName'], $_SESSION[$guid]['surname'], 'Student'))->isRequired()->readonly();
+            $row->addTextField('name')->setValue(Format::name('', $_SESSION[$guid]['preferredName'], $_SESSION[$guid]['surname'], 'Student'))->required()->readonly();
 
         $row = $form->addRow();
             $row->addLabel('date', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-            $row->addDate('date')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']))->isRequired();
+            $row->addDate('date')->setValue(date($_SESSION[$guid]['i18n']['dateFormatPHP']))->required();
 
         $row = $form->addRow();
             $row->addLabel('timeIn', __('Time In'))->description("Format: hh:mm (24hr)");
-            $row->addTime('timeIn')->setValue(date("H:i"))->isRequired();
+            $row->addTime('timeIn')->setValue(date("H:i"))->required();
 
         $row = $form->addRow();
             $column = $row->addColumn();

--- a/modules/Students/firstAidRecord_edit.php
+++ b/modules/Students/firstAidRecord_edit.php
@@ -82,19 +82,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
             $form->addHiddenValue('gibbonPersonID', $values['gibbonPersonIDPatient']);
             $row = $form->addRow();
                 $row->addLabel('patient', __('Patient'));
-                $row->addTextField('patient')->setValue(Format::name('', $values['preferredNamePatient'], $values['surnamePatient'], 'Student'))->isRequired()->readonly();
+                $row->addTextField('patient')->setValue(Format::name('', $values['preferredNamePatient'], $values['surnamePatient'], 'Student'))->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('name', __('First Aider'));
-                $row->addTextField('name')->setValue(Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider'], 'Staff', false, true))->isRequired()->readonly();
+                $row->addTextField('name')->setValue(Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider'], 'Staff', false, true))->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('date', __('Date'));
-                $row->addDate('date')->setValue(dateConvertBack($guid, $values['date']))->isRequired()->readonly();
+                $row->addDate('date')->setValue(dateConvertBack($guid, $values['date']))->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('timeIn', __('Time In'));
-                $row->addTime('timeIn')->setValue(substr($values['timeIn'], 0, 5))->isRequired()->readonly();
+                $row->addTime('timeIn')->setValue(substr($values['timeIn'], 0, 5))->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('timeOut', __('Time Out'));

--- a/modules/Students/medicalForm_manage_add.php
+++ b/modules/Students/medicalForm_manage_add.php
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Student'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->isRequired()->placeholder()->selected($gibbonPersonID);
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->required()->placeholder()->selected($gibbonPersonID);
 
     $row = $form->addRow();
         $row->addLabel('bloodType', __('Blood Type'));

--- a/modules/Students/medicalForm_manage_condition_add.php
+++ b/modules/Students/medicalForm_manage_condition_add.php
@@ -88,16 +88,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
             $row = $form->addRow();
                 $row->addLabel('personName', __('Student'));
-                $row->addTextField('personName')->setValue(Format::name('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->isRequired()->readonly();
+                $row->addTextField('personName')->setValue(Format::name('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->required()->readonly();
 
             $sql = "SELECT name AS value, name FROM gibbonMedicalCondition ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('name', __('Condition Name'));
-                $row->addSelect('name')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+                $row->addSelect('name')->fromQuery($pdo, $sql)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('gibbonAlertLevelID', __('Risk'));
-                $row->addSelectAlert('gibbonAlertLevelID')->isRequired();
+                $row->addSelectAlert('gibbonAlertLevelID')->required();
 
             $row = $form->addRow();
                 $row->addLabel('triggers', __('Triggers'));

--- a/modules/Students/medicalForm_manage_condition_edit.php
+++ b/modules/Students/medicalForm_manage_condition_edit.php
@@ -75,16 +75,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
             $row = $form->addRow();
                 $row->addLabel('personName', __('Student'));
-                $row->addTextField('personName')->setValue(Format::name('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->isRequired()->readonly();
+                $row->addTextField('personName')->setValue(Format::name('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->required()->readonly();
 
             $sql = "SELECT name AS value, name FROM gibbonMedicalCondition ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('name', __('Condition Name'));
-                $row->addSelect('name')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+                $row->addSelect('name')->fromQuery($pdo, $sql)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addLabel('gibbonAlertLevelID', __('Risk'));
-                $row->addSelectAlert('gibbonAlertLevelID')->isRequired();
+                $row->addSelectAlert('gibbonAlertLevelID')->required();
 
             $row = $form->addRow();
                 $row->addLabel('triggers', __('Triggers'));

--- a/modules/Students/medicalForm_manage_edit.php
+++ b/modules/Students/medicalForm_manage_edit.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Student'));
-                $row->addTextField('name')->setValue(Format::name('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->isRequired()->readonly();
+                $row->addTextField('name')->setValue(Format::name('', htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Student'))->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('bloodType', __('Blood Type'));

--- a/modules/Students/report_emergencySMS_byTransport.php
+++ b/modules/Students/report_emergencySMS_byTransport.php
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_emergencyS
 
     $row = $form->addRow();
         $row->addLabel('transport', __('Transport'));
-        $row->addSelectTransport('transport', true)->isRequired()->selected($transport);
+        $row->addSelectTransport('transport', true)->required()->selected($transport);
 
     $row = $form->addRow();
         $row->addLabel('prefix', __('Prefix'));

--- a/modules/Students/report_emergencySMS_byYearGroup.php
+++ b/modules/Students/report_emergencySMS_byYearGroup.php
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_emergencyS
 
     $row = $form->addRow();
         $row->addLabel('gibbonYearGroupID', __('Year Group'));
-        $row->addSelectYearGroup('gibbonYearGroupID', true)->isRequired()->selected($gibbonYearGroupID);
+        $row->addSelectYearGroup('gibbonYearGroupID', true)->required()->selected($gibbonYearGroupID);
 
     $row = $form->addRow();
         $row->addLabel('prefix', __('Prefix'));

--- a/modules/Students/report_familyAddress_byStudent.php
+++ b/modules/Students/report_familyAddress_byStudent.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_familyAddr
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Students'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->isRequired()->placeholder()->selectMultiple()->selected($choices);
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->required()->placeholder()->selectMultiple()->selected($choices);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Students/report_graph_studentEnrolment.php
+++ b/modules/Students/report_graph_studentEnrolment.php
@@ -95,11 +95,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_graph_stud
 
     $row = $form->addRow();
         $row->addLabel('dateStart', __('Start Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->isRequired();
+        $row->addDate('dateStart')->setValue(dateConvertBack($guid, $dateStart))->required();
 
     $row = $form->addRow();
         $row->addLabel('dateEnd', __('End Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->isRequired();
+        $row->addDate('dateEnd')->setValue(dateConvertBack($guid, $dateEnd))->required();
 
     $row = $form->addRow();
         $row->addLabel('interval', __('Interval'));

--- a/modules/Students/report_student_emergencySummary.php
+++ b/modules/Students/report_student_emergencySummary.php
@@ -52,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_em
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Students'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->isRequired()->placeholder()->selectMultiple()->selected($choices);
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->required()->placeholder()->selectMultiple()->selected($choices);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Students/report_student_medicalSummary.php
+++ b/modules/Students/report_student_medicalSummary.php
@@ -52,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_me
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Students'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->isRequired()->placeholder()->selectMultiple()->selected($choices);
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->required()->placeholder()->selectMultiple()->selected($choices);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Students/report_students_IDCards.php
+++ b/modules/Students/report_students_IDCards.php
@@ -52,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_I
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Students'));
-        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->isRequired()->placeholder()->selectMultiple()->selected($choices);
+        $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array("allStudents" => false, "byName" => true, "byRoll" => true))->required()->placeholder()->selectMultiple()->selected($choices);
 
     $row = $form->addRow();
         $row->addLabel('file', __('Card Background'))->description('.png or .jpg file, 448 x 268px.');

--- a/modules/Students/report_students_byRollGroup.php
+++ b/modules/Students/report_students_byRollGroup.php
@@ -52,11 +52,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_b
 
         $row = $form->addRow();
             $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'], true)->selected($gibbonRollGroupID)->placeholder()->isRequired();
+            $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'], true)->selected($gibbonRollGroupID)->placeholder()->required();
 
         $row = $form->addRow();
             $row->addLabel('view', __('View'));
-            $row->addSelect('view')->fromArray(array('basic' => __('Basic'), 'extended' =>__('Extended')))->selected($view)->isRequired();
+            $row->addSelect('view')->fromArray(array('basic' => __('Basic'), 'extended' =>__('Extended')))->selected($view)->required();
 
         $row = $form->addRow();
             $row->addFooter();

--- a/modules/Students/report_students_left.php
+++ b/modules/Students/report_students_left.php
@@ -54,17 +54,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_l
 
         $row = $form->addRow();
             $row->addLabel('type', __('Type'));
-            $row->addSelect('type')->fromArray(array('Current School Year' => __('Current School Year'), 'Date Range' => __('Date Range')))->selected($type)->isRequired();
+            $row->addSelect('type')->fromArray(array('Current School Year' => __('Current School Year'), 'Date Range' => __('Date Range')))->selected($type)->required();
 
         $form->toggleVisibilityByClass('dateRange')->onSelect('type')->when('Date Range');
 
         $row = $form->addRow()->addClass('dateRange');
             $row->addLabel('endDateFrom', __('From Date'))->description('Earliest student end date to include.')->append('<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-            $row->addDate('endDateFrom')->setValue($endDateFrom)->isRequired();
+            $row->addDate('endDateFrom')->setValue($endDateFrom)->required();
 
         $row = $form->addRow()->addClass('dateRange');
             $row->addLabel('endDateTo', __('To Date'))->description('Latest student end date to include.')->append('<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-            $row->addDate('endDateTo')->setValue($endDateTo)->isRequired();
+            $row->addDate('endDateTo')->setValue($endDateTo)->required();
 
         $row = $form->addRow()->addClass('dateRange');
             $row->addLabel('ignoreStatus', __('Ignore Status'))->description('This is useful for picking up students who have not yet left, but have an End Date set.');

--- a/modules/Students/report_students_new.php
+++ b/modules/Students/report_students_new.php
@@ -54,17 +54,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_n
 
         $row = $form->addRow();
             $row->addLabel('type', __('Type'));
-            $row->addSelect('type')->fromArray(array('Current School Year' => __('Current School Year'), 'Date Range' => __('Date Range')))->selected($type)->isRequired();
+            $row->addSelect('type')->fromArray(array('Current School Year' => __('Current School Year'), 'Date Range' => __('Date Range')))->selected($type)->required();
 
         $form->toggleVisibilityByClass('dateRange')->onSelect('type')->when('Date Range');
 
         $row = $form->addRow()->addClass('dateRange');
             $row->addLabel('startDateFrom', __('From Date'))->description('Earliest student start date to include.')->append('<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-            $row->addDate('startDateFrom')->setValue($startDateFrom)->isRequired();
+            $row->addDate('startDateFrom')->setValue($startDateFrom)->required();
 
         $row = $form->addRow()->addClass('dateRange');
             $row->addLabel('startDateTo', __('To Date'))->description('Latest student start date to include.')->append('<br/>')->append(__('Format:').' ')->append($_SESSION[$guid]['i18n']['dateFormat']);
-            $row->addDate('startDateTo')->setValue($startDateTo)->isRequired();
+            $row->addDate('startDateTo')->setValue($startDateTo)->required();
 
         $row = $form->addRow()->addClass('dateRange');
             $row->addLabel('ignoreEnrolment', __('Ignore Enrolment'))->description('This is useful for picking up students who are set to Full, have a start date but are not yet enroled.');

--- a/modules/Students/studentEnrolment_manage_add.php
+++ b/modules/Students/studentEnrolment_manage_add.php
@@ -71,15 +71,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
 
         $row = $form->addRow();
             $row->addLabel('gibbonPersonID', __('Student'));
-            $row->addSelectStudent('gibbonPersonID', $gibbonSchoolYearID, array('allStudents' => true))->isRequired()->placeholder();
+            $row->addSelectStudent('gibbonPersonID', $gibbonSchoolYearID, array('allStudents' => true))->required()->placeholder();
 
         $row = $form->addRow();
             $row->addLabel('gibbonYearGroupID', __('Year Group'));
-            $row->addSelectYearGroup('gibbonYearGroupID')->isRequired();
+            $row->addSelectYearGroup('gibbonYearGroupID')->required();
 
         $row = $form->addRow();
             $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-            $row->addSelectRollGroup('gibbonRollGroupID', $gibbonSchoolYearID)->isRequired();
+            $row->addSelectRollGroup('gibbonRollGroupID', $gibbonSchoolYearID)->required();
 
         $row = $form->addRow();
             $row->addLabel('rollOrder', __('Roll Order'));

--- a/modules/Students/studentEnrolment_manage_edit.php
+++ b/modules/Students/studentEnrolment_manage_edit.php
@@ -93,11 +93,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
 
             $row = $form->addRow();
                 $row->addLabel('gibbonYearGroupID', __('Year Group'));
-                $row->addSelectYearGroup('gibbonYearGroupID')->isRequired();
+                $row->addSelectYearGroup('gibbonYearGroupID')->required();
 
             $row = $form->addRow();
                 $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-                $row->addSelectRollGroup('gibbonRollGroupID', $gibbonSchoolYearID)->isRequired();
+                $row->addSelectRollGroup('gibbonRollGroupID', $gibbonSchoolYearID)->required();
 
             $row = $form->addRow();
                 $row->addLabel('rollOrder', __('Roll Order'));

--- a/modules/Students/student_view_details_notes_add.php
+++ b/modules/Students/student_view_details_notes_add.php
@@ -80,17 +80,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
 				$row = $form->addRow();
 					$row->addLabel('title', __('Title'));
-					$row->addTextField('title')->isRequired()->maxLength(100);
+					$row->addTextField('title')->required()->maxLength(100);
 
 				$sql = "SELECT gibbonStudentNoteCategoryID as value, name FROM gibbonStudentNoteCategory WHERE active='Y' ORDER BY name";
 				$row = $form->addRow();
 					$row->addLabel('gibbonStudentNoteCategoryID', __('Category'));
-					$row->addSelect('gibbonStudentNoteCategoryID')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+					$row->addSelect('gibbonStudentNoteCategoryID')->fromQuery($pdo, $sql)->required()->placeholder();
 
 				$row = $form->addRow();
 					$column = $row->addColumn();
 					$column->addLabel('note', __('Note'));
-					$column->addEditor('note', $guid)->isRequired()->setRows(25)->showMedia();
+					$column->addEditor('note', $guid)->required()->setRows(25)->showMedia();
 								
 				$row = $form->addRow();
 					$row->addFooter();

--- a/modules/Students/student_view_details_notes_edit.php
+++ b/modules/Students/student_view_details_notes_edit.php
@@ -104,17 +104,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                         $row = $form->addRow();
                             $row->addLabel('title', __('Title'));
-                            $row->addTextField('title')->isRequired()->maxLength(100);
+                            $row->addTextField('title')->required()->maxLength(100);
 
                         $sql = "SELECT gibbonStudentNoteCategoryID as value, name FROM gibbonStudentNoteCategory WHERE active='Y' ORDER BY name";
                         $row = $form->addRow();
                             $row->addLabel('gibbonStudentNoteCategoryID', __('Category'));
-                            $row->addSelect('gibbonStudentNoteCategoryID')->fromQuery($pdo, $sql)->isRequired()->placeholder();
+                            $row->addSelect('gibbonStudentNoteCategoryID')->fromQuery($pdo, $sql)->required()->placeholder();
 
                         $row = $form->addRow();
                             $column = $row->addColumn();
                             $column->addLabel('note', __('Note'));
-                            $column->addEditor('note', $guid)->isRequired()->setRows(25)->showMedia();
+                            $column->addEditor('note', $guid)->required()->setRows(25)->showMedia();
                                         
                         $row = $form->addRow();
                             $row->addFooter();

--- a/modules/System Admin/alarm.php
+++ b/modules/System Admin/alarm.php
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/alarm.php') =
 
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromArray($alarmTypes)->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray($alarmTypes)->selected($setting['value'])->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/System Admin/displaySettings.php
+++ b/modules/System Admin/displaySettings.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/displaySettin
     $setting = getSettingByScope($connection2, 'System', 'mainMenuCategoryOrder', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
     
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/System Admin/i18n_manage.php
+++ b/modules/System Admin/i18n_manage.php
@@ -108,7 +108,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.p
             if (version_compare($version, $i18n['version'], '>')) {
                 $actions->addAction('update', __('Update'))
                     ->setIcon('delivery2')
-                    ->isModal(650, 135)
+                    ->modalWindow(650, 135)
                     ->addParam('mode', 'update')
                     ->setURL('/modules/System Admin/i18n_manage_install.php');
             }
@@ -166,7 +166,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.p
             if ($i18n['active'] == 'Y') {
                 $actions->addAction('install', __('Install'))
                     ->setIcon('page_new')
-                    ->isModal(650, 135)
+                    ->modalWindow(650, 135)
                     ->addParam('mode', 'install')
                     ->setURL('/modules/System Admin/i18n_manage_install.php');
             }

--- a/modules/System Admin/import_history.php
+++ b/modules/System Admin/import_history.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_histor
         ->addParam('gibbonLogID')
         ->format(function ($importType, $actions) {
             $actions->addAction('view', __('View'))
-                ->isModal('600', '550')
+                ->modalWindow('600', '550')
                 ->setURL('/modules/System Admin/import_history_view.php');
         });
 

--- a/modules/System Admin/import_manage.php
+++ b/modules/System Admin/import_manage.php
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_manage
                         ->setURL('/modules/System Admin/import_run.php');
 
                     $actions->addAction('export', __('Export Columns'))
-                        ->isDirect()
+                        ->directLink()
                         ->addParam('q', $_GET['q'])
                         ->addParam('data', 0)
                         ->setIcon('download')

--- a/modules/System Admin/import_run.php
+++ b/modules/System Admin/import_run.php
@@ -108,7 +108,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
 
         $row = $form->addRow();
         $row->addLabel('mode', __('Mode'));
-        $row->addSelect('mode')->fromArray($availableModes)->isRequired();
+        $row->addSelect('mode')->fromArray($availableModes)->required();
 
         $columnOrders = array(
             'guess'      => __('Best Guess'),
@@ -119,19 +119,19 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
         $selectedOrder = (!empty($importLog))? 'last' : 'guess';
         $row = $form->addRow();
         $row->addLabel('columnOrder', __('Column Order'));
-        $row->addSelect('columnOrder')->fromArray($columnOrders)->isRequired()->selected($selectedOrder);
+        $row->addSelect('columnOrder')->fromArray($columnOrders)->required()->selected($selectedOrder);
 
         $row = $form->addRow();
         $row->addLabel('file', __('File'))->description(__('See Notes below for specification.'));
-        $row->addFileUpload('file')->isRequired()->accepts('.csv,.xls,.xlsx,.xml,.ods');
+        $row->addFileUpload('file')->required()->accepts('.csv,.xls,.xlsx,.xml,.ods');
 
         $row = $form->addRow();
         $row->addLabel('fieldDelimiter', __('Field Delimiter'));
-        $row->addTextField('fieldDelimiter')->isRequired()->maxLength(1)->setValue(',');
+        $row->addTextField('fieldDelimiter')->required()->maxLength(1)->setValue(',');
 
         $row = $form->addRow();
         $row->addLabel('stringEnclosure', __('String Enclosure'));
-        $row->addTextField('stringEnclosure')->isRequired()->maxLength(1)->setValue('"');
+        $row->addTextField('stringEnclosure')->required()->maxLength(1)->setValue('"');
 
         $row = $form->addRow();
         $row->addFooter();
@@ -265,7 +265,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
                     ->fromArray($headings)
                     ->selected($lastColumnValue)
                     ->placeholder()
-                    ->isRequired();
+                    ->required();
             }
 
             $form->addRow()->addContent('&nbsp;');
@@ -356,7 +356,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
                             ->setID('columnOrder'.$count)
                             ->fromArray($defaultColumns($fieldName))
                             ->fromArray($columns)
-                            ->isRequired()
+                            ->required()
                             ->setClass('columnOrder mediumWidth')
                             ->selected($selectedColumn)
                             ->placeholder();

--- a/modules/System Admin/import_run.php
+++ b/modules/System Admin/import_run.php
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
                 ->addParam('type', $type)
                 ->addParam('sidebar', 'false')
                 ->setIcon('download')
-                ->isDirect()
+                ->directLink()
                 ->displayLabel();
         }
 

--- a/modules/System Admin/import_run.php
+++ b/modules/System Admin/import_run.php
@@ -364,7 +364,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
                             ->setID('columnText'.$count)
                             ->setClass('shortWidth columnText')
                             ->readonly()
-                            ->isDisabled();
+                            ->disabled();
 
                     $count++;
                 }
@@ -523,7 +523,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
                 $row->onlyIf($overallSuccess)->addContent('');
                 
                 if (!$overallSuccess && !$ignoreErrors) {
-                    $row->addButton(__('Failed'))->setID('submitStep3')->isDisabled()->addClass('right');
+                    $row->addButton(__('Failed'))->setID('submitStep3')->disabled()->addClass('right');
                 } else {
                     $row->addSubmit()->setID('submitStep3');
                 }

--- a/modules/System Admin/module_manage.php
+++ b/modules/System Admin/module_manage.php
@@ -187,7 +187,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
                 if ($row['manifestOK']) {
                     $actions->addAction('install', __('Install'))
                             ->setIcon('page_new')
-                            ->isDirect()
+                            ->directLink()
                             ->setURL('/modules/System Admin/module_manage_installProcess.php');
                 }
             });

--- a/modules/System Admin/module_manage_edit.php
+++ b/modules/System Admin/module_manage_edit.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
 
              $row = $form->addRow();
                 $row->addLabel('category', __('Category'))->description(__('Determines menu structure'));
-                $row->addTextField('category')->isRequired()->maxLength(10);
+                $row->addTextField('category')->required()->maxLength(10);
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));

--- a/modules/System Admin/notificationSettings_manage_edit.php
+++ b/modules/System Admin/notificationSettings_manage_edit.php
@@ -186,7 +186,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/notificationS
 
                 $row = $form->addRow();
                     $row->addLabel('gibbonPersonID', __('Person'))->description(__('Available only to users with the required permission.'));
-                    $row->addSelect('gibbonPersonID')->fromArray($staffMembers)->placeholder(__('Please select...'))->isRequired();
+                    $row->addSelect('gibbonPersonID')->fromArray($staffMembers)->placeholder(__('Please select...'))->required();
 
                 if ($event['scopes'] == 'All') {
                     $form->addHiddenValue('scopeType', 'All');
@@ -208,17 +208,17 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/notificationS
                     $form->toggleVisibilityByClass('scopeTypeStudent')->onSelect('scopeType')->when('gibbonPersonIDStudent');
                     $row = $form->addRow()->addClass('scopeTypeStudent');
                         $row->addLabel('gibbonPersonIDStudent', __('Student'));
-                        $row->addSelectStudent('gibbonPersonIDStudent', $_SESSION[$guid]['gibbonSchoolYearID'])->isRequired()->placeholder();
+                        $row->addSelectStudent('gibbonPersonIDStudent', $_SESSION[$guid]['gibbonSchoolYearID'])->required()->placeholder();
 
                     $form->toggleVisibilityByClass('scopeTypeStaff')->onSelect('scopeType')->when('gibbonPersonIDStaff');
                     $row = $form->addRow()->addClass('scopeTypeStaff');
                         $row->addLabel('gibbonPersonIDStaff', __('Student'));
-                        $row->addSelectStaff('gibbonPersonIDStaff')->isRequired()->placeholder();
+                        $row->addSelectStaff('gibbonPersonIDStaff')->required()->placeholder();
 
                     $form->toggleVisibilityByClass('scopeTypeYearGroup')->onSelect('scopeType')->when('gibbonYearGroupID');
                     $row = $form->addRow()->addClass('scopeTypeYearGroup');
                         $row->addLabel('gibbonYearGroupID', __('Year Group'));
-                        $row->addSelectYearGroup('gibbonYearGroupID')->isRequired()->placeholder();
+                        $row->addSelectYearGroup('gibbonYearGroupID')->required()->placeholder();
                 }
 
                 $row = $form->addRow();

--- a/modules/System Admin/stringReplacement_manage_add.php
+++ b/modules/System Admin/stringReplacement_manage_add.php
@@ -55,11 +55,11 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
 
     $row = $form->addRow();
         $row->addLabel('original', __('Original String'));
-        $row->addTextField('original')->isRequired()->maxLength(100);
+        $row->addTextField('original')->required()->maxLength(100);
 
     $row = $form->addRow();
         $row->addLabel('replacement', __('Replacement String'));
-        $row->addTextField('replacement')->isRequired()->maxLength(100);
+        $row->addTextField('replacement')->required()->maxLength(100);
 
     $row = $form->addRow();
         $row->addLabel('mode', __('Mode'));
@@ -67,11 +67,11 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
 
     $row = $form->addRow();
         $row->addLabel('caseSensitive', __('Case Sensitive'));
-        $row->addYesNo('caseSensitive')->selected('N')->isRequired();
+        $row->addYesNo('caseSensitive')->selected('N')->required();
 
     $row = $form->addRow();
         $row->addLabel('priority', __('Priority'))->description(__('Higher priorities are substituted first.'));
-        $row->addNumber('priority')->isRequired()->maxLength(2)->setValue('0');
+        $row->addNumber('priority')->required()->maxLength(2)->setValue('0');
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/System Admin/stringReplacement_manage_edit.php
+++ b/modules/System Admin/stringReplacement_manage_edit.php
@@ -75,11 +75,11 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
 
             $row = $form->addRow();
                 $row->addLabel('original', __('Original String'));
-                $row->addTextField('original')->isRequired()->maxLength(100)->setValue($values['original']);
+                $row->addTextField('original')->required()->maxLength(100)->setValue($values['original']);
 
             $row = $form->addRow();
                 $row->addLabel('replacement', __('Replacement String'));
-                $row->addTextField('replacement')->isRequired()->maxLength(100)->setValue($values['replacement']);
+                $row->addTextField('replacement')->required()->maxLength(100)->setValue($values['replacement']);
 
             $row = $form->addRow();
                 $row->addLabel('mode', __('Mode'));
@@ -89,11 +89,11 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
 
             $row = $form->addRow();
                 $row->addLabel('caseSensitive', __('Case Sensitive'));
-                $row->addYesNo('caseSensitive')->selected('N')->isRequired()->selected($values['caseSensitive']);
+                $row->addYesNo('caseSensitive')->selected('N')->required()->selected($values['caseSensitive']);
 
             $row = $form->addRow();
                 $row->addLabel('priority', __('Priority'))->description(__('Higher priorities are substituted first.'));
-                $row->addNumber('priority')->isRequired()->maxLength(2)->setValue($values['priority']);
+                $row->addNumber('priority')->required()->maxLength(2)->setValue($values['priority']);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/System Admin/systemSettings.php
+++ b/modules/System Admin/systemSettings.php
@@ -80,22 +80,22 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'absoluteURL', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addURL($setting['name'])->setValue($setting['value'])->maxLength(100)->isRequired();
+        $row->addURL($setting['name'])->setValue($setting['value'])->maxLength(100)->required();
 
     $setting = getSettingByScope($connection2, 'System', 'absolutePath', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(100)->isRequired();
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(100)->required();
 
     $setting = getSettingByScope($connection2, 'System', 'systemName', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50)->isRequired();
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50)->required();
 
     $setting = getSettingByScope($connection2, 'System', 'indexText', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value'])->setRows(8)->isRequired();
+        $row->addTextArea($setting['name'])->setValue($setting['value'])->setRows(8)->required();
 
     $installTypes = array(
         'Production' => __("Production"),
@@ -105,7 +105,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'installType', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromArray($installTypes)->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray($installTypes)->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'System', 'cuttingEdgeCode', true);
     $row = $form->addRow();
@@ -115,7 +115,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'statsCollection', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     // ORGANISATION
     $form->addRow()->addHeading(__('Organisation Settings'));
@@ -123,22 +123,22 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'organisationName', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50)->isRequired();
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50)->required();
 
     $setting = getSettingByScope($connection2, 'System', 'organisationNameShort', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50)->isRequired();
+        $row->addTextField($setting['name'])->setValue($setting['value'])->maxLength(50)->required();
 
     $setting = getSettingByScope($connection2, 'System', 'organisationEmail', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addEmail($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addEmail($setting['name'])->setValue($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'System', 'organisationLogo', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextField($setting['name'])->setValue($setting['value'])->isRequired();
+        $row->addTextField($setting['name'])->setValue($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'System', 'organisationBackground', true);
     $row = $form->addRow();
@@ -148,22 +148,22 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'organisationAdministrator', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->isRequired();
+        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->required();
 
     $setting = getSettingByScope($connection2, 'System', 'organisationDBA', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->isRequired();
+        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->required();
 
     $setting = getSettingByScope($connection2, 'System', 'organisationAdmissions', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->isRequired();
+        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->required();
 
     $setting = getSettingByScope($connection2, 'System', 'organisationHR', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->isRequired();
+        $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->required();
 
     // SECURITY SETTINGS
     $form->addRow()->addHeading(__('Security Settings'));
@@ -172,29 +172,29 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'passwordPolicyMinLength', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromArray(range(4, 12))->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray(range(4, 12))->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'System', 'passwordPolicyAlpha', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'System', 'passwordPolicyNumeric', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'System', 'passwordPolicyNonAlphaNumeric', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->addRow()->addSubheading(__('Miscellaneous'));
 
     $setting = getSettingByScope($connection2, 'System', 'sessionDuration', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addNumber($setting['name'])->setValue($setting['value'])->minimum(1200)->maxLength(50)->isRequired();
+        $row->addNumber($setting['name'])->setValue($setting['value'])->minimum(1200)->maxLength(50)->required();
 
     // VALUE ADDED
     $form->addRow()->addHeading(__('gibbonedu.com Value Added Services'));
@@ -225,7 +225,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'firstDayOfTheWeek', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromArray($firstDayOfTheWeekOptions)->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromArray($firstDayOfTheWeekOptions)->selected($setting['value'])->required();
 
     $tzlist = array_reduce(DateTimeZone::listIdentifiers(DateTimeZone::ALL), function($group, $item) {
         $group[$item] = __($item);
@@ -234,12 +234,12 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'timezone', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromArray($tzlist)->selected($setting['value'])->placeholder()->isRequired();
+        $row->addSelect($setting['name'])->fromArray($tzlist)->selected($setting['value'])->placeholder()->required();
 
     $setting = getSettingByScope($connection2, 'System', 'currency', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelectCurrency($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addSelectCurrency($setting['name'])->selected($setting['value'])->required();
 
     // MISCELLANEOUS
     $form->addRow()->addHeading(__('Miscellaneous'));
@@ -257,7 +257,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $setting = getSettingByScope($connection2, 'System', 'pagination', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addNumber($setting['name'])->setValue($setting['value'])->minimum(5)->maxLength(50)->isRequired();
+        $row->addNumber($setting['name'])->setValue($setting['value'])->minimum(5)->maxLength(50)->required();
 
     $setting = getSettingByScope($connection2, 'System', 'analytics', true);
     $row = $form->addRow();

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $setting = getSettingByScope($connection2, 'System', 'googleOAuth', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('googleSettings')->onSelect($setting['name'])->when('Y');
 
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $setting = getSettingByScope($connection2, 'System', 'enablePayments', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('paypalSettings')->onSelect($setting['name'])->when('Y');
 
@@ -169,7 +169,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $setting = getSettingByScope($connection2, 'System', 'enableMailerSMTP', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('smtpSettings')->onSelect($setting['name'])->when('Y');
 

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
@@ -137,7 +137,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
-                $row->addSelect('role')->fromArray($roles)->isRequired()->selected($selectedRole);
+                $row->addSelect('role')->fromArray($roles)->required()->selected($selectedRole);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
@@ -106,11 +106,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
-				$row->addSelect('role')->fromArray($roles)->isRequired()->selected($values['role']);
+				$row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
 			
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable'));
-				$row->addYesNo('reportable')->isRequired()->selected($values['reportable']);
+				$row->addYesNo('reportable')->required()->selected($values['reportable']);
 
 			$row = $form->addRow();
 				$row->addFooter();

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
@@ -101,7 +101,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
-                $row->addSelect('role')->fromArray($roles)->isRequired();
+                $row->addSelect('role')->fromArray($roles)->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
@@ -97,11 +97,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
-				$row->addSelect('role')->fromArray($roles)->isRequired()->selected($values['role']);
+				$row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
 			
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable'));
-				$row->addYesNo('reportable')->isRequired()->selected($values['reportable']);
+				$row->addYesNo('reportable')->required()->selected($values['reportable']);
 
 			$row = $form->addRow();
 				$row->addFooter();

--- a/modules/Timetable Admin/courseEnrolment_sync.php
+++ b/modules/Timetable Admin/courseEnrolment_sync.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     $setting = getSettingByScope($connection2, 'Timetable Admin', 'autoEnrolCourses', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow();
         $row->addSubmit();

--- a/modules/Timetable Admin/courseEnrolment_sync_add.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_add.php
@@ -54,14 +54,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
     $row = $form->addRow();
         $row->addLabel('gibbonYearGroupID', __('Year Group'))->description(__('Determines the available courses and classes to map.'));
-        $row->addSelectYearGroup('gibbonYearGroupID')->isRequired();
+        $row->addSelectYearGroup('gibbonYearGroupID')->required();
 
     $row = $form->addRow();
         $column = $row->addColumn();
         $column->addLabel('courseClassMapping', __('Compare to Pattern'))->description(sprintf(__('Classes will be matched to Roll Groups that fit the specified pattern. Choose from %1$s. Must contain %2$s'), '[courseShortName] [yearGroupShortName] [rollGroupShortName]', '[classShortName]'));
 
         $row->addTextField('pattern')
-            ->isRequired()
+            ->required()
             ->setValue('[yearGroupShortName].[classShortName]')
             ->addValidation('Validate.Format', 'pattern: /(\[classShortName\])/');
 

--- a/modules/Timetable Admin/course_manage.php
+++ b/modules/Timetable Admin/course_manage.php
@@ -143,7 +143,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
                 ->setIcon('copy')
                 ->onCLick('return confirm("Are you sure you want to do this? All courses and classes, but not their participants, will be copied.");')
                 ->displayLabel()
-                ->isDirect()
+                ->directLink()
                 ->append('&nbsp;|&nbsp;');
         }
 

--- a/modules/Timetable Admin/course_manage_add.php
+++ b/modules/Timetable Admin/course_manage_add.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
-				$row->addTextField('schoolYearName')->isRequired()->readonly()->setValue($schoolYear['name']);
+				$row->addTextField('schoolYearName')->required()->readonly()->setValue($schoolYear['name']);
 			
 			$sql = "SELECT gibbonDepartmentID as value, name FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
 			$row = $form->addRow();
@@ -83,11 +83,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-				$row->addTextField('name')->isRequired()->maxLength(60);
+				$row->addTextField('name')->required()->maxLength(60);
 			
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'));
-				$row->addTextField('nameShort')->isRequired()->maxLength(12);
+				$row->addTextField('nameShort')->required()->maxLength(12);
 			
 			$row = $form->addRow();
 				$row->addLabel('orderBy', __('Order'))->description(__('May be used to adjust arrangement of courses in reports.'));
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			
 			$row = $form->addRow();
 				$row->addLabel('map', __('Include In Curriculum Map'));
-				$row->addYesNo('map')->isRequired();
+				$row->addYesNo('map')->required();
 			
 			$row = $form->addRow();
 				$row->addLabel('gibbonYearGroupIDList', __('Year Groups'))->description(__('Enrolable year groups.'));

--- a/modules/Timetable Admin/course_manage_class_add.php
+++ b/modules/Timetable Admin/course_manage_class_add.php
@@ -71,19 +71,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
-				$row->addTextField('schoolYearName')->isRequired()->readonly()->setValue($values['yearName']);
+				$row->addTextField('schoolYearName')->required()->readonly()->setValue($values['yearName']);
 			
 			$row = $form->addRow();
 				$row->addLabel('courseName', __('Course'));
-				$row->addTextField('courseName')->isRequired()->readonly()->setValue($values['courseName']);
+				$row->addTextField('courseName')->required()->readonly()->setValue($values['courseName']);
 
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'))->description(__('Must be unique for this course.'));
-				$row->addTextField('name')->isRequired()->maxLength(30);
+				$row->addTextField('name')->required()->maxLength(30);
 			
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this course.'));
-				$row->addTextField('nameShort')->isRequired()->maxLength(8);
+				$row->addTextField('nameShort')->required()->maxLength(8);
 
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable?'))->description(__('Should this class show in reports?'));

--- a/modules/Timetable Admin/course_manage_class_edit.php
+++ b/modules/Timetable Admin/course_manage_class_edit.php
@@ -70,19 +70,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
-				$row->addTextField('schoolYearName')->isRequired()->readonly()->setValue($values['yearName']);
+				$row->addTextField('schoolYearName')->required()->readonly()->setValue($values['yearName']);
 			
 			$row = $form->addRow();
 				$row->addLabel('courseName', __('Course'));
-				$row->addTextField('courseName')->isRequired()->readonly()->setValue($values['courseName']);
+				$row->addTextField('courseName')->required()->readonly()->setValue($values['courseName']);
 
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'))->description(__('Must be unique for this course.'));
-				$row->addTextField('name')->isRequired()->maxLength(30);
+				$row->addTextField('name')->required()->maxLength(30);
 			
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this course.'));
-				$row->addTextField('nameShort')->isRequired()->maxLength(8);
+				$row->addTextField('nameShort')->required()->maxLength(8);
 
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable?'))->description(__('Should this class show in reports?'));

--- a/modules/Timetable Admin/course_manage_edit.php
+++ b/modules/Timetable Admin/course_manage_edit.php
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
-				$row->addTextField('schoolYearName')->isRequired()->readonly()->setValue($values['yearName']);
+				$row->addTextField('schoolYearName')->required()->readonly()->setValue($values['yearName']);
 
 			$sql = "SELECT gibbonDepartmentID as value, name FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
 			$row = $form->addRow();
@@ -101,11 +101,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-				$row->addTextField('name')->isRequired()->maxLength(60);
+				$row->addTextField('name')->required()->maxLength(60);
 
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'));
-				$row->addTextField('nameShort')->isRequired()->maxLength(12);
+				$row->addTextField('nameShort')->required()->maxLength(12);
 
 			$row = $form->addRow();
 				$row->addLabel('orderBy', __('Order'))->description(__('May be used to adjust arrangement of courses in reports.'));
@@ -118,7 +118,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
 			$row = $form->addRow();
 				$row->addLabel('map', __('Include In Curriculum Map'));
-                $row->addYesNo('map')->isRequired();
+                $row->addYesNo('map')->required();
 
 			$row = $form->addRow();
 				$row->addLabel('gibbonYearGroupIDList', __('Year Groups'))->description(__('Enrolable year groups.'));

--- a/modules/Timetable Admin/report_classEnrolment_byRollGroup.php
+++ b/modules/Timetable Admin/report_classEnrolment_byRollGroup.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/report_cla
 
     $row = $form->addRow();
         $row->addLabel('gibbonRollGroupID', __('Roll Group'));
-        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->isRequired()->placeholder();
+        $row->addSelectRollGroup('gibbonRollGroupID', $_SESSION[$guid]['gibbonSchoolYearID'])->selected($gibbonRollGroupID)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session);

--- a/modules/Timetable Admin/ttColumn_add.php
+++ b/modules/Timetable Admin/ttColumn_add.php
@@ -47,11 +47,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_a
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-        $row->addTextField('name')->maxLength(30)->isRequired();
+        $row->addTextField('name')->maxLength(30)->required();
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'));
-        $row->addTextField('nameShort')->maxLength(12)->isRequired();
+        $row->addTextField('nameShort')->maxLength(12)->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Timetable Admin/ttColumn_edit.php
+++ b/modules/Timetable Admin/ttColumn_edit.php
@@ -65,11 +65,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('name')->maxLength(30)->isRequired();
+                $row->addTextField('name')->maxLength(30)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'));
-                $row->addTextField('nameShort')->maxLength(12)->isRequired();
+                $row->addTextField('nameShort')->maxLength(12)->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/ttColumn_edit_row_add.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_add.php
@@ -68,23 +68,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
 
             $row = $form->addRow();
                 $row->addLabel('columnName', __('Column'));
-                $row->addTextField('columnName')->maxLength(30)->isRequired()->readonly()->setValue($values['columnName']);
+                $row->addTextField('columnName')->maxLength(30)->required()->readonly()->setValue($values['columnName']);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('name')->maxLength(12)->isRequired();
+                $row->addTextField('name')->maxLength(12)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('nameShort')->maxLength(4)->isRequired();
+                $row->addTextField('nameShort')->maxLength(4)->required();
 
             $row = $form->addRow();
                 $row->addLabel('timeStart', __('Start Time'));
-                $row->addTime('timeStart')->isRequired();
+                $row->addTime('timeStart')->required();
 
             $row = $form->addRow();
                 $row->addLabel('timeEnd', __('End Time'));
-                $row->addTime('timeEnd')->isRequired()->chainedTo('timeStart');
+                $row->addTime('timeEnd')->required()->chainedTo('timeStart');
 
             $types = array(
                 'Lesson' => __('Lesson'),
@@ -95,7 +95,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                 'Other' => __('Other'));
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromArray($types)->isRequired();
+                $row->addSelect('type')->fromArray($types)->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/ttColumn_edit_row_edit.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_edit.php
@@ -68,23 +68,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
 
             $row = $form->addRow();
                 $row->addLabel('columnName', __('Column'));
-                $row->addTextField('columnName')->maxLength(30)->isRequired()->readonly()->setValue($values['columnName']);
+                $row->addTextField('columnName')->maxLength(30)->required()->readonly()->setValue($values['columnName']);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('name')->maxLength(12)->isRequired();
+                $row->addTextField('name')->maxLength(12)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('nameShort')->maxLength(4)->isRequired();
+                $row->addTextField('nameShort')->maxLength(4)->required();
 
             $row = $form->addRow();
                 $row->addLabel('timeStart', __('Start Time'));
-                $row->addTime('timeStart')->isRequired();
+                $row->addTime('timeStart')->required();
 
             $row = $form->addRow();
                 $row->addLabel('timeEnd', __('End Time'));
-                $row->addTime('timeEnd')->isRequired()->chainedTo('timeStart');
+                $row->addTime('timeEnd')->required()->chainedTo('timeStart');
 
             $types = array(
                 'Lesson' => __('Lesson'),
@@ -95,7 +95,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                 'Other' => __('Other'));
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromArray($types)->isRequired();
+                $row->addSelect('type')->fromArray($types)->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/ttDates_edit_add.php
+++ b/modules/Timetable Admin/ttDates_edit_add.php
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
 
 				$row = $form->addRow();
                     $row->addLabel('gibbonTTDayID', __('Day'));
-                    $row->addSelect('gibbonTTDayID')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder();
+                    $row->addSelect('gibbonTTDayID')->fromQuery($pdo, $sql, $data)->required()->placeholder();
 
 				$row = $form->addRow();
 					$row->addFooter();

--- a/modules/Timetable Admin/tt_add.php
+++ b/modules/Timetable Admin/tt_add.php
@@ -74,23 +74,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php
 
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-                $row->addTextField('schoolYear')->maxLength(20)->isRequired()->readonly()->setValue($values['schoolYear']);
+                $row->addTextField('schoolYear')->maxLength(20)->required()->readonly()->setValue($values['schoolYear']);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('name')->maxLength(30)->isRequired();
+                $row->addTextField('name')->maxLength(30)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'));
-                $row->addTextField('nameShort')->maxLength(12)->isRequired();
+                $row->addTextField('nameShort')->maxLength(12)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShortDisplay', __('Day Column Name'));
-                $row->addSelect('nameShortDisplay')->fromArray(array('Day Of The Week' => __('Day Of The Week'), 'Timetable Day Short Name' => __('Timetable Day Short Name')))->isRequired();
+                $row->addSelect('nameShortDisplay')->fromArray(array('Day Of The Week' => __('Day Of The Week'), 'Timetable Day Short Name' => __('Timetable Day Short Name')))->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $yearGroupsOptions = $timetableGateway->getNonTimetabledYearGroups($gibbonSchoolYearID);
             $row = $form->addRow();

--- a/modules/Timetable Admin/tt_edit.php
+++ b/modules/Timetable Admin/tt_edit.php
@@ -69,23 +69,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
 
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-                $row->addTextField('schoolYear')->maxLength(20)->isRequired()->readonly()->setValue($values['schoolYear']);
+                $row->addTextField('schoolYear')->maxLength(20)->required()->readonly()->setValue($values['schoolYear']);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('name')->maxLength(30)->isRequired();
+                $row->addTextField('name')->maxLength(30)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'));
-                $row->addTextField('nameShort')->maxLength(12)->isRequired();
+                $row->addTextField('nameShort')->maxLength(12)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShortDisplay', __('Day Column Name'));
-                $row->addSelect('nameShortDisplay')->fromArray(array('Day Of The Week' => __('Day Of The Week'), 'Timetable Day Short Name' => __('Timetable Day Short Name')))->isRequired();
+                $row->addSelect('nameShortDisplay')->fromArray(array('Day Of The Week' => __('Day Of The Week'), 'Timetable Day Short Name' => __('Timetable Day Short Name')))->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $yearGroupsOptions = $timetableGateway->getNonTimetabledYearGroups($gibbonSchoolYearID, $gibbonTTID);
             $row = $form->addRow();

--- a/modules/Timetable Admin/tt_edit_day_add.php
+++ b/modules/Timetable Admin/tt_edit_day_add.php
@@ -70,19 +70,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
 
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-                $row->addTextField('schoolYear')->maxLength(20)->isRequired()->readonly()->setValue($values['schoolYear']);
+                $row->addTextField('schoolYear')->maxLength(20)->required()->readonly()->setValue($values['schoolYear']);
 
             $row = $form->addRow();
                 $row->addLabel('ttName', __('Timetable'));
-                $row->addTextField('ttName')->maxLength(20)->isRequired()->readonly()->setValue($values['ttName']);
+                $row->addTextField('ttName')->maxLength(20)->required()->readonly()->setValue($values['ttName']);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('name')->maxLength(12)->isRequired();
+                $row->addTextField('name')->maxLength(12)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('nameShort')->maxLength(4)->isRequired();
+                $row->addTextField('nameShort')->maxLength(4)->required();
 
             $row = $form->addRow();
                 $row->addLabel('color', __('Header Background Colour'))->description(__('RGB Hex value, without leading #.'));
@@ -96,7 +96,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             $sql = "SELECT gibbonTTColumnID as value, name FROM gibbonTTColumn ORDER BY name";
             $row = $form->addRow();
                 $row->addLabel('gibbonTTColumnID', __('Timetable Column'));
-                $row->addSelect('gibbonTTColumnID')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder();
+                $row->addSelect('gibbonTTColumnID')->fromQuery($pdo, $sql, $data)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/tt_edit_day_edit.php
+++ b/modules/Timetable Admin/tt_edit_day_edit.php
@@ -65,19 +65,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
 
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
-                $row->addTextField('schoolYear')->maxLength(20)->isRequired()->readonly()->setValue($values['schoolYear']);
+                $row->addTextField('schoolYear')->maxLength(20)->required()->readonly()->setValue($values['schoolYear']);
 
             $row = $form->addRow();
                 $row->addLabel('ttName', __('Timetable'));
-                $row->addTextField('ttName')->maxLength(20)->isRequired()->readonly()->setValue($values['ttName']);
+                $row->addTextField('ttName')->maxLength(20)->required()->readonly()->setValue($values['ttName']);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('name')->maxLength(12)->isRequired();
+                $row->addTextField('name')->maxLength(12)->required();
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this school year.'));
-                $row->addTextField('nameShort')->maxLength(4)->isRequired();
+                $row->addTextField('nameShort')->maxLength(4)->required();
 
             $row = $form->addRow();
                 $row->addLabel('color', __('Header Background Colour'))->description(__('RGB Hex value, without leading #.'));
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
 
             $row = $form->addRow();
                 $row->addLabel('columnName', __('Timetable Column'));
-                $row->addTextField('columnName')->maxLength(30)->isRequired()->readonly();
+                $row->addTextField('columnName')->maxLength(30)->required()->readonly();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/tt_edit_day_edit_class_add.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_add.php
@@ -74,15 +74,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
 
             $row = $form->addRow();
                 $row->addLabel('ttName', __('Timetable'));
-                $row->addTextField('ttName')->maxLength(20)->isRequired()->readonly()->setValue($values['ttName']);
+                $row->addTextField('ttName')->maxLength(20)->required()->readonly()->setValue($values['ttName']);
 
             $row = $form->addRow();
                 $row->addLabel('dayName', __('Day'));
-                $row->addTextField('dayName')->maxLength(20)->isRequired()->readonly()->setValue($values['dayName']);
+                $row->addTextField('dayName')->maxLength(20)->required()->readonly()->setValue($values['dayName']);
 
             $row = $form->addRow();
                 $row->addLabel('rowName', __('Period'));
-                $row->addTextField('rowName')->maxLength(20)->isRequired()->readonly()->setValue($values['rowName']);
+                $row->addTextField('rowName')->maxLength(20)->required()->readonly()->setValue($values['rowName']);
 
             $classes = array();
             $years = explode(',', $values['gibbonYearGroupIDList']);
@@ -116,7 +116,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             }
             $row = $form->addRow();
                 $row->addLabel('gibbonCourseClassID', __('Class'));
-                $row->addSelect('gibbonCourseClassID')->fromArray($classes)->isRequired()->placeholder();
+                $row->addSelect('gibbonCourseClassID')->fromArray($classes)->required()->placeholder();
 
             $locations = array() ;
             try {

--- a/modules/Timetable Admin/tt_edit_day_edit_class_edit.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_edit.php
@@ -95,19 +95,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
 
                 $row = $form->addRow();
                     $row->addLabel('ttName', __('Timetable'));
-                    $row->addTextField('ttName')->maxLength(20)->isRequired()->readonly()->setValue($values['ttName']);
+                    $row->addTextField('ttName')->maxLength(20)->required()->readonly()->setValue($values['ttName']);
 
                 $row = $form->addRow();
                     $row->addLabel('dayName', __('Day'));
-                    $row->addTextField('dayName')->maxLength(20)->isRequired()->readonly()->setValue($values['dayName']);
+                    $row->addTextField('dayName')->maxLength(20)->required()->readonly()->setValue($values['dayName']);
 
                 $row = $form->addRow();
                     $row->addLabel('rowName', __('Period'));
-                    $row->addTextField('rowName')->maxLength(20)->isRequired()->readonly()->setValue($values['rowName']);
+                    $row->addTextField('rowName')->maxLength(20)->required()->readonly()->setValue($values['rowName']);
 
                 $row = $form->addRow();
                     $row->addLabel('class', __('Class'));
-                    $row->addTextField('class')->maxLength(20)->isRequired()->readonly()->setValue($course.'.'.$class);
+                    $row->addTextField('class')->maxLength(20)->required()->readonly()->setValue($course.'.'.$class);
 
                 $locations = array() ;
                 try {

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
 
             $row = $form->addRow();
                 $row->addLabel('Members', __('Participants'));
-                $row->addSelect('Members')->fromArray($participants)->selectMultiple()->isRequired()->setSize(8);
+                $row->addSelect('Members')->fromArray($participants)->selectMultiple()->required()->setSize(8);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable Admin/tt_import.php
+++ b/modules/Timetable Admin/tt_import.php
@@ -99,15 +99,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
 
                 $row = $form->addRow();
                     $row->addLabel('file', __('CSV File'))->description(__('See Notes below for specification.'));
-                    $row->addFileUpload('file')->isRequired();
+                    $row->addFileUpload('file')->required();
 
                 $row = $form->addRow();
                     $row->addLabel('fieldDelimiter', __('Field Delimiter'));
-                    $row->addTextField('fieldDelimiter')->isRequired()->maxLength(1)->setValue(',');
+                    $row->addTextField('fieldDelimiter')->required()->maxLength(1)->setValue(',');
 
                 $row = $form->addRow();
                     $row->addLabel('stringEnclosure', __('String Enclosure'));
-                    $row->addTextField('stringEnclosure')->isRequired()->maxLength(1)->setValue('"');
+                    $row->addTextField('stringEnclosure')->required()->maxLength(1)->setValue('"');
 
                 $row = $form->addRow();
                     $row->addFooter();

--- a/modules/Timetable/report_viewAvailableSpaces.php
+++ b/modules/Timetable/report_viewAvailableSpaces.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     $row = $form->addRow();
         $row->addLabel('gibbonTTID', __('Timetable'));
-        $row->addSelect('gibbonTTID')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder(__('Please select...'))->selected($gibbonTTID);
+        $row->addSelect('gibbonTTID')->fromQuery($pdo, $sql, $data)->required()->placeholder(__('Please select...'))->selected($gibbonTTID);
 
     $facilityTypes = getSettingByScope($connection2, 'School Admin', 'facilityTypes');
     $facilityTypes = (!empty($facilityTypes))? explode(',', $facilityTypes) : array();

--- a/modules/Timetable/report_viewAvailableTeachers.php
+++ b/modules/Timetable/report_viewAvailableTeachers.php
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     $row = $form->addRow();
         $row->addLabel('gibbonTTID', __('Timetable'));
-        $row->addSelect('gibbonTTID')->fromQuery($pdo, $sql, $data)->isRequired()->placeholder(__('Please select...'))->selected($gibbonTTID);
+        $row->addSelect('gibbonTTID')->fromQuery($pdo, $sql, $data)->required()->placeholder(__('Please select...'))->selected($gibbonTTID);
 
     $row = $form->addRow();
         $row->addLabel('viewBy', __('View'));

--- a/modules/Timetable/spaceBooking_manage_add.php
+++ b/modules/Timetable/spaceBooking_manage_add.php
@@ -88,19 +88,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
 
             $row = $form->addRow();
                 $row->addLabel('foreignKeyID', __('Facility'));
-                $row->addSelect('foreignKeyID')->fromArray($facilities)->isRequired()->placeholder()->selected($foreignKeyID);
+                $row->addSelect('foreignKeyID')->fromArray($facilities)->required()->placeholder()->selected($foreignKeyID);
 
             $row = $form->addRow();
                 $row->addLabel('date', __('Date'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                $row->addDate('date')->isRequired()->setValue($date);
+                $row->addDate('date')->required()->setValue($date);
 
             $row = $form->addRow();
                 $row->addLabel('timeStart', __('Start Time'));
-                $row->addTime('timeStart')->isRequired()->setValue($timeStart);
+                $row->addTime('timeStart')->required()->setValue($timeStart);
 
             $row = $form->addRow();
                 $row->addLabel('timeEnd', __('End Time'));
-                $row->addTime('timeEnd')->isRequired()->chainedTo('timeStart')->setValue($timeEnd);
+                $row->addTime('timeEnd')->required()->chainedTo('timeStart')->setValue($timeEnd);
 
             $repeatOptions = array('No' => __('No'), 'Daily' => __('Daily'), 'Weekly' => __('Weekly'));
             $row = $form->addRow();

--- a/modules/Timetable/spaceBooking_manage_add.php
+++ b/modules/Timetable/spaceBooking_manage_add.php
@@ -204,7 +204,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                         } else {
                             $row = $form->addRow()->addClass('error');
                             $row->addLabel('dates[]', dateConvertBack($guid, $date))->description(__('Not Available'));
-                            $row->addCheckbox('dates[]')->setValue($date)->isDisabled();
+                            $row->addCheckbox('dates[]')->setValue($date)->disabled();
                         }
                     } elseif ($repeat == 'Daily' and $repeatDaily >= 2 and $repeatDaily <= 20) {
                         $continue = true;
@@ -228,7 +228,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                                 } else {
                                     $row = $form->addRow()->addClass('error');
                                     $row->addLabel('dates[]', dateConvertBack($guid, $dateTemp))->description(__('Not Available'));
-                                    $row->addCheckbox('dates[]')->setValue($dateTemp)->isDisabled();
+                                    $row->addCheckbox('dates[]')->setValue($dateTemp)->disabled();
                                 }
                             } else {
                                 ++$failCount;
@@ -260,7 +260,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                                 } else {
                                     $row = $form->addRow()->addClass('error');
                                     $row->addLabel('dates[]', dateConvertBack($guid, $dateTemp))->description(__('Not Available'));
-                                    $row->addCheckbox('dates[]')->setValue($dateTemp)->isDisabled();
+                                    $row->addCheckbox('dates[]')->setValue($dateTemp)->disabled();
                                 }
                             } else {
                                 ++$failCount;

--- a/modules/Timetable/spaceChange_manage_add.php
+++ b/modules/Timetable/spaceChange_manage_add.php
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
 
             $row = $form->addRow();
                 $row->addLabel('gibbonCourseClassID', __('Class'));
-                $row->addSelect('gibbonCourseClassID')->fromArray($classes)->isRequired()->placeholder();
+                $row->addSelect('gibbonCourseClassID')->fromArray($classes)->required()->placeholder();
 
             $row = $form->addRow();
                 $row->addSubmit(__('Proceed'));
@@ -161,7 +161,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
 
                 $row = $form->addRow();
                     $row->addLabel('gibbonTTDayRowClassID', __('Upcoming Class Slots'));
-                    $row->addSelect('gibbonTTDayRowClassID')->fromArray($classSlots)->isRequired()->placeholder();
+                    $row->addSelect('gibbonTTDayRowClassID')->fromArray($classSlots)->required()->placeholder();
 
                 $row = $form->addRow();
                     $row->addLabel('gibbonSpaceID', __('Facility'));

--- a/modules/Timetable/studentEnrolment_manage_edit.php
+++ b/modules/Timetable/studentEnrolment_manage_edit.php
@@ -111,7 +111,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
 
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
-                $row->addSelect('role')->fromArray($roles)->isRequired();
+                $row->addSelect('role')->fromArray($roles)->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable/studentEnrolment_manage_edit_edit.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_edit.php
@@ -95,7 +95,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
 
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
-                $row->addSelect('role')->fromArray($roles)->isRequired()->selected($values['role']);
+                $row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
             
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/Timetable/tt_master.php
+++ b/modules/Timetable/tt_master.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_master.php') 
 
     $row = $form->addRow();
         $row->addLabel('gibbonTTID', __('Timetable'));
-        $row->addSelect('gibbonTTID')->fromArray($ttList)->isRequired()->selected($gibbonTTID);
+        $row->addSelect('gibbonTTID')->fromArray($ttList)->required()->selected($gibbonTTID);
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session);

--- a/modules/Tracking/graphing.php
+++ b/modules/Tracking/graphing.php
@@ -61,10 +61,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') ==
 
         $row = $form->addRow();
             $row->addLabel('gibbonPersonIDs', __('Student'));
-            $row->addSelectStudent('gibbonPersonIDs', $_SESSION[$guid]['gibbonSchoolYearID'], array('byName' => true, 'byRoll' => true))->selectMultiple()->isRequired();
+            $row->addSelectStudent('gibbonPersonIDs', $_SESSION[$guid]['gibbonSchoolYearID'], array('byName' => true, 'byRoll' => true))->selectMultiple()->required();
         $row = $form->addRow();
             $row->addLabel('dataType', __('Data Type'));
-            $row->addSelect('dataType')->fromArray($dataTypes)->isRequired();
+            $row->addSelect('dataType')->fromArray($dataTypes)->required();
 
         $sql = "SELECT gibbonDepartmentID as value, name FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
         $results = $pdo->executeQuery(array(), $sql);

--- a/modules/User Admin/applicationFormSettings.php
+++ b/modules/User Admin/applicationFormSettings.php
@@ -68,12 +68,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
         $row->addNumber($setting['name'])
             ->setValue($setting['value'])
             ->decimalPlaces(2)
-            ->isRequired();
+            ->required();
 
     $setting = getSettingByScope($connection2, 'Application Form', 'publicApplications', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Application Form', 'milestones', true);
     $row = $form->addRow();
@@ -88,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'enableLimitedYearsOfEntry', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('yearsOfEntry')->onSelect('enableLimitedYearsOfEntry')->when('Y');
 
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
             ->setSize(3)
             ->selectMultiple()
             ->selected(explode(',', $setting['value']))
-            ->isRequired();
+            ->required();
 
         if (empty($setting['value'])) {
             $years->selectAll();
@@ -125,14 +125,14 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'requiredDocumentsCompulsory', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Language Learning Options'))->append(__('Set values for applicants to specify which language they wish to learn.'));
 
     $setting = getSettingByScope($connection2, 'Application Form', 'languageOptionsActive', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('languageOptions')->onSelect($setting['name'])->when('Y');
 
@@ -151,7 +151,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'senOptionsActive', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('senOptions')->onSelect($setting['name'])->when('Y');
 
@@ -163,7 +163,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'scholarshipOptionsActive', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('scholarshipOptions')->onSelect($setting['name'])->when('Y');
 
@@ -175,7 +175,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'paymentOptionsActive', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Acceptance Options'));
 
@@ -192,7 +192,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'notificationStudentDefault', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Application Form', 'notificationParentsMessage', true);
     $row = $form->addRow();
@@ -202,7 +202,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'notificationParentsDefault', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Application Form', 'studentDefaultEmail', true);
     $row = $form->addRow();
@@ -217,7 +217,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $setting = getSettingByScope($connection2, 'Application Form', 'autoHouseAssign', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow();
         $row->addContent('<span class="emphasis small">* '.__('denotes a required field').'</span>');

--- a/modules/User Admin/dataUpdaterSettings.php
+++ b/modules/User Admin/dataUpdaterSettings.php
@@ -54,12 +54,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/dataUpdaterSett
     $setting = getSettingByScope($connection2, 'Data Updater', 'requiredUpdatesByType', true);
     $row = $form->addRow()->addClass('requiredUpdates');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addSelect($setting['name'])->fromArray($updateTypes)->isRequired()->selectMultiple()->selected(explode(',', $setting['value']));
+        $row->addSelect($setting['name'])->fromArray($updateTypes)->required()->selectMultiple()->selected(explode(',', $setting['value']));
 
     $setting = getSettingByScope($connection2, 'Data Updater', 'cutoffDate', true);
     $row = $form->addRow()->addClass('requiredUpdates');
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addDate($setting['name'])->isRequired()->setValue(dateConvertBack($guid, $setting['value']));
+        $row->addDate($setting['name'])->required()->setValue(dateConvertBack($guid, $setting['value']));
 
     $sql = "SELECT DISTINCT category as value, category as name FROM gibbonRole ORDER BY category";
     $setting = getSettingByScope($connection2, 'Data Updater', 'redirectByRoleCategory', true);

--- a/modules/User Admin/district_manage_add.php
+++ b/modules/User Admin/district_manage_add.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-        $row->addTextField('name')->maxLength(30)->isRequired();
+        $row->addTextField('name')->maxLength(30)->required();
 
     $row = $form->addRow();
     $row->addFooter();

--- a/modules/User Admin/district_manage_edit.php
+++ b/modules/User Admin/district_manage_edit.php
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
-                $row->addTextField('name')->setValue($values['name'])->maxLength(30)->isRequired();
+                $row->addTextField('name')->setValue($values['name'])->maxLength(30)->required();
 
             $row = $form->addRow();
             $row->addFooter();

--- a/modules/User Admin/family_manage_add.php
+++ b/modules/User Admin/family_manage_add.php
@@ -57,11 +57,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_a
 
     $row = $form->addRow();
         $row->addLabel('name', __('Family Name'));
-        $row->addTextField('name')->maxLength(100)->isRequired();
+        $row->addTextField('name')->maxLength(100)->required();
 
     $row = $form->addRow();
 		$row->addLabel('status', __('Marital Status'));
-		$row->addSelectMaritalStatus('status')->isRequired();
+		$row->addSelectMaritalStatus('status')->required();
 
     $row = $form->addRow();
         $row->addLabel('languageHomePrimary', __('Home Language - Primary'));
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_a
 
     $row = $form->addRow();
         $row->addLabel('nameAddress', __('Address Name'))->description(__('Formal name to address parents with.'));
-        $row->addTextField('nameAddress')->maxLength(100)->isRequired();
+        $row->addTextField('nameAddress')->maxLength(100)->required();
 
     $row = $form->addRow();
         $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));

--- a/modules/User Admin/family_manage_edit.php
+++ b/modules/User Admin/family_manage_edit.php
@@ -86,11 +86,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Family Name'));
-                $row->addTextField('name')->maxLength(100)->isRequired();
+                $row->addTextField('name')->maxLength(100)->required();
 
             $row = $form->addRow();
         		$row->addLabel('status', __('Marital Status'));
-        		$row->addSelectMaritalStatus('status')->isRequired();
+        		$row->addSelectMaritalStatus('status')->required();
 
             $row = $form->addRow();
                 $row->addLabel('languageHomePrimary', __('Home Language - Primary'));
@@ -102,7 +102,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('nameAddress', __('Address Name'))->description(__('Formal name to address parents with.'));
-                $row->addTextField('nameAddress')->maxLength(100)->isRequired();
+                $row->addTextField('nameAddress')->maxLength(100)->required();
 
             $row = $form->addRow();
                 $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
@@ -323,7 +323,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonID', __('Child\'s Name'));
-                $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array('allStudents' => true, 'byName' => true, 'byRoll' => true, 'showRoll' => true))->placeholder()->isRequired();
+                $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'], array('allStudents' => true, 'byName' => true, 'byRoll' => true, 'showRoll' => true))->placeholder()->required();
 
             $row = $form->addRow();
                 $row->addLabel('comment', __('Comment'));
@@ -452,7 +452,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
             }
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonID2', __('Adult\'s Name'));
-                $row->addSelect('gibbonPersonID2')->fromArray($adults)->placeHolder()->isRequired();
+                $row->addSelect('gibbonPersonID2')->fromArray($adults)->placeHolder()->required();
 
             $row = $form->addRow();
                 $row->addLabel('comment2', __('Comment'))->description(__('Data displayed in full Student Profile'));
@@ -460,7 +460,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('childDataAccess', __('Data Access?'))->description(__('Access data on family\'s children?'));
-                $row->addYesNo('childDataAccess')->isRequired();
+                $row->addYesNo('childDataAccess')->required();
 
             $priorities = array(
                 '1' => __('1'),
@@ -469,23 +469,23 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
             );
             $row = $form->addRow();
                 $row->addLabel('contactPriority', __('Contact Priority'))->description(__('The order in which school should contact family members.'));
-                $row->addSelect('contactPriority')->fromArray($priorities)->isRequired();
+                $row->addSelect('contactPriority')->fromArray($priorities)->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactCall', __('Call?'))->description(__('Receive non-emergency phone calls from school?'));
-                $row->addYesNo('contactCall')->isRequired();
+                $row->addYesNo('contactCall')->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactSMS', __('SMS?'))->description(__('Receive non-emergency SMS messages from school?'));
-                $row->addYesNo('contactSMS')->isRequired();
+                $row->addYesNo('contactSMS')->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactEmail', __('Email?'))->description(__('Receive non-emergency emails from school?'));
-                $row->addYesNo('contactEmail')->isRequired();
+                $row->addYesNo('contactEmail')->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactMail', __('Mail?'))->description(__('Receive postage mail from school?'));
-                $row->addYesNo('contactMail')->isRequired();
+                $row->addYesNo('contactMail')->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/User Admin/family_manage_edit_editAdult.php
+++ b/modules/User Admin/family_manage_edit_editAdult.php
@@ -79,7 +79,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('adult', __('Adult\'s Name'));
-                $row->addTextField('adult')->setValue(formatName(htmlPrep($values['title']), htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Parent'))->isRequired()->readonly();
+                $row->addTextField('adult')->setValue(formatName(htmlPrep($values['title']), htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Parent'))->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('comment', __('Comment'))->description(__('Data displayed in full Student Profile'));
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('childDataAccess', __('Data Access?'))->description(__('Access data on family\'s children?'));
-                $row->addYesNo('childDataAccess')->isRequired();
+                $row->addYesNo('childDataAccess')->required();
 
             $priorities = array(
                 '1' => __('1'),
@@ -96,23 +96,23 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
             );
             $row = $form->addRow();
                 $row->addLabel('contactPriority', __('Contact Priority'))->description(__('The order in which school should contact family members.'));
-                $row->addSelect('contactPriority')->fromArray($priorities)->isRequired();
+                $row->addSelect('contactPriority')->fromArray($priorities)->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactCall', __('Call?'))->description(__('Receive non-emergency phone calls from school?'));
-                $row->addYesNo('contactCall')->isRequired();
+                $row->addYesNo('contactCall')->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactSMS', __('SMS?'))->description(__('Receive non-emergency SMS messages from school?'));
-                $row->addYesNo('contactSMS')->isRequired();
+                $row->addYesNo('contactSMS')->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactEmail', __('Email?'))->description(__('Receive non-emergency emails from school?'));
-                $row->addYesNo('contactEmail')->isRequired();
+                $row->addYesNo('contactEmail')->required();
 
             $row = $form->addRow()->addClass('contact');
                 $row->addLabel('contactMail', __('Mail?'))->description(__('Receive postage mail from school?'));
-                $row->addYesNo('contactMail')->isRequired();
+                $row->addYesNo('contactMail')->required();
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/User Admin/family_manage_edit_editChild.php
+++ b/modules/User Admin/family_manage_edit_editChild.php
@@ -79,7 +79,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $row = $form->addRow();
                 $row->addLabel('child', __('Childs\'s Name'));
-                $row->addTextField('child')->setValue(formatName(htmlPrep($values['title']), htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Parent'))->isRequired()->readonly();
+                $row->addTextField('child')->setValue(formatName(htmlPrep($values['title']), htmlPrep($values['preferredName']), htmlPrep($values['surname']), 'Parent'))->required()->readonly();
 
             $row = $form->addRow();
                 $row->addLabel('comment', __('Comment'))->description(__('Data displayed in full Student Profile'));

--- a/modules/User Admin/import_userPhotos.php
+++ b/modules/User Admin/import_userPhotos.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/import_userPhot
 
         $row = $form->addRow();
             $row->addLabel('file', __('ZIP File'))->description(__('See Notes below for specification.'));
-            $row->addFileUpload('file')->isRequired();
+            $row->addFileUpload('file')->required();
 
         $row = $form->addRow();
             $row->addFooter();

--- a/modules/User Admin/publicRegistrationSettings.php
+++ b/modules/User Admin/publicRegistrationSettings.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/publicRegistrat
     $setting = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'User Admin', 'publicRegistrationMinimumAge', true);
     $row = $form->addRow();
@@ -51,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/publicRegistrat
     $setting = getSettingByScope($connection2, 'User Admin', 'publicRegistrationDefaultStatus', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addSelect($setting['name'])->fromString('Full, Pending Approval')->selected($setting['value'])->isRequired();
+        $row->addSelect($setting['name'])->fromString('Full, Pending Approval')->selected($setting['value'])->required();
 
     $sql = "SELECT gibbonRoleID AS value, name FROM gibbonRole ORDER BY name";
     $setting = getSettingByScope($connection2, 'User Admin', 'publicRegistrationDefaultRole', true);
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/publicRegistrat
         $row->addSelect($setting['name'])
             ->fromQuery($pdo, $sql)
             ->selected($setting['value'])
-            ->isRequired();
+            ->required();
 
     $row = $form->addRow()->addHeading(__('Interface Options'));
 

--- a/modules/User Admin/role_manage_add.php
+++ b/modules/User Admin/role_manage_add.php
@@ -57,40 +57,40 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_add
 
     $row = $form->addRow();
         $row->addLabel('category', __('Category'));
-        $row->addSelect('category')->fromArray($categories)->isRequired()->placeholder();
+        $row->addSelect('category')->fromArray($categories)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->isRequired()->maxLength(20);
+        $row->addTextField('name')->required()->maxLength(20);
 
     $row = $form->addRow();
         $row->addLabel('nameShort', __('Short Name'));
-        $row->addTextField('nameShort')->isRequired()->maxLength(4);
+        $row->addTextField('nameShort')->required()->maxLength(4);
 
     $row = $form->addRow();
         $row->addLabel('description', __('Description'));
-        $row->addTextField('description')->isRequired()->maxLength(60);
+        $row->addTextField('description')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addTextField('type')->isRequired()->readonly()->setValue('Additional');
+        $row->addTextField('type')->required()->readonly()->setValue('Additional');
 
     $row = $form->addRow();
         $row->addLabel('canLoginRole', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
-        $row->addYesNo('canLoginRole')->isRequired()->selected('Y');
+        $row->addYesNo('canLoginRole')->required()->selected('Y');
 
     $form->toggleVisibilityByClass('loginOptions')->onSelect('canLoginRole')->when('Y');
     $row = $form->addRow()->addClass('loginOptions');
         $row->addLabel('pastYearsLogin', __('Login To Past Years'));
-        $row->addYesNo('pastYearsLogin')->isRequired();
+        $row->addYesNo('pastYearsLogin')->required();
 
     $row = $form->addRow()->addClass('loginOptions');
         $row->addLabel('futureYearsLogin', __('Login To Future Years'));
-        $row->addYesNo('futureYearsLogin')->isRequired();
+        $row->addYesNo('futureYearsLogin')->required();
 
     $row = $form->addRow();
         $row->addLabel('restriction', __('Restriction'))->description('Determines who can grant or remove this role in Manage Users.');
-        $row->addSelect('restriction')->fromArray($restrictions)->isRequired();
+        $row->addSelect('restriction')->fromArray($restrictions)->required();
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/User Admin/role_manage_duplicate.php
+++ b/modules/User Admin/role_manage_duplicate.php
@@ -66,16 +66,16 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_dup
 
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
-                $row->addTextField('role')->isRequired()->readonly()->setValue($role['name']);
+                $row->addTextField('role')->required()->readonly()->setValue($role['name']);
 
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(20);
+                $row->addTextField('name')->required()->maxLength(20);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(4);
+                $row->addTextField('nameShort')->required()->maxLength(4);
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/modules/User Admin/role_manage_edit.php
+++ b/modules/User Admin/role_manage_edit.php
@@ -79,50 +79,50 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
             $row = $form->addRow();
                 $row->addLabel('category', __('Category'));
             if ($isReadOnly) {
-                $row->addTextField('category')->isRequired()->readonly()->setValue($role['category']);
+                $row->addTextField('category')->required()->readonly()->setValue($role['category']);
             } else {
-                $row->addSelect('category')->fromArray($categories)->isRequired()->placeholder()->selected($role['category']);
+                $row->addSelect('category')->fromArray($categories)->required()->placeholder()->selected($role['category']);
             }
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->isRequired()->maxLength(20)->readonly($isReadOnly)->setValue($role['name']);
+                $row->addTextField('name')->required()->maxLength(20)->readonly($isReadOnly)->setValue($role['name']);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'));
-                $row->addTextField('nameShort')->isRequired()->maxLength(4)->readonly($isReadOnly)->setValue($role['nameShort']);
+                $row->addTextField('nameShort')->required()->maxLength(4)->readonly($isReadOnly)->setValue($role['nameShort']);
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));
-                $row->addTextField('description')->isRequired()->maxLength(60)->readonly($isReadOnly)->setValue($role['description']);
+                $row->addTextField('description')->required()->maxLength(60)->readonly($isReadOnly)->setValue($role['description']);
 
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addTextField('type')->isRequired()->readonly()->setValue($role['type']);
+                $row->addTextField('type')->required()->readonly()->setValue($role['type']);
 
             $row = $form->addRow();
                 $row->addLabel('canLoginRole', __('Can Login?'))->description(__('Are users with this primary role able to login?'));
                 if ($role['name'] == 'Administrator') {
-                    $row->addTextField('canLoginRole')->isRequired()->readonly()->setValue(__('Yes'));
+                    $row->addTextField('canLoginRole')->required()->readonly()->setValue(__('Yes'));
                 } else {
-                    $row->addYesNo('canLoginRole')->isRequired()->selected($role['canLoginRole']);
+                    $row->addYesNo('canLoginRole')->required()->selected($role['canLoginRole']);
                     $form->toggleVisibilityByClass('loginOptions')->onSelect('canLoginRole')->when('Y');
                 }
 
             $row = $form->addRow()->addClass('loginOptions');
                 $row->addLabel('pastYearsLogin', __('Login To Past Years'));
-                $row->addYesNo('pastYearsLogin')->isRequired()->selected($role['pastYearsLogin']);
+                $row->addYesNo('pastYearsLogin')->required()->selected($role['pastYearsLogin']);
 
             $row = $form->addRow()->addClass('loginOptions');
                 $row->addLabel('futureYearsLogin', __('Login To Future Years'));
-                $row->addYesNo('futureYearsLogin')->isRequired()->selected($role['futureYearsLogin']);
+                $row->addYesNo('futureYearsLogin')->required()->selected($role['futureYearsLogin']);
 
             $row = $form->addRow();
                 $row->addLabel('restriction', __('Restriction'))->description('Determines who can grant or remove this role in Manage Users.');
             if ($role['name'] == 'Administrator') {
-                $row->addTextField('restriction')->isRequired()->readonly()->setValue('Admin Only');
+                $row->addTextField('restriction')->required()->readonly()->setValue('Admin Only');
             } else {
-                $row->addSelect('restriction')->fromArray($restrictions)->isRequired()->selected($role['restriction']);
+                $row->addSelect('restriction')->fromArray($restrictions)->required()->selected($role['restriction']);
             }
 
             $row = $form->addRow();

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -168,23 +168,23 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                     $row = $form->addRow();
                         $row->addLabel('nextname', __('School Year Name'))->description(__('Must be unique.'));
-                        $row->addTextField('nextname')->isRequired()->maxLength(9);
+                        $row->addTextField('nextname')->required()->maxLength(9);
 
                     $row = $form->addRow();
                         $row->addLabel('nextstatus', __('Status'));
-                        $row->addTextField('nextstatus')->setValue(__('Upcoming'))->isRequired()->readonly();
+                        $row->addTextField('nextstatus')->setValue(__('Upcoming'))->required()->readonly();
 
                     $row = $form->addRow();
                         $row->addLabel('nextsequenceNumber', __('Sequence Number'))->description(__('Must be unique. Controls chronological ordering.'));
-                        $row->addSequenceNumber('nextsequenceNumber', 'gibbonSchoolYear', '', 'sequenceNumber')->isRequired()->maxLength(3)->readonly();
+                        $row->addSequenceNumber('nextsequenceNumber', 'gibbonSchoolYear', '', 'sequenceNumber')->required()->maxLength(3)->readonly();
 
                     $row = $form->addRow();
                         $row->addLabel('nextfirstDay', __('First Day'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                        $row->addDate('nextfirstDay')->isRequired();
+                        $row->addDate('nextfirstDay')->required();
 
                     $row = $form->addRow();
                         $row->addLabel('nextlastDay', __('Last Day'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-                        $row->addDate('nextlastDay')->isRequired();
+                        $row->addDate('nextlastDay')->required();
                 }
 
                 //SET EXPECTED USERS TO FULL
@@ -217,7 +217,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                             $row->addColumn()->addContent(__($rowExpect['name']));
                             $row->addColumn()->addContent(__('Expected'));
                             $column = $row->addColumn();
-                                $column->addSelect($count."-expect-status")->fromArray($statuses)->isRequired()->setClass('shortWidth floatNone');
+                                $column->addSelect($count."-expect-status")->fromArray($statuses)->required()->setClass('shortWidth floatNone');
                     }
                     $form->addHiddenValue("expect-count", $count);
                 }
@@ -258,9 +258,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                 $column = $row->addColumn();
                                     $column->addCheckbox($count."-enrol-enrol")->setValue('Y')->checked('Y');
                                 $column = $row->addColumn();
-                                    $column->addSelect($count."-enrol-gibbonYearGroupID")->fromArray($yearGroups)->isRequired()->setClass('shortWidth floatNone');
+                                    $column->addSelect($count."-enrol-gibbonYearGroupID")->fromArray($yearGroups)->required()->setClass('shortWidth floatNone');
                                 $column = $row->addColumn();
-                                    $column->addSelect($count."-enrol-gibbonRollGroupID")->fromArray($rollGroups)->isRequired()->setClass('shortWidth floatNone');
+                                    $column->addSelect($count."-enrol-gibbonRollGroupID")->fromArray($rollGroups)->required()->setClass('shortWidth floatNone');
                         }
                         $form->addHiddenValue("enrol-count", $count);
                     }
@@ -350,9 +350,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                     $column = $row->addColumn();
                                         $column->addCheckbox($count."-enrolFull-enrol")->setValue('Y')->checked('Y');
                                     $column = $row->addColumn();
-                                        $column->addSelect($count."-enrolFull-gibbonYearGroupID")->fromArray($yearGroups)->isRequired()->setClass('shortWidth floatNone')->selected($yearGroupSelect);
+                                        $column->addSelect($count."-enrolFull-gibbonYearGroupID")->fromArray($yearGroups)->required()->setClass('shortWidth floatNone')->selected($yearGroupSelect);
                                     $column = $row->addColumn();
-                                        $column->addSelect($count."-enrolFull-gibbonRollGroupID")->fromArray($rollGroups)->isRequired()->setClass('shortWidth floatNone')->selected($rollGroupSelect);
+                                        $column->addSelect($count."-enrolFull-gibbonRollGroupID")->fromArray($rollGroups)->required()->setClass('shortWidth floatNone')->selected($rollGroupSelect);
                             }
                             $form->addHiddenValue("enrolFull-count", $count);
                         }
@@ -424,9 +424,9 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                     $enrolmentCheckRollGroup=$rowReenrol['gibbonRollGroupIDNext'];
                                 }
                                 $column = $row->addColumn();
-                                    $column->addSelect($count."-reenrol-gibbonYearGroupID")->fromArray($yearGroups)->isRequired()->setClass('shortWidth floatNone')->selected($enrolmentCheckYearGroup);
+                                    $column->addSelect($count."-reenrol-gibbonYearGroupID")->fromArray($yearGroups)->required()->setClass('shortWidth floatNone')->selected($enrolmentCheckYearGroup);
                                 $column = $row->addColumn();
-                                        $column->addSelect($count."-reenrol-gibbonRollGroupID")->fromArray($rollGroups)->isRequired()->setClass('shortWidth floatNone')->selected($enrolmentCheckRollGroup);
+                                        $column->addSelect($count."-reenrol-gibbonRollGroupID")->fromArray($rollGroups)->required()->setClass('shortWidth floatNone')->selected($enrolmentCheckRollGroup);
                         }
                         $form->addHiddenValue("reenrol-count", $count);
                     }
@@ -462,7 +462,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                             $row->addColumn()->addContent(__($rowFinal['name']));
                             $row->addColumn()->addContent(__('Full'));
                             $column = $row->addColumn();
-                                $column->addSelect($count."-final-status")->fromArray($statuses)->isRequired()->setClass('shortWidth floatNone')->selected('Left');
+                                $column->addSelect($count."-final-status")->fromArray($statuses)->required()->setClass('shortWidth floatNone')->selected('Left');
                     }
                     $form->addHiddenValue("final-count", $count);
                 }
@@ -499,7 +499,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                             $column = $row->addColumn();
                                 $column->addCheckbox($count."-register-enrol")->setValue('Y')->checked('Y');
                             $column = $row->addColumn();
-                                $column->addSelect($count."-register-type")->fromArray(array('Teaching' => __('Teaching'), 'Support' => __('Support')))->isRequired()->setClass('shortWidth floatNone');
+                                $column->addSelect($count."-register-type")->fromArray(array('Teaching' => __('Teaching'), 'Support' => __('Support')))->required()->setClass('shortWidth floatNone');
                             $column = $row->addColumn();
                                 $column->addtextField($count."-register-jobTitle")->setClass('shortWidth floatNone')->maxLength(100);
                     }

--- a/modules/User Admin/staffApplicationFormSettings.php
+++ b/modules/User Admin/staffApplicationFormSettings.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffApplicatio
     $setting = getSettingByScope($connection2, 'Staff Application Form', 'staffApplicationFormPublicApplications', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Staff', 'staffApplicationFormMilestones', true);
     $row = $form->addRow();
@@ -114,7 +114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffApplicatio
     $setting = getSettingByScope($connection2, 'Staff', 'staffApplicationFormRequiredDocumentsCompulsory', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Acceptance Options'));
 
@@ -131,7 +131,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffApplicatio
     $setting = getSettingByScope($connection2, 'Staff', 'staffApplicationFormNotificationDefault', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $setting = getSettingByScope($connection2, 'Staff', 'staffApplicationFormDefaultEmail', true);
     $row = $form->addRow();

--- a/modules/User Admin/staffSettings.php
+++ b/modules/User Admin/staffSettings.php
@@ -70,8 +70,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
             __('Example').': '.formatName($title, $preferredName, $surname, 'Staff', false, false).'<br/>'.
             __('Reversed').': '.formatName($title, $preferredName, $surname, 'Staff', true, false));
         $col = $row->addColumn($setting['name'])->addClass('stacked');
-        $col->addTextField($setting['name'])->isRequired()->maxLength(60)->setValue($setting['value']);
-        $col->addTextField($settingRev['name'])->isRequired()->maxLength(60)->setTitle(__('Reversed'))->setValue($settingRev['value']);
+        $col->addTextField($setting['name'])->required()->maxLength(60)->setValue($setting['value']);
+        $col->addTextField($settingRev['name'])->required()->maxLength(60)->setTitle(__('Reversed'))->setValue($settingRev['value']);
 
     $setting = getSettingByScope($connection2, 'System', 'nameFormatStaffInformal', true);
     $settingRev = getSettingByScope($connection2, 'System', 'nameFormatStaffInformalReversed', true);
@@ -81,8 +81,8 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
             __('Example').': '.formatName($title, $preferredName, $surname, 'Staff', false, true).'<br/>'.
             __('Reversed').': '.formatName($title, $preferredName, $surname, 'Staff', true, true));
         $col = $row->addColumn($setting['name'])->addClass('stacked right');
-        $col->addTextField($setting['name'])->isRequired()->maxLength(60)->setValue($setting['value']);
-        $col->addTextField($settingRev['name'])->isRequired()->maxLength(60)->setTitle(__('Reversed'))->setValue($settingRev['value']);
+        $col->addTextField($setting['name'])->required()->maxLength(60)->setValue($setting['value']);
+        $col->addTextField($settingRev['name'])->required()->maxLength(60)->setTitle(__('Reversed'))->setValue($settingRev['value']);
 
     $form->loadAllValuesFrom($formats);
 

--- a/modules/User Admin/userFields_add.php
+++ b/modules/User Admin/userFields_add.php
@@ -46,15 +46,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_add.
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-        $row->addTextField('name')->maxLength(50)->isRequired();
+        $row->addTextField('name')->maxLength(50)->required();
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-        $row->addYesNo('active')->isRequired();
+        $row->addYesNo('active')->required();
 
     $row = $form->addRow();
         $row->addLabel('description', __('Description'));
-        $row->addTextField('description')->maxLength(255)->isRequired();
+        $row->addTextField('description')->maxLength(255)->required();
 
     $types = array(
         'varchar' => __('Short Text (max 255 characters)'),
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_add.
     );
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addSelect('type')->fromArray($types)->isRequired()->placeholder();
+        $row->addSelect('type')->fromArray($types)->required()->placeholder();
 
     $form->toggleVisibilityByClass('optionsRow')->onSelect('type')->when(array('varchar', 'text', 'select'));
 
@@ -74,11 +74,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_add.
             ->description(__('Short Text: number of characters, up to 255.'))
             ->description(__('Long Text: number of rows for field.'))
             ->description(__('Dropdown: comma separated list of options.'));
-        $row->addTextArea('options')->setRows(3)->isRequired();
+        $row->addTextArea('options')->setRows(3)->required();
 
     $row = $form->addRow();
         $row->addLabel('required', __('Required'))->description(__('Is this field compulsory?'));
-        $row->addYesNo('required')->isRequired();
+        $row->addYesNo('required')->required();
 
     $activePersonOptions = array(
         'activePersonStudent' => __('Student'),
@@ -92,17 +92,17 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_add.
 
     $row = $form->addRow();
         $row->addLabel('activeDataUpdater', __('Include In Data Updater?'));
-        $row->addSelect('activeDataUpdater')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('1')->isRequired();
+        $row->addSelect('activeDataUpdater')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('1')->required();
 
     $row = $form->addRow();
         $row->addLabel('activeApplicationForm', __('Include In Application Form?'));
-        $row->addSelect('activeApplicationForm')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->isRequired();
+        $row->addSelect('activeApplicationForm')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->required();
     
     $enablePublicRegistration = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration');
     if ($enablePublicRegistration == 'Y') {
         $row = $form->addRow();
             $row->addLabel('activePublicRegistration', __('Include In Public Registration Form?'));
-            $row->addSelect('activePublicRegistration')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->isRequired();
+            $row->addSelect('activePublicRegistration')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->required();
     }
 
     $row = $form->addRow();

--- a/modules/User Admin/userFields_edit.php
+++ b/modules/User Admin/userFields_edit.php
@@ -66,15 +66,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_edit
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
-                $row->addTextField('name')->maxLength(50)->isRequired();
+                $row->addTextField('name')->maxLength(50)->required();
 
             $row = $form->addRow();
                 $row->addLabel('active', __('Active'));
-                $row->addYesNo('active')->isRequired();
+                $row->addYesNo('active')->required();
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));
-                $row->addTextField('description')->maxLength(255)->isRequired();
+                $row->addTextField('description')->maxLength(255)->required();
 
             $types = array(
                 'varchar' => __('Short Text (max 255 characters)'),
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_edit
             );
             $row = $form->addRow();
                 $row->addLabel('type', __('Type'));
-                $row->addSelect('type')->fromArray($types)->isRequired()->placeholder();
+                $row->addSelect('type')->fromArray($types)->required()->placeholder();
 
             $form->toggleVisibilityByClass('optionsRow')->onSelect('type')->when(array('varchar', 'text', 'select'));
 
@@ -94,11 +94,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_edit
                     ->description(__('Short Text: number of characters, up to 255.'))
                     ->description(__('Long Text: number of rows for field.'))
                     ->description(__('Dropdown: comma separated list of options.'));
-                $row->addTextArea('options')->setRows(3)->isRequired();
+                $row->addTextArea('options')->setRows(3)->required();
 
             $row = $form->addRow();
                 $row->addLabel('required', __('Required'))->description(__('Is this field compulsory?'));
-                $row->addYesNo('required')->isRequired();
+                $row->addYesNo('required')->required();
 
             $activePersonOptions = array(
                 'activePersonStudent' => __('Student'),
@@ -115,17 +115,17 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_edit
 
             $row = $form->addRow();
                 $row->addLabel('activeDataUpdater', __('Include In Data Updater?'));
-                $row->addSelect('activeDataUpdater')->fromArray(array('1' => __('Yes'), '0' => __('No')))->isRequired();
+                $row->addSelect('activeDataUpdater')->fromArray(array('1' => __('Yes'), '0' => __('No')))->required();
 
             $row = $form->addRow();
                 $row->addLabel('activeApplicationForm', __('Include In Application Form?'));
-                $row->addSelect('activeApplicationForm')->fromArray(array('1' => __('Yes'), '0' => __('No')))->isRequired();
+                $row->addSelect('activeApplicationForm')->fromArray(array('1' => __('Yes'), '0' => __('No')))->required();
 
             $enablePublicRegistration = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration');
             if ($enablePublicRegistration == 'Y') {
                 $row = $form->addRow();
                     $row->addLabel('activePublicRegistration', __('Include In Public Registration Form?'));
-                    $row->addSelect('activePublicRegistration')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->isRequired();
+                    $row->addSelect('activePublicRegistration')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->required();
             }
 
             $row = $form->addRow();

--- a/modules/User Admin/userSettings.php
+++ b/modules/User Admin/userSettings.php
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
     $setting = getSettingByScope($connection2, 'User Admin', 'privacy', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $form->toggleVisibilityByClass('privacy')->onSelect($setting['name'])->when('Y');
 
@@ -133,7 +133,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
     $setting = getSettingByScope($connection2, 'User Admin', 'personalBackground', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
-        $row->addYesNo($setting['name'])->selected($setting['value'])->isRequired();
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     $row = $form->addRow()->addHeading(__('Day-Type Options'));
 

--- a/modules/User Admin/userSettings_usernameFormat_add.php
+++ b/modules/User Admin/userSettings_usernameFormat_add.php
@@ -47,12 +47,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
 
     $row = $form->addRow();
         $row->addLabel('format', __('Username Format'))->description(__('How should usernames be formated? Choose from [preferredName], [firstName], [surname].').'<br>'.__('Use a colon to limit the number of letters, for example [preferredName:1] will use the first initial.'));
-        $row->addTextField('format')->isRequired()->setValue('[preferredName:1][surname]');
+        $row->addTextField('format')->required()->setValue('[preferredName:1][surname]');
 
     $row = $form->addRow();
         $row->addLabel('gibbonRoleIDList', __('Roles'));
         $row->addSelect('gibbonRoleIDList')
-            ->isRequired()
+            ->required()
             ->selectMultiple()
             ->setSize(4)
             ->fromResults($result);
@@ -69,15 +69,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
 
     $row = $form->addRow()->addClass('numericValueSettings');
         $row->addLabel('numericValue', __('Starting Value'))->description(__('Each time a username is generated this value will increase by the increment defined below.'));
-        $row->addTextField('numericValue')->isRequired()->setValue('0')->maxLength(12);
+        $row->addTextField('numericValue')->required()->setValue('0')->maxLength(12);
 
     $row = $form->addRow()->addClass('numericValueSettings');
         $row->addLabel('numericSize', __('Number of Digits'));
-        $row->addNumber('numericSize')->isRequired()->setValue('4')->minimum(0)->maximum(12);
+        $row->addNumber('numericSize')->required()->setValue('4')->minimum(0)->maximum(12);
 
     $row = $form->addRow()->addClass('numericValueSettings');
         $row->addLabel('numericIncrement', __('Increment By'));
-        $row->addNumber('numericIncrement')->isRequired()->setValue('1')->minimum(0)->maximum(100);
+        $row->addNumber('numericIncrement')->required()->setValue('1')->minimum(0)->maximum(100);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/User Admin/userSettings_usernameFormat_edit.php
+++ b/modules/User Admin/userSettings_usernameFormat_edit.php
@@ -69,12 +69,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
 
     $row = $form->addRow();
         $row->addLabel('format', __('Username Format'))->description(__('How should usernames be formated? Choose from [preferredName], [firstName], [surname].').'<br>'.__('Use a colon to limit the number of letters, for example [preferredName:1] will use the first initial.'));
-        $row->addTextField('format')->isRequired();
+        $row->addTextField('format')->required();
 
     $row = $form->addRow();
         $row->addLabel('gibbonRoleIDList', __('Roles'));
         $row->addSelect('gibbonRoleIDList')
-            ->isRequired()
+            ->required()
             ->selectMultiple()
             ->setSize(4)
             ->fromResults($result);
@@ -91,15 +91,15 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
 
     $row = $form->addRow()->addClass('numericValueSettings');
         $row->addLabel('numericValue', __('Starting Value'))->description(__('Each time a username is generated this value will increase by the increment defined below.'));
-        $row->addTextField('numericValue')->isRequired()->maxLength(12);
+        $row->addTextField('numericValue')->required()->maxLength(12);
 
     $row = $form->addRow()->addClass('numericValueSettings');
         $row->addLabel('numericSize', __('Number of Digits'));
-        $row->addNumber('numericSize')->isRequired()->minimum(0)->maximum(12);
+        $row->addNumber('numericSize')->required()->minimum(0)->maximum(12);
 
     $row = $form->addRow()->addClass('numericValueSettings');
         $row->addLabel('numericIncrement', __('Increment By'));
-        $row->addNumber('numericIncrement')->isRequired()->minimum(0)->maximum(100);
+        $row->addNumber('numericIncrement')->required()->minimum(0)->maximum(100);
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -66,19 +66,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 
     $row = $form->addRow();
         $row->addLabel('surname', __('Surname'))->description(__('Family name as shown in ID documents.'));
-        $row->addTextField('surname')->isRequired()->maxLength(60);
+        $row->addTextField('surname')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('firstName', __('First Name'))->description(__('First name as shown in ID documents.'));
-        $row->addTextField('firstName')->isRequired()->maxLength(60);
+        $row->addTextField('firstName')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('preferredName', __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-        $row->addTextField('preferredName')->isRequired()->maxLength(60);
+        $row->addTextField('preferredName')->required()->maxLength(60);
 
     $row = $form->addRow();
         $row->addLabel('officialName', __('Official Name'))->description(__('Full name as shown in ID documents.'));
-        $row->addTextField('officialName')->isRequired()->maxLength(150)->setTitle(__('Please enter full name as shown in ID documents'));
+        $row->addTextField('officialName')->required()->maxLength(150)->setTitle(__('Please enter full name as shown in ID documents'));
 
     $row = $form->addRow();
         $row->addLabel('nameInCharacters', __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 
     $row = $form->addRow();
         $row->addLabel('gender', __('Gender'));
-        $row->addSelectGender('gender')->isRequired();
+        $row->addSelectGender('gender')->required();
 
     $row = $form->addRow();
         $row->addLabel('dob', __('Date of Birth'));
@@ -126,12 +126,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
 
     $row = $form->addRow();
         $row->addLabel('gibbonRoleIDPrimary', __('Primary Role'))->description(__('Controls what a user can do and see.'));
-        $row->addSelect('gibbonRoleIDPrimary')->fromArray($availableRoles)->isRequired()->placeholder();
+        $row->addSelect('gibbonRoleIDPrimary')->fromArray($availableRoles)->required()->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('username', __('Username'))->description(__('System login name.'));
         $row->addUsername('username')
-            ->isRequired()
+            ->required()
             ->addGenerateUsernameButton($form);
 
     $policy = getPasswordPolicy($guid, $connection2);
@@ -143,27 +143,27 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addPassword('passwordNew')
             ->addPasswordPolicy($pdo)
             ->addGeneratePasswordButton($form)
-            ->isRequired()
+            ->required()
             ->maxLength(30);
 
     $row = $form->addRow();
         $row->addLabel('passwordConfirm', __('Confirm Password'));
         $row->addPassword('passwordConfirm')
             ->addConfirmation('passwordNew')
-            ->isRequired()
+            ->required()
             ->maxLength(30);
 
     $row = $form->addRow();
         $row->addLabel('status', __('Status'))->description(__('This determines visibility within the system.'));
-        $row->addSelectStatus('status')->isRequired();
+        $row->addSelectStatus('status')->required();
 
     $row = $form->addRow();
         $row->addLabel('canLogin', __('Can Login?'));
-        $row->addYesNo('canLogin')->isRequired();
+        $row->addYesNo('canLogin')->required();
 
     $row = $form->addRow();
         $row->addLabel('passwordForceReset', __('Force Reset Password?'))->description(__('User will be prompted on next login.'));
-        $row->addYesNo('passwordForceReset')->isRequired();
+        $row->addYesNo('passwordForceReset')->required();
 
     // CONTACT INFORMATION
     $form->addRow()->addHeading(__('Contact Information'));

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         
     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
     if ($uniqueEmailAddress == 'Y') {
-        $email->isUnique($_SESSION[$guid]['absoluteURL'].'/modules/User Admin/user_manage_emailAjax.php');
+        $email->uniqueField($_SESSION[$guid]['absoluteURL'].'/modules/User Admin/user_manage_emailAjax.php');
     }
 
     $row = $form->addRow();

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -236,7 +236,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
 			if ($uniqueEmailAddress == 'Y') {
-				$email->isUnique('./modules/User Admin/user_manage_emailAjax.php', array('gibbonPersonID' => $gibbonPersonID));
+				$email->uniqueField('./modules/User Admin/user_manage_emailAjax.php', array('gibbonPersonID' => $gibbonPersonID));
 			}
 
 			$row = $form->addRow();

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -105,19 +105,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$row = $form->addRow();
 				$row->addLabel('surname', __('Surname'))->description(__('Family name as shown in ID documents.'));
-				$row->addTextField('surname')->isRequired()->maxLength(60);
+				$row->addTextField('surname')->required()->maxLength(60);
 
 			$row = $form->addRow();
 				$row->addLabel('firstName', __('First Name'))->description(__('First name as shown in ID documents.'));
-				$row->addTextField('firstName')->isRequired()->maxLength(60);
+				$row->addTextField('firstName')->required()->maxLength(60);
 
 			$row = $form->addRow();
 				$row->addLabel('preferredName', __('Preferred Name'))->description(__('Most common name, alias, nickname, etc.'));
-				$row->addTextField('preferredName')->isRequired()->maxLength(60);
+				$row->addTextField('preferredName')->required()->maxLength(60);
 
 			$row = $form->addRow();
 				$row->addLabel('officialName', __('Official Name'))->description(__('Full name as shown in ID documents.'));
-				$row->addTextField('officialName')->isRequired()->maxLength(150)->setTitle(__('Please enter full name as shown in ID documents'));
+				$row->addTextField('officialName')->required()->maxLength(150)->setTitle(__('Please enter full name as shown in ID documents'));
 
 			$row = $form->addRow();
 				$row->addLabel('nameInCharacters', __('Name In Characters'))->description(__('Chinese or other character-based name.'));
@@ -125,7 +125,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			$row = $form->addRow();
 				$row->addLabel('gender', __('Gender'));
-				$row->addSelectGender('gender')->isRequired();
+				$row->addSelectGender('gender')->required();
 
 			$row = $form->addRow();
 				$row->addLabel('dob', __('Date of Birth'));
@@ -186,7 +186,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 			} else {
                 $row = $form->addRow();
                 $row->addLabel('gibbonRoleIDPrimary', __('Primary Role'))->description(__('Controls what a user can do and see.'));
-                $row->addSelect('gibbonRoleIDPrimary')->fromArray($availableRoles)->isRequired()->placeholder();
+                $row->addSelect('gibbonRoleIDPrimary')->fromArray($availableRoles)->required()->placeholder();
 			}
 
 			// Grab the selected roles, and break apart into selectable roles and restricted roles
@@ -212,20 +212,20 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
             $row = $form->addRow();
                 $row->addLabel('username', __('Username'))->description(__('System login name.'));
                 $row->addUsername('username')
-                    ->isRequired()
+                    ->required()
                     ->setValue($values['username']);
 
 			$row = $form->addRow();
 				$row->addLabel('status', __('Status'))->description(__('This determines visibility within the system.'));
-				$row->addSelectStatus('status')->isRequired();
+				$row->addSelectStatus('status')->required();
 
 			$row = $form->addRow();
 				$row->addLabel('canLogin', __('Can Login?'));
-				$row->addYesNo('canLogin')->isRequired();
+				$row->addYesNo('canLogin')->required();
 
 			$row = $form->addRow();
 				$row->addLabel('passwordForceReset', __('Force Reset Password?'))->description(__('User will be prompted on next login.'));
-				$row->addYesNo('passwordForceReset')->isRequired();
+				$row->addYesNo('passwordForceReset')->required();
 
 			// CONTACT INFORMATION
 			$form->addRow()->addHeading(__('Contact Information'));

--- a/modules/User Admin/user_manage_password.php
+++ b/modules/User Admin/user_manage_password.php
@@ -95,26 +95,26 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
 
             $row = $form->addRow();
                 $row->addLabel('username', __('Username'));
-                $row->addTextField('username')->isRequired()->readOnly()->setValue($values['username']);
+                $row->addTextField('username')->required()->readOnly()->setValue($values['username']);
 
             $row = $form->addRow();
                 $row->addLabel('passwordNew', __('Password'));
                 $row->addPassword('passwordNew')
                     ->addPasswordPolicy($pdo)
                     ->addGeneratePasswordButton($form)
-                    ->isRequired()
+                    ->required()
                     ->maxLength(30);
 
             $row = $form->addRow();
                 $row->addLabel('passwordConfirm', __('Confirm Password'));
                 $row->addPassword('passwordConfirm')
                     ->addConfirmation('passwordNew')
-                    ->isRequired()
+                    ->required()
                     ->maxLength(30);
 
             $row = $form->addRow();
                 $row->addLabel('passwordForceReset', __('Force Reset Password?'))->description(__('User will be prompted on next login.'));
-                $row->addYesNo('passwordForceReset')->isRequired()->selected('N');
+                $row->addYesNo('passwordForceReset')->required()->selected('N');
 
             $row = $form->addRow();
                 $row->addFooter();

--- a/passwordReset.php
+++ b/passwordReset.php
@@ -55,7 +55,7 @@ if ($step == 1) {
 
     $row = $form->addRow();
         $row->addLabel('email', __('Username/Email'));
-        $row->addTextField('email')->maxLength(255)->isRequired();
+        $row->addTextField('email')->maxLength(255)->required();
 
     $row = $form->addRow();
         $row->addFooter();
@@ -109,14 +109,14 @@ else {
             $row->addPassword('passwordNew')
                 ->addPasswordPolicy($pdo)
                 ->addGeneratePasswordButton($form)
-                ->isRequired()
+                ->required()
                 ->maxLength(30);
 
         $row = $form->addRow();
             $row->addLabel('passwordConfirm', __('Confirm New Password'));
             $row->addPassword('passwordConfirm')
                 ->addConfirmation('passwordNew')
-                ->isRequired()
+                ->required()
                 ->maxLength(30);
 
         $row = $form->addRow();

--- a/preferences.php
+++ b/preferences.php
@@ -81,7 +81,7 @@ if (!isset($_SESSION[$guid]["username"])) {
     $row = $form->addRow();
         $row->addLabel('password', __('Current Password'));
         $row->addPassword('password')
-            ->isRequired()
+            ->required()
             ->maxLength(30);
 
     $row = $form->addRow();
@@ -90,14 +90,14 @@ if (!isset($_SESSION[$guid]["username"])) {
         $row->addPassword('passwordNew')
             ->addPasswordPolicy($pdo)
             ->addGeneratePasswordButton($form)
-            ->isRequired()
+            ->required()
             ->maxLength(30);
 
     $row = $form->addRow();
         $row->addLabel('passwordConfirm', __('Confirm New Password'));
         $row->addPassword('passwordConfirm')
             ->addConfirmation('passwordNew')
-            ->isRequired()
+            ->required()
             ->maxLength(30);
 
     $row = $form->addRow();

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -83,7 +83,7 @@ if ($proceed == false) {
 
     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
     if ($uniqueEmailAddress == 'Y') {
-        $email->isUnique('./publicRegistrationCheck.php');
+        $email->uniqueField('./publicRegistrationCheck.php');
     }
 
     $row = $form->addRow();
@@ -99,7 +99,7 @@ if ($proceed == false) {
         $row->addTextField('usernameCheck')
             ->maxLength(20)
             ->isRequired()
-            ->isUnique('./publicRegistrationCheck.php', array('fieldName' => 'username'));
+            ->uniqueField('./publicRegistrationCheck.php', array('fieldName' => 'username'));
 
     $policy = getPasswordPolicy($guid, $connection2);
     if ($policy != false) {

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -71,15 +71,15 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('surname', __('Surname'));
-        $row->addTextField('surname')->isRequired()->maxLength(30);
+        $row->addTextField('surname')->required()->maxLength(30);
 
     $row = $form->addRow();
         $row->addLabel('firstName', __('First Name'));
-        $row->addTextField('firstName')->isRequired()->maxLength(30);
+        $row->addTextField('firstName')->required()->maxLength(30);
 
     $row = $form->addRow();
         $row->addLabel('email', __('Email'));
-        $email = $row->addEmail('email')->isRequired();
+        $email = $row->addEmail('email')->required();
 
     $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
     if ($uniqueEmailAddress == 'Y') {
@@ -88,17 +88,17 @@ if ($proceed == false) {
 
     $row = $form->addRow();
         $row->addLabel('gender', __('Gender'));
-        $row->addSelectGender('gender')->isRequired();
+        $row->addSelectGender('gender')->required();
 
     $row = $form->addRow();
         $row->addLabel('dob', __('Date of Birth'))->description($_SESSION[$guid]['i18n']['dateFormat'])->prepend(__('Format:'));
-        $row->addDate('dob')->isRequired();
+        $row->addDate('dob')->required();
 
     $row = $form->addRow();
         $row->addLabel('usernameCheck', __('Username'));
         $row->addTextField('usernameCheck')
             ->maxLength(20)
-            ->isRequired()
+            ->required()
             ->uniqueField('./publicRegistrationCheck.php', array('fieldName' => 'username'));
 
     $policy = getPasswordPolicy($guid, $connection2);
@@ -111,7 +111,7 @@ if ($proceed == false) {
         $row->addPassword('passwordNew')
             ->addPasswordPolicy($pdo)
             ->addGeneratePasswordButton($form)
-            ->isRequired()
+            ->required()
             ->maxLength(30);
     
     // CUSTOM FIELDS
@@ -140,7 +140,7 @@ if ($proceed == false) {
 
         $row = $form->addRow();
             $row->addLabel('agreement', __('Do you agree to the above?'));
-            $row->addCheckbox('agreement')->isRequired()->prepend('Yes');
+            $row->addCheckbox('agreement')->required()->prepend('Yes');
     }
 
     $row = $form->addRow();

--- a/src/Forms/Input/CustomField.php
+++ b/src/Forms/Input/CustomField.php
@@ -86,8 +86,8 @@ class CustomField extends Input
         }
 
         if ($fields['required'] == 'Y') {
-            $this->customField->isRequired();
-            $this->isRequired();
+            $this->customField->required();
+            $this->required();
         }
 
         if (!empty($fields['default'])) {

--- a/src/Forms/Input/Username.php
+++ b/src/Forms/Input/Username.php
@@ -58,7 +58,7 @@ class Username extends TextField
     protected function getElement()
     {
         $this->maxLength(20)
-            ->isUnique('./publicRegistrationCheck.php', ['currentUsername' => $this->getValue()])
+            ->uniqueField('./publicRegistrationCheck.php', ['currentUsername' => $this->getValue()])
             ->addValidation('Validate.Format', 'pattern: /^[a-zA-Z0-9_\-\.]*$/, failureMessage: "'.__('Must be alphanumeric').'"');
 
         return parent::getElement();

--- a/src/Forms/Prefab/BulkActionForm.php
+++ b/src/Forms/Prefab/BulkActionForm.php
@@ -65,7 +65,7 @@ class BulkActionForm extends Form
 
         $col->addSelect('action')
             ->fromArray($actions)
-            ->isRequired()
+            ->required()
             ->setClass('shortWidth')
             ->placeholder(__('Select action'));
 

--- a/src/Forms/Prefab/DeleteForm.php
+++ b/src/Forms/Prefab/DeleteForm.php
@@ -48,7 +48,7 @@ class DeleteForm extends Form
             $row = $form->addRow();
             $row->addLabel('confirm', sprintf(__('Type %1$s to confirm'), __('DELETE')));
             $row->addTextField('confirm')
-                ->isRequired()
+                ->required()
                 ->addValidation(
                     'Validate.Inclusion',
                     'within: [\''.__('DELETE').'\'], failureMessage: "'.__('Please enter the text exactly as it is displayed to confirm this action.').'", caseSensitive: false')

--- a/src/Tables/Prefab/ReportTable.php
+++ b/src/Tables/Prefab/ReportTable.php
@@ -52,7 +52,7 @@ class ReportTable extends DataTable
             ->addParam('format', 'print')
             ->addParam('search', $criteria->getSearchText(true))
             ->setTarget('_blank')
-            ->isDirect()
+            ->directLink()
             ->append('&nbsp;');
 
         $table->addHeaderAction('export', __('Export'))
@@ -60,7 +60,7 @@ class ReportTable extends DataTable
             ->addParams($_GET)
             ->addParam('format', 'export')
             ->addParam('search', $criteria->getSearchText(true))
-            ->isDirect();
+            ->directLink();
 
         return $table;
     }


### PR DESCRIPTION
This PR is the followup to the changes in https://github.com/GibbonEdu/core/pull/798, which updates the existing instances of the following methods in the core:

`isUnique` → `uniqueField`
`isDisabled` → `disabled`
`isRequired` → `required`
`isModal` → `modalWindow`
`isDirect` → `directLink`

Sorry it's a big PR 😬  a large number of files changed, but the scope is small: no other changes aside from these method renames.