### PR TITLE
System Admin: add a clear cache option under System Check

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -61,6 +61,7 @@ v18.0.00
         School Admin: fixed interface string typos
         Staff: fixed staff photo not displaying on Facilities sub-page in staff profile
         System Admin: fixed typo in Google integration settings
+        System Admin: added a clear cache option under System Check
         Timetable Admin: fixed malformed translatable interface strings
         User Admin: fixed issue preventing action names from being translated in Manage Permissions
         User Admin: improved interface string consistency

--- a/modules/System Admin/systemCheck.php
+++ b/modules/System Admin/systemCheck.php
@@ -31,6 +31,10 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.p
     //Proceed!
     $page->breadcrumbs->add(__('System Check'));
 
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
     $versionDB = getSettingByScope($connection2, 'System', 'version');
 
     $trueIcon = "<img title='" . __('Yes'). "' src='".$_SESSION[$guid]["absoluteURL"]."/themes/".$_SESSION[$guid]["gibbonThemeName"]."/img/iconTick.png' style='width:20px;height:20px;margin-right:10px' />";
@@ -151,6 +155,17 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.p
         $row->addTextField('uploadsFolder')->setValue($_SESSION[$guid]['absoluteURL'].'/uploads')->readonly();
         $row->addContent(is_writable($_SESSION[$guid]['absolutePath'].'/uploads')? $trueIcon : $falseIcon);
 
+
+    echo $form->getOutput();
+
+
+    // CLEAR CACHE
+    $form = Form::create('clearCache', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/systemCheck_clearCacheProcess.php');
+    $form->addClass('mt-10');
+
+    $form->addRow()->addHeading(__('System Data'));
+
+    $row = $form->addRow()->addSubmit(__('Clear Cache'));
 
     echo $form->getOutput();
 }

--- a/modules/System Admin/systemCheck_clearCacheProcess.php
+++ b/modules/System Admin/systemCheck_clearCacheProcess.php
@@ -1,0 +1,39 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+include '../../gibbon.php';
+include '../../config.php';
+
+//Module includes
+include './moduleFunctions.php';
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/System Admin/systemCheck.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Clear the templates cache folder
+    removeDirectoryContents($_SESSION[$guid]['absolutePath'].'/uploads/cache');
+
+    $URL .= '&return=success0';
+    header("Location: {$URL}");
+    exit;
+}


### PR DESCRIPTION
Template cache is cleared on update, and Development systems continuously reload the cache, so for the most part admins don't need to worry about it. However for Production systems running cutting edge code, it is handy to be able to quickly clear the cache folder after uploading changes. This PR adds a Clear Cache button under the System Check page.