### PR TITLE
Forms: remove explicit calls to setClass in forms

### DIFF
--- a/modules/Behaviour/behaviour_manage_add.php
+++ b/modules/Behaviour/behaviour_manage_add.php
@@ -83,10 +83,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             echo '</div>';
 
             $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_addProcess.php?step=1&gibbonPersonID='.$gibbonPersonID.'&gibbonRollGroupID='.$gibbonRollGroupID.'&gibbonYearGroupID='.$gibbonYearGroupID.'&type='.$type);
-                $form->setClass('smallIntBorder fullWidth');
-                $form->setFactory(DatabaseFormFactory::create($pdo));
-                $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
-                $form->addRow()->addHeading(__('Step 1'));
+            $form->setFactory(DatabaseFormFactory::create($pdo));
+            $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
+            $form->addRow()->addHeading(__('Step 1'));
 
             //Student
             $row = $form->addRow();
@@ -176,11 +175,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                     $values = $result->fetch();
 
                     $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_addProcess.php?step=2&gibbonPersonID='.$gibbonPersonID.'&gibbonRollGroupID='.$gibbonRollGroupID.'&gibbonYearGroupID='.$gibbonYearGroupID.'&type='.$type);
-                        $form->setClass('smallIntBorder fullWidth');
-                        $form->setFactory(DatabaseFormFactory::create($pdo));
-                        $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
-                        $form->addHiddenValue('gibbonBehaviourID', $gibbonBehaviourID);
-                        $form->addRow()->addHeading(__('Step 2 (Optional)'));
+                    $form->setFactory(DatabaseFormFactory::create($pdo));
+                    $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
+                    $form->addHiddenValue('gibbonBehaviourID', $gibbonBehaviourID);
+                    $form->addRow()->addHeading(__('Step 2 (Optional)'));
 
                     //Student
                     $row = $form->addRow();

--- a/modules/Behaviour/behaviour_manage_addMulti.php
+++ b/modules/Behaviour/behaviour_manage_addMulti.php
@@ -56,10 +56,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
 
 
     $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_addMultiProcess.php?gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
-        $form->setClass('smallIntBorder fullWidth');
-        $form->setFactory(DatabaseFormFactory::create($pdo));
-        $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_addMulti.php");
-        $form->addRow()->addHeading(__('Step 1'));
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+    $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_addMulti.php");
+    $form->addRow()->addHeading(__('Step 1'));
 
     //Student
     $row = $form->addRow();

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -91,9 +91,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 $values = $result->fetch();
 
                 $form = Form::create('addform', $_SESSION[$guid]['absoluteURL'].'/modules/Behaviour/behaviour_manage_editProcess.php?gibbonBehaviourID='.$gibbonBehaviourID.'&gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonRollGroupID='.$_GET['gibbonRollGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
-                    $form->setClass('smallIntBorder fullWidth');
-                    $form->setFactory(DatabaseFormFactory::create($pdo));
-                    $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
+                $form->setFactory(DatabaseFormFactory::create($pdo));
+                $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
 
                 //Student
                 $row = $form->addRow();

--- a/modules/Finance/budgets_manage_add.php
+++ b/modules/Finance/budgets_manage_add.php
@@ -43,9 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_add
     }
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/budgets_manage_addProcess.php');
-
     $form->setFactory(DatabaseFormFactory::create($pdo));
-    $form->setClass('smallIntBorder fullWidth');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Finance/budgets_manage_edit.php
+++ b/modules/Finance/budgets_manage_edit.php
@@ -63,9 +63,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
             $values = $result->fetch();
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/budgets_manage_editProcess.php?gibbonFinanceBudgetID=$gibbonFinanceBudgetID");
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Finance/expenseApprovers_manage_add.php
+++ b/modules/Finance/expenseApprovers_manage_add.php
@@ -40,9 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
     }
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/expenseApprovers_manage_addProcess.php');
-
     $form->setFactory(DatabaseFormFactory::create($pdo));
