### PR TITLE
Attendance: update the Take Attendance grid to use responsive breakpoints

### DIFF
--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -252,7 +252,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
 
                         $form = Form::create('attendanceByClass', $_SESSION[$guid]['absoluteURL'] . '/modules/' . $_SESSION[$guid]['module'] . '/attendance_take_byCourseClassProcess.php');
                         $form->setAutocomplete('off');
-                        $form->addClass('attendanceGrid');
 
                         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
                         $form->addHiddenValue('gibbonCourseClassID', $gibbonCourseClassID);
@@ -261,31 +260,34 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
 
                         $form->addRow()->addHeading(__('Take Attendance') . ': ' . htmlPrep($class['course']) . '.' . htmlPrep($class['class']));
 
-                        $grid = $form->addRow()->addGrid('attendance')->setColumns(4);
+                        $grid = $form->addRow()->addGrid('attendance')->setBreakpoints('w-1/2 sm:w-1/4 md:w-1/5 lg:w-1/4');
 
                         foreach ($students as $student) {
                             $form->addHiddenValue($count . '-gibbonPersonID', $student['gibbonPersonID']);
 
-                            $cell = $grid->addCell()->addClass('textCenter stacked')->addClass($student['cellHighlight']);
+                            $cell = $grid->addCell()
+                                ->setClass('text-center py-2 px-1  -mr-px -mb-px')
+                                ->addClass($student['cellHighlight']);
+
                             $cell->addContent(getUserPhoto($guid, $student['image_240'], 75));
                             $cell->addWebLink(formatName('', htmlPrep($student['preferredName']), htmlPrep($student['surname']), 'Student', false))
                                 ->setURL('index.php?q=/modules/Students/student_view_details.php')
                                 ->addParam('gibbonPersonID', $student['gibbonPersonID'])
                                 ->addParam('subpage', 'Attendance')
-                                ->wrap('<b>', '</b>');
-                            $cell->addContent($student['absenceCount'])->wrap('<span class="small emphasis">', '<span>');
+                                ->setClass('pt-2 font-bold underline');
+                            $cell->addContent($student['absenceCount'])->wrap('<div class="text-xxs italic py-2">', '</div>');
                             $cell->addSelect($count . '-type')
                                 ->fromArray(array_keys($attendance->getAttendanceTypes()))
                                 ->selected($student['log']['type'])
-                                ->setClass('attendanceField floatNone shortWidth');
+                                ->setClass('mx-auto float-none w-32 m-0 mb-px');
                             $cell->addSelect($count . '-reason')
                                 ->fromArray($attendance->getAttendanceReasons())
                                 ->selected($student['log']['reason'])
-                                ->setClass('attendanceField attendanceFieldStacked floatNone shortWidth');
+                                ->setClass('mx-auto float-none w-32 m-0 mb-px');
                             $cell->addTextField($count . '-comment')
                                 ->maxLength(255)
                                 ->setValue($student['log']['comment'])
-                                ->setClass('attendanceField attendanceFieldStacked floatNone shortWidth');
+                                ->setClass('mx-auto float-none w-32 m-0 mb-2');
                             $cell->addContent($attendance->renderMiniHistory($student['gibbonPersonID']));
 
                             $count++;
@@ -297,12 +299,16 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                             ->wrap('<b>', '</b>');
 
                         $row = $form->addRow();
+
                         // Drop-downs to change the whole group at once
-                        $col = $row->addColumn()->addClass('inline');
-                        $col->addSelect('set-all-type')->fromArray(array_keys($attendance->getAttendanceTypes()))->setClass('attendanceField');
-                        $col->addSelect('set-all-reason')->fromArray($attendance->getAttendanceReasons())->setClass('attendanceField');
-                        $col->addTextField('set-all-comment')->maxLength(255)->setClass('attendanceField');
+                        $row->addWebLink(__('Change All').'?')->addData('toggle', '.change-all')->addClass('w-32 sm:self-center');
+
+                        $col = $row->addColumn()->setClass('change-all hidden flex flex-col sm:flex-row items-stretch sm:items-center');
+                            $col->addSelect('set-all-type')->fromArray(array_keys($attendance->getAttendanceTypes()));
+                            $col->addSelect('set-all-reason')->fromArray($attendance->getAttendanceReasons());
+                            $col->addTextField('set-all-comment')->maxLength(255);
                         $col->addButton(__('Change All'))->setID('set-all');
+
                         $row->addSubmit();
 
                         echo $form->getOutput();

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -214,7 +214,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
                             $form = Form::create('attendanceByRollGroup', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']. '/attendance_take_byRollGroupProcess.php');
                             $form->setAutocomplete('off');
-                            $form->addClass('attendanceGrid');
 
                             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
                             $form->addHiddenValue('gibbonRollGroupID', $gibbonRollGroupID);
@@ -223,31 +222,34 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
                             $form->addRow()->addHeading(__('Take Attendance') . ': '. htmlPrep($rollGroup['name']));
 
-                            $grid = $form->addRow()->addGrid('attendance')->setColumns(4);
+                            $grid = $form->addRow()->addGrid('attendance')->setBreakpoints('w-1/2 sm:w-1/4 md:w-1/5 lg:w-1/4');
 
                             foreach ($students as $student) {
                                 $form->addHiddenValue($count . '-gibbonPersonID', $student['gibbonPersonID']);
 
-                                $cell = $grid->addCell()->addClass('textCenter stacked')->addClass($student['cellHighlight']);
+                                $cell = $grid->addCell()
+                                    ->setClass('text-center py-2 px-1 -mr-px -mb-px')
+                                    ->addClass($student['cellHighlight']);
+
                                 $cell->addContent(getUserPhoto($guid, $student['image_240'], 75));
                                 $cell->addWebLink(formatName('', htmlPrep($student['preferredName']), htmlPrep($student['surname']), 'Student', false))
                                      ->setURL('index.php?q=/modules/Students/student_view_details.php')
                                      ->addParam('gibbonPersonID', $student['gibbonPersonID'])
                                      ->addParam('subpage', 'Attendance')
-                                     ->wrap('<b>', '</b>');
-                                $cell->addContent($student['absenceCount'])->wrap('<span class="small emphasis">', '<span>');
+                                     ->setClass('pt-2 font-bold underline');
+                                $cell->addContent($student['absenceCount'])->wrap('<div class="text-xxs italic py-2">', '</div>');
                                 $cell->addSelect($count.'-type')
                                      ->fromArray(array_keys($attendance->getAttendanceTypes()))
                                      ->selected($student['log']['type'])
-                                     ->setClass('attendanceField floatNone shortWidth');
+                                     ->setClass('mx-auto float-none w-32 m-0 mb-px');
                                 $cell->addSelect($count.'-reason')
                                      ->fromArray($attendance->getAttendanceReasons())
                                      ->selected($student['log']['reason'])
-                                     ->setClass('attendanceField attendanceFieldStacked floatNone shortWidth');
+                                     ->setClass('mx-auto float-none w-32 m-0 mb-px');
                                 $cell->addTextField($count.'-comment')
                                      ->maxLength(255)
                                      ->setValue($student['log']['comment'])
-                                     ->setClass('attendanceField attendanceFieldStacked floatNone shortWidth');
+                                     ->setClass('mx-auto float-none w-32 m-0 mb-2');
                                 $cell->addContent($attendance->renderMiniHistory($student['gibbonPersonID']));
 
                                 $count++;
@@ -259,13 +261,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                                 ->wrap('<b>', '</b>');
 
                             $row = $form->addRow();
-                                // Drop-downs to change the whole group at once
-                                $col = $row->addColumn()->addClass('inline');
-                                    $col->addSelect('set-all-type')->fromArray(array_keys($attendance->getAttendanceTypes()))->setClass('attendanceField');
-                                    $col->addSelect('set-all-reason')->fromArray($attendance->getAttendanceReasons())->setClass('attendanceField');
-                                    $col->addTextField('set-all-comment')->maxLength(255)->setClass('attendanceField');
-                                    $col->addButton(__('Change All'))->setID('set-all');
-                                $row->addSubmit();
+
+                            // Drop-downs to change the whole group at once
+                            $row->addWebLink(__('Change All').'?')->addData('toggle', '.change-all')->addClass('w-32 sm:self-center');
+
+                            $col = $row->addColumn()->setClass('change-all hidden flex flex-col sm:flex-row items-stretch sm:items-center');
+                                $col->addSelect('set-all-type')->fromArray(array_keys($attendance->getAttendanceTypes()));
+                                $col->addSelect('set-all-reason')->fromArray($attendance->getAttendanceReasons());
+                                $col->addTextField('set-all-comment')->maxLength(255);
+                            $col->addButton(__('Change All'))->setID('set-all');
+
+                            $row->addSubmit();
 
                             echo $form->getOutput();
                         }

--- a/modules/Attendance/css/module.css
+++ b/modules/Attendance/css/module.css
@@ -17,25 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 */
 
-.attendanceGrid .grid {
-	border-collapse: collapse; 
-}
-
-.attendanceGrid td {
-	padding: 5px !important;
-	border: 0;
-}
-
-.attendanceField {
-	display:inline-block;
-	width: 133px;
-	margin-right: 8px;
-}
-
-.attendanceFieldStacked {
-	margin-top: -4px;
-}
-
 .verticalHeader {
 	overflow: hidden;
 	padding: 4px !important;

--- a/resources/templates/components/form.twig.html
+++ b/resources/templates/components/form.twig.html
@@ -16,7 +16,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
         <input type="hidden" name="{{ values.name }}" value="{{ values.value }}">
     {% endfor %}
 
-    <table class="{{ form.getClass }} px-3 py-2 sm:p-0" cellspacing=0>
+    <table class="{{ form.getClass }}" cellspacing=0>
     {% for row in form.getRows %}
         <tr id="{{ row.getID }}" class="{{ row.getClass|replace({'standardWidth': ''}) }} flex flex-col sm:flex-row justify-between content-center p-0">
 

--- a/src/Forms/Input/CustomBlocks.php
+++ b/src/Forms/Input/CustomBlocks.php
@@ -55,7 +55,7 @@ class CustomBlocks implements OutputableInterface
         $this->name = $name;
 
         $this->toolsTable = $factory->createTable()->setClass('inputTools fullWidth');
-        $this->blockButtons = $factory->createGrid()->setClass('blockButtons blank fullWidth')->setColumns(2);
+        $this->blockButtons = $factory->createGrid()->setClass('blockButtons blank fullWidth');
         $this->addBlockButton('delete', __('Delete'), 'garbage.png');
 
         $this->settings = array(

--- a/src/Forms/Layout/Grid.php
+++ b/src/Forms/Layout/Grid.php
@@ -43,22 +43,21 @@ class Grid implements OutputableInterface, ValidatableInterface
      * @param  FormFactoryInterface  $factory
      * @param  string                $id
      */
-    public function __construct(FormFactoryInterface $factory, $id = '', $columns = 1)
+    public function __construct(FormFactoryInterface $factory, $id = '', $breakpoints = 'w-1/2 sm:w-1/3')
     {
         $this->factory = $factory;
-        $this->setColumns($columns);
+        $this->setBreakpoints($breakpoints);
         $this->setID($id);
-        $this->setClass('fullWidth grid');
     }
 
     /**
-     * Sets the number of columns wide to render the grid.
+     * Sets the breakpoints in the grid with css classes, eg: w-1/2 sm:w-1/3
      * @param int $columns
      * @return self
      */
-    public function setColumns($columns)
+    public function setBreakpoints($breakpoints)
     {
-        $this->columns = $columns;
+        $this->breakpoints = $breakpoints;
 
         return $this;
     }
@@ -91,26 +90,19 @@ class Grid implements OutputableInterface, ValidatableInterface
      */
     public function getOutput()
     {
-        $output = '<table '.$this->getAttributeString().' cellspacing="0">';
-        $output .= '<tbody>';
+        $this->addClass('w-full flex flex-wrap');
 
-        $cellWidth = 100 / $this->columns;
-        $emptyCell = $this->factory->createColumn();
-        $rows = array_chunk($this->getElements(), $this->columns);
+        $output = '<div '.$this->getAttributeString().'>';
         
-        foreach ($rows as $cells) {
-            $cells = array_pad($cells, $this->columns, $emptyCell);
+        foreach ($this->getElements() as $cell) {
+            $cell->addClass($this->breakpoints);
 
-            $output .= '<tr>';
-            foreach ($cells as $cell) {
-                $output .= '<td class="' . $cell->getClass() . '" style="width: '.$cellWidth.'%">';
-                $output .= $cell->getOutput();
-                $output .= '</td>';
-            }
-            $output .= '</tr>';
+            $output .= '<div '.$cell->getAttributeString().'>';
+            $output .= $cell->getOutput();
+            $output .= '</div>';
         }
-        $output .= '</tbody>';
-        $output .= '</table>';
+
+        $output .= '</div>';
 
         return $output;
     }


### PR DESCRIPTION
Another follow-up to #827. This PR updates the form Grid class to make use of flexbox, and applies some responsive breakpoints via Tailwind to the attendance pages. The result is the Take Attendance actions are now usable on all device sizes:

<img width="461" alt="Screen Shot 2019-04-05 at 5 40 08 PM" src="https://user-images.githubusercontent.com/897700/55619017-720d5f00-57ca-11e9-88bc-d73582832f07.png">
<img width="753" alt="Screen Shot 2019-04-05 at 5 44 05 PM" src="https://user-images.githubusercontent.com/897700/55619019-733e8c00-57ca-11e9-9d12-80f3c6898dba.png">

