### PR TITLE
Rubric Visualisation Image Export

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ v18.0.00
     Significant Changes
         System: added a webpack-based build process for javascript and css files
         Attendance: added ability to set future absence for multiple students
+        Rubrics: added ability to export Visualise chart to PNG
 
     Security
 

--- a/modules/Rubrics/moduleFunctions.php
+++ b/modules/Rubrics/moduleFunctions.php
@@ -390,7 +390,7 @@ function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID
                 $output .= "</p>";
 
                 require_once __DIR__ . '/src/Visualise.php';
-                $visualise = new Visualise($gibbon, $pdo, $page, $gibbonPersonID, $columns, $rows, $cells, $contexts);
+                $visualise = new Visualise($gibbon->session->get('absoluteURL'), $page, $gibbonPersonID, $columns, $rows, $cells, $contexts);
 
                 $output .= $visualise->renderVisualise();
 

--- a/modules/Rubrics/moduleFunctions.php
+++ b/modules/Rubrics/moduleFunctions.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
-use Gibbon\UI\Chart\Chart;
+use Gibbon\Module\Rubrics\Visualise;
 
 function rubricEdit($guid, $connection2, $gibbonRubricID, $scaleName = '', $search = '', $filter2 = '')
 {
@@ -41,14 +41,14 @@ function rubricEdit($guid, $connection2, $gibbonRubricID, $scaleName = '', $sear
     $resultCells = $pdo->executeQuery($data, $sqlCells);
     $cellCount = $resultCells->rowCount();
 
-    $sqlGradeScales = "SELECT gibbonScaleGrade.gibbonScaleGradeID, gibbonScaleGrade.* FROM gibbonRubricColumn 
-        JOIN gibbonScaleGrade ON (gibbonRubricColumn.gibbonScaleGradeID=gibbonScaleGrade.gibbonScaleGradeID) 
+    $sqlGradeScales = "SELECT gibbonScaleGrade.gibbonScaleGradeID, gibbonScaleGrade.* FROM gibbonRubricColumn
+        JOIN gibbonScaleGrade ON (gibbonRubricColumn.gibbonScaleGradeID=gibbonScaleGrade.gibbonScaleGradeID)
         WHERE gibbonRubricColumn.gibbonRubricID=:gibbonRubricID";
     $resultGradeScales = $pdo->executeQuery($data, $sqlGradeScales);
     $gradeScales = ($resultGradeScales->rowCount() > 0)? $resultGradeScales->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
 
-    $sqlOutcomes = "SELECT gibbonOutcome.gibbonOutcomeID, gibbonOutcome.* FROM gibbonRubricRow 
-        JOIN gibbonOutcome ON (gibbonRubricRow.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) 
+    $sqlOutcomes = "SELECT gibbonOutcome.gibbonOutcomeID, gibbonOutcome.* FROM gibbonRubricRow
+        JOIN gibbonOutcome ON (gibbonRubricRow.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID)
         WHERE gibbonRubricRow.gibbonRubricID=:gibbonRubricID";
     $resultOutcomes = $pdo->executeQuery($data, $sqlOutcomes);
     $outcomes = ($resultOutcomes->rowCount() > 0)? $resultOutcomes->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
@@ -77,7 +77,7 @@ function rubricEdit($guid, $connection2, $gibbonRubricID, $scaleName = '', $sear
 
         $row = $form->addRow()->addClass();
             $row->addContent()->addClass('rubricCellEmpty');
-            
+
         // Column Headers
         for ($n = 0; $n < $columnCount; ++$n) {
             $col = $row->addColumn()->addClass('rubricHeading');
@@ -128,7 +128,7 @@ function rubricEdit($guid, $connection2, $gibbonRubricID, $scaleName = '', $sear
 
         $row = $form->addRow();
             $row->addSubmit();
-        
+
         $output .= $form->getOutput();
     }
 
@@ -138,8 +138,8 @@ function rubricEdit($guid, $connection2, $gibbonRubricID, $scaleName = '', $sear
 //If $mark=TRUE, then marking tools are made available, otherwise it is view only
 function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID = '', $contextDBTable = '', $contextDBTableIDField = '', $contextDBTableID = '', $contextDBTableGibbonRubricIDField = '', $contextDBTableNameField = '', $contextDBTableDateField = '')
 {
-    global $pdo, $page;
-    
+    global $pdo, $page, $gibbon;
+
     $output = false;
     $hasContexts = $contextDBTable != '' and $contextDBTableIDField != '' and $contextDBTableID != '' and $contextDBTableGibbonRubricIDField != '' and $contextDBTableNameField != '' and $contextDBTableDateField != '';
 
@@ -172,42 +172,49 @@ function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID
         $resultCells = $pdo->executeQuery($data, $sqlCells);
         $cellCount = $resultCells->rowcount();
 
-        $sqlGradeScales = "SELECT gibbonScaleGrade.gibbonScaleGradeID, gibbonScaleGrade.*, gibbonScale.name FROM gibbonRubricColumn 
-            JOIN gibbonScaleGrade ON (gibbonRubricColumn.gibbonScaleGradeID=gibbonScaleGrade.gibbonScaleGradeID) 
+        $sqlGradeScales = "SELECT gibbonScaleGrade.gibbonScaleGradeID, gibbonScaleGrade.*, gibbonScale.name FROM gibbonRubricColumn
+            JOIN gibbonScaleGrade ON (gibbonRubricColumn.gibbonScaleGradeID=gibbonScaleGrade.gibbonScaleGradeID)
             JOIN gibbonScale ON (gibbonScale.gibbonScaleID=gibbonScaleGrade.gibbonScaleID)
             WHERE gibbonRubricColumn.gibbonRubricID=:gibbonRubricID";
         $resultGradeScales = $pdo->executeQuery($data, $sqlGradeScales);
         $gradeScales = ($resultGradeScales->rowCount() > 0)? $resultGradeScales->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
 
-        $sqlOutcomes = "SELECT gibbonOutcome.gibbonOutcomeID, gibbonOutcome.* FROM gibbonRubricRow 
-            JOIN gibbonOutcome ON (gibbonRubricRow.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) 
+        $sqlOutcomes = "SELECT gibbonOutcome.gibbonOutcomeID, gibbonOutcome.* FROM gibbonRubricRow
+            JOIN gibbonOutcome ON (gibbonRubricRow.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID)
             WHERE gibbonRubricRow.gibbonRubricID=:gibbonRubricID";
         $resultOutcomes = $pdo->executeQuery($data, $sqlOutcomes);
         $outcomes = ($resultOutcomes->rowCount() > 0)? $resultOutcomes->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
 
         // Check if outcomes are specified in unit
+        $unitOutcomes = array();
         if ($hasContexts) {
-            $dataUnitOutcomes = array('gibbonRubricID' => $gibbonRubricID, 'contextDBTableID' => $contextDBTableID);
-            $sqlUnitOutcomes = "SELECT gibbonUnitOutcome.gibbonOutcomeID, gibbonUnitOutcome.gibbonUnitOutcomeID FROM gibbonRubricRow 
-                JOIN gibbonOutcome ON (gibbonRubricRow.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) 
-                JOIN gibbonUnitOutcome ON (gibbonUnitOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) 
-                JOIN `$contextDBTable` ON (`$contextDBTable`.gibbonUnitID=gibbonUnitOutcome.gibbonUnitID AND `$contextDBTableIDField`=:contextDBTableID)
-                WHERE gibbonRubricRow.gibbonRubricID=:gibbonRubricID";
+            $dataUnitOutcomes = array();
+            $sqlUnitOutcomes = "SHOW COLUMNS FROM `$contextDBTable` LIKE 'gibbonUnitID'";
             $resultUnitOutcomes = $pdo->executeQuery($dataUnitOutcomes, $sqlUnitOutcomes);
-            $unitOutcomes = ($resultUnitOutcomes->rowCount() > 0)? $resultUnitOutcomes->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
+
+            if ($resultUnitOutcomes->rowCount() > 0) {
+                $dataUnitOutcomes = array('gibbonRubricID' => $gibbonRubricID, 'contextDBTableID' => $contextDBTableID);
+                $sqlUnitOutcomes = "SELECT gibbonUnitOutcome.gibbonOutcomeID, gibbonUnitOutcome.gibbonUnitOutcomeID FROM gibbonRubricRow
+                    JOIN gibbonOutcome ON (gibbonRubricRow.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID)
+                    JOIN gibbonUnitOutcome ON (gibbonUnitOutcome.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID)
+                    JOIN `$contextDBTable` ON (`$contextDBTable`.gibbonUnitID=gibbonUnitOutcome.gibbonUnitID AND `$contextDBTableIDField`=:contextDBTableID)
+                    WHERE gibbonRubricRow.gibbonRubricID=:gibbonRubricID";
+                $resultUnitOutcomes = $pdo->executeQuery($dataUnitOutcomes, $sqlUnitOutcomes);
+                $unitOutcomes = ($resultUnitOutcomes->rowCount() > 0)? $resultUnitOutcomes->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
+            }
         }
 
         // Load rubric data for this student
         $dataEntries = array('gibbonRubricID' => $gibbonRubricID, 'gibbonPersonID' => $gibbonPersonID, 'contextDBTable' => $contextDBTable, 'contextDBTableID' => $contextDBTableID);
-        $sqlEntries = "SELECT gibbonRubricEntry.gibbonRubricCellID, gibbonRubricEntry.* FROM gibbonRubricCell 
-            LEFT JOIN gibbonRubricEntry ON (gibbonRubricEntry.gibbonRubricCellID=gibbonRubricCell.gibbonRubricCellID) 
-            WHERE gibbonRubricCell.gibbonRubricID=:gibbonRubricID 
-            AND gibbonRubricEntry.gibbonPersonID=:gibbonPersonID 
-            AND gibbonRubricEntry.contextDBTable=:contextDBTable 
+        $sqlEntries = "SELECT gibbonRubricEntry.gibbonRubricCellID, gibbonRubricEntry.* FROM gibbonRubricCell
+            LEFT JOIN gibbonRubricEntry ON (gibbonRubricEntry.gibbonRubricCellID=gibbonRubricCell.gibbonRubricCellID)
+            WHERE gibbonRubricCell.gibbonRubricID=:gibbonRubricID
+            AND gibbonRubricEntry.gibbonPersonID=:gibbonPersonID
+            AND gibbonRubricEntry.contextDBTable=:contextDBTable
             AND gibbonRubricEntry.contextDBTableID=:contextDBTableID";
         $resultEntries = $pdo->executeQuery($dataEntries, $sqlEntries);
         $entries = ($resultEntries->rowCount() > 0)? $resultEntries->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
-                
+
 
         if ($rowCount <= 0 or $columnCount <= 0) {
             $output .= "<div class='error'>";
@@ -226,16 +233,16 @@ function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID
             $contexts = array();
             if ($hasContexts) {
                 $dataContext = array('gibbonPersonID' => $gibbonPersonID);
-                $sqlContext = "SELECT gibbonRubricEntry.*, $contextDBTable.*, gibbonRubricEntry.*, gibbonRubricCell.*, gibbonCourse.nameShort AS course, gibbonCourseClass.nameshort AS class 
-                    FROM gibbonRubricEntry 
-                    JOIN $contextDBTable ON (gibbonRubricEntry.contextDBTableID=$contextDBTable.$contextDBTableIDField 
-                        AND gibbonRubricEntry.gibbonRubricID=$contextDBTable.$contextDBTableGibbonRubricIDField) 
-                    JOIN gibbonRubricCell ON (gibbonRubricEntry.gibbonRubricCellID=gibbonRubricCell.gibbonRubricCellID) 
-                    LEFT JOIN gibbonCourseClass ON ($contextDBTable.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) 
-                    LEFT JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) 
-                    WHERE contextDBTable='$contextDBTable' 
-                    AND gibbonRubricEntry.gibbonPersonID=:gibbonPersonID 
-                    AND NOT $contextDBTableDateField IS NULL 
+                $sqlContext = "SELECT gibbonRubricEntry.*, $contextDBTable.*, gibbonRubricEntry.*, gibbonRubricCell.*, gibbonCourse.nameShort AS course, gibbonCourseClass.nameshort AS class
+                    FROM gibbonRubricEntry
+                    JOIN $contextDBTable ON (gibbonRubricEntry.contextDBTableID=$contextDBTable.$contextDBTableIDField
+                        AND gibbonRubricEntry.gibbonRubricID=$contextDBTable.$contextDBTableGibbonRubricIDField)
+                    JOIN gibbonRubricCell ON (gibbonRubricEntry.gibbonRubricCellID=gibbonRubricCell.gibbonRubricCellID)
+                    LEFT JOIN gibbonCourseClass ON ($contextDBTable.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
+                    LEFT JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID)
+                    WHERE contextDBTable='$contextDBTable'
+                    AND gibbonRubricEntry.gibbonPersonID=:gibbonPersonID
+                    AND NOT $contextDBTableDateField IS NULL
                     ORDER BY $contextDBTableDateField DESC";
                 $resultContext = $pdo->executeQuery($dataContext,  $sqlContext);
 
@@ -243,7 +250,7 @@ function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID
                     while ($rowContext = $resultContext->fetch()) {
                         $context = $rowContext['course'].'.'.$rowContext['class'].' - '.$rowContext[$contextDBTableNameField].' ('.dateConvertBack($guid, $rowContext[$contextDBTableDateField]).')';
                         $cells[$rowContext['gibbonRubricRowID']][$rowContext['gibbonRubricColumnID']]['context'][] = $context;
-                    
+
                         array_push($contexts, array('gibbonRubricEntry' => $rowContext['gibbonRubricEntry'], 'gibbonRubricID' => $rowContext['gibbonRubricID'], 'gibbonPersonID' => $rowContext['gibbonPersonID'], 'gibbonRubricCellID' => $rowContext['gibbonRubricCellID'], 'contextDBTable' => $rowContext['contextDBTable'], 'contextDBTableID' => $rowContext['contextDBTableID']));
                     }
                 }
@@ -329,7 +336,7 @@ function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID
 
                             $highlightClass = isset($entries[$cell['gibbonRubricCellID']])? 'rubricCellHighlight' : '';
                             $markableClass = ($mark == true)? 'markableCell' : '';
-                            
+
                             $col = $row->addColumn()->addClass('rubricCell '.$highlightClass);
                                 $col->addContent($cell['contents'])
                                     ->addClass('currentView '.$markableClass)
@@ -382,76 +389,14 @@ function rubricView($guid, $connection2, $gibbonRubricID, $mark, $gibbonPersonID
                     $output .= __("This view offers a visual representation of all rubric data for the current student, this year, in the current context:");
                 $output .= "</p>";
 
-                //Filter out columns to ignore from visualisation
-                $columns = array_filter($columns, function ($item) {
-                    return (isset($item['visualise']) && $item['visualise'] == 'Y'); 
-                });
+                require_once __DIR__ . '/src/Visualise.php';
+                $visualise = new Visualise($gibbon, $pdo, $page, $gibbonPersonID, $columns, $rows, $cells, $contexts);
 
-                if (!empty($columns) && !empty($cells)) {
-                    //Cycle through rows to calculate means
-                    $means = array() ;
-                    foreach ($rows as $row) {
-                        $means[$row['gibbonRubricRowID']]['title'] = $row['title'];
-                        $means[$row['gibbonRubricRowID']]['cumulative'] = 0;
-                        $means[$row['gibbonRubricRowID']]['denonimator'] = 0;
+                $output .= $visualise->renderVisualise();
 
-                        //Cycle through cells, and grab those for this row
-                        $cellCount = 1 ;
-                        foreach ($cells[$row['gibbonRubricRowID']] as $cell) {
-                            $visualise = false ;
-                            foreach ($columns as $column) {
-                                if ($column['gibbonRubricColumnID'] == $cell['gibbonRubricColumnID']) {
-                                    $visualise = true ;
-                                }
-                            }
-
-                            if ($visualise) {
-                                foreach ($contexts as $entry) {
-                                    if ($entry['gibbonRubricCellID'] == $cell['gibbonRubricCellID']) {
-                                        $means[$row['gibbonRubricRowID']]['cumulative'] += $cellCount;
-                                        $means[$row['gibbonRubricRowID']]['denonimator']++;
-                                    }
-                                }
-                                $cellCount++;
-                            }
-                        }
-                    }
-                
-                    $columnCount = count($columns);
-                    $data = array_map(function ($mean) use ($columnCount) {
-                        return !empty($mean['denonimator'])
-                        ? round((($mean['cumulative']/$mean['denonimator'])/$columnCount), 2)
-                        : 0;
-                    }, $means);
-
-                    $page->scripts->add('chart');
-                
-                    $chart = Chart::create('visualisation', 'polarArea')
-                        ->setLegend(['display' => true, 'position' => 'right'])
-                        ->setLabels(array_column($means, 'title'))
-                        ->setColorOpacity(0.6);
-
-                        $chart->setOptions([
-                        'height' => '120%',
-                        'scale'  => [
-                            'ticks' => [
-                                'min' => 0.0,
-                                'max' => 1.0,
-                                'callback' => $chart->addFunction('function(tickValue, index, ticks) {
-                                    return Number(tickValue).toFixed(1);
-                                }'),
-                            ],
-                        ],
-                    ]);
-
-                    $chart->addDataset('rubric')->setData($data);
-
-                    $output .= $chart->render();
-                }
-    
             $output .= "</div>";
 
-            //Function to show/hide rubric/visualisation 
+            //Function to show/hide rubric/visualisation
             $output .= "<script type='text/javascript'>
                  $(document).ready(function(){
                     $('#type').change(function () {

--- a/modules/Rubrics/src/Visualise.php
+++ b/modules/Rubrics/src/Visualise.php
@@ -19,28 +19,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Module\Rubrics;
 
-use Gibbon\Contracts\Database\Connection;
-use Gibbon\session;
 use Gibbon\UI\Chart\Chart;
 
 /**
  * Attendance display & edit class
  *
- * @version 12th Sept 2016
- * @since   12th Sept 2016
- * @author  Sandra Kuipers
+ * @version v18
+ * @since   v18
  */
 class Visualise
 {
-    /**
-     * Gibbon\Contracts\Database\Connection
-     */
-    protected $pdo;
-
-    /**
-     * Gibbon\session
-     */
-    protected $session;
+    protected $absoluteURL;
 
     protected $page;
 
@@ -59,18 +48,13 @@ class Visualise
     /**
      * Constructor
      *
-     * @version  3rd May 2016
-     * @since    3rd May 2016
-     * @param    Gibbon\session
-     * @param    Gibbon\config
-     * @param    Gibbon\Contracts\Database\Connection
+     * @version  v18
+     * @since    v18
      * @return   void
      */
-    public function __construct(\Gibbon\Core $gibbon, Connection $pdo, $page, Int $gibbonPersonID, Array $columns, Array $rows, Array $cells, Array $contexts)
+    public function __construct($absoluteURL, $page, Int $gibbonPersonID, Array $columns, Array $rows, Array $cells, Array $contexts)
     {
-        $this->session = $gibbon->session;
-
-        $this->pdo = $pdo;
+        $this->absoluteURL = $absoluteURL;
 
         $this->page = $page;
 
@@ -153,7 +137,7 @@ class Visualise
                     'duration' => 0,
                     'onComplete' => $chart->addFunction('function(e) {
                         var img = visualisation.toDataURL("image/png");
-                        $.ajax({ url: "'.$this->session->get('absoluteURL').'/modules/Rubrics/src/visualise_saveAjax.php", type: "POST", data: {img: img, gibbonPersonID: '.$this->gibbonPersonID.'}, dataType: "html"})
+                        $.ajax({ url: "'.$this->absoluteURL.'/modules/Rubrics/src/visualise_saveAjax.php", type: "POST", data: {img: img, gibbonPersonID: '.$this->gibbonPersonID.'}, dataType: "html"})
                         $.ajax({ url: "./"});
                     }'),
                 ];

--- a/modules/Rubrics/src/Visualise.php
+++ b/modules/Rubrics/src/Visualise.php
@@ -1,0 +1,168 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Gibbon\Module\Rubrics;
+
+use Gibbon\Contracts\Database\Connection;
+use Gibbon\session;
+use Gibbon\UI\Chart\Chart;
+
+/**
+ * Attendance display & edit class
+ *
+ * @version 12th Sept 2016
+ * @since   12th Sept 2016
+ * @author  Sandra Kuipers
+ */
+class Visualise
+{
+    /**
+     * Gibbon\Contracts\Database\Connection
+     */
+    protected $pdo;
+
+    /**
+     * Gibbon\session
+     */
+    protected $session;
+
+    protected $page;
+
+    protected $guid;
+
+    protected $gibbonPersonID;
+
+    protected $columns;
+
+    protected $rows;
+
+    protected $cells;
+
+    protected $contexts;
+
+    /**
+     * Constructor
+     *
+     * @version  3rd May 2016
+     * @since    3rd May 2016
+     * @param    Gibbon\session
+     * @param    Gibbon\config
+     * @param    Gibbon\Contracts\Database\Connection
+     * @return   void
+     */
+    public function __construct(\Gibbon\Core $gibbon, Connection $pdo, $page, Int $gibbonPersonID, Array $columns, Array $rows, Array $cells, Array $contexts)
+    {
+        $this->session = $gibbon->session;
+
+        $this->pdo = $pdo;
+
+        $this->page = $page;
+
+        $this->gibbonPersonID = $gibbonPersonID;
+
+        $this->columns = $columns;
+
+        $this->rows = $rows;
+
+        $this->cells = $cells;
+
+        $this->contexts = $contexts;
+    }
+
+    public function renderVisualise($legend = true, $image = false)
+    {
+        //Filter out columns to ignore from visualisation
+        $this->columns = array_filter($this->columns, function ($item) {
+            return (isset($item['visualise']) && $item['visualise'] == 'Y');
+        });
+
+        if (!empty($this->columns) && !empty($this->cells)) {
+            //Cycle through rows to calculate means
+            $means = array() ;
+            foreach ($this->rows as $row) {
+                $means[$row['gibbonRubricRowID']]['title'] = $row['title'];
+                $means[$row['gibbonRubricRowID']]['cumulative'] = 0;
+                $means[$row['gibbonRubricRowID']]['denonimator'] = 0;
+
+                //Cycle through cells, and grab those for this row
+                $cellCount = 1 ;
+                foreach ($this->cells[$row['gibbonRubricRowID']] as $cell) {
+                    $visualise = false ;
+                    foreach ($this->columns as $column) {
+                        if ($column['gibbonRubricColumnID'] == $cell['gibbonRubricColumnID']) {
+                            $visualise = true ;
+                        }
+                    }
+
+                    if ($visualise) {
+                        foreach ($this->contexts as $entry) {
+                            if ($entry['gibbonRubricCellID'] == $cell['gibbonRubricCellID']) {
+                                $means[$row['gibbonRubricRowID']]['cumulative'] += $cellCount;
+                                $means[$row['gibbonRubricRowID']]['denonimator']++;
+                            }
+                        }
+                        $cellCount++;
+                    }
+                }
+            }
+
+            $columnCount = count($this->columns);
+            $data = array_map(function ($mean) use ($columnCount) {
+                return !empty($mean['denonimator'])
+                ? round((($mean['cumulative']/$mean['denonimator'])/$columnCount), 2)
+                : 0;
+            }, $means);
+
+            $this->page->scripts->add('chart');
+
+            $chart = Chart::create('visualisation', 'polarArea')
+                ->setLegend(['display' => $legend, 'position' => 'right'])
+                ->setLabels(array_column($means, 'title'))
+                ->setColorOpacity(0.6);
+
+            $options = [
+                'height' => '120%',
+                'scale'  => [
+                    'ticks' => [
+                        'min' => 0.0,
+                        'max' => 1.0,
+                        'callback' => $chart->addFunction('function(tickValue, index, ticks) {
+                            return Number(tickValue).toFixed(1);
+                        }'),
+                    ],
+                ]
+            ];
+            if ($image) {
+                $options['animation'] = [
+                    'duration' => 0,
+                    'onComplete' => $chart->addFunction('function(e) {
+                        var img = visualisation.toDataURL("image/png");
+                        $.ajax({ url: "'.$this->session->get('absoluteURL').'/modules/Rubrics/src/visualise_saveAjax.php", type: "POST", data: {img: img, gibbonPersonID: '.$this->gibbonPersonID.'}, dataType: "html"})
+                        $.ajax({ url: "./"});
+                    }'),
+                ];
+            }
+            $chart->setOptions($options);
+
+            $chart->addDataset('rubric')->setData($data);
+
+            return $chart->render();
+        }
+    }
+}

--- a/modules/Rubrics/src/visualise_saveAjax.php
+++ b/modules/Rubrics/src/visualise_saveAjax.php
@@ -1,0 +1,40 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once "../../../gibbon.php";
+
+$fileUploader = new Gibbon\FileUploader($pdo, $gibbon->session);
+$uploadsFolder = $fileUploader->getUploadsFolderByDate();
+
+$img = (!empty($_POST['img'])) ? $_POST['img'] : null;
+$gibbonPersonID = (!empty($_POST['gibbonPersonID'])) ? str_pad($_POST['gibbonPersonID'], 10, '0', STR_PAD_LEFT) : null;
+
+list($type, $img) = explode(';', $img);
+list(, $img)      = explode(',', $img);
+$img = base64_decode($img);
+
+$destinationFolder = $gibbon->session->get('absolutePath').'/'.$uploadsFolder;
+
+if (is_dir($destinationFolder) == false) {
+    mkdir($destinationFolder, 0755, true);
+}
+
+$fp = fopen($destinationFolder.'/rubric_visualisation_'.$gibbonPersonID.'.png', 'w');
+fwrite($fp, $img);
+fclose($fp);

--- a/src/UI/Chart/Chart.php
+++ b/src/UI/Chart/Chart.php
@@ -92,7 +92,7 @@ class Chart
     {
         return $this->elementID;
     }
-    
+
     /**
      * Set the HTML element ID for the chart.
      * @param string $id
@@ -164,7 +164,7 @@ class Chart
     public function setOptions($options)
     {
         $this->options = array_replace($this->options, $options);
-        
+
         return $this;
     }
 
@@ -369,11 +369,11 @@ class Chart
         foreach ($this->datasets as $dataset) {
             $chartDataset = $dataset->getProperties();
             $chartDataset['data'] = $dataset->getData();
-            
+
             if (!empty($dataset->getLabel())) {
                 $chartDataset['label'] = $dataset->getLabel();
             }
-            
+
             if ($this->useDefaultColors) {
                 if (in_array($this->chartType, array('doughnut', 'pie', 'polarArea'))) {
                     $chartDataset['backgroundColor'] = [];


### PR DESCRIPTION
**Description**
This PR separates out the rubric visual into an object, which can be invoked to display normally (e.g. within the rubric) or to export as a PNG image, via ajax, to the file system.

**Motivation and Context**
ICHK are moving towards including a visual rubric overview in reports, and this is a first step. 

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="864" alt="Screenshot 2019-04-22 at 12 59 58 AM" src="https://user-images.githubusercontent.com/5436438/56473182-f84bc580-6499-11e9-8ee8-26876a750b86.png">