-    $form->setClass('smallIntBorder fullWidth');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Finance/expenseApprovers_manage_edit.php
+++ b/modules/Finance/expenseApprovers_manage_edit.php
@@ -60,9 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
             $values = $result->fetch();
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/expenseApprovers_manage_editProcess.php?gibbonFinanceExpenseApproverID=$gibbonFinanceExpenseApproverID");
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Finance/expenseRequest_manage_add.php
+++ b/modules/Finance/expenseRequest_manage_add.php
@@ -98,8 +98,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/expenseRequest_manage_addProcess.php');
 
-                    $form->setClass('smallIntBorder fullWidth');
-
                     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
                     $form->addHiddenValue('status2', $status2);
                     $form->addHiddenValue('gibbonFinanceBudgetID2', $gibbonFinanceBudgetID2);

--- a/modules/Finance/expenseRequest_manage_reimburse.php
+++ b/modules/Finance/expenseRequest_manage_reimburse.php
@@ -106,8 +106,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/expenseRequest_manage_reimburseProcess.php');
 
-                    $form->setClass('smallIntBorder fullWidth');
-
                     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
                     $form->addHiddenValue('status2', $status2);
                     $form->addHiddenValue('gibbonFinanceBudgetID2', $gibbonFinanceBudgetID2);

--- a/modules/Finance/expenseRequest_manage_view.php
+++ b/modules/Finance/expenseRequest_manage_view.php
@@ -115,8 +115,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                         $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/expenseRequest_manage_viewProcess.php');
 
-                        $form->setClass('smallIntBorder fullWidth');
-
                         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
                         $form->addHiddenValue('status2', $status2);
                         $form->addHiddenValue('gibbonFinanceBudgetID2', $gibbonFinanceBudgetID2);

--- a/modules/Finance/feeCategories_manage_add.php
+++ b/modules/Finance/feeCategories_manage_add.php
@@ -43,8 +43,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/feeCategories_manage_addProcess.php');
 
-    $form->setClass('smallIntBorder fullWidth');
-
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
     $row = $form->addRow();

--- a/modules/Finance/feeCategories_manage_edit.php
+++ b/modules/Finance/feeCategories_manage_edit.php
@@ -63,8 +63,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/feeCategories_manage_editProcess.php?gibbonFinanceFeeCategoryID=$gibbonFinanceFeeCategoryID");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $row = $form->addRow();

--- a/modules/Finance/fees_manage_add.php
+++ b/modules/Finance/fees_manage_add.php
@@ -57,8 +57,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/fees_manage_add.ph
 
         $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/fees_manage_addProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&search=$search");
 
