### PR TITLE
Timetable: fix some staff not showing up in View Timetable by Person

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -63,6 +63,7 @@ v18.0.00
         Staff: fixed staff photo not displaying on Facilities sub-page in staff profile
         System Admin: fixed typo in Google integration settings
         System Admin: added a clear cache option under System Check
+        Timetable: fixed some staff not showing up in View Timetable by Person
         Timetable Admin: fixed malformed translatable interface strings
         User Admin: fixed issue preventing action names from being translated in Manage Permissions
         User Admin: improved interface string consistency

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -162,7 +162,7 @@ class StudentGateway extends QueryableGateway
         if ($criteria->hasFilter('all')) {
             $query->where("(gibbonPerson.status = 'Full' OR gibbonPerson.status = 'Expected')");
         } else {
-            $query->where("(gibbonStudentEnrolment.gibbonStudentEnrolmentID IS NOT NULL OR (gibbonStaff.gibbonStaffID IS NOT NULL AND gibbonStaff.type='Teaching') )")
+            $query->where("(gibbonStudentEnrolment.gibbonStudentEnrolmentID IS NOT NULL OR (gibbonStaff.gibbonStaffID IS NOT NULL AND gibbonRole.category='Staff') )")
                   ->where("gibbonPerson.status = 'Full'")
                   ->where('(gibbonPerson.dateStart IS NULL OR gibbonPerson.dateStart <= :today)')
                   ->where('(gibbonPerson.dateEnd IS NULL OR gibbonPerson.dateEnd >= :today)')


### PR DESCRIPTION
A small fix. The staff `type` field allows selecting general "Teaching", "Support" types, as well as specific roles. This was causing the particular query used for View Timetable by Person to not list some staff if their type was set a role, eg: "Teacher".