### PR TITLE
Attendance: add more options to control attendance prefilling

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -916,4 +916,7 @@ $sql[$count][1] = "
 UPDATE `gibboni18n` SET dateFormatRegEx = '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i' WHERE gibboni18n.code = 'pl_PL';end
 UPDATE `gibboni18n` SET dateFormatRegEx = '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\\d\\\d$/i' WHERE gibboni18n.code = 'pl_PL';end
 INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Attendance', 'recordFirstClassAsSchool', 'Enable First Class as School Attendance', 'Should the first class in a day have the option to record class attendance as school-wide attendance?', 'N');end
+ALTER TABLE `gibbonAttendanceCode` ADD `prefill` ENUM('Y','N') NOT NULL DEFAULT 'Y' AFTER `future`;end
+UPDATE `gibbonAttendanceCode` SET prefill='N' WHERE name='Present - Late';end
+ALTER TABLE `gibbonAttendanceLogPerson` ADD `gibbonRollGroupID` INT(5) UNSIGNED ZEROFILL NULL AFTER gibbonPersonIDTaker;end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -915,4 +915,5 @@ $sql[$count][0] = '19.0.00';
 $sql[$count][1] = "
 UPDATE `gibboni18n` SET dateFormatRegEx = '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i' WHERE gibboni18n.code = 'pl_PL';end
 UPDATE `gibboni18n` SET dateFormatRegEx = '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\\d\\\d$/i' WHERE gibboni18n.code = 'pl_PL';end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Attendance', 'recordFirstClassAsSchool', 'Enable First Class as School Attendance', 'Should the first class in a day have the option to record class attendance as school-wide attendance?', 'N');end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -915,7 +915,7 @@ $sql[$count][0] = '19.0.00';
 $sql[$count][1] = "
 UPDATE `gibboni18n` SET dateFormatRegEx = '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i' WHERE gibboni18n.code = 'pl_PL';end
 UPDATE `gibboni18n` SET dateFormatRegEx = '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\\d\\\d$/i' WHERE gibboni18n.code = 'pl_PL';end
-INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Attendance', 'recordFirstClassAsSchool', 'Enable First Class as School Attendance', 'Should the first class in a day have the option to record class attendance as school-wide attendance?', 'N');end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Attendance', 'recordFirstClassAsSchool', 'Enable First Class as School Attendance', 'Should the first class attendance taken in a day have the option to record as school-wide attendance?', 'N');end
 ALTER TABLE `gibbonAttendanceCode` ADD `prefill` ENUM('Y','N') NOT NULL DEFAULT 'Y' AFTER `future`;end
 UPDATE `gibbonAttendanceCode` SET prefill='N' WHERE name='Present - Late';end
 ALTER TABLE `gibbonAttendanceLogPerson` ADD `gibbonRollGroupID` INT(5) UNSIGNED ZEROFILL NULL AFTER gibbonPersonIDTaker;end

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,8 @@ v19.0.00
     Tweaks & Additions
         System: added Maldivian Rufiyaa as a currency option
         System: update DatePicker to use gibboni18n date format