-        $form->setClass('smallIntBorder fullWidth');
-
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
         try {

--- a/modules/Finance/fees_manage_edit.php
+++ b/modules/Finance/fees_manage_edit.php
@@ -75,8 +75,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/fees_manage_edit.p
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/fees_manage_editProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&search=$search");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonFinanceFeeID', $gibbonFinanceFeeID);
 

--- a/modules/Library/library_lending_item_edit.php
+++ b/modules/Library/library_lending_item_edit.php
@@ -73,9 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             }
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/library_lending_item_editProcess.php?gibbonLibraryItemEventID=$gibbonLibraryItemEventID&gibbonLibraryItemID=$gibbonLibraryItemID&name=".$_GET['name'].'&gibbonLibraryTypeID='.$_GET['gibbonLibraryTypeID'].'&gibbonSpaceID='.$_GET['gibbonSpaceID'].'&status='.$_GET['status']);
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Library/library_lending_item_renew.php
+++ b/modules/Library/library_lending_item_renew.php
@@ -74,9 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             }
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/library_lending_item_renewProcess.php?gibbonLibraryItemEventID=$gibbonLibraryItemEventID&gibbonLibraryItemID=$gibbonLibraryItemID&name=".$_GET['name'].'&gibbonLibraryTypeID='.$_GET['gibbonLibraryTypeID'].'&gibbonSpaceID='.$_GET['gibbonSpaceID'].'&status='.$_GET['status']);
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Library/library_lending_item_return.php
+++ b/modules/Library/library_lending_item_return.php
@@ -68,9 +68,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             }
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/library_lending_item_returnProcess.php?gibbonLibraryItemEventID=$gibbonLibraryItemEventID&gibbonLibraryItemID=$gibbonLibraryItemID&name=".$_GET['name'].'&gibbonLibraryTypeID='.$_GET['gibbonLibraryTypeID'].'&gibbonSpaceID='.$_GET['gibbonSpaceID'].'&status='.$_GET['status']);
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Library/library_lending_item_signout.php
+++ b/modules/Library/library_lending_item_signout.php
@@ -100,9 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             }
 
             $form = Form::create('libraryLendingSignout', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/library_lending_item_signoutProcess.php?name=".$_GET['name'].'&gibbonLibraryTypeID='.$_GET['gibbonLibraryTypeID'].'&gibbonSpaceID='.$_GET['gibbonSpaceID'].'&status='.$_GET['status']);
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonLibraryItemID', $gibbonLibraryItemID);

--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -148,8 +148,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/planner_addProcess.php?viewBy=$viewBy&subView=$subView&address=".$_SESSION[$guid]['address']);
             $form->setFactory(PlannerFormFactory::create($pdo));
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             //BASIC INFORMATION

--- a/modules/Planner/planner_bump.php
+++ b/modules/Planner/planner_bump.php
@@ -119,8 +119,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_bump.php')
 
                     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/planner_bumpProcess.php?gibbonPlannerEntryID=$gibbonPlannerEntryID");
 
-                    $form->setClass('smallIntBorder fullWidth');
-
                     $form->addHiddenValue('viewBy', $viewBy);
                     $form->addHiddenValue('subView', $subView);
                     $form->addHiddenValue('date', $date);

--- a/modules/Planner/planner_duplicate.php
+++ b/modules/Planner/planner_duplicate.php
@@ -150,8 +150,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.
 
                     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/planner_duplicate.php&gibbonPlannerEntryID=$gibbonPlannerEntryID&viewBy=$viewBy&gibbonCourseClassID=$gibbonCourseClassID&date=$date&step=2");
 
-                    $form->setClass('smallIntBorder fullWidth');
-
                     $form->addHiddenValue('viewBy', $viewBy);
                     $form->addHiddenValue('gibbonPlannerEntryID_org',  $gibbonPlannerEntryID);
                     $form->addHiddenValue('subView', $subView);
@@ -210,8 +208,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.
                         echo '</div>';
                     } else {
                         $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/planner_duplicateProcess.php?gibbonPlannerEntryID=$gibbonPlannerEntryID");
-
-                        $form->setClass('smallIntBorder fullWidth');
 
                         $form->addHiddenValue('duplicate', $duplicate);
                         $form->addHiddenValue('gibbonPlannerEntryID_org', $gibbonPlannerEntryID_org);

--- a/modules/Planner/planner_view_full_post.php
+++ b/modules/Planner/planner_view_full_post.php
@@ -166,8 +166,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
 
                     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/planner_view_full_postProcess.php');
 
-                    $form->setClass('smallIntBorder fullWidth');
-
                     $form->addHiddenValue('search', $search);
                     $form->addHiddenValue('replyTo', $replyTo);
                     $form->addHiddenValue('params', $paramsVar);

--- a/modules/Planner/planner_view_full_submit_edit.php
+++ b/modules/Planner/planner_view_full_submit_edit.php
@@ -160,8 +160,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
 
                                 $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/planner_view_full_submit_editProcess.php');
 
-                                $form->setClass('smallIntBorder fullWidth');
-
                                 $form->addHiddenValue('search', '');
                                 $form->addHiddenValue('params', $paramsVar);
                                 $form->addHiddenValue('gibbonPlannerEntryID', $gibbonPlannerEntryID);
@@ -224,8 +222,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
                                 }
 
                                 $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/planner_view_full_submit_editProcess.php');
-
-                                $form->setClass('smallIntBorder fullWidth');
 
                                 $form->addHiddenValue('count', $count);
                                 $form->addHiddenValue('lesson', $values['name']);

