### PR TITLE
System: enable use of Aura\SqlQuery classes for basic CRUD operations

### DIFF
--- a/src/Domain/QueryableGateway.php
+++ b/src/Domain/QueryableGateway.php
@@ -22,6 +22,9 @@ namespace Gibbon\Domain;
 use Gibbon\Domain\QueryCriteria;
 use Aura\SqlQuery\QueryFactory;
 use Aura\SqlQuery\Common\SelectInterface;
+use Aura\SqlQuery\Common\InsertInterface;
+use Aura\SqlQuery\Common\UpdateInterface;
+use Aura\SqlQuery\Common\DeleteInterface;
 
 /**
  * Queryable Gateway
@@ -59,6 +62,26 @@ abstract class QueryableGateway extends Gateway
         return $this->getQueryFactory()->newSelect()->calcFoundRows();
     }
 
+    protected function newSelect()
+    {
+        return $this->getQueryFactory()->newSelect();
+    }
+
+    protected function newInsert()
+    {
+        return $this->getQueryFactory()->newInsert();
+    }
+
+    protected function newUpdate()
+    {
+        return $this->getQueryFactory()->newUpdate();
+    }
+
+    protected function newDelete()
+    {
+        return $this->getQueryFactory()->newDelete();
+    }
+
     /**
      * Runs a query with a defined set of criteria and returns the result as a data set with pagination info.
      *
@@ -76,6 +99,26 @@ abstract class QueryableGateway extends Gateway
         $totalRows = $this->countAll();
 
         return $result->toDataSet()->setResultCount($foundRows, $totalRows)->setPagination($criteria->getPage(), $criteria->getPageSize());
+    }
+
+    protected function runSelect(SelectInterface $query)
+    {
+        return $this->db()->select($query->getStatement(), $query->getBindValues());
+    }
+
+    protected function runInsert(InsertInterface $query)
+    {
+        return $this->db()->insert($query->getStatement(), $query->getBindValues());
+    }
+
+    protected function runUpdate(UpdateInterface $query) : bool
+    {
+        return $this->db()->update($query->getStatement(), $query->getBindValues());
+    }
+
+    protected function runDelete(DeleteInterface $query) : bool
+    {
+        return $this->db()->delete($query->getStatement(), $query->getBindValues());
     }
 
     /**
@@ -167,7 +210,7 @@ abstract class QueryableGateway extends Gateway
      *
      * @return QueryFactory
      */
