### PR TITLE
Forms: remove calls to setWrapper

### DIFF
--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -195,8 +195,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
             echo '</div>';
         }
 
-        $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/activities_attendanceProcess.php?gibbonActivityID='.$gibbonActivityID)->setClass('');
-        $form->getRenderer()->setWrapper('form', 'div')->setWrapper('row', 'div')->setWrapper('cell', 'div');
+        $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/activities_attendanceProcess.php?gibbonActivityID='.$gibbonActivityID);
+        $form->setClass('w-full blank');
 
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
         $form->addHiddenValue('gibbonPersonID', $_SESSION[$guid]['gibbonPersonID']);

--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -201,17 +201,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
         $form->addHiddenValue('gibbonPersonID', $_SESSION[$guid]['gibbonPersonID']);
 
-        $row = $form->addRow()->addClass('doublescroll-wrapper smallIntBorder');
+        $row = $form->addRow('doublescroll-wrapper')->addClass('doublescroll-wrapper smallIntBorder');
 
         // Headings as a separate table (for double-scroll)
         $table = $row->addTable()->setClass('mini fullWidth noMargin noBorder');
         $header = $table->addHeaderRow();
-            $header->addContent(__('Student'))->addClass('attendanceRowHeader py-8');
+            $header->addContent(__('Student'))->addClass('attendanceRowHeader');
             $header->addContent(__('Attendance'));
             $header->addContent(sprintf(__('Sessions Recorded: %s of %s'), count($sessionAttendanceData), count($activitySessions)))
                 ->addClass('emphasis subdued right');
 
-        $row->addContent("<div class='doublescroll-top -mt-4'><div class='doublescroll-top-tablewidth'></div></div>");
+        $row->addContent("<div class='doublescroll-top'><div class='doublescroll-top-tablewidth'></div></div>");
 
         // Wrap the attendance table in a double-scroll container
         $table = $row->addColumn()->addClass('doublescroll-container')

--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -196,22 +196,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
         }
 
         $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/activities_attendanceProcess.php?gibbonActivityID='.$gibbonActivityID);
-        $form->setClass('w-full blank');
+        $form->setClass('blank w-full');
 
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
         $form->addHiddenValue('gibbonPersonID', $_SESSION[$guid]['gibbonPersonID']);
 
-        $row = $form->addRow()->addClass('doublescroll-wrapper');
+        $row = $form->addRow()->addClass('doublescroll-wrapper smallIntBorder');
 
         // Headings as a separate table (for double-scroll)
         $table = $row->addTable()->setClass('mini fullWidth noMargin noBorder');
         $header = $table->addHeaderRow();
-            $header->addContent(__('Student'))->addClass('attendanceRowHeader');
+            $header->addContent(__('Student'))->addClass('attendanceRowHeader py-8');
             $header->addContent(__('Attendance'));
             $header->addContent(sprintf(__('Sessions Recorded: %s of %s'), count($sessionAttendanceData), count($activitySessions)))
                 ->addClass('emphasis subdued right');
 
-        $row->addContent("<div class='doublescroll-top'><div class='doublescroll-top-tablewidth'></div></div>");
+        $row->addContent("<div class='doublescroll-top -mt-4'><div class='doublescroll-top-tablewidth'></div></div>");
 
         // Wrap the attendance table in a double-scroll container
         $table = $row->addColumn()->addClass('doublescroll-container')

--- a/modules/Activities/activities_payment.php
+++ b/modules/Activities/activities_payment.php
@@ -60,10 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_paym
 
         $form = Form::create('generateInvoices', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/activities_paymentProcessBulk.php');
         $form->addConfirmation(__('Are you sure you wish to process this action? It cannot be undone.'));
-
-        $form->getRenderer()->setWrapper('form', 'div');
-        $form->getRenderer()->setWrapper('row', 'div');
-        $form->getRenderer()->setWrapper('cell', 'fieldset');
+        $form->setClass('w-full blank');
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
         
         $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);

--- a/modules/Activities/css/module.css
+++ b/modules/Activities/css/module.css
@@ -17,6 +17,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 */
 
