### PR TITLE
Form Groups: added staff-only summary of Year Groups after Form Group…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ v19.0.00
         System: added Maldivian Rufiyaa as a currency option
         System: update DatePicker to use gibboni18n date format
         Behaviour: new Copy To Notes feature
+        Form Groups: added staff-only summary of Year Groups after Form Group listing
         Students: improved display of Teachers' emails in student profile
         Timetable Admin: included student reportable flag in student enrolment
 

--- a/src/Domain/School/YearGroupGateway.php
+++ b/src/Domain/School/YearGroupGateway.php
@@ -48,4 +48,21 @@ class YearGroupGateway extends QueryableGateway
 
         return $this->runQuery($query, $criteria);
     }
+
+    public function studentCountByYearGroup($gibbonYearGroupID)
+    {
+        $data = array('gibbonYearGroupID' => $gibbonYearGroupID, 'today' => date('Y-m-d'));
+        $sql = "SELECT count(*)
+            FROM gibbonStudentEnrolment
+                JOIN gibbonPerson ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
+            WHERE gibbonPerson.status='Full'
+                AND gibbonSchoolYear.status='Current'
+                AND (dateStart IS NULL OR dateStart<=:today)
+                AND (dateEnd IS NULL OR dateEnd>=:today)
+                AND gibbonYearGroupID=:gibbonYearGroupID
+                ";
+
+        return $this->db()->selectOne($sql, $data);
+    }
 }


### PR DESCRIPTION
**Description**
Adds a Year Group table, with student totals, after the Form Group table

**Motivation and Context**
For schools with vertical form groups (e.g. groups including students from multiple years), counting the number of students in a year group can get tricky. This change addresses that need.

**How Has This Been Tested?**
Locally and in production

**Screenshots**
<img width="816" alt="Screenshot 2019-09-04 at 8 34 03 PM" src="https://user-images.githubusercontent.com/5436438/64257143-65e32480-cf57-11e9-9c30-222006c1128c.png">