-    private function getQueryFactory()
+    protected function getQueryFactory()
     {
         if (!isset(self::$queryFactory)) {
             self::$queryFactory = new QueryFactory('mysql');

--- a/src/Domain/Traits/TableAware.php
+++ b/src/Domain/Traits/TableAware.php
@@ -22,18 +22,11 @@ namespace Gibbon\Domain\Traits;
 /**
  * Provides methods for Gateway classes that are tied to a specific database table.
  * For QueryableGateways, this trait implements the required countAll() method.
- * 
- * The classes using this trait must implement a static $tableName;
+ *
+ * The classes using this trait must implement a static $tableName and $primaryKey
  */
 trait TableAware
 {
-    /**
-     * Internal array of column name => data type.
-     *
-     * @var array
-     */
-    protected static $columns;
-
     /**
      * Gets the database table name.
      *
@@ -49,14 +42,17 @@ trait TableAware
     }
 
     /**
-     * Gets the schema information for the columns in this database table.
+     * Gets the primary key column name for the table.
      *
-     * @return array
+     * @return string
      */
-    public function getTableSchema()
+    public function getPrimaryKey()
     {
-        $result = $this->db()->select("SELECT * FROM information_schema.columns WHERE table_name='{$this->getTableName()}'");
-        return $result->fetchAll();
+        if (empty(static::$primaryKey)) {
+            throw new \BadMethodCallException(get_called_class().' must define a $primaryKey');
+        }
+
+        return static::$primaryKey;
     }
 
     /**
@@ -77,5 +73,169 @@ trait TableAware
     public function countAll()
     {
         return $this->db()->selectOne("SELECT COUNT(*) FROM `{$this->getTableName()}`");
+    }
+
+    /**
+     * Gets the values of a table row by it's primary key.
+     *
+     * @param string $primaryKeyValue
+     * @return array
+     */
+    public function getByID($primaryKeyValue) : array
+    {
+        if (empty($primaryKeyValue)) {
+            throw new \InvalidArgumentException("Gateway getByID method for {$this->getTableName()} must provide a primary key value.");
+        }
+
+        $query = $this
+            ->newSelect()
+            ->cols(['*'])
+            ->from($this->getTableName())
+            ->where($this->getPrimaryKey().' = :primaryKey')
+            ->bindValue('primaryKey', $primaryKeyValue);
+
+        return $this->runSelect($query)->fetch();
+    }
+
+    /**
+     * Selects a number of rows matching a simple key => value select.
+     *
+     * @param string $primaryKeyValue
+     * @return array
+     */
+    public function selectBy(array $keysAndValues)
+    {
+        if (empty($keysAndValues)) {
+            throw new \InvalidArgumentException("Gateway selectBy method for {$this->getTableName()} must provide an array of keys and values.");
+        }
+
+        $query = $this
+            ->newSelect()
+            ->cols(['*'])
+            ->from($this->getTableName());
+
+        $count = 0;
+        foreach ($keysAndValues as $key => $value) {
+            $query->where($key." = :key{$count}")
+                  ->bindValue("key{$count}", $value);
+            $count++;
+        }
+
+        return $this->runSelect($query);
+    }
+    
+    /**
+     * Inserts a row into the table and returns the primary key.
+     *
+     * @param array $data
+     * @return void
+     */
+    public function insert(array $data)
+    {
+        unset($data[$this->getPrimaryKey()]);
+
+        $query = $this
+            ->newInsert()
+            ->into($this->getTableName())
+            ->cols($data);
+
+        return $this->runInsert($query);
+    }
+
+    /**
+     * Updates a row in the table based on primary key and returns true on success.
+     *
+     * @param string $primaryKeyValue
+     * @param array $data
+     * @return bool
+     */
+    public function update($primaryKeyValue, array $data) : bool
+    {
+        if (empty($primaryKeyValue)) {
+            throw new \InvalidArgumentException("Gateway update method for {$this->getTableName()} must provide a primary key value.");
+        }
+        
+        unset($data[$this->getPrimaryKey()]);
+
+        $query = $this
+            ->newUpdate()
+            ->table($this->getTableName())
+            ->cols($data)
+            ->where($this->getPrimaryKey().' = :primaryKey')
+            ->bindValue('primaryKey', $primaryKeyValue);
+
+        return $this->runUpdate($query);
+    }
+
+    /**
+     * Deletes a row in the table based on primary key and returns true on success.
+     *
+     * @param string $primaryKeyValue
+     * @return bool
+     */
+    public function delete($primaryKeyValue) : bool
+    {
+        if (empty($primaryKeyValue)) {
+            throw new \InvalidArgumentException("Gateway delete method for {$this->getTableName()} must provide a primary key value.");
+        }
+
+        $query = $this
+            ->newDelete()
+            ->from($this->getTableName())
+            ->where($this->getPrimaryKey().' = :primaryKey')
+            ->bindValue('primaryKey', $primaryKeyValue);
+
+        return $this->runDelete($query);
+    }
+
+    /**
+     * Returns true if no rows match the provided key => value pair of data.
+     * Can optionally omit a row by primary key, when checking other rows only.
+     *
+     * @param array $data
+     * @param array $uniqueKeys
+     * @param string $primaryKeyValue
+     * @return bool
+     */
+    public function unique(array $data, array $uniqueKeys, $primaryKeyValue = '') : bool
+    {
+        $query = $this
+            ->newSelect()
+            ->cols([$this->getPrimaryKey()])
+            ->from($this->getTableName());
+
+        $query->where(function ($query) use ($uniqueKeys, $data) {
+            foreach ($uniqueKeys as $i => $key) {
+                if (empty($data[$key])) return false;
+
+                $query->where("{$key} = :key{$i}")
+                    ->bindValue("key{$i}", $data[$key]);
+            }
+        });
+
+        if (!empty($primaryKeyValue)) {
+            $query->where($this->getPrimaryKey().' <> :primaryKey')
+                  ->bindValue('primaryKey', $primaryKeyValue);
+        }
+            
+        return $this->runSelect($query)->rowCount() == 0;
+    }
+
+    /**
+     * Returns true if the primary key value exists in the table.
+     *
+     * @param string $primaryKeyValue
+     * @return bool
+     */
+    public function exists($primaryKeyValue) : bool
+    {
+        $query = $this
+            ->newSelect()
+            ->cols($this->getPrimaryKey())
+            ->from($this->getTableName())
+            ->where($this->getPrimaryKey().' = :primaryKey')
+            ->bindValue('primaryKey', $primaryKeyValue);
+
+        return $this->runSelect($query)->rowCount() > 0;
     }
 }


### PR DESCRIPTION
So-far we've been using the `Aura\SqlQuery` library in the background to power the pagination, search and filters in DataTables. This PR updates the QueryableGateway and TableAware trait to enable some additional functionality from the library: simple inserts, updates, deletes and selects. 

Many Gateways relate one-to-one to a database table, so using the query builder methods provides a simplified way to access the basic CRUD operations without writing additional SQL.


```php
// For example, deleting a user:
$data = array('gibbonPersonID' => $gibbonPersonID);
$sql = "DELETE FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID";

// Becomes:
$userGateway->delete($gibbonPersonID);
```

```php
// Getting a record
$data = array('gibbonPersonID' => $gibbonPersonID);
$sql = "SELECT * FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID";

// Becomes:
$userGateway->getByID($gibbonPersonID);

// Or just see if it exists (lower overhead):
$userGateway->exists($gibbonPersonID);
```

Inserting and updating in particular becomes easier, because we can avoid maintaining two separate sets of field names in the `$data` array and `SET gibbonPersonID=:gibbonPersonID` etc lists.

```php
// Inserting:
$gibbonPersonID = $userGateway->insert($values);

// Updating:
$userGateway->update($gibbonPersonID, $values);
```

I've used this somewhat extensively in the upcoming staff absence & coverage features, and it really helps to trim down writing extra SQL commands 😄 