### PR TITLE
Templates: responsive Thickbox update

### DIFF
--- a/fullscreen.php
+++ b/fullscreen.php
@@ -36,9 +36,6 @@ if (!$session->has('systemSettingsSet')) {
 
 $address = $page->getAddress();
 
-// Register scripts available to the core, but not included by default
-$page->scripts->register('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js', ['context' => 'head']);
-
 $page->addData([
     'isLoggedIn' => $session->has('username') && $session->has('gibbonRoleIDCurrent'),
 ]);

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -43,6 +43,9 @@ $hasEffortName = ($effortAlternativeName != '' && $effortAlternativeNameAbrev !=
 $studentOrderBy = (isset($_SESSION[$guid]['markbookOrderBy']))? $_SESSION[$guid]['markbookOrderBy'] : 'surname';
 $studentOrderBy = (isset($_GET['markbookOrderBy']))? $_GET['markbookOrderBy'] : $studentOrderBy;
 
+// Register scripts available to the core, but not included by default
+$page->scripts->add('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js', ['context' => 'head']);
+
 // This script makes entering raw marks easier, by capturing the enter key and moving to the next field insted of submitting
 echo "<script type='text/javascript'>";
 ?>

--- a/modules/Markbook/markbook_view.php
+++ b/modules/Markbook/markbook_view.php
@@ -27,6 +27,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
     echo __('Your request failed because you do not have access to this action.');
     echo '</div>';
 } else {
+    // Register scripts available to the core, but not included by default
+    $page->scripts->add('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js', ['context' => 'head']);
+    
     //Get action with highest precendence
     $highestAction = getHighestGroupedAction($guid, $_GET['q'], $connection2);
     $highestAction2 = getHighestGroupedAction($guid, '/modules/Markbook/markbook_edit.php', $connection2);

--- a/modules/Rubrics/rubrics.php
+++ b/modules/Rubrics/rubrics.php
@@ -39,6 +39,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics.php') == f
         //Proceed!
         $page->breadcrumbs->add(__('Manage Rubrics'));
 
+        // Register scripts available to the core, but not included by default
+        $page->scripts->add('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js', ['context' => 'head']);
+    
         if (isset($_GET['return'])) {
             returnProcess($guid, $_GET['return'], null, null);
         }

--- a/modules/Rubrics/rubrics_view.php
+++ b/modules/Rubrics/rubrics_view.php
@@ -32,6 +32,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_view.php')
     //Proceed!
     $page->breadcrumbs->add(__('View Rubrics'));
 
+    // Register scripts available to the core, but not included by default
+    $page->scripts->add('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js', ['context' => 'head']);
+
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);
     }

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -2000,6 +2000,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             echo __('Your request failed because you do not have access to this action.');
                             echo '</div>';
                         } else {
+                            // Register scripts available to the core, but not included by default
+                            $page->scripts->add('chart', 'lib/Chart.js/2.0/Chart.bundle.min.js', ['context' => 'head']);
+
                             $highestAction = getHighestGroupedAction($guid, '/modules/Markbook/markbook_view.php', $connection2);
                             if ($highestAction == false) {
                                 echo "<div class='error'>";

--- a/resources/templates/components/form.twig.html
+++ b/resources/templates/components/form.twig.html
@@ -18,7 +18,12 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
     <table class="{{ form.getClass }} px-3 py-2 sm:p-0" cellspacing=0>
     {% for row in form.getRows %}
-        <tr id="{{ row.getID }}" class="{{ row.getClass|replace({'standardWidth': ''}) }} flex flex-col sm:flex-row justify-between content-center p-0">
+
+        {% if "smallIntBorder" in form.getClass or "noIntBorder" in form.getClass %}
+            {% set rowClass = 'flex flex-col sm:flex-row justify-between content-center p-0' %}
+        {% endif %}
+
+        <tr id="{{ row.getID }}" class="{{ row.getClass|replace({'standardWidth': ''}) }} {{ rowClass }}">
 
         {% for element in row.getElements %}
             {% set colspan = loop.last and loop.length < totalColumns ? (totalColumns + 1 - loop.length) : 0  %}

--- a/resources/templates/finder.twig.html
+++ b/resources/templates/finder.twig.html
@@ -9,7 +9,7 @@ Fast Finder
 -->#}
 
 <style>
-    #fastFinder ul.token-input-list-facebook { width: 100% !important; float: none !important; background: #fff; margin-right: 10px !important; margin-top: 2px; margin-bottom: -2px; }
+    #fastFinder ul.token-input-list-facebook { width: 100% !important; float: none !important; background: #fff; margin-right: 10px !important; }
 </style>
 
 <button data-toggle="#fastFinder" class="flex md:hidden items-center rounded bg-gray-300 px-4 py-3 text-base absolute top-0 right-0 mt-20 mr-6">

--- a/resources/templates/fullscreen.twig.html
+++ b/resources/templates/fullscreen.twig.html
@@ -8,7 +8,8 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 <!DOCTYPE html>
 <html>
     <head>
-        {{ include('head.twig.html') }}
+        {{ block('meta', 'head.twig.html') }}
+        {{ block('styles', 'head.twig.html') }}
     </head>
     <body style='background-image: none'>
 
@@ -19,7 +20,5 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
         {% endfor %}
 
         {{ content|join("\n")|raw }}
-        
-        {{ include('foot.twig.html') }}
     </body>
 </html>

--- a/resources/templates/head.twig.html
+++ b/resources/templates/head.twig.html
@@ -9,34 +9,42 @@ Page Foot: Outputs the contents of the HTML <head> tag. This includes
 all stylesheets and scripts with a 'head' context.
 -->#}
 
-<title>{{ page.title }}</title>
+{% block meta %}
+    <title>{{ page.title }}</title>
 
-<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-<meta http-equiv="content-language" content="{{ locale }}"/>
-<meta name="author" content="Ross Parker, International College Hong Kong"/>
-<meta name="robots" content="none"/>
-<meta name="Referrer‐Policy" value="no‐referrer | same‐origin"/>
-<link rel="shortcut icon" type="image/x-icon" href="./favicon.ico"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <meta http-equiv="content-language" content="{{ locale }}"/>
+    <meta name="author" content="Ross Parker, International College Hong Kong"/>
+    <meta name="robots" content="none"/>
+    <meta name="Referrer‐Policy" value="no‐referrer | same‐origin"/>
+    <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico"/>
+{% endblock meta %}
 
-{% for asset in page.stylesheets %}
-    {% set assetVersion = asset.version is not empty ? asset.version : version %}
-    {% if asset.type == 'inline' %}
-        <style type="text/css">{{ asset.src|raw }}</style>
-    {% else %}
-        <link rel="stylesheet" href="{{ absoluteURL }}/{{ asset.src }}?v={{ assetVersion }}" type="text/css" media="{{ asset.media }}" />
-    {% endif %}
-{% endfor %}
 
-{% for asset in page.scriptsHead %}
-    {% set assetVersion = asset.version is not empty ? asset.version : version %}
-    {% if asset.type == 'inline' %}
-        <script type="text/javascript">{{ asset.src|raw }}</script>
-    {% else %}
-        <script type="text/javascript" src="{{ absoluteURL }}/{{ asset.src }}?v={{ assetVersion }}"></script>
-    {% endif %}
-{% endfor %}
+{% block styles %}
+    {% for asset in page.stylesheets %}
+        {% set assetVersion = asset.version is not empty ? asset.version : version %}
+        {% if asset.type == 'inline' %}
+            <style type="text/css">{{ asset.src|raw }}</style>
+        {% else %}
+            <link rel="stylesheet" href="{{ absoluteURL }}/{{ asset.src }}?v={{ assetVersion }}" type="text/css" media="{{ asset.media }}" />
+        {% endif %}
+    {% endfor %}
+{% endblock styles %}
 
-{% for code in page.extraHead %}
-    {{ code|raw }}
-{% endfor %}
+
+{% block scripts %}
+    {% for asset in page.scriptsHead %}
+        {% set assetVersion = asset.version is not empty ? asset.version : version %}
+        {% if asset.type == 'inline' %}
+            <script type="text/javascript">{{ asset.src|raw }}</script>
+        {% else %}
+            <script type="text/javascript" src="{{ absoluteURL }}/{{ asset.src }}?v={{ assetVersion }}"></script>
+        {% endif %}
+    {% endfor %}
+
+    {% for code in page.extraHead %}
+        {{ code|raw }}
+    {% endfor %}
+{% endblock scripts %}

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1276,11 +1276,6 @@ tr.head td {
 	text-align: center!important;
 }
 
-/* Hide breadcrumbs in fullscreen */
-#TB_window .trail {
-	display: none;
-}
-
 .ttDates {
 	height: 80px;
 	width: 8%;
@@ -1641,5 +1636,34 @@ body.print div.trail {
 @media print {
     table tr {
         page-break-inside: avoid;
+    }
+}
+
+/* Thickbox: Hide breadcrumbs in fullscreen */
+#TB_window .trail {
+	display: none;
+}
+
+/* Thickbox: Prevent random scrollbars */
+#TB_ajaxContent {
+    max-height: 90vh;
+    min-height: 25vh;
+    margin: 0 auto;
+}
+
+/* Wrangle the Thickbox into displaying somewhat usably on mobile */
+@media only screen and (max-width: 1000px) {
+
+    #TB_window {
+        margin-left: -45vw !important;
+        width: 90vw !important;
+    }
+
+    #TB_ajaxContent {
+        width: 76vw !important;
+        max-width: 100vw;
+        overflow: initial;
+        padding: 0.5rem;
+        height: auto !important;
     }
 }


### PR DESCRIPTION
This PR adds some extra styles to help the Thickbox size more reasonably on small screens.

It also helps address the XMLHTTPRequest error seen on newer browsers by removing the additional ajax-loading of scripts in a thickbox window. The caveat is that scripts needed in a thickbox will have to be loaded by their parent widow, so this PR updates the Markbook to load the Chart script for rubrics.

Also adjusts the flexbox form rendering via tempalte to not apply to non-standard tables. The rubric looked very artistic in it's non-linear form, but not as usable as I expect teachers would like : )