--- a/modules/Staff/applicationForm.php
+++ b/modules/Staff/applicationForm.php
@@ -106,9 +106,7 @@ if ($proceed == false) {
         echo '</div>';
 
         $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/applicationFormProcess.php');
-
         $form->setFactory(DatabaseFormFactory::create($pdo));
-        $form->setClass('smallIntBorder fullWidth');
 
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -75,9 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
             echo '</div>';
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/applicationForm_manage_editProcess.php?search=$search");
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Staff/applicationForm_manage_reject.php
+++ b/modules/Staff/applicationForm_manage_reject.php
@@ -72,8 +72,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/applicationForm_manage_rejectProcess.php?gibbonStaffApplicationFormID=$gibbonStaffApplicationFormID&search=$search");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonStaffApplicationFormID', $gibbonStaffApplicationFormID);
 

--- a/modules/Staff/jobOpenings_manage_add.php
+++ b/modules/Staff/jobOpenings_manage_add.php
@@ -40,8 +40,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage_a
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/jobOpenings_manage_addProcess.php');
 
-    $form->setClass('smallIntBorder fullWidth');
-
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
     $types = array(__('Basic') => array ('Teaching' => __('Teaching'), 'Support' => __('Support')));

--- a/modules/Staff/jobOpenings_manage_edit.php
+++ b/modules/Staff/jobOpenings_manage_edit.php
@@ -60,8 +60,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage_e
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/jobOpenings_manage_editProcess.php?gibbonStaffJobOpeningID=$gibbonStaffJobOpeningID");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $types = array(__('Basic') => array ('Teaching' => __('Teaching'), 'Support' => __('Support')));

--- a/modules/Staff/staff_manage_add.php
+++ b/modules/Staff/staff_manage_add.php
@@ -49,9 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_add.php
     }
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_addProcess.php?search=$search&allStaff=$allStaff");
-
     $form->setFactory(DatabaseFormFactory::create($pdo));
-    $form->setClass('smallIntBorder fullWidth');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Staff/staff_manage_edit.php
+++ b/modules/Staff/staff_manage_edit.php
@@ -81,7 +81,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
                 $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/staff_manage_editProcess.php?gibbonStaffID='.$values['gibbonStaffID']."&search=$search&allStaff=$allStaff");
 
                 $form->setFactory(DatabaseFormFactory::create($pdo));
-                $form->setClass('smallIntBorder fullWidth');
 
                 $form->addHiddenValue('address', $_SESSION[$guid]['address']);
                 $form->addHiddenValue('gibbonPersonID', $values['gibbonPersonID']);

--- a/modules/Staff/staff_manage_edit_contract_add.php
+++ b/modules/Staff/staff_manage_edit_contract_add.php
@@ -74,9 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_co
             }
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_edit_contract_addProcess.php?gibbonStaffID=$gibbonStaffID&search=$search");
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Staff/staff_manage_edit_contract_edit.php
+++ b/modules/Staff/staff_manage_edit_contract_edit.php
@@ -71,9 +71,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_co
             }
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_edit_contract_editProcess.php?gibbonStaffContractID=$gibbonStaffContractID&gibbonStaffID=$gibbonStaffID&search=$search");
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Staff/staff_manage_edit_facility_add.php
+++ b/modules/Staff/staff_manage_edit_facility_add.php
@@ -71,10 +71,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_fa
             }
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/staff_manage_edit_facility_addProcess.php?gibbonPersonID=$gibbonPersonID&gibbonStaffID=$gibbonStaffID&search=$search");
-
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
-
+            
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $row = $form->addRow();

--- a/modules/Students/applicationForm_manage_reject.php
+++ b/modules/Students/applicationForm_manage_reject.php
@@ -74,8 +74,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/applicationForm_manage_rejectProcess.php?gibbonApplicationFormID=$gibbonApplicationFormID&search=$search");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
             $form->addHiddenValue('gibbonApplicationFormID', $gibbonApplicationFormID);

--- a/modules/Students/medicalForm_manage_add.php
+++ b/modules/Students/medicalForm_manage_add.php
@@ -50,7 +50,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_addProcess.php?search=$search");
 
     $form->setFactory(DatabaseFormFactory::create($pdo));
