### PR TITLE
System: fix Connection::update return value, add some method to Gateway classes

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -125,7 +125,7 @@ class Connection implements ConnectionInterface
      */
     public function update($query, $bindings = [])
     {
-        return $this->affectingStatement($query, $bindings);
+        return $this->statement($query, $bindings);
     }
 
     /**

--- a/src/Domain/Messenger/GroupGateway.php
+++ b/src/Domain/Messenger/GroupGateway.php
@@ -100,10 +100,28 @@ class GroupGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
+    public function selectGroupsByIDList($gibbonGroupID)
+    {
+        $gibbonGroupIDList = is_array($gibbonGroupID)? $gibbonGroupID : [$gibbonGroupID];
+
+        $data = array('gibbonGroupIDList' => implode(',', $gibbonGroupIDList));
+        $sql = "SELECT gibbonGroupID, name FROM gibbonGroup WHERE FIND_IN_SET(gibbonGroupID, :gibbonGroupIDList) ORDER BY FIND_IN_SET(gibbonGroupID, :gibbonGroupIDList)";
+
+        return $this->db()->select($sql, $data);
+    }
+
     public function selectGroupPersonByID($gibbonGroupID, $gibbonPersonID)
     {
         $data = array('gibbonGroupID' => $gibbonGroupID, 'gibbonPersonID' => $gibbonPersonID);
         $sql = "SELECT * FROM gibbonGroupPerson WHERE gibbonGroupID=:gibbonGroupID AND gibbonPersonID=:gibbonPersonID";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectPersonIDsByGroup($gibbonGroupID)
+    {
+        $data = array('gibbonGroupID' => $gibbonGroupID);
+        $sql = "SELECT gibbonGroupPerson.gibbonPersonID FROM gibbonGroupPerson WHERE gibbonGroupID=:gibbonGroupID";
 
         return $this->db()->select($sql, $data);
     }

--- a/src/Domain/RollGroups/RollGroupGateway.php
+++ b/src/Domain/RollGroups/RollGroupGateway.php
@@ -93,6 +93,21 @@ class RollGroupGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
+    public function selectRollGroupsByTutor($gibbonPersonID)
+    {
+        $data = array('gibbonPersonID' => $gibbonPersonID);
+        $sql = "SELECT gibbonRollGroup.*, gibbonSpace.name as spaceName
+                FROM gibbonRollGroup 
+                LEFT JOIN gibbonSpace ON (gibbonSpace.gibbonSpaceID=gibbonRollGroup.gibbonSpaceID)
+                WHERE (gibbonRollGroup.gibbonPersonIDTutor = :gibbonPersonID
+                    OR gibbonRollGroup.gibbonPersonIDTutor2 = :gibbonPersonID
+                    OR gibbonRollGroup.gibbonPersonIDTutor3 = :gibbonPersonID)
+                AND gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current' LIMIT 1)
+                ORDER BY gibbonRollGroup.nameShort";
+
+        return $this->db()->select($sql, $data);
+    }
+
     public function getRollGroupByID($gibbonRollGroupID)
     {
         $data = array('gibbonRollGroupID' => $gibbonRollGroupID);

--- a/src/Domain/User/UserGateway.php
+++ b/src/Domain/User/UserGateway.php
@@ -36,6 +36,7 @@ class UserGateway extends QueryableGateway
     use SharedUserLogic;
 
     private static $tableName = 'gibbonPerson';
+    private static $primaryKey = 'gibbonPersonID';
 
     private static $searchableColumns = ['preferredName', 'surname', 'username', 'studentID', 'email', 'emailAlternate', 'phone1', 'phone2', 'phone3', 'phone4', 'vehicleRegistration', 'gibbonRole.name'];
     
@@ -94,6 +95,21 @@ class UserGateway extends QueryableGateway
                 JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary)
                 WHERE FIND_IN_SET(gibbonPerson.status, :statusList) 
                 ORDER BY surname, preferredName";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectNotificationDetailsByPerson($gibbonPersonID)
+    {
+        $gibbonPersonIDList = is_array($gibbonPersonID)? $gibbonPersonID : [$gibbonPersonID];
+
+        $data = ['gibbonPersonIDList' => implode(',', $gibbonPersonIDList)];
+        $sql = "SELECT gibbonPerson.gibbonPersonID as groupBy, gibbonPerson.gibbonPersonID, title, surname, preferredName, gibbonPerson.status, image_240, username, email, phone1, phone1CountryCode, phone1Type, gibbonRole.category as roleCategory, gibbonStaff.jobTitle, gibbonStaff.type
+                FROM gibbonPerson 
+                JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary)
+                LEFT JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                WHERE FIND_IN_SET(gibbonPerson.gibbonPersonID, :gibbonPersonIDList) 
+                ORDER BY FIND_IN_SET(gibbonPerson.gibbonPersonID, :gibbonPersonIDList), surname, preferredName";
 
         return $this->db()->select($sql, $data);
     }


### PR DESCRIPTION
These are part of a set of upcoming changes, I split them out to try and keep the future PR size sane.

The `Connection::update` method was using an `affectingStatement` for the return value, which only returns true if the update actually changed values. This fix changes the return value to a `statement` so it's always true if the update was successful, regardless of values changed (eg: submitting an Edit form even with no changes shouldn't fail).