### PR TITLE
Forms: update the Form class to use a template-based renderer

### DIFF
--- a/gibbon.php
+++ b/gibbon.php
@@ -29,6 +29,7 @@ $container->delegate(new League\Container\ReflectionContainer);
 $container->add('autoloader', $autoloader);
 
 $container->addServiceProvider(new Gibbon\Services\CoreServiceProvider(__DIR__));
+$container->addServiceProvider(new Gibbon\Services\ViewServiceProvider());
 
 // Globals for backwards compatibility
 $gibbon = $container->get('config');

--- a/resources/templates/components/form.twig.html
+++ b/resources/templates/components/form.twig.html
@@ -1,0 +1,40 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+<form {{ form.getAttributeString|raw }} onsubmit="gibbonFormSubmitted(this)">
+
+    {% if form.getTitle %}
+        <h2>{{ form.getTitle }}</h2>
+    {% endif %}
+
+    {% for values in form.getHiddenValues %}
+        <input type="hidden" name="{{ values.name }}" value="{{ values.value }}">
+    {% endfor %}
+
+    <table class="{{ form.getClass }}" cellspacing=0>
+    {% for row in form.getRows %}
+        <tr id="{{ row.getID }}" class="{{ row.getClass }}">
+
+        {% for element in row.getElements %}
+            {% set colspan = loop.last and loop.length < totalColumns ? (totalColumns + 1 - loop.length) : 0  %}
+
+            <td class="{{ element.getClass }}" {{ colspan ? 'colspan="%s"'|format(colspan)|raw }}>
+                {{ element.getOutput|raw }}
+            </td>
+        {% endfor %}
+
+        </tr>
+    {% endfor %}
+    </table>
+
+    <script type="text/javascript">
+        {% for code in javascript %}
+            {{ code|raw }}
+        {% endfor %}
+    </script>
+</form>

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -19,8 +19,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Forms;
 
-use Gibbon\Forms\FormFactory;
 use Gibbon\Forms\Traits\BasicAttributesTrait;
+use Gibbon\Forms\View\FormRendererInterface;
+use Gibbon\Forms\FormFactoryInterface;
 
 /**
  * Form
@@ -47,7 +48,7 @@ class Form implements OutputableInterface
      * @param    string                 $action
      * @param    string                 $method
      */
-    public function __construct(FormFactoryInterface $factory, FormRendererInterface $renderer, $action, $method)
+    public function __construct(FormFactoryInterface $factory, FormRendererInterface $renderer, $action = '', $method = 'post')
     {
         $this->factory = $factory;
         $this->renderer = $renderer;
@@ -67,13 +68,13 @@ class Form implements OutputableInterface
      */
     public static function create($id, $action, $method = 'post', $class = 'smallIntBorder fullWidth standardForm')
     {
-        $factory = FormFactory::create();
-        $renderer = FormRenderer::create();
+        global $container;
 
-        $form = new Form($factory, $renderer, $action, $method);
-
-        $form->setID($id);
-        $form->setClass($class);
+        $form = $container->get(Form::class)
+            ->setID($id)
+            ->setClass($class)
+            ->setAction($action)
+            ->setMethod($method);
 
         return $form;
     }
@@ -147,6 +148,13 @@ class Form implements OutputableInterface
         return $this->getAttribute('method');
     }
 
+    public function setMethod(string $method)
+    {
+        $this->setAttribute('method', $method);
+
+        return $this;
+    }
+
     /**
      * Get the current action URL for the form.
      * @return  string
@@ -154,6 +162,13 @@ class Form implements OutputableInterface
     public function getAction()
     {
         return $this->getAttribute('action');
+    }
+
+    public function setAction(string $action)
+    {
+        $this->setAttribute('action', $action);
+
+        return $this;
     }
 
     /**

--- a/src/Forms/FormRenderer.php
+++ b/src/Forms/FormRenderer.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Forms;
 
-use Gibbon\Forms\FormRendererInterface;
+use Gibbon\Forms\View\FormRendererInterface;
 
 /**
  * FormRenderer

--- a/src/Forms/View/FormRendererInterface.php
+++ b/src/Forms/View/FormRendererInterface.php
@@ -17,7 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-namespace Gibbon\Forms;
+namespace Gibbon\Forms\View;
+
+use Gibbon\Forms\Form;
 
 interface FormRendererInterface
 {

--- a/src/Forms/View/FormView.php
+++ b/src/Forms/View/FormView.php
@@ -1,0 +1,86 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Forms\View;
+
+use Gibbon\View\View;
+use Gibbon\Forms\Form;
+use Gibbon\Forms\ValidatableInterface;
+use Gibbon\Forms\View\FormRendererInterface;
+
+/**
+ * FormView
+ *
+ * @version v18
+ * @since   v18
+ */
+class FormView extends View implements FormRendererInterface
+{
+    /**
+     * Transform a Form object into HTML and javascript output using a Twig template.
+     * @param   Form    $form
+     * @return  string
+     */
+    public function renderForm(Form $form)
+    {
+        $this->addData('form', $form);
+        $this->addData('javascript', $this->getInlineJavascript($form));
+        $this->addData('totalColumns', $this->getColumnCount($form));
+
+        return $this->render('components/form.twig.html');
+    }
+
+    protected function getInlineJavascript(Form $form)
+    {
+        $javascript = [];
+
+        foreach ($form->getRows() as $row) {
+            foreach ($row->getElements() as $element) {
+                if ($element instanceof ValidatableInterface) {
+                    $javascript[] = $element->getValidationOutput();
+                }
+            }
+        }
+
+        foreach (array_reverse($form->getTriggers()) as $trigger) {
+            $javascript[] = $trigger->getOutput();
+        }
+        
+        return $javascript;
+    }
+
+    /**
+     * Get the maximum columns required to render this form.
+     * @return  int
+     */
+    protected function getColumnCount(Form $form)
+    {
+        return array_reduce($form->getRows(), function ($count, $row) {
+            return max($count, $row->getElementCount());
+        }, 0);
+    }
+
+    /**
+     * @deprecated Empty-method for module backwards compatibility.
+     * Will be removed by the end of the mobile-responsive refactoring.
+     */
+    public function setWrapper($name, $value) {
+        return $this;
+    }
+}

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -105,7 +105,6 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
         $container = $this->getContainer();
         $absolutePath = $this->absolutePath;
         $session = $container->get('session');