-    $form->setClass('smallIntBorder fullWidth');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/Students/medicalForm_manage_condition_add.php
+++ b/modules/Students/medicalForm_manage_condition_add.php
@@ -79,7 +79,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_condition_addProcess.php?gibbonPersonMedicalID=$gibbonPersonMedicalID&search=$search");
 
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonPersonMedicalID', $gibbonPersonMedicalID);

--- a/modules/Students/medicalForm_manage_condition_edit.php
+++ b/modules/Students/medicalForm_manage_condition_edit.php
@@ -66,7 +66,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/medicalForm_manage_condition_editProcess.php?gibbonPersonMedicalID=$gibbonPersonMedicalID&search=$search&gibbonPersonMedicalConditionID=$gibbonPersonMedicalConditionID");
 
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
             $form->addHiddenValue('gibbonPersonMedicalID', $gibbonPersonMedicalID);

--- a/modules/Students/medicalForm_manage_edit.php
+++ b/modules/Students/medicalForm_manage_edit.php
@@ -66,7 +66,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/medicalForm_manage_editProcess.php?gibbonPersonMedicalID='.$gibbonPersonMedicalID."&search=$search");
 
             $form->setFactory(DatabaseFormFactory::create($pdo));
-            $form->setClass('smallIntBorder fullWidth');
 
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 

--- a/modules/User Admin/district_manage_add.php
+++ b/modules/User Admin/district_manage_add.php
@@ -40,8 +40,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/district_manage_addProcess.php");
 
-    $form->setClass('smallIntBorder fullWidth');
-
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
     $row = $form->addRow();

--- a/modules/User Admin/district_manage_edit.php
+++ b/modules/User Admin/district_manage_edit.php
@@ -60,8 +60,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/district_manage_editProcess.php?gibbonDistrictID=$gibbonDistrictID");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $row = $form->addRow();

--- a/modules/User Admin/family_manage_edit_editAdult.php
+++ b/modules/User Admin/family_manage_edit_editAdult.php
@@ -71,8 +71,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_edit_editAdultProcess.php?gibbonPersonID=$gibbonPersonID&gibbonFamilyID=$gibbonFamilyID&search=$search");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $form->addRow()->addHeading(__('Edit Adult'));

--- a/modules/User Admin/family_manage_edit_editChild.php
+++ b/modules/User Admin/family_manage_edit_editChild.php
@@ -71,8 +71,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/family_manage_edit_editChildProcess.php?gibbonPersonID=$gibbonPersonID&gibbonFamilyID=$gibbonFamilyID&search=$search");
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $form->addRow()->addHeading(__('Edit Child'));

--- a/modules/User Admin/userFields_add.php
+++ b/modules/User Admin/userFields_add.php
@@ -40,8 +40,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_add.
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/userFields_addProcess.php');
 
-    $form->setClass('smallIntBorder fullWidth');
-
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
     $row = $form->addRow();

--- a/modules/User Admin/userFields_edit.php
+++ b/modules/User Admin/userFields_edit.php
@@ -60,8 +60,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userFields_edit
 
             $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/userFields_editProcess.php?gibbonPersonFieldID='.$gibbonPersonFieldID);
 
-            $form->setClass('smallIntBorder fullWidth');
-
             $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
             $row = $form->addRow();

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -64,7 +64,6 @@ if ($proceed == false) {
 
     $form = Form::create('publicRegistration', $_SESSION[$guid]['absoluteURL'].'/publicRegistrationProcess.php');
 
-    $form->setClass('smallIntBorder fullWidth');
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
     $form->addRow()->addHeading(__('Account Details'));


### PR DESCRIPTION
Many of our forms have been using `setClass('smallIntBorder fullWidth')` to set the form's class, even though the Form class handles the default classes automatically (thus, overwriting the defaults). This PR removes those explicit calls, allowing us to adjust the defaults in the future and affect these forms as well. There are still some cases where it's helpful to overwrite the defaults, when the form displays as a table-like structure, so I've left those cases untouched.