### PR TITLE
Templates: update the printable report page to use a template

### DIFF
--- a/report.php
+++ b/report.php
@@ -17,120 +17,68 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Gibbon system-wide includes
-include './gibbon.php';
-include './version.php';
+use Gibbon\Services\Format;
 
-//Check to see if system settings are set from databases
-if ($_SESSION[$guid]['systemSettingsSet'] == false) {
+// Gibbon system-wide include
+require_once './gibbon.php';
+
+// Setup the Page and Session objects
+$page = $container->get('page');
+$session = $container->get('session');
+
+// Check to see if system settings are set from databases
+if (!$session->has('systemSettingsSet')) {
     getSystemSettings($guid, $connection2);
 }
-//If still false, show warning, otherwise display page
-if ($_SESSION[$guid]['systemSettingsSet'] == false) {
-    echo __('System Settings are not set: the system cannot be displayed');
-} else {
-    ?>
-	<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-	<html xmlns="http://www.w3.org/1999/xhtml">
-		<head>
-			<title><?php echo $_SESSION[$guid]['organisationNameShort'].' - '.$_SESSION[$guid]['systemName'] ?></title>
-			<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-			<meta http-equiv="content-language" content="en"/>
-			<meta name="author" content="Ross Parker, International College Hong Kong"/>
-			<meta name="robots" content="none"/>
 
-			<?php
-            //Set theme
-            $themeCSS = "<link rel='stylesheet' type='text/css' href='./themes/Default/css/main.css' />";
-			if ($_SESSION[$guid]['i18n']['rtl'] == 'Y') {
-				$themeCSS .= "<link rel='stylesheet' type='text/css' href='./themes/Default/css/main_rtl.css' />";
-			}
-			$themeJS = "<script type='text/javascript' src='./themes/Default/js/common.js'></script>";
-			$_SESSION[$guid]['gibbonThemeID'] = '001';
-			$_SESSION[$guid]['gibbonThemeName'] = 'Default';
-
-			if ($_SESSION[$guid]['gibbonThemeIDPersonal'] != null) {
-				$dataTheme = array('gibbonThemeIDPersonal' => $_SESSION[$guid]['gibbonThemeIDPersonal']);
-				$sqlTheme = 'SELECT * FROM gibbonTheme WHERE gibbonThemeID=:gibbonThemeIDPersonal';
-			} else {
-				$dataTheme = array();
-				$sqlTheme = "SELECT * FROM gibbonTheme WHERE active='Y'";
-			}
-			$resultTheme = $connection2->prepare($sqlTheme);
-			$resultTheme->execute($dataTheme);
-			if ($resultTheme->rowCount() == 1) {
-				$rowTheme = $resultTheme->fetch();
-				$themeCSS = "<link rel='stylesheet' type='text/css' href='./themes/".$rowTheme['name']."/css/main.css' />";
-				if ($_SESSION[$guid]['i18n']['rtl'] == 'Y') {
-					$themeCSS .= "<link rel='stylesheet' type='text/css' href='./themes/".$rowTheme['name']."/css/main_rtl.css' />";
-				}
-				$themeJS = "<script type='text/javascript' src='./themes/".$rowTheme['name']."/js/common.js'></script>";
-				$_SESSION[$guid]['gibbonThemeID'] = $rowTheme['gibbonThemeID'];
-				$_SESSION[$guid]['gibbonThemeName'] = $rowTheme['name'];
-			}
-			echo $themeCSS;
-			echo $themeJS;
-
-            //Set module CSS & JS
-            $moduleCSS = "<link rel='stylesheet' type='text/css' href='./modules/".$_SESSION[$guid]['module']."/css/module.css' />";
-			$moduleJS = "<script type='text/javascript' src='./modules/".$_SESSION[$guid]['module']."/js/module.js'></script>";
-			echo $moduleCSS;
-			echo $moduleJS;
-
-            
-   			?>
-
-			<link rel="shortcut icon" type="image/x-icon" href="./favicon.ico"/>
-			<script type="text/javascript" src="./lib/LiveValidation/livevalidation_standalone.compressed.js"></script>
-
-			<?php
-            if ($_SESSION[$guid]['analytics'] != '') {
-                echo $_SESSION[$guid]['analytics'];
-            }
-   			 ?>
-		</head>
-		<body style="background: none" class="print">
-			<div id="wrap-report" style="width:750px">
-				<div id="header-report">
-					<div style="width:400px; font-size: 100%; float: right">
-						<?php
-                        echo "<div style='padding-top: 10px'>";
-						echo "<p style='margin-bottom: 0; padding-bottom: 0'>";
-						echo sprintf(__('This printout contains information that is the property of %1$s. If you find this report, and do not have permission to read it, please return it to %2$s (%3$s). In the event that it cannot be returned, please destroy it.'), $_SESSION[$guid]['organisationName'], $_SESSION[$guid]['organisationAdministratorName'], $_SESSION[$guid]['organisationAdministratorEmail']);
-						echo '</p>';
-						echo '</div>';
-						?>
-					</div>
-					<div id="header-logo-report" style="text-align: right">
-						<img height='75px' width='300px' alt="Logo" src="<?php echo $_SESSION[$guid]['absoluteURL'].'/'.$_SESSION[$guid]['organisationLogo'];?>"/>
-					</div>
-				</div>
-				<div id="content-wrap-report" style="min-height: 500px">
-
-					<?php
-                    $_SESSION[$guid]['address'] = $_GET['q'];
-					$_SESSION[$guid]['module'] = getModuleName($_SESSION[$guid]['address']);
-					$_SESSION[$guid]['action'] = getActionName($_SESSION[$guid]['address']);
-
-					if (strstr($_SESSION[$guid]['address'], '..') != false) {
-						echo "<div class='error'>";
-						echo __('Illegal address detected: access denied.');
-						echo '</div>';
-					} else {
-						if (is_file('./'.$_SESSION[$guid]['address'])) {
-							include './'.$_SESSION[$guid]['address'];
-						} else {
-							include './error.php';
-						}
-					}
-					?>
-				</div>
-				<div id="footer-report">
-					<?php echo sprintf(__('Created by %1$s (%2$s) at %3$s on %4$s.'), $_SESSION[$guid]['username'], $_SESSION[$guid]['organisationNameShort'], date('H:i'), date($_SESSION[$guid]['i18n']['dateFormatPHP']));?>
-				</div>
-			</div>
-		</body>
-	</html>
-	<?php
+// If still false, show warning, otherwise display page
+if (!$session->has('systemSettingsSet')) {
+    exit(__('System Settings are not set: the system cannot be displayed'));
 }
-?>
+
+$address = $page->getAddress();
+
+if (empty($address)) {
+    $page->addWarning(__('There is no content to display'));
+} elseif ($page->isAddressValid($address) == false) {
+    $page->addError(__('Illegal address detected: access denied.'));
+} else {
+    // Pass these globals into the script of the included file, for backwards compatibility.
+    // These will be removed when we begin the process of ooifying action pages.
+    $globals = [
+        'guid'        => $guid,
+        'gibbon'      => $gibbon,
+        'version'     => $version,
+        'pdo'         => $pdo,
+        'connection2' => $connection2,
+        'autoloader'  => $autoloader,
+        'container'   => $container,
+        'page'        => $page,
+    ];
+
+    if (is_file('./'.$address)) {
+        $page->writeFromFile('./'.$address, $globals);
+    } else {
+        $page->writeFromFile('./error.php', $globals);
+    }
+}
+
+$page->addHeadExtra($session->get('analytics'));
+$page->stylesheets->add('theme-dev', 'resources/assets/css/theme.min.css');
+$page->stylesheets->add('core', 'resources/assets/css/core.min.css', ['weight' => 10]);
+
+$page->addData([
+    'isLoggedIn'                     => $session->has('username') && $session->has('gibbonRoleIDCurrent'),
+    'username'                       => $session->get('username'),
+    'gibbonThemeName'                => $session->get('gibbonThemeName'),
+    'organisationName'               => $session->get('organisationName'),
+    'organisationNameShort'          => $session->get('organisationNameShort'),
+    'organisationAdministratorName'  => $session->get('organisationAdministratorName'),
+    'organisationAdministratorEmail' => $session->get('organisationAdministratorEmail'),
+    'organisationLogo'               => $session->get('organisationLogo'),
+    'time'                           => Format::time(date('H:i:s')),
+    'date'                           => Format::date(date('Y-m-d')),
+    'rightToLeft'                    => $session->get('i18n')['rtl'] == 'Y',
+]);
+
+echo $page->render('report.twig.html');

--- a/resources/templates/report.twig.html
+++ b/resources/templates/report.twig.html
@@ -1,0 +1,38 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+<!DOCTYPE html>
+<html {{ rightToLeft ? 'dir="rtl"' : '' }}>
+    <head>
+        {{ include('head.twig.html') }}
+    </head>
+    <body class="print">
+
+        <div id="wrap-report" class="mx-auto max-w-3xl">
+            <div id="header-report" class="flex items-center w-full my-6">
+                
+                <div id="header-logo" class="leading-none">
+                    <img class="block max-w-full" alt="{{ organisationNameShort }}" src="{{ absoluteURL }}/{{ organisationLogo|default("/themes/Default/img/logo.png") }}" width="400"/>
+                </div>
+
+                <div id="header-text" class="w-3/4 text-xs leading-tight pl-10">
+                    {{  __('This printout contains information that is the property of %1$s. If you find this report, and do not have permission to read it, please return it to %2$s (%3$s). In the event that it cannot be returned, please destroy it.')|format(organisationName, organisationAdministratorName, organisationAdministratorEmail) }}
+                </div>
+            </div>
+
+            <div id="content-wrap-report" class="w-full max-w-full">
+                {% if isLoggedIn %}
+                    {{ content|join("\n")|raw }}
+                {% endif %}
+            </div>
+
+            <div id="footer-report" class="pt-8 text-xs text-right italic">
+                {{ __('Created by %1$s (%2$s) at %3$s on %4$s.')|format(username, organisationNameShort, time, date) }}
+            </div>
+        </div>
+    </body>
+</html>

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -39,47 +39,6 @@ body {
 
 /* LAYOUT */
 
-#wrap-report {
-	width:1101px;
-	padding-top: 10px;
-	padding-left: 1px;
-	margin: 10px auto ;
-	position:relative ;
-}
-
-#header-logo-report {
-	margin:0 0 0 0px;
-	padding:0px 0;
-	color:#ccc;
-	border:none;
-	width: 250px;
-}
-
-#header-finder {
-	float: right ;
-	color:#fff;
-	font-weight:bold;
-	position:absolute;
-	top:24px;
-	right:24px;
-	left:auto;
-	width:400px;
-}
-#header-finder h2 {
-	text-align: right ;
-	border-bottom: none ;
-	font-size: 90% ;
-	margin-bottom: 0!important ;
-	margin-top: 0!important ;
-}
-
-
-#content-wrap-report {
-	background-color: rgba(255,255,255,0.9) ;
-	position:relative;
-	width:100%;
-}
-
 #content div.trail {
 	text-align: left;
 	font-size: 70%;
@@ -127,16 +86,6 @@ div.sidebarExtra {
 	margin-bottom: 10px ;
 }
 
-#footer-report {
-	clear:both;
-	width:750px;
-	color: #333;
-	margin: 0 0 0 -1px;
-	padding: 5px 0px 5px 0px;
-	font-size:75%;
-	text-align: right ;
-	font-style: italic ;
-}
 
 
 img.minorLinkIconLarge {
@@ -195,9 +144,7 @@ h1, h2, h3, h4, h5, h6 {
 h1 {
 	font-size: 17pt;
 }
-h1.report {
-	font-size: 17pt;
-}
+
 h2 {
 	font-size: 14pt;
 }


### PR DESCRIPTION
The `report.php` page is one the the last places still outputting the page layout manually. This PR updates the reports to use a `report.twig.html` template. Also deletes the now-unused styles from `main.css`.