### PR TITLE
School Admin: increase field lengths for Roll Group name and nameShort

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -846,4 +846,5 @@ INSERT INTO `gibboni18n` (`code`, `name`, `active`, `systemDefault`, `dateFormat
 ALTER TABLE gibbonPlannerEntry DROP COLUMN gibbonHookID;end
 ALTER TABLE `gibbonHook` CHANGE `type` `type` ENUM('Public Home Page','Student Profile','Parental Dashboard','Staff Dashboard','Student Dashboard') CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 DROP TABLE gibbonUnitBlockStar;end
+ALTER TABLE `gibbonRollGroup` CHANGE `name` `name` VARCHAR(20) NOT NULL, CHANGE `nameShort` `nameShort` VARCHAR(8) NOT NULL;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ v18.0.00
         Markbook: fixed bug preventing parents and students from viewing the markbook with work submitted to a lesson plan
         Markbook: fixed column widths when modified assessment is enabled
         School Admin: fixed interface string typos
+        School Admin: increased field lengths for Roll Group name and nameShort
         Staff: fixed staff photo not displaying on Facilities sub-page in staff profile
         System Admin: fixed typo in Google integration settings
         System Admin: added a clear cache option under System Check

--- a/modules/School Admin/rollGroup_manage_add.php
+++ b/modules/School Admin/rollGroup_manage_add.php
@@ -76,11 +76,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/rollGroup_man
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('name')->required()->maxLength(10);
+                $row->addTextField('name')->required()->maxLength(20);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('nameShort')->required()->maxLength(5);
+                $row->addTextField('nameShort')->required()->maxLength(8);
 
             $row = $form->addRow();
                 $row->addLabel('tutors', __('Tutors'))->description(__('Up to 3 per roll group. The first-listed will be marked as "Main Tutor".'));

--- a/modules/School Admin/rollGroup_manage_edit.php
+++ b/modules/School Admin/rollGroup_manage_edit.php
@@ -73,11 +73,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/rollGroup_man
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('name')->required()->maxLength(10);
+                $row->addTextField('name')->required()->maxLength(20);
 
             $row = $form->addRow();
                 $row->addLabel('nameShort', __('Short Name'))->description(__('Needs to be unique in school year.'));
-                $row->addTextField('nameShort')->required()->maxLength(5);
+                $row->addTextField('nameShort')->required()->maxLength(8);
 
             $row = $form->addRow();
                 $row->addLabel('tutors', __('Tutors'))->description(__('Up to 3 per roll group. The first-listed will be marked as "Main Tutor".'));


### PR DESCRIPTION
Another small change. Currently, the Roll Group names are limited to 10 characters, which isn't quite enough for the word "Kindergarten" 😄 Abbreviations work fine in the `nameShort`, but some schools prefer the full word in the `name` field.  Similarly, even with abbreviations, the 5 char limit on short names can be a bit restrictive. I've bumped the field lengths up a bit, but not so much that should should cause any display issues.