+/* Odd use-case for Activity Attendance double-scroll container */
+table.blank, 
+table.blank > tbody > tr,
+table.blank > tbody > tr > td {
+    display: block !important;
+}
 
 /* These could be moved to style.css */
 .hidden {

--- a/modules/Activities/css/module.css
+++ b/modules/Activities/css/module.css
@@ -36,11 +36,12 @@ table.blank > tbody > tr > td {
 
 /* Double-scroll */
 
-.doublescroll-wrapper {
+.doublescroll-wrapper,
+#doublescroll-wrapper {
 	position: relative;
-	background: #FBFBFB none repeat scroll 0% 0%;
-	border: 1px solid #CCC;
-	border-radius: 3px;
+	background: #FBFBFB none repeat scroll 0% 0% !important;
+	border: 1px solid #CCC !important;
+	border-radius: 3px !important;
 
 }
 

--- a/modules/Individual Needs/in_edit.php
+++ b/modules/Individual Needs/in_edit.php
@@ -160,7 +160,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_edit.p
             $form = Form::create('individualNeeds', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/in_editProcess.php?gibbonPersonID=$gibbonPersonID&search=$search&source=$source&gibbonINDescriptorID=$gibbonINDescriptorID&gibbonAlertLevelID=$gibbonAlertLevelID&gibbonRollGroupID=$gibbonRollGroupID&gibbonYearGroupID=$gibbonYearGroupID");
 
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->getRenderer()->setWrapper('form', 'div')->setWrapper('row', 'div')->setWrapper('cell', 'div');
+            $form->setClass('w-full blank');
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonPersonID', $gibbonPersonID);
 

--- a/modules/System Admin/css/module.css
+++ b/modules/System Admin/css/module.css
@@ -22,11 +22,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 	color: #666666;
 }
 
-table.blank td::first-line {
-	font-size: 115%;
-	font-weight: bold;
-}
-
 tr.error td {
 	border-top: 1px solid #F8E4E2;
 	border-bottom: 1px solid #E7B7B2;

--- a/modules/System Admin/i18n_manage.php
+++ b/modules/System Admin/i18n_manage.php
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.p
 
     $form->setClass('fullWidth');
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
-    $form->getRenderer()->setWrapper('form', 'div')->setWrapper('row', 'div')->setWrapper('cell', 'fieldset');
+    $form->setClass('w-full blank');
 
     // DATA TABLE
     $table = $form->addRow()->addDataTable('i18n', $criteria)->withData($languages);

--- a/modules/System Admin/import_run.php
+++ b/modules/System Admin/import_run.php
@@ -234,7 +234,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
             echo "</script>";
             
             $form = Form::create('importStep2', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/import_run.php&type='.$type.'&step=3');
-            $form->getRenderer()->setWrapper('form', 'div')->setWrapper('row', 'div')->setWrapper('cell', 'div');
+            $form->setClass('w-full blank');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('mode', $mode);
@@ -505,7 +505,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_run.ph
             
             if ($step==3) {
                 $form = Form::create('importStep2', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/import_run.php&type='.$type.'&step=4');
-                $form->getRenderer()->setWrapper('form', 'div')->setWrapper('row', 'div')->setWrapper('cell', 'div');
+                $form->setClass('w-full blank');
 
                 $form->addHiddenValue('address', $_SESSION[$guid]['address']);
                 $form->addHiddenValue('mode', $mode);

--- a/modules/Timetable Admin/courseEnrolment_sync_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_edit.php
@@ -49,12 +49,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     }
 
     $form = Form::create('courseEnrolmentSyncEdit', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/courseEnrolment_sync_addEditProcess.php');
+    $form->setClass('w-full blank');
     $form->setFactory(DatabaseFormFactory::create($pdo));
-
-    // To render the form as miltiple tables
-    $form->getRenderer()->setWrapper('form', 'div');
-    $form->getRenderer()->setWrapper('row', 'div');
-    $form->getRenderer()->setWrapper('cell', 'div');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
     $form->addHiddenValue('gibbonYearGroupID', $gibbonYearGroupID);

--- a/modules/Timetable Admin/courseEnrolment_sync_run.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_run.php
@@ -80,12 +80,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     }
 
     $form = Form::create('courseEnrolmentSyncRun', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/courseEnrolment_sync_runProcess.php');
+    $form->setClass('w-full blank');
     $form->setFactory(DatabaseFormFactory::create($pdo));
-
-    // To render the form as multiple tables
-    $form->getRenderer()->setWrapper('form', 'div');
-    $form->getRenderer()->setWrapper('row', 'div');
-    $form->getRenderer()->setWrapper('cell', 'div');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
     $form->addHiddenValue('gibbonYearGroupIDList', $gibbonYearGroupIDList);

--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -144,11 +144,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                 }, $currentCourses);
 
                 $form = Form::create('courseRollover', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/course_rollover.php&step=3');
-
-                $form->getRenderer()->setWrapper('form', 'div');
-                $form->getRenderer()->setWrapper('row', 'div');
-                $form->getRenderer()->setWrapper('cell', 'div');
-
+                $form->setClass('w-full blank');
+ 
                 $form->addHiddenValue('nextYear', $nextYear);
 
                 $table = $form->addRow()->addTable()->setClass('smallIntBorder fullWidth');

--- a/modules/Timetable Admin/ttDates.php
+++ b/modules/Timetable Admin/ttDates.php
@@ -100,11 +100,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
         } else {
 
             $form = Form::create('ttDates', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/ttDates_addMultiProcess.php?gibbonSchoolYearID='.$gibbonSchoolYearID);
+            $form->setClass('w-full blank');
             
             $form->addHiddenValue('q', $_SESSION[$guid]['address']);
-            $form->getRenderer()->setWrapper('form', 'div');
-            $form->getRenderer()->setWrapper('row', 'div');
-            $form->getRenderer()->setWrapper('cell', 'div');
 
             while ($values = $result->fetch()) {
                 $row = $form->addRow()->addHeading($values['name']);

--- a/modules/User Admin/permission_manage.php
+++ b/modules/User Admin/permission_manage.php
@@ -109,15 +109,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/permission_mana
         $permissionsArray = ($resultPermissions->rowCount() > 0)? $resultPermissions->fetchAll() : array();
         $totalCount = 0;
 
-        $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/permission_manageProcess.php');
+        $form = Form::create('permissions', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/permission_manageProcess.php');
+        $form->setClass('w-full blank');
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
         $form->addHiddenValue('gibbonModuleID', $gibbonModuleID);
         $form->addHiddenValue('gibbonRoleID', $gibbonRoleID);
-
-        // To render the form as multiple tables
-        $form->getRenderer()->setWrapper('form', 'div');
-        $form->getRenderer()->setWrapper('row', 'div');
-        $form->getRenderer()->setWrapper('cell', 'div');
 
         while ($rowModules = $resultModules->fetch()) {
             $form->addRow()->addHeading(__($rowModules['name']));

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -654,11 +654,11 @@ table.blank, table.blank > tbody > tr {
 	border: none!important ;
 	padding: 0px!important ;
 	background: none!important ;
-	box-shadow: none!important;
+    box-shadow: none!important;
 }
 table.blank > tbody > tr > td {
 	border: none!important ;
-	padding: 1px!important ;
+	padding: 0px!important ;
 	background: none!important ;
 }
 

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -566,7 +566,7 @@ table tr.even > td {
 	background: -webkit-gradient(linear, left top, left bottom, from(#f2f2f2), to(#f0f0f0));
 	background: -moz-linear-gradient(top,  #f2f2f2,  #f0f0f0);
 }
-table tr:last-child td {
+table tr:last-child > td {
 	border-bottom:0;
 
 }
@@ -649,17 +649,19 @@ table.mini td {
 table.mini tr.head th {
 	padding: 5px!important ;
 }
-table.blank, table.blank tr {
+
+table.blank, table.blank > tbody > tr {
 	border: none!important ;
 	padding: 0px!important ;
 	background: none!important ;
-	box-shadow: none;!important
+	box-shadow: none!important;
 }
-table.blank td {
+table.blank > tbody > tr > td {
 	border: none!important ;
 	padding: 1px!important ;
 	background: none!important ;
 }
+
 table.mceToolbar td, table.mceToolbar tr {
 	padding: 0px!important ;
 	background: none;


### PR DESCRIPTION
Cleaning some things up to get ready to introduce templating for the Form class. This removes the `setWrapper()` calls, which were somewhat hack-ish and used for forms which have a blank layout and contain nested tables. It replaces the wrapper method calls with the `blank` css class, from the original main.css file. Also contains some small tweaks to the activity attendance page for displaying the double-scrollbar.