### PR TITLE
System: add a GoogleServiceProvider class for accessing google APIs 

### DIFF
--- a/gibbon.php
+++ b/gibbon.php
@@ -36,6 +36,7 @@ $container->inflector(\Gibbon\Services\BackgroundProcess::class)
 
 $container->addServiceProvider(new Gibbon\Services\CoreServiceProvider(__DIR__));
 $container->addServiceProvider(new Gibbon\Services\ViewServiceProvider());
+$container->addServiceProvider(new Gibbon\Services\GoogleServiceProvider());
 
 // Globals for backwards compatibility
 $gibbon = $container->get('config');

--- a/index.php
+++ b/index.php
@@ -362,9 +362,11 @@ $page->stylesheets->add('core', 'resources/assets/css/core.min.css', ['weight' =
 if ($session->exists('calendarFeedPersonal') && $session->exists('googleAPIAccessToken')) {
     if (!$session->has('calendarFeedPersonal') && $session->has('googleAPIAccessToken')) {
         $service = $container->get('Google_Service_Calendar');
-        $calendar = $service->calendars->get('primary');
+        try {
+            $calendar = $service->calendars->get('primary');
+        } catch (\Google_Service_Exception $e) {}
 
-        if ($calendar['id'] != '') {
+        if (!empty($calendar['id'])) {
             $session->set('calendarFeedPersonal', $calendar['id']);
             $container->get(UserGateway::class)->update($session->get('gibbonPersonID'), [
                 'calendarFeedPersonal' => $calendar['id'],

--- a/index.php
+++ b/index.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http:// www.gnu.org/licenses/>.
 use Gibbon\Domain\System\ModuleGateway;
 use Gibbon\Domain\DataUpdater\DataUpdaterGateway;
 use Gibbon\Domain\Students\StudentGateway;
+use Gibbon\Domain\User\UserGateway;
 
 /**
  * BOOTSTRAP
@@ -364,20 +365,10 @@ if ($session->exists('calendarFeedPersonal') && $session->exists('googleAPIAcces
         $calendar = $service->calendars->get('primary');
 
         if ($calendar['id'] != '') {
-            try {
-                $dataCalendar = [
-                    'calendarFeedPersonal' => $calendar['id'],
-                    'gibbonPersonID' => $session->get('gibbonPersonID'),
-                ];
-                $sqlCalendar = 'UPDATE gibbonPerson SET
-                    calendarFeedPersonal=:calendarFeedPersonal
-                    WHERE gibbonPersonID=:gibbonPersonID';
-                $resultCalendar = $connection2->prepare($sqlCalendar);
-                $resultCalendar->execute($dataCalendar);
-            } catch (PDOException $e) {
-                exit($e->getMessage());
-            }
             $session->set('calendarFeedPersonal', $calendar['id']);
+            $container->get(UserGateway::class)->update($session->get('gibbonPersonID'), [
+                'calendarFeedPersonal' => $calendar['id'],
+            ]);
         }
     }
 }

--- a/index.php
+++ b/index.php
@@ -360,9 +360,7 @@ $page->stylesheets->add('core', 'resources/assets/css/core.min.css', ['weight' =
 // Try to auto-set user's calendar feed if not set already
 if ($session->exists('calendarFeedPersonal') && $session->exists('googleAPIAccessToken')) {
     if (!$session->has('calendarFeedPersonal') && $session->has('googleAPIAccessToken')) {
-        $client2 = new Google_Client();
-        $client2->setAccessToken($session->get('googleAPIAccessToken'));
-        $service = new Google_Service_Calendar($client2);
+        $service = $container->get('Google_Service_Calendar');
         $calendar = $service->calendars->get('primary');
 
         if ($calendar['id'] != '') {

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -41,6 +41,11 @@ $service = new Google_Service_Oauth2($client);
   bundle in the session, and redirect to ourself.
 */
 
+if (isset($_GET['error'])) {
+    header('Location: '.getSettingByScope($connection2, 'System', 'absoluteURL').'?loginReturn=fail7');
+    exit;
+}
+
 if (isset($_GET['code'])) {
   $client->authenticate($_GET['code']);
   $_SESSION[$guid]['googleAPIAccessToken']  = $client->getAccessToken();

--- a/lib/google/index.php
+++ b/lib/google/index.php
@@ -15,11 +15,7 @@ $_SESSION[$guid]["pageLoads"] = NULL;
 
 $URL = "index.php";
 
-//Cleint ID and Secret
-$client_id = getSettingByScope($connection2, "System", "googleClientID" );
-$client_secret = getSettingByScope($connection2, "System", "googleClientSecret" );
 $redirect_uri = getSettingByScope($connection2, "System", "googleRedirectUri" );
-
 
 /************************************************
   Make an API request on behalf of a user. In
@@ -28,14 +24,7 @@ $redirect_uri = getSettingByScope($connection2, "System", "googleRedirectUri" );
   through a login flow. To do this we need some
   information from our API console project.
  ************************************************/
-$client = new Google_Client();
-$client->setClientId($client_id);
-$client->setClientSecret($client_secret);
-$client->setRedirectUri($redirect_uri);
-$client->setAccessType('offline');
-$client->setScopes(array('email',
-    'profile',
-    'https://www.googleapis.com/auth/calendar')); // set scope during user login
+$client = $container->get('Google_Client');
 
 /************************************************
   When we create the service here, we pass the

--- a/src/Services/GoogleServiceProvider.php
+++ b/src/Services/GoogleServiceProvider.php
@@ -1,0 +1,101 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Gibbon\Services;
+
+use Google_Client;
+use Google_Service_Calendar;
+use League\Container\ServiceProvider\AbstractServiceProvider;
+
+/**
+ * Google API Services
+ *
+ * @version v18
+ * @since   v18
+ */
+class GoogleServiceProvider extends AbstractServiceProvider
+{
+    /**
+     * The provides array is a way to let the container know that a service
+     * is provided by this service provider. Every service that is registered
+     * via this service provider must have an alias added to this array or
+     * it will be ignored.
+     *
+     * @var array
+     */
+    protected $provides = [
+        'Google_Client',
+        'Google_Service_Calendar',
+    ];
+
+    /**
+     * This is where the magic happens, within the method you can
+     * access the container and register or retrieve anything
+     * that you need to, but remember, every alias registered
+     * within this method must be declared in the `$provides` array.
+     */
+    public function register()
+    {
+        $container = $this->getContainer();
+
+        $container->share(Google_Client::class, function () {
+            $session = $this->getContainer()->get('session');
+
+            try {
+                // Setup the Client
+                $client = new Google_Client();
+                $client->setApplicationName($session->get('googleClientName'));
+                $client->setScopes(array('email', 'profile', 'https://www.googleapis.com/auth/calendar'));
+                $client->setClientId($session->get('googleClientID'));
+                $client->setClientSecret($session->get('googleClientSecret'));
+                $client->setRedirectUri($session->get('googleRedirectUri'));
+                $client->setDeveloperKey($session->get('googleDeveloperKey'));
+                $client->setAccessType('offline');
+
+                if (!$session->has('googleAPIAccessToken')) {
+                    return $client;
+                }
+
+                $client->setAccessToken($session->get('googleAPIAccessToken'));
+                
+                if ($client->isAccessTokenExpired()) {
+                    // Re-establish the Client and get a new token
+                    if ($session->exists('googleAPIRefreshToken')) {
+                        $client->refreshToken($session->get('googleAPIRefreshToken'));
+                        $session->set('googleAPIAccessToken', $client->getAccessToken());
+                    } else {
+                        return null;
+                    }
+                }
+            } catch (\InvalidArgumentException $e) {
+                return null;
+            } catch (\Google_Service_Exception $e) {
+                return null;
+            }
+
+            return $client;
+        });
+
+        $container->share(Google_Service_Calendar::class, function () {
+            $client = $this->getContainer()->get(Google_Client::class);
+
+            return $client ? new Google_Service_Calendar($client) : null;
+        });
+    }
+}


### PR DESCRIPTION
When we access a Google service via one of the classes like `Google_Service_Calendar`, we first need to instantiate the `Google_Client` class and configure it, including adding scopes. Currently this code has been duplicated in a couple different locations. As we add any additional features that interact with Google, the code needs a standardized way to retrieve and configure the client, as well as refresh any expired tokens.

This PR adds a `GoogleServiceProvider` class, which enables us to grab a fully-configured Google_Client object from the DI container. It also updates the three locations in the code currently accessing Google services.