### PR TITLE
Attendance: refactor the attendance log table in Attendance by Person

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ v18.0.00
     Significant Changes
         System: added a webpack-based build process for javascript and css files
         Attendance: added ability to set future absence for multiple students
+        Attendance: replaced the attendance pre-fill settings with Count Class Attendance as School Attendance
         Rubrics: added ability to export Visualise chart to PNG
 
     Security
@@ -41,6 +42,7 @@ v18.0.00
         System: method for columns that require the translation, and update the columns where this is applicable
         System: added Omani Rial as a currency option
         System: added an option to select SMTP encryption in Third Party Settings
+        Attendance: updated Take Attendance by Person logs to separate class and school wide attendance
         Form Groups: hide student count from non-staff
         Students: added link from student profile to Individual Needs edit screen
         School Admin: add a Manage Staff Settings page

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -20,7 +20,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Module\Attendance\AttendanceView;
+use Gibbon\Domain\Attendance\AttendanceLogPersonGateway;
 use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -75,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
         } else {
             if (isSchoolOpen($guid, $currentDate, $connection2) == false) {
                 echo "<div class='error'>";
-                echo 'School is closed on the specified date, and so attendance information cannot be recorded.';
+                echo __('School is closed on the specified date, and so attendance information cannot be recorded.');
                 echo '</div>';
             } else {
                 $countClassAsSchool = getSettingByScope($connection2, 'Attendance', 'countClassAsSchool');
@@ -83,105 +85,112 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                 //Get last 5 school days from currentDate within the last 100
                 $timestamp = dateConvertToTimestamp($currentDate);
 
-                $lastType = '';
-                $lastReason = '';
-                $lastComment = '';
+                $attendanceLogGateway = $container->get(AttendanceLogPersonGateway::class);
+                $criteria = $attendanceLogGateway->newQueryCriteria()
+                    ->sortBy('timestampTaken')
+                    ->pageSize(0);
 
-                //Show attendance log for the current day
-                try {
-                    $dataLog = array('gibbonPersonID' => $gibbonPersonID, 'date' => "$currentDate%");
-                    $sqlLog = 'SELECT gibbonAttendanceLogPersonID, direction, type, reason, context, comment, timestampTaken, gibbonAttendanceLogPerson.gibbonCourseClassID, preferredName, surname, gibbonCourseClass.nameShort as className, gibbonCourse.nameShort as courseName FROM gibbonAttendanceLogPerson JOIN gibbonPerson ON (gibbonAttendanceLogPerson.gibbonPersonIDTaker=gibbonPerson.gibbonPersonID) LEFT JOIN gibbonCourseClass ON (gibbonAttendanceLogPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) LEFT JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) WHERE  gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID AND date LIKE :date';
-                    if ($countClassAsSchool == "N") {
-                        $sqlLog .= ' AND NOT context=\'Class\'';
-                    }
-                    $sqlLog .= ' ORDER BY gibbonAttendanceLogPersonID';
-                    $resultLog = $connection2->prepare($sqlLog);
-                    $resultLog->execute($dataLog);
-                } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
-                }
-                if ($resultLog->rowCount() < 1) {
-                    echo "<div class='error'>";
-                    echo __('There is currently no attendance data today for the selected student.');
-                    echo '</div>';
-                } else {
-                    echo '<h4>';
-                        echo __('Attendance Log');
-                    echo '</h4>';
-
-                    echo "<p><span class='emphasis small'>";
-                        echo __('The following attendance log has been recorded for the selected student today:');
-                    echo '</span></p>';
-
-                    echo '<table class="mini smallIntBorder fullWidth colorOddEven" cellspacing=0>';
-                    echo '<tr class="head">';
-                        echo '<th>'.__('Time').'</th>';
-                        echo '<th>'.__('Attendance').'</th>';
-                        echo '<th>'.__('Where').'</th>';
-                        echo '<th>'.__('Recorded By').'</th>';
-
-                        if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_edit.php') == true) {
-                            echo '<th style="width: 60px;">'.__('Actions').'</th>';
-                        }
-                    echo '</tr>';
-                    while ($rowLog = $resultLog->fetch()) {
-                        $logTimestamp = strtotime($rowLog['timestampTaken']);
-
-                        echo '<tr class="'.( $rowLog['direction'] == 'Out'? 'error' : 'current').'">';
-
-                        if (  $currentDate != substr($rowLog['timestampTaken'], 0, 10) ) {
-                            echo '<td>'.Format::dateTimeReadable($rowLog['timestampTaken'], '%H:%M, %b %d').'</td>';
-                        } else {
-                            echo '<td>'.Format::dateTimeReadable($rowLog['timestampTaken'], '%H:%M').'</td>';
-                        }
-
-                        echo '<td>';
-                        echo '<b>'.__($rowLog['direction']).'</b> ('.__($rowLog['type']). ( !empty($rowLog['reason'])? ', '.__($rowLog['reason']) : '') .')';
-
-                        if ( !empty($rowLog['comment']) ) {
-                            echo '&nbsp;<img title="'.$rowLog['comment'].'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/messageWall.png" width=16 height=16/>';
-                        }
-                        echo '</td>';
-
-
-                        if ($rowLog['context'] != '') {
-                            if ($rowLog['context'] == 'Class' && $rowLog['gibbonCourseClassID'] > 0)
-                                echo '<td>'.__($rowLog['context']).' ('.$rowLog['courseName'].'.'.$rowLog['className'].')</td>';
-                            else
-                                echo '<td>'.__($rowLog['context']).'</td>';
-                        } else {
-                            echo '<td>'.__('Roll Group').'</td>';
-                        }
-
-                        echo '<td>';
-                            echo Format::name('', $rowLog['preferredName'], $rowLog['surname'], 'Staff', false, true);
-                        echo '</td>';
-
-                        if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_edit.php') == true) {
-                            echo '<td>';
-                                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module'].'/attendance_take_byPerson_edit.php&gibbonAttendanceLogPersonID='.$rowLog['gibbonAttendanceLogPersonID']."&gibbonPersonID=$gibbonPersonID&currentDate=".dateConvertBack($guid, $currentDate)."'><img title='".__('Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
-                                echo "<a class='thickbox' href='".$_SESSION[$guid]['absoluteURL']. '/fullscreen.php?q=/modules/'.$_SESSION[$guid]['module'].'/attendance_take_byPerson_delete.php&gibbonAttendanceLogPersonID='.$rowLog['gibbonAttendanceLogPersonID']."&gibbonPersonID=$gibbonPersonID&currentDate=".dateConvertBack($guid, $currentDate)."&width=650&height=135'><img title='".__('Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']. "/img/garbage.png'/></a> ";
-                            echo '</td>';
-                        }
-
-                        $lastType = $rowLog['type'];
-                        $lastReason = $rowLog['reason'];
-                        $lastComment = $rowLog['comment'];
-                        echo '</tr>';
-                    }
-                    echo '</table><br/>';
+                if ($countClassAsSchool == 'N') {
+                    $criteria->filterBy('notClass', true);
                 }
 
