### PR TITLE
Adjusted the size of Datepicker Calendar

### DIFF
--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -568,6 +568,7 @@ div.ui-dialog button.ui-button {
 
 div#ui-datepicker-div {
     z-index: 1000 !important;
+    width: 220px;
 }
 
 /* From WP for tinymce display */


### PR DESCRIPTION
**Motivation and Context**
In Languages that the name of day has three chars, the calendar needs be greater

**How Has This Been Tested?**
Local and Travis

**Screenshots**
![image](https://user-images.githubusercontent.com/1969911/58490806-2d57d180-8144-11e9-9b0f-73741d60c5fd.png)