-        $pdo = $container->get('db');
 
         // Logging removed until properly setup & tested
         
@@ -149,7 +148,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
             return $twig;
         });
 
-        $container->share('action', function () use ($session, $pdo) {
+        $container->share('action', function () use ($session) {
             $data = [
                 'actionName'   => '%'.$session->get('action').'%',
                 'moduleName'   => $session->get('module'),
@@ -163,20 +162,20 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
                     WHERE gibbonAction.URLList LIKE :actionName 
                     AND gibbonModule.name=:moduleName";
 
-            $actionData = $pdo->selectOne($sql, $data);
+            $actionData = $this->getContainer()->get('db')->selectOne($sql, $data);
 
             return $actionData ? $actionData : null;
         });
 
-        $container->share('module', function () use ($session, $pdo) {
+        $container->share('module', function () use ($session) {
             $data = ['moduleName' => $session->get('module')];
             $sql = "SELECT * FROM gibbonModule WHERE name=:moduleName AND active='Y'";
-            $moduleData = $pdo->selectOne($sql, $data);
+            $moduleData = $this->getContainer()->get('db')->selectOne($sql, $data);
 
             return $moduleData ? new Module($moduleData) : null;
         });
 
-        $container->share('theme', function () use ($session, $pdo) {
+        $container->share('theme', function () use ($session) {
             if ($session->has('gibbonThemeIDPersonal')) {
                 $data = ['gibbonThemeID' => $session->get('gibbonThemeIDPersonal')];
                 $sql = "SELECT * FROM gibbonTheme WHERE gibbonThemeID=:gibbonThemeID";
@@ -185,7 +184,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
                 $sql = "SELECT * FROM gibbonTheme WHERE active='Y'";
             }
 
-            $themeData = $pdo->selectOne($sql, $data);
+            $themeData = $this->getContainer()->get('db')->selectOne($sql, $data);
 
             $session->set('gibbonThemeID', $themeData['gibbonThemeID'] ?? 001);
             $session->set('gibbonThemeName', $themeData['name'] ?? 'Default');

--- a/src/Services/ViewServiceProvider.php
+++ b/src/Services/ViewServiceProvider.php
@@ -1,0 +1,64 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Gibbon\Services;
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\FormFactory;
+use Gibbon\Forms\View\FormView;
+use League\Container\ServiceProvider\AbstractServiceProvider;
+
+/**
+ * DI Container Services for rendering Views
+ *
+ * @version v18
+ * @since   v18
+ */
+class ViewServiceProvider extends AbstractServiceProvider
+{
+    /**
+     * The provides array is a way to let the container know that a service
+     * is provided by this service provider. Every service that is registered
+     * via this service provider must have an alias added to this array or
+     * it will be ignored.
+     *
+     * @var array
+     */
+    protected $provides = [
+        Form::class,
+    ];
+
+    /**
+     * This is where the magic happens, within the method you can
+     * access the container and register or retrieve anything
+     * that you need to, but remember, every alias registered
+     * within this method must be declared in the `$provides` array.
+     */
+    public function register()
+    {
+        $container = $this->getContainer();
+        
+        $container->add(Form::class, function () {
+            $factory = new FormFactory();
+            $renderer = new FormView($this->getContainer()->get('twig'));
+
+            return (new Form($factory, $renderer))->setClass('w-full smallIntBorder standardForm');
+        });
+    }
+}

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 namespace Gibbon\Forms;
 
 use PHPUnit\Framework\TestCase;
-use Gibbon\Forms\Renderer\FormRendererInterface;
+use Gibbon\Forms\View\FormRendererInterface;
 use Gibbon\Forms\FormFactoryInterface;
 
 /**

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -10,6 +10,8 @@ file that was distributed with this source code.
 namespace Gibbon\Forms;
 
 use PHPUnit\Framework\TestCase;
+use Gibbon\Forms\Renderer\FormRendererInterface;
+use Gibbon\Forms\FormFactoryInterface;
 
 /**
  * @covers Form


### PR DESCRIPTION
This is part of the re-wiring to get setup for mobile-responsive layouts in v18. The Form classes predate the Twig templating and DI container, so we can now update them to remove the FormRenderer class and handle the HTML output using a View class. This is done through the new `FormView` class and `form.twig.html` template.

This PR also adds a `ViewServiceProvider` class, which will be the home of view-related services. It sets up the service provider to create Forms and inject their necessary dependencies.

There is a somewhat sneaky use of a `global` here, as a transitional step for the `Form::create` method. I did this in part to keep the scope of this PR small: I'll put in some follow-up PRs to replace the static `Form::create` method used by our many forms with the DI `$container->get()` call. Part of the learn-while-doing nature of the refactoring cycle : )

Tested locally in a bunch of random use-cases. If all works well, you should notice no change in the forms themselves. You could always edit `form.twig.html` randomly to see the template in effect though.