-                //Show student form
-                echo "<script type='text/javascript'>
-                    function dateCheck() {
-                        var date = new Date();
-                        if ('".$currentDate."'<getDate()) {
-                            return confirm(\"".__('The selected date for attendance is in the past. Are you sure you want to continue?').'")
-                        }
-                    }
-                </script>';
+                $logs = $attendanceLogGateway->queryByPersonAndDate($criteria, $gibbonPersonID, $currentDate);
+                $lastLog = $logs->getRow(count($logs) - 1);
 
+                // DATA TABLE: Show attendance log for the current day
+                $table = DataTable::create('attendanceLogs');
+
+                $table->modifyRows(function ($log, $row) {
+                    if ($log['direction'] == 'Out') $row->addClass('error');
+                    elseif (!empty($log['direction'])) $row->addClass('current');
+                    return $row;
+                });
+
+                $table->addColumn('period', __('Period'))
+                    ->format(function ($log) {
+                        return $log['period'].'<br/>'.Format::small(Format::timeRange($log['timeStart'], $log['timeEnd']));
+                    });
+
+                $table->addColumn('time', __('Time'))
+                    ->format(function ($log) use ($currentDate) {
+                        if (empty($log['timestampTaken'])) return Format::small(__('N/A'));
+
+                        return $currentDate != substr($log['timestampTaken'], 0, 10)
+                            ? Format::dateTimeReadable($log['timestampTaken'], '%H:%M, %b %d')
+                            : Format::dateTimeReadable($log['timestampTaken'], '%H:%M');
+                    });
+
+                $table->addColumn('direction', __('Attendance'))
+                    ->format(function ($log) use ($guid) {
+                        if (empty($log['direction'])) return Format::small(__('Not Taken'));
+
+                        $output = '<b>'.__($log['direction']).'</b> ('.__($log['type']). (!empty($log['reason'])? ', '.__($log['reason']) : '') .')';
+                        if (!empty($log['comment'])) {
+                            $output .= '&nbsp;<img title="'.$log['comment'].'" src="./themes/'.$_SESSION[$guid]['gibbonThemeName'].'/img/messageWall.png" width=16 height=16/>';
+                        }
+
+                        return $output;
+                    });
+
+                $table->addColumn('where', __('Where'))
+                    ->format(function ($log) {
+                        return ($log['context'] == 'Class' && !empty($log['gibbonCourseClassID']))
+                            ? __($log['context']).' ('.Format::courseClassName($log['courseName'], $log['className']).')'
+                            : __($log['context']);
+                    });
+
+                $table->addColumn('timestampTaken', __('Recorded By'))
+                    ->format(Format::using('name', ['title', 'preferredName', 'surname', 'Staff', false, true]));
+
+                // ACTIONS
+                if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byPerson_edit.php')) {
+                    $table->addActionColumn()
+                        ->addParam('gibbonAttendanceLogPersonID')
+                        ->addParam('gibbonPersonID', $gibbonPersonID)
+                        ->addParam('currentDate', $currentDate)
+                        ->format(function ($log, $actions) {
+                            if (empty($log['gibbonAttendanceLogPersonID'])) return;
+
+                            $actions->addAction('edit', __('Edit'))
+                                ->setURL('/modules/Attendance/attendance_take_byPerson_edit.php');
+
+                            $actions->addAction('delete', __('Delete'))
+                                ->setURL('/modules/Attendance/attendance_take_byPerson_delete.php');
+                        });
+                }
+
+                // School-wide attendance
+                $schoolTable = clone $table;
+                $schoolTable->setTitle(__('Attendance Log'));
+                $schoolTable->setDescription(count($logs) > 0 ? __('The following attendance log has been recorded for the selected student today:') : '');
+                $schoolTable->addMetaData('blankSlate', __('There is currently no attendance data today for the selected student.'));
+                $schoolTable->removeColumn('period');
+
+                echo $schoolTable->render($logs);
+
+                // Class Attendance
+                if ($countClassAsSchool == 'N') {
+                    $criteria = $attendanceLogGateway->newQueryCriteria()
+                        ->sortBy(['timeStart', 'timeEnd', 'timestampTaken'])
+                        ->pageSize(0);
+
+                    $logCount = 0;
+                    $logs = $attendanceLogGateway->queryClassAttendanceByPersonAndDate($criteria, $gibbon->session->get('gibbonSchoolYearID'), $gibbonPersonID, $currentDate);
+                    $logs->transform(function (&$log) use (&$logCount) {
+                        if (!empty($log['gibbonAttendanceLogPersonID'])) $logCount++;
+                    });
+
+                    if ($logCount > 0) {
+                        $classTable = clone $table;
+                        $classTable->setTitle(__('Class Attendance'));
+
+                        echo $classTable->render($logs);
+                    }
+                }
+                
+                echo '<br/>';
+
+                // FORM: Attendance by Person
                 $form = Form::create('attendanceByPerson', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']. '/attendance_take_byPersonProcess.php?gibbonPersonID='.$gibbonPersonID);
                 $form->setAutocomplete('off');
 
@@ -200,15 +209,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
                 $row = $form->addRow();
                     $row->addLabel('type', __('Type'));
-                    $row->addSelect('type')->fromArray(array_keys($attendance->getAttendanceTypes()))->selected($lastType);
+                    $row->addSelect('type')->fromArray(array_keys($attendance->getAttendanceTypes()))->selected($lastLog['type'] ?? '');
 
                 $row = $form->addRow();
                     $row->addLabel('reason', __('Reason'));
-                    $row->addSelect('reason')->fromArray($attendance->getAttendanceReasons())->selected($lastReason);
+                    $row->addSelect('reason')->fromArray($attendance->getAttendanceReasons())->selected($lastLog['reason'] ?? '');
 
                 $row = $form->addRow();
                     $row->addLabel('comment', __('Comment'))->description(__('255 character limit'));
-                    $row->addTextArea('comment')->setRows(3)->maxLength(255)->setValue($lastComment);
+                    $row->addTextArea('comment')->setRows(3)->maxLength(255)->setValue($lastLog['comment'] ?? '');
 
                 $row = $form->addRow();
                     $row->addFooter();

--- a/src/Domain/Attendance/AttendanceLogPersonGateway.php
+++ b/src/Domain/Attendance/AttendanceLogPersonGateway.php
@@ -91,7 +91,9 @@ class AttendanceLogPersonGateway extends QueryableGateway
                 AND gibbonAttendanceLogPerson.context = 'Class'")
             ->leftJoin('gibbonPerson as takenBy', 'gibbonAttendanceLogPerson.gibbonPersonIDTaker=takenBy.gibbonPersonID')
 
-            ->where("gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassPerson.role = 'Student'")
+            ->where("gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID")
+            ->where("gibbonCourseClassPerson.role = 'Student'")
+            ->where("gibbonCourseClass.attendance='Y'")
             ->bindValue('gibbonPersonID', $gibbonPersonID)
             ->where('gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID')
             ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID)

