### PR TITLE
Departments: fix duplicate list of departments

### DIFF
--- a/modules/Departments/departments.php
+++ b/modules/Departments/departments.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Tables\View\GridView;
+use Gibbon\Domain\DataSet;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -36,6 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/departments.ph
     // Data Table
     $gridRenderer = new GridView($container->get('twig'));
     $table = $container->get(DataTable::class)->setRenderer($gridRenderer);
+    $table->setTitle(__('Departments'));
 
     $table->addColumn('logo')
         ->format(function ($department) {
@@ -52,26 +54,27 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/departments.ph
     // Learning Areas
     $sql = "SELECT * FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
     $learningAreas = $pdo->select($sql)->toDataSet();
-    
-    $tableLA = clone $table;
-    $tableLA->setTitle(__('Learning Areas'));
-    
-    echo $tableLA->render($learningAreas);
+
+    if (count($learningAreas) > 0) {
+        $tableLA = clone $table;
+        $tableLA->setTitle(__('Learning Areas'));
+        
+        echo $tableLA->render($learningAreas);
+    }
     
     // Administration
     $sql = "SELECT * FROM gibbonDepartment WHERE type='Administration' ORDER BY name";
     $administration = $pdo->select($sql)->toDataSet();
 
-    $tableAdmin = clone $table;
-    $tableAdmin->setTitle(__('Administration'));
+    if (count($administration) > 0) {
+        $tableAdmin = clone $table;
+        $tableAdmin->setTitle(__('Administration'));
 
-    echo $tableAdmin->render($administration);
+        echo $tableAdmin->render($administration);
+    }
 
-
-    if (empty($learningAreas) && empty($administration)) {
-        echo "<div class='warning'>";
-        echo __('There are no records to display.');
-        echo '</div>';
+    if (count($learningAreas) == 0 && count($administration) == 0) {
+        echo $table->render(new DataSet([]));
     }
 
     if (isset($_SESSION[$guid]['username'])) {

--- a/resources/templates/components/dataTable.twig.html
+++ b/resources/templates/components/dataTable.twig.html
@@ -31,9 +31,9 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     </header>
 
     {% if not rows and not isFiltered and dataSet.getResultCount == 0 %}
-        <div class="rounded-sm border overflow-hidden">
+        <div class="h-48 rounded-sm border bg-gray-100 shadow-inner overflow-hidden">
         {% block blankslate %}
-            <div class="w-full h-48 flex flex-col items-center justify-center bg-gray-100 shadow-inner text-gray-600 text-lg">
+            <div class="w-full h-full flex flex-col items-center justify-center text-gray-600 text-lg">
                 {% if isFiltered %}
                     {{ __('No results matched your search.') }}
                 {% elseif blankSlate %}
@@ -70,7 +70,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
             <tbody>
             {% if not rows and isFiltered %}
-                <tr class="">
+                <tr class="h-48 bg-gray-100 shadow-inner">
                     <td class="p-0" colspan="{{ columns|length }}">
                     {{ block('blankslate') }}
                     </td>

--- a/resources/templates/components/gridTable.twig.html
+++ b/resources/templates/components/gridTable.twig.html
@@ -13,7 +13,9 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     {{ block("header") }}
 
     {% if dataSet.getResultCount == 0 %}
-
+        <div class="h-24 ">
+        {{ block('blankslate') }}
+        </div>
     {% else %}
     <div class="flex flex-wrap {{ table.getMetaData('gridClass')|default('py-2') }}">
         <div class="w-full">

--- a/src/Tables/View/GridView.php
+++ b/src/Tables/View/GridView.php
@@ -40,17 +40,14 @@ class GridView extends DataTableView implements RendererInterface
      */
     public function renderTable(DataTable $table, DataSet $dataSet)
     {
-        $this->addData('table', $table);
-        $this->addData('blankSlate', $table->getMetaData('blankSlate'));
-
-        if ($dataSet->count() > 0) {
-            $this->addData([
-                'columns' => $table->getColumns(),
-                'dataSet' => $dataSet,
-                'gridHeader' => $table->getMetaData('gridHeader'),
-                'gridFooter' => $table->getMetaData('gridFooter'),
-            ]);
-        }
+        $this->addData([
+            'table'      => $table,
+            'columns'    => $table->getColumns(),
+            'dataSet'    => $dataSet,
+            'gridHeader' => $table->getMetaData('gridHeader'),
+            'gridFooter' => $table->getMetaData('gridFooter'),
+            'blankSlate' => $table->getMetaData('blankSlate'),
+        ]);
 
         return $this->render('components/gridTable.twig.html');
     }


### PR DESCRIPTION
Fixes a bug from my GridView refactor and tweaks the blank slates a bit. Currently, if a school has Learning Areas but no Administration departments defined, the learning areas were showing up twice. This was from the data present in the renderer object when the second table was rendered.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
Blank slate (rather than alert-style message):
<img width="1133" alt="Screen Shot 2019-05-22 at 3 40 14 PM" src="https://user-images.githubusercontent.com/897700/58156167-14fd3800-7ca8-11e9-855c-5c29cf02fe72.png">
