### PR TITLE
Students: improved display of Teachers' emails in student profile

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ v19.0.00
     Tweaks & Additions
         System: added Maldivian Rufiyaa as a currency option
         Behaviour: new Copy To Notes feature
+        Students: improved display of Teachers' emails in student profile
         Timetable Admin: included student reportable flag in student enrolment
 
     Bug Fixes

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -627,7 +627,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                         //Get and display a list of student's teachers
                         echo '<h4>';
-                        echo sprintf(__('Teachers Of %1$s'), $row['preferredName']);
+                        echo __('Teachers Of {student}', ['student' => $row['preferredName']]);
                         echo '</h4>';
                         echo '<p>';
                         echo __('Includes Teachers, Tutors, Educational Assistants and Head of Year.');

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -474,8 +474,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         echo "<span style='font-size: 115%; font-weight: bold'>".__('Tutors').'</span><br/>';
                         if (isset($rowDetail['gibbonPersonIDTutor'])) {
                             try {
-                                $dataDetail = array('gibbonPersonIDTutor' => $rowDetail['gibbonPersonIDTutor'], 'gibbonPersonIDTutor2' => $rowDetail['gibbonPersonIDTutor2'], 'gibbonPersonIDTutor3' => $rowDetail['gibbonPersonIDTutor3']);
-                                $sqlDetail = 'SELECT gibbonPersonID, title, surname, preferredName FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonIDTutor OR gibbonPersonID=:gibbonPersonIDTutor2 OR gibbonPersonID=:gibbonPersonIDTutor3';
+                                $dataDetail = array('gibbonRollGroupID' => $row['gibbonRollGroupID']);
+                                $sqlDetail = 'SELECT gibbonPersonID, title, surname, preferredName FROM gibbonRollGroup JOIN gibbonPerson ON (gibbonRollGroup.gibbonPersonIDTutor=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor2=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor3=gibbonPerson.gibbonPersonID) WHERE gibbonRollGroupID=:gibbonRollGroupID ORDER BY surname, preferredName';
                                 $resultDetail = $connection2->prepare($sqlDetail);
                                 $resultDetail->execute($dataDetail);
                             } catch (PDOException $e) {
@@ -627,14 +627,34 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                         //Get and display a list of student's teachers
                         echo '<h4>';
-                        echo __("Student's Teachers");
+                        echo sprintf(__('Teachers Of %1$s'), $row['preferredName']);
                         echo '</h4>';
+                        echo '<p>';
+                        echo __('Includes Teachers, Tutors, Educational Assistants and Head of Year.');
+                        echo '</p>';
                         try {
-                            $dataDetail = array('gibbonPersonID' => $gibbonPersonID, 'gibbonYearGroupID' => $row['gibbonYearGroupID']);
+                            $dataDetail = array('gibbonPersonID1' => $gibbonPersonID, 'gibbonYearGroupID' => $row['gibbonYearGroupID'], 'gibbonPersonID2' => $gibbonPersonID, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID3' => $gibbonPersonID, 'gibbonRollGroupID' => $row['gibbonRollGroupID']);
                             $sqlDetail = "
-                                (SELECT DISTINCT teacher.surname, teacher.preferredName, teacher.email FROM gibbonPerson AS teacher JOIN gibbonCourseClassPerson AS teacherClass ON (teacherClass.gibbonPersonID=teacher.gibbonPersonID)  JOIN gibbonCourseClassPerson AS studentClass ON (studentClass.gibbonCourseClassID=teacherClass.gibbonCourseClassID) JOIN gibbonPerson AS student ON (studentClass.gibbonPersonID=student.gibbonPersonID) JOIN gibbonCourseClass ON (studentClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE teacher.status='Full' AND teacherClass.role='Teacher' AND studentClass.role='Student' AND student.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current') ORDER BY teacher.preferredName, teacher.surname, teacher.email)
+                                (SELECT DISTINCT teacher.surname, teacher.preferredName, teacher.email FROM gibbonPerson AS teacher JOIN gibbonCourseClassPerson AS teacherClass ON (teacherClass.gibbonPersonID=teacher.gibbonPersonID)  JOIN gibbonCourseClassPerson AS studentClass ON (studentClass.gibbonCourseClassID=teacherClass.gibbonCourseClassID) JOIN gibbonPerson AS student ON (studentClass.gibbonPersonID=student.gibbonPersonID) JOIN gibbonCourseClass ON (studentClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE teacher.status='Full' AND teacherClass.role='Teacher' AND studentClass.role='Student' AND student.gibbonPersonID=:gibbonPersonID1 AND gibbonCourse.gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current') ORDER BY teacher.preferredName, teacher.surname, teacher.email)
                                 UNION
                                 (SELECT DISTINCT surname, preferredName, email FROM gibbonPerson JOIN gibbonYearGroup ON (gibbonYearGroup.gibbonPersonIDHOY=gibbonPersonID) WHERE status='Full' AND gibbonYearGroupID=:gibbonYearGroupID)
+                                UNION
+                                (SELECT DISTINCT surname, preferredName, email
+                                    FROM gibbonPerson
+                                        JOIN gibbonINAssistant ON (gibbonINAssistant.gibbonPersonIDAssistant=gibbonPerson.gibbonPersonID)
+                                    WHERE status='Full'
+                                        AND gibbonPersonIDStudent=:gibbonPersonID2)
+                                UNION
+                                (SELECT DISTINCT surname, preferredName, email
+                                    FROM gibbonPerson
+                                        JOIN gibbonRollGroup ON (gibbonRollGroup.gibbonPersonIDEA=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDEA2=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDEA3=gibbonPerson.gibbonPersonID)
+                                        JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                                        JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
+                                    WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID
+                                        AND gibbonStudentEnrolment.gibbonPersonID=:gibbonPersonID3
+                                )
+                                UNION
+                                (SELECT surname, preferredName, email FROM gibbonRollGroup JOIN gibbonPerson ON (gibbonRollGroup.gibbonPersonIDTutor=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor2=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor3=gibbonPerson.gibbonPersonID) WHERE gibbonRollGroupID=:gibbonRollGroupID)
                                 ORDER BY preferredName, surname, email";
                             $resultDetail = $connection2->prepare($sqlDetail);
                             $resultDetail->execute($dataDetail);
@@ -646,45 +666,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             echo __('There are no records to display.');
                             echo '</div>';
                         } else {
-                            echo '<ul>';
-                            while ($rowDetail = $resultDetail->fetch()) {
-                                echo '<li>'.htmlPrep(Format::name('', $rowDetail['preferredName'], $rowDetail['surname'], 'Student', false));
-                                if ($rowDetail['email'] != '') {
-                                    echo htmlPrep(' <'.$rowDetail['email'].'>');
-                                }
-                                echo '</li>';
-                            }
-                            echo '</ul>';
-                        }
-
-                        //Get and display a list of student's educational assistants
-                        try {
-                            $dataDetail = array('gibbonPersonID1' => $gibbonPersonID, 'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID2' => $gibbonPersonID);
-                            $sqlDetail = "(SELECT DISTINCT surname, preferredName, email
-                                FROM gibbonPerson
-                                    JOIN gibbonINAssistant ON (gibbonINAssistant.gibbonPersonIDAssistant=gibbonPerson.gibbonPersonID)
-                                WHERE status='Full'
-                                    AND gibbonPersonIDStudent=:gibbonPersonID1)
-                            UNION
-                            (SELECT DISTINCT surname, preferredName, email
-                                FROM gibbonPerson
-                                    JOIN gibbonRollGroup ON (gibbonRollGroup.gibbonPersonIDEA=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDEA2=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDEA3=gibbonPerson.gibbonPersonID)
-                                    JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
-                                    JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
-                                WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID
-                                    AND gibbonStudentEnrolment.gibbonPersonID=:gibbonPersonID2
-                            )
-                            ORDER BY preferredName, surname, email";
-                            $resultDetail = $connection2->prepare($sqlDetail);
-                            $resultDetail->execute($dataDetail);
-                        } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
-                        }
-                        if ($resultDetail->rowCount() > 0) {
-                            echo '<h4>';
-                            echo __("Student's Educational Assistants");
-                            echo '</h4>';
-
                             echo '<ul>';
                             while ($rowDetail = $resultDetail->fetch()) {
                                 echo '<li>'.htmlPrep(Format::name('', $rowDetail['preferredName'], $rowDetail['surname'], 'Student', false));


### PR DESCRIPTION
**Description**
For various historical reasons, Tutors and Learning Support Assistants aren’t listed with teachers in the Student’s Teachers of the student profile. This PR unifies everything into a single list.


**Motivation and Context**
Some people weren't getting emails they ought to have.

**How Has This Been Tested?**
Locally and in production.