--- a/src/Domain/Attendance/AttendanceLogPersonGateway.php
+++ b/src/Domain/Attendance/AttendanceLogPersonGateway.php
@@ -1,0 +1,104 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Attendance;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * @version v18
+ * @since   v18
+ */
+class AttendanceLogPersonGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonAttendanceLogPerson';
+    private static $primaryKey = 'gibbonAttendanceLogPersonID';
+
+    private static $searchableColumns = [''];
+    
+    /**
+     * @param QueryCriteria $criteria
+     * @return DataSet
+     */
+    public function queryByPersonAndDate(QueryCriteria $criteria, $gibbonPersonID, $date)
+    {
+        $query = $this
+            ->newQuery()
+            ->from($this->getTableName())
+            ->cols([
+                'gibbonAttendanceLogPersonID', 'gibbonAttendanceLogPerson.direction', 'gibbonAttendanceLogPerson.type', 'gibbonAttendanceLogPerson.reason', 'gibbonAttendanceLogPerson.context', 'gibbonAttendanceLogPerson.comment', 'gibbonAttendanceLogPerson.timestampTaken', 'gibbonAttendanceLogPerson.gibbonCourseClassID', 'takenBy.title', 'takenBy.preferredName', 'takenBy.surname', 'gibbonCourseClass.nameShort as className', 'gibbonCourse.nameShort as courseName',
+            ])
+            ->innerJoin('gibbonPerson as takenBy', 'gibbonAttendanceLogPerson.gibbonPersonIDTaker=takenBy.gibbonPersonID')
+            ->leftJoin('gibbonCourseClass', 'gibbonAttendanceLogPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID')
+            ->leftJoin('gibbonCourse', 'gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID')
+            ->where('gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID')
+            ->bindValue('gibbonPersonID', $gibbonPersonID)
+            ->where('gibbonAttendanceLogPerson.date=:date')
+            ->bindValue('date', $date);
+
+        $criteria->addFilterRules([
+            'notClass' => function ($query, $context) {
+                return $query->where('NOT gibbonAttendanceLogPerson.context="Class"');
+            },
+        ]);
+
+        return $this->runQuery($query, $criteria);
+    }
+
+    public function queryClassAttendanceByPersonAndDate(QueryCriteria $criteria, $gibbonSchoolYearID, $gibbonPersonID, $date)
+    {
+        $query = $this
+            ->newQuery()
+            ->from('gibbonCourseClassPerson')
+            ->cols([
+                'gibbonAttendanceLogPersonID', 'gibbonAttendanceLogPerson.direction', 'gibbonAttendanceLogPerson.type', 'gibbonAttendanceLogPerson.reason',  "'Class' as context", 'gibbonAttendanceLogPerson.comment', 'gibbonAttendanceLogPerson.timestampTaken', 'gibbonCourseClass.gibbonCourseClassID', 
+                'takenBy.title', 'takenBy.preferredName', 'takenBy.surname', 
+                'gibbonCourseClass.nameShort as className', 'gibbonCourse.nameShort as courseName',
+                'gibbonTTColumnRow.name as period', 'gibbonTTColumnRow.timeStart', 'gibbonTTColumnRow.timeEnd',
+                'COUNT(*) as count'
+            ])
+            ->innerJoin('gibbonCourseClass', 'gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID')
+            ->innerJoin('gibbonCourse', 'gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID')
+            
+            ->innerJoin('gibbonTTDayRowClass', 'gibbonTTDayRowClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID')
+            ->innerJoin('gibbonTTColumnRow', 'gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID')
+            ->innerJoin('gibbonTTDay', 'gibbonTTDay.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID AND gibbonTTDay.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID')
+            ->innerJoin('gibbonTTDayDate', 'gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID')
+
+            ->leftJoin('gibbonAttendanceLogPerson', "gibbonAttendanceLogPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID 
+                AND gibbonAttendanceLogPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID 
+                AND gibbonAttendanceLogPerson.date=gibbonTTDayDate.date
+                AND gibbonAttendanceLogPerson.context = 'Class'")
+            ->leftJoin('gibbonPerson as takenBy', 'gibbonAttendanceLogPerson.gibbonPersonIDTaker=takenBy.gibbonPersonID')
+
+            ->where("gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassPerson.role = 'Student'")
+            ->bindValue('gibbonPersonID', $gibbonPersonID)
+            ->where('gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID')
+            ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID)
+            ->where('gibbonTTDayDate.date=:date')
+            ->bindValue('date', $date)
+            ->groupBy(['gibbonTTDayRowClass.gibbonTTDayRowClassID', 'gibbonAttendanceLogPerson.gibbonAttendanceLogPersonID']);
+        
+        return $this->runQuery($query, $criteria);
+    }
+}

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -246,6 +246,21 @@ class DataTable implements OutputableInterface
     }
 
     /**
+     * Remove a column by id.
+     *
+     * @param string $id
+     * @return self
+     */
+    public function removeColumn($id)
+    {
+        if (isset($this->columns[$id])) {
+            unset($this->columns[$id]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get all columns in the table.
      *
      * @return array


### PR DESCRIPTION
Continuing the attendance changes started in #860 and #863

This PR updates the attendance logs displayed per student.

If `countClassAsSchool` is set to `N`, then the attendance logs are separated into two tables. The class attendance log is ordered by the timetable, and helps highlight gaps where attendance wasn't taken:

<img width="814" alt="Screen Shot 2019-05-09 at 9 48 16 AM" src="https://user-images.githubusercontent.com/897700/57421772-a21fa600-723f-11e9-9919-d2c866bb0607.png">

If `countClassAsSchool` is set to `Y`, all attendance logs are displayed together:

<img width="816" alt="Screen Shot 2019-05-09 at 9 57 24 AM" src="https://user-images.githubusercontent.com/897700/57422015-e1022b80-7240-11e9-9738-8122c37ca95e.png">