+        Attendance: added an option to record the first class attendance in a day as school-wide attendance
+        Attendance: added an option to disable prefilling by attendance code, applied to Present - Late by default
         Behaviour: new Copy To Notes feature
         Students: improved display of Teachers' emails in student profile
         Timetable Admin: included student reportable flag in student enrolment

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -218,7 +218,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                         // Build the attendance log data per student
                         foreach ($students as $key => $student) {
                             $data = array('gibbonPersonID' => $student['gibbonPersonID'], 'date' => $currentDate . '%', 'gibbonCourseClassID' => $gibbonCourseClassID);
-                            $sql = "SELECT type, reason, comment, context, timestampTaken FROM gibbonAttendanceLogPerson
+                            $sql = "SELECT gibbonAttendanceLogPerson.type, reason, comment, context, timestampTaken FROM gibbonAttendanceLogPerson
                                     JOIN gibbonPerson ON (gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID)
                                     WHERE gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID
                                     AND date LIKE :date
@@ -230,11 +230,13 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                             $countLogs += $result->rowCount();
 
                             //Check for school prefill if attendance not taken in this class
-                            if ($result->rowCount() == 0 ) {
+                            if ($result->rowCount() == 0) {
                                 $data = array('gibbonPersonID' => $student['gibbonPersonID'], 'date' => $currentDate . '%');
-                                $sql = "SELECT type, reason, comment, context, timestampTaken FROM gibbonAttendanceLogPerson
+                                $sql = "SELECT gibbonAttendanceLogPerson.type, reason, comment, context, timestampTaken FROM gibbonAttendanceLogPerson
                                         JOIN gibbonPerson ON (gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                                        JOIN gibbonAttendanceCode ON (gibbonAttendanceCode.gibbonAttendanceCodeID=gibbonAttendanceLogPerson.gibbonAttendanceCodeID)
                                         WHERE gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID
+                                        AND gibbonAttendanceCode.prefill='Y'
                                         AND date LIKE :date";
                                 if ($crossFillClasses == "N") {
                                     $sql .= " AND NOT context='Class'";

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -104,6 +104,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                 echo "</div>";
             } else {
                 $defaultAttendanceType = getSettingByScope($connection2, 'Attendance', 'defaultClassAttendanceType');
+                $recordFirstClassAsSchool = getSettingByScope($connection2, 'Attendance', 'recordFirstClassAsSchool');
                 $crossFillClasses = getSettingByScope($connection2, 'Attendance', 'crossFillClasses');
 
                 // Check class
@@ -208,6 +209,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                     } else {
                         $count = 0;
                         $countPresent = 0;
+                        $countLogs = 0;
                         $columns = 4;
 
                         $defaults = array('type' => $defaultAttendanceType, 'reason' => '', 'comment' => '', 'context' => '');
@@ -225,6 +227,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                             $result = $pdo->executeQuery($data, $sql);
 
                             $log = ($result->rowCount() > 0) ? $result->fetch() : $defaults;
+                            $countLogs += $result->rowCount();
 
                             //Check for school prefill if attendance not taken in this class
                             if ($result->rowCount() == 0 ) {
@@ -240,6 +243,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                                 $result = $pdo->executeQuery($data, $sql);
 
                                 $log = ($result->rowCount() > 0) ? $result->fetch() : $log;
+                                $countLogs += $result->rowCount();
                             }
 
                             $students[$key]['cellHighlight'] = '';
@@ -304,6 +308,12 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                             $cell->addContent($attendance->renderMiniHistory($student['gibbonPersonID'], 'Class', $gibbonCourseClassID));
 
                             $count++;
+                        }
+
+                        // Option to record first class in a day as school-wide attendance
+                        if ($recordFirstClassAsSchool == 'Y' && $countLogs == 0) {
+                            $row = $form->addRow();
+                                $row->addCheckbox('recordSchoolAttendance')->setValue('Y')->description(__('Record as school-wide attendance'))->checked('Y');
                         }
 
                         $form->addRow()->addAlert(__('Total students:') . ' ' . $count, 'success')->setClass('right')

--- a/modules/Attendance/attendance_take_byCourseClassProcess.php
+++ b/modules/Attendance/attendance_take_byCourseClassProcess.php
@@ -129,7 +129,8 @@ else {
                         die();
                     }
 
-                    $attendanceLogGateway = $container->get(AttendanceLogPersonGateway::class); 
+                    $attendanceLogGateway = $container->get(AttendanceLogPersonGateway::class);
+
                     $recordSchoolAttendance = $_POST['recordSchoolAttendance'] ?? 'N';
                     $count=$_POST["count"] ;
                     $partialFail=FALSE ;
@@ -172,16 +173,17 @@ else {
                         }
 
                         $data = [
-                            'gibbonPersonID'      => $gibbonPersonID,
-                            'context'             => 'Class',
-                            'direction'           => $direction,
-                            'type'                => $type,
-                            'reason'              => $reason,
-                            'comment'             => $comment,
-                            'gibbonPersonIDTaker' => $_SESSION[$guid]['gibbonPersonID'],
-                            'gibbonCourseClassID' => $gibbonCourseClassID,
-                            'date'                => $currentDate,
-                            'timestampTaken'      => date('Y-m-d H:i:s'),
+                            'gibbonAttendanceCodeID' => $attendanceCode['gibbonAttendanceCodeID'],
+                            'gibbonPersonID'         => $gibbonPersonID,
+                            'context'                => 'Class',
+                            'direction'              => $direction,
+                            'type'                   => $type,
+                            'reason'                 => $reason,
+                            'comment'                => $comment,
+                            'gibbonPersonIDTaker'    => $_SESSION[$guid]['gibbonPersonID'],
+                            'gibbonCourseClassID'    => $gibbonCourseClassID,
+                            'date'                   => $currentDate,
+                            'timestampTaken'         => date('Y-m-d H:i:s'),
                         ];
                         
                         if (!$existing) {

--- a/modules/Attendance/attendance_take_byCourseClassProcess.php
+++ b/modules/Attendance/attendance_take_byCourseClassProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Module\Attendance\AttendanceView;
+use Gibbon\Domain\Attendance\AttendanceLogPersonGateway;
 
 //Gibbon system-wide includes
 require __DIR__ . '/../../gibbon.php';
@@ -32,178 +33,185 @@ $today=date("Y-m-d");
 $moduleName = getModuleName($_POST["address"]);
 
 if ($moduleName == "Planner") {
-	$gibbonPlannerEntryID = $_POST['gibbonPlannerEntryID'];
-	$URL=$_SESSION[$guid]["absoluteURL"] . "/index.php?q=/modules/" . $moduleName . "/planner_view_full.php&gibbonPlannerEntryID=$gibbonPlannerEntryID&viewBy=date&gibbonCourseClassID=$gibbonCourseClassID&date=" . $currentDate ;
+    $gibbonPlannerEntryID = $_POST['gibbonPlannerEntryID'];
+    $URL=$_SESSION[$guid]["absoluteURL"] . "/index.php?q=/modules/" . $moduleName . "/planner_view_full.php&gibbonPlannerEntryID=$gibbonPlannerEntryID&viewBy=date&gibbonCourseClassID=$gibbonCourseClassID&date=" . $currentDate ;
 } else {
-	$URL=$_SESSION[$guid]["absoluteURL"] . "/index.php?q=/modules/" . $moduleName . "/attendance_take_byCourseClass.php&gibbonCourseClassID=$gibbonCourseClassID&currentDate=" . dateConvertBack($guid, $currentDate) ;
+    $URL=$_SESSION[$guid]["absoluteURL"] . "/index.php?q=/modules/" . $moduleName . "/attendance_take_byCourseClass.php&gibbonCourseClassID=$gibbonCourseClassID&currentDate=" . dateConvertBack($guid, $currentDate) ;
 }
 
 if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take_byCourseClass.php")==FALSE) {
-	//Fail 0
-	$URL.="&return=error0" ;
-	header("Location: {$URL}");
-	die();
+    //Fail 0
+    $URL.="&return=error0" ;
+    header("Location: {$URL}");
+    die();
 }
 else {
-	//Proceed!
-	//Check if school year specified
-	if ($gibbonCourseClassID=="" AND $currentDate=="") {
-		//Fail1
-		$URL.="&return=error1" ;
-		header("Location: {$URL}");
-		die();
-	}
-	else {
-		try {
-			$data=array("gibbonCourseClassID"=>$gibbonCourseClassID);
-			$sql="SELECT * FROM gibbonCourseClass WHERE gibbonCourseClassID=:gibbonCourseClassID" ;
-			$result=$connection2->prepare($sql);
-			$result->execute($data);
-		}
-		catch(PDOException $e) {
-			//Fail2
-			$URL.="&return=error2" ;
-			header("Location: {$URL}");
-			die();
-		}
+    //Proceed!
+    //Check if school year specified
+    if ($gibbonCourseClassID=="" AND $currentDate=="") {
+        //Fail1
+        $URL.="&return=error1" ;
+        header("Location: {$URL}");
+        die();
+    }
+    else {
+        try {
+            $data=array("gibbonCourseClassID"=>$gibbonCourseClassID);
+            $sql="SELECT * FROM gibbonCourseClass WHERE gibbonCourseClassID=:gibbonCourseClassID" ;
+            $result=$connection2->prepare($sql);
+            $result->execute($data);
+        }
+        catch(PDOException $e) {
+            //Fail2
+            $URL.="&return=error2" ;
+            header("Location: {$URL}");
+            die();
+        }
 
-		if ($result->rowCount()!=1) {
-			//Fail 2
-			$URL.="&return=error1" ;
-			header("Location: {$URL}");
-			die();
-		}
-		else {
-			//Check that date is not in the future
-			if ($currentDate>$today) {
-				//Fail 4
-				$URL.="&return=error3" ;
-				header("Location: {$URL}");
-				die();
-			}
-			else {
-				//Check that date is a school day
-				if (isSchoolOpen($guid, $currentDate, $connection2)==FALSE) {
-					//Fail 5
-					$URL.="&return=error3" ;
-					header("Location: {$URL}");
-					die();
-				}
-				else {
-					//Write to database
-					require_once __DIR__ . '/src/AttendanceView.php';
-					$attendance = new AttendanceView($gibbon, $pdo);
+        if ($result->rowCount()!=1) {
+            //Fail 2
+            $URL.="&return=error1" ;
+            header("Location: {$URL}");
+            die();
+        }
+        else {
+            //Check that date is not in the future
+            if ($currentDate>$today) {
+                //Fail 4
+                $URL.="&return=error3" ;
+                header("Location: {$URL}");
+                die();
+            }
+            else {
+                //Check that date is a school day
+                if (isSchoolOpen($guid, $currentDate, $connection2)==FALSE) {
+                    //Fail 5
+                    $URL.="&return=error3" ;
+                    header("Location: {$URL}");
+                    die();
+                }
+                else {
+                    //Write to database
+                    require_once __DIR__ . '/src/AttendanceView.php';
+                    $attendance = new AttendanceView($gibbon, $pdo);
 
-					try {
-						$data=array("gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate);
-						$sql="SELECT gibbonAttendanceLogCourseClassID FROM gibbonAttendanceLogCourseClass WHERE gibbonCourseClassID=:gibbonCourseClassID AND date LIKE :date ORDER BY gibbonAttendanceLogCourseClassID DESC" ;
-						$resultLog=$connection2->prepare($sql);
-						$resultLog->execute($data);
-					}
-					catch(PDOException $e) {
-						//Fail 2
-						$URL.="&return=error2" ;
-						header("Location: {$URL}");
-						die();
-					}
+                    try {
+                        $data=array("gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate);
+                        $sql="SELECT gibbonAttendanceLogCourseClassID FROM gibbonAttendanceLogCourseClass WHERE gibbonCourseClassID=:gibbonCourseClassID AND date LIKE :date ORDER BY gibbonAttendanceLogCourseClassID DESC" ;
+                        $resultLog=$connection2->prepare($sql);
+                        $resultLog->execute($data);
+                    }
+                    catch(PDOException $e) {
+                        //Fail 2
+                        $URL.="&return=error2" ;
+                        header("Location: {$URL}");
+                        die();
+                    }
 
-					if ($resultLog->rowCount()<1) {
-						$data=array("gibbonPersonIDTaker"=>$_SESSION[$guid]["gibbonPersonID"], "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
-						$sql="INSERT INTO gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken" ;
+                    if ($resultLog->rowCount()<1) {
+                        $data=array("gibbonPersonIDTaker"=>$_SESSION[$guid]["gibbonPersonID"], "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
+                        $sql="INSERT INTO gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken" ;
 
-					} else {
-						$resultUpdate=$resultLog->fetch() ;
-						$data=array("gibbonAttendanceLogCourseClassID" => $resultUpdate['gibbonAttendanceLogCourseClassID'], "gibbonPersonIDTaker"=>$_SESSION[$guid]["gibbonPersonID"], "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
-						$sql="UPDATE gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken WHERE gibbonAttendanceLogCourseClassID=:gibbonAttendanceLogCourseClassID" ;
-					}
+                    } else {
+                        $resultUpdate=$resultLog->fetch() ;
+                        $data=array("gibbonAttendanceLogCourseClassID" => $resultUpdate['gibbonAttendanceLogCourseClassID'], "gibbonPersonIDTaker"=>$_SESSION[$guid]["gibbonPersonID"], "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
+                        $sql="UPDATE gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken WHERE gibbonAttendanceLogCourseClassID=:gibbonAttendanceLogCourseClassID" ;
+                    }
 
-					try {
-						$result=$connection2->prepare($sql);
-						$result->execute($data);
-					}
-					catch(PDOException $e) {
-						//Fail 2
-						$URL.="&return=error2" ;
-						header("Location: {$URL}");
-						die();
-					}
+                    try {
+                        $result=$connection2->prepare($sql);
+                        $result->execute($data);
+                    }
+                    catch(PDOException $e) {
+                        //Fail 2
+                        $URL.="&return=error2" ;
+                        header("Location: {$URL}");
+                        die();
+                    }
 
-					$count=$_POST["count"] ;
-					$partialFail=FALSE ;
+                    $attendanceLogGateway = $container->get(AttendanceLogPersonGateway::class); 
+                    $recordSchoolAttendance = $_POST['recordSchoolAttendance'] ?? 'N';
+                    $count=$_POST["count"] ;
+                    $partialFail=FALSE ;
 
-					for ($i=0; $i<$count; $i++) {
-						$gibbonPersonID=$_POST[$i . "-gibbonPersonID"] ;
+                    for ($i=0; $i<$count; $i++) {
+                        $gibbonPersonID=$_POST[$i . "-gibbonPersonID"] ;
 
-						$type=$_POST[$i . "-type"] ;
-						$reason=$_POST[$i . "-reason"] ;
-						$comment=$_POST[$i . "-comment"] ;
+                        $type=$_POST[$i . "-type"] ;
+                        $reason=$_POST[$i . "-reason"] ;
+                        $comment=$_POST[$i . "-comment"] ;
 
-						$attendanceCode = $attendance->getAttendanceCodeByType($type);
-						$direction = $attendanceCode['direction'];
+                        $attendanceCode = $attendance->getAttendanceCodeByType($type);
+                        $direction = $attendanceCode['direction'];
 
-						//Check for last record on same day
-						try {
-							$data=array("gibbonPersonID"=>$gibbonPersonID, "date"=>$currentDate . "%");
-							$sql="SELECT * FROM gibbonAttendanceLogPerson WHERE gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY gibbonAttendanceLogPersonID DESC" ;
-							$result=$connection2->prepare($sql);
-							$result->execute($data);
-						}
-						catch(PDOException $e) {
-							//Fail 2
-							$URL.="&return=error2" ;
-							header("Location: {$URL}");
-							die();
-						}
+                        //Check for last record on same day
+                        try {
+                            $data=array("gibbonPersonID"=>$gibbonPersonID, "date"=>$currentDate . "%");
+                            $sql="SELECT * FROM gibbonAttendanceLogPerson WHERE gibbonPersonID=:gibbonPersonID AND date LIKE :date ORDER BY gibbonAttendanceLogPersonID DESC" ;
+                            $result=$connection2->prepare($sql);
+                            $result->execute($data);
+                        }
+                        catch(PDOException $e) {
+                            //Fail 2
+                            $URL.="&return=error2" ;
+                            header("Location: {$URL}");
+                            die();
+                        }
 
-                        //Check context, gibbonCourseClassID and type, updating only if not a match
+                        // Check context, gibbonCourseClassID and type, updating only if not a match
                         $existing = false ;
                         $gibbonAttendanceLogPersonID = '';
                         if ($result->rowCount()>0) {
-                            $row=$result->fetch() ;
-                            if ($row['context'] == 'Class' && $row['gibbonCourseClassID'] == $gibbonCourseClassID && $row['type'] == $type) {
-                                $existing = true ;
-                                $gibbonAttendanceLogPersonID = $row['gibbonAttendanceLogPersonID'];
+                            while ($row=$result->fetch()) {
+                                if ($row['context'] == 'Class' && $row['gibbonCourseClassID'] == $gibbonCourseClassID) {
+                                    $existing = true ;
+                                    $gibbonAttendanceLogPersonID = $row['gibbonAttendanceLogPersonID'];
+                                    break;
+                                }
                             }
                         }
 
-						if (!$existing) {
-							//If no records then create one
-							try {
-								$dataUpdate=array("gibbonPersonID"=>$gibbonPersonID, "direction"=>$direction, "type"=>$type, "reason"=>$reason, "comment"=>$comment, "gibbonPersonIDTaker"=>$_SESSION[$guid]["gibbonPersonID"], "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
-								$sqlUpdate="INSERT INTO gibbonAttendanceLogPerson SET gibbonAttendanceCodeID=(SELECT gibbonAttendanceCodeID FROM gibbonAttendanceCode WHERE name=:type), gibbonPersonID=:gibbonPersonID, direction=:direction, type=:type, context='Class', reason=:reason, comment=:comment, gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken" ;
-								$resultUpdate=$connection2->prepare($sqlUpdate);
-								$resultUpdate->execute($dataUpdate);
-							}
-							catch(PDOException $e) {
-								$partialFail=TRUE ;
-							}
-						}
-						else {
-							try {
-								$dataUpdate=array("gibbonAttendanceLogPersonID"=>$gibbonAttendanceLogPersonID, "gibbonPersonID"=>$gibbonPersonID, "direction"=>$direction, "type"=>$type, "reason"=>$reason, "comment"=>$comment, "gibbonPersonIDTaker"=>$_SESSION[$guid]["gibbonPersonID"], "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
-								$sqlUpdate="UPDATE gibbonAttendanceLogPerson SET gibbonAttendanceCodeID=(SELECT gibbonAttendanceCodeID FROM gibbonAttendanceCode WHERE name=:type), gibbonPersonID=:gibbonPersonID, direction=:direction, type=:type, context='Class', reason=:reason, comment=:comment, gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken WHERE gibbonAttendanceLogPersonID=:gibbonAttendanceLogPersonID" ;
-								$resultUpdate=$connection2->prepare($sqlUpdate);
-								$resultUpdate->execute($dataUpdate);
-							}
-							catch(PDOException $e) {
-								$partialFail=TRUE ;
-							}
-						}
-					}
+                        $data = [
+                            'gibbonPersonID'      => $gibbonPersonID,
+                            'context'             => 'Class',
+                            'direction'           => $direction,
+                            'type'                => $type,
+                            'reason'              => $reason,
+                            'comment'             => $comment,
+                            'gibbonPersonIDTaker' => $_SESSION[$guid]['gibbonPersonID'],
+                            'gibbonCourseClassID' => $gibbonCourseClassID,
+                            'date'                => $currentDate,
+                            'timestampTaken'      => date('Y-m-d H:i:s'),
+                        ];
+                        
+                        if (!$existing) {
+                            // If no records then create one
+                            $inserted = $attendanceLogGateway->insert($data);
+                            $partialFail &= !$inserted;
+                        } else {
+                            $updated = $attendanceLogGateway->update($gibbonAttendanceLogPersonID, $data);
+                            $partialFail &= !$updated;
+                        }
+                        
+                        if ($recordSchoolAttendance == 'Y') {
+                            $data['context'] = 'Person';
+                            $inserted = $attendanceLogGateway->insert($data);
+                            $partialFail &= !$inserted;
+                        }
+                    }
 
-					if ($partialFail==TRUE) {
-						//Fail 3
-						$URL.="&return=warning1" ;
-						header("Location: {$URL}");
-						die();
-					}
-					else {
-						//Success 0
-						$URL.="&return=success0&time=" . date("H-i-s") ;
-						header("Location: {$URL}");
-					}
-				}
-			}
-		}
-	}
+                    if ($partialFail == true) {
+                        //Fail 3
+                        $URL.="&return=warning1" ;
+                        header("Location: {$URL}");
+                        die();
+                    } else {
+                        //Success 0
+                        $URL.="&return=success0&time=" . date("H-i-s") ;
+                        header("Location: {$URL}");
+                    }
+                }
+            }
+        }
+    }
 }

--- a/modules/Attendance/attendance_take_byRollGroup.php
+++ b/modules/Attendance/attendance_take_byRollGroup.php
@@ -178,10 +178,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 
                             // Build the attendance log data per student
                             foreach ($students as $key => $student) {
-                                $data = array('gibbonPersonID' => $student['gibbonPersonID'], 'date' => $currentDate.'%');
-                                $sql = "SELECT type, reason, comment, context, timestampTaken FROM gibbonAttendanceLogPerson
+                                $data = array('gibbonPersonID' => $student['gibbonPersonID'], 'date' => $currentDate.'%', 'gibbonRollGroupID' => $gibbonRollGroupID);
+                                $sql = "SELECT gibbonAttendanceLogPerson.type, reason, comment, context, timestampTaken FROM gibbonAttendanceLogPerson
                                         JOIN gibbonPerson ON (gibbonAttendanceLogPerson.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                                        JOIN gibbonAttendanceCode ON (gibbonAttendanceCode.gibbonAttendanceCodeID=gibbonAttendanceLogPerson.gibbonAttendanceCodeID)
                                         WHERE gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID
+                                        AND (gibbonAttendanceCode.prefill='Y' OR gibbonAttendanceLogPerson.gibbonRollGroupID=:gibbonRollGroupID)
                                         AND date LIKE :date";
 
                                 if ($countClassAsSchool == 'N') {

--- a/modules/School Admin/attendanceSettings.php
+++ b/modules/School Admin/attendanceSettings.php
@@ -106,6 +106,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
+    $setting = getSettingByScope($connection2, 'Attendance', 'recordFirstClassAsSchool', true);
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
+
     $setting = getSettingByScope($connection2, 'Attendance', 'crossFillClasses', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));

--- a/modules/School Admin/attendanceSettingsProcess.php
+++ b/modules/School Admin/attendanceSettingsProcess.php
@@ -47,6 +47,16 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         $fail = true;
     }
 
+    $recordFirstClassAsSchool = (isset($_POST['recordFirstClassAsSchool'])) ? $_POST['recordFirstClassAsSchool'] : NULL;
+    try {
+        $data = array('value' => $recordFirstClassAsSchool);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Attendance' AND name='recordFirstClassAsSchool'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
     $crossFillClasses = (isset($_POST['crossFillClasses'])) ? $_POST['crossFillClasses'] : NULL;
     try {
         $data = array('value' => $crossFillClasses);

--- a/modules/School Admin/attendanceSettings_manage_add.php
+++ b/modules/School Admin/attendanceSettings_manage_add.php
@@ -86,6 +86,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         $row->addYesNo('reportable')->required();
 
     $row = $form->addRow();
+        $row->addLabel('prefill', __('Prefillable'))->description(__('Can this code prefill when taking attendance?'));
+        $row->addYesNo('prefill')->required();
+
+    $row = $form->addRow();
         $row->addLabel('future', __('Allow Future Use'))->description(__('Can this code be used in Set Future Absence?'));
         $row->addYesNo('future')->required();
 

--- a/modules/School Admin/attendanceSettings_manage_edit.php
+++ b/modules/School Admin/attendanceSettings_manage_edit.php
@@ -106,6 +106,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
                 $row->addYesNo('reportable')->required();
         
             $row = $form->addRow();
+                $row->addLabel('prefill', __('Prefillable'))->description(__('Can this code prefill when taking attendance?'));
+                $row->addYesNo('prefill')->required();
+
+            $row = $form->addRow();
                 $row->addLabel('future', __('Allow Future Use'))->description(__('Can this code be used in Set Future Absence?'));
                 $row->addYesNo('future')->required();
         

--- a/src/Domain/Attendance/AttendanceCodeGateway.php
+++ b/src/Domain/Attendance/AttendanceCodeGateway.php
@@ -32,6 +32,7 @@ class AttendanceCodeGateway extends QueryableGateway
     use TableAware;
 
     private static $tableName = 'gibbonAttendanceCode';
+    private static $primaryKey = 'gibbonAttendanceCodeID';
 
     private static $searchableColumns = ['name', 'nameShort'];
     


### PR DESCRIPTION
This PR further refines the available settings for attendance by adding two options:

- A setting to enable the first class attendance taken in a day to optionally count as school-wide attendance.
  <img width="787" alt="Screen Shot 2019-09-05 at 1 08 07 PM" src="https://user-images.githubusercontent.com/897700/64313450-3d523d80-cfde-11e9-8bb4-c7a25de18750.png">

  Which enables a checkbox on Take Attendance by Class:
  <img width="795" alt="Screen Shot 2019-09-05 at 1 05 08 PM" src="https://user-images.githubusercontent.com/897700/64313297-d3399880-cfdd-11e9-9ca6-ef37762ff6f3.png">

- An option to disable the prefilling of an attendance code, applied to Present - Late by default.
  <img width="789" alt="Screen Shot 2019-09-05 at 1 04 06 PM" src="https://user-images.githubusercontent.com/897700/64313273-bbfaab00-cfdd-11e9-9e21-25d95f20619b.png">


The notable code and database changes in this PR are:
- Added and implemented a `recordFirstClassAsSchool` setting.
- Added a `prefill` column to the `gibbonAttendanceCode` table.
- Added a `gibbonRollGroupID` column to the `gibbonAttendanceLogPerson` table. This was necessary to track the roll group for each log, so the difference between recorded and prefilled logs could be determined.
- Updated the prefill logic for Take Attendance by Class and Take Attendance by Roll Group to ignore non-prefillable attendance codes.
- Refactored the `attendanceSettings_manage_addProcess.php` and `attendanceSettings_manage_editProcess.php` pages to use a gateway class.

_Best viewed with whitespace changes ignored_