### PR TITLE
Fix 'Uncaught SyntaxError: Unexpected token <' caused by empty script on 'en-US' locale

### DIFF
--- a/index.php
+++ b/index.php
@@ -291,12 +291,15 @@ $page->scripts->addMultiple([
 $page->scripts->addMultiple([
     'jquery-latex'    => 'lib/jquery-jslatex/jquery.jslatex.js',
     'jquery-form'     => 'lib/jquery-form/jquery.form.js',
-    //This sets the default for en-US, or changes for none en-US
-    'jquery-date'     => $datepickerLocale === 'en-US' ? '' : 'lib/jquery-ui/i18n/jquery.ui.datepicker-'.$datepickerLocale.'.js',
     'jquery-autosize' => 'lib/jquery-autosize/jquery.autosize.min.js',
     'jquery-timeout'  => 'lib/jquery-sessionTimeout/jquery.sessionTimeout.min.js',
     'jquery-token'    => 'lib/jquery-tokeninput/src/jquery.tokeninput.js',
 ], ['context' => 'foot']);
+
+//This sets the default for en-US, or changes for none en-US
+if($datepickerLocale !== 'en-US'){
+    $page->scripts->add('jquery-date', 'lib/jquery-ui/i18n/jquery.ui.datepicker-'.$datepickerLocale.'.js');
+}
 
 // Set page scripts: foot - misc
 $thickboxInline = 'var tb_pathToImage="'.$session->get('absoluteURL').'/lib/thickbox/loadingAnimation.gif";';


### PR DESCRIPTION
**Description**
Page generated by index.php has an error in the console log 'Uncaught SyntaxError: Unexpected token <' due to empty 'jquery-date' script for "en-US" locale caused by the fix from #769 
The empty script attached generated a <script> tag with src back to the site url where the main page is being loaded as a script hence causing the error.