### PR TITLE
System Admin: fix Notification Events to only send to Full users

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ v19.0.00
     Bug Fixes
         System: fix installer bug where passwords are unnecessarily encoded
         System: fixed date picker validation error for Polish language
+        System: fixed Notification Events to only send to users who have status Full
         Activities: improved interface string advising users of disabled external activity registration
         Attendance: fixed missing data in printable view of Student History
         Finance: fixed missing payment info in invoice receipt email for multiple partial payments

--- a/modules/System Admin/notificationSettings_manage_edit.php
+++ b/modules/System Admin/notificationSettings_manage_edit.php
@@ -162,7 +162,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/notificationS
                     JOIN gibbonPermission ON (gibbonRole.gibbonRoleID=gibbonPermission.gibbonRoleID)
                     JOIN gibbonAction ON (gibbonPermission.gibbonActionID=gibbonAction.gibbonActionID)
                     WHERE gibbonPerson.status='Full'
-                    AND (gibbonAction.name=:action)
+                    AND (gibbonAction.name=:action OR gibbonAction.name LIKE CONCAT(:action, '_%'))
                     GROUP BY gibbonPerson.gibbonPersonID
                     ORDER BY gibbonRole.gibbonRoleID, surname, preferredName" ;
             $resultSelect=$pdo->executeQuery($data, $sql);

--- a/modules/System Admin/notificationSettings_manage_edit.php
+++ b/modules/System Admin/notificationSettings_manage_edit.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/notificationSettings_manage_edit.php') == false) {
     //Acess denied
@@ -77,87 +78,80 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/notificationS
 
             echo $form->getOutput();
 
-            echo '<h3>';
-            echo __('Edit Subscribers');
-            echo '</h3>';
-
+            $description = '';
             if ($event['active'] == 'N') {
-                echo "<div class='warning'>";
-                echo __('This notification event is not active. The following subscribers will not receive any notifications until the event is set to active.');
-                echo '</div>';
+                $description .= Format::alert(__('This notification event is not active. The following subscribers will not receive any notifications until the event is set to active.'), 'warning');
             }
 
             if ($event['type'] == 'CLI') {
-                echo "<div class='message'>";
-                echo __('This is a CLI notification event. It will only run if the corresponding CLI script has been setup on the server.');
-                echo '</div>';
+                $description .= Format::alert(__('This is a CLI notification event. It will only run if the corresponding CLI script has been setup on the server.'), 'message');
             }
 
             $gateway = new NotificationGateway($pdo);
             $result = $gateway->selectAllNotificationListeners($gibbonNotificationEventID, false);
 
-            if ($result->rowCount() == 0) {
-                echo "<div class='error'>";
-                echo __('There are no records to display.');
-                echo '</div>';
-            } else {
-                echo '<table class="colorOddEven fullWidth" cellspacing="0">';
-                echo '<tr class="head">';
-                echo '<th>';
-                echo __('Name');
-                echo '</th>';
-                echo '<th style="width: 120px;" title="'.__('Notifications can always be viewed on screen.').'">';
-                echo __('Receive Email Notifications?');
-                echo '</th>';
-                echo '<th>';
-                echo __('Scope');
-                echo '</th>';
-                echo '<th style="width: 80px;">';
-                echo __('Actions');
-                echo '</th>';
-                echo '</tr>';
+            $table = DataTable::create('subscribers');
+            $table->setTitle(__('Edit Subscribers'));
+            $table->setDescription($description);
 
-                while ($listener = $result->fetch()) {
-                    echo '<tr class="'.(($listener['receiveNotificationEmails'] == 'N')? 'warning' : '').'">';
-                    echo '<td>';
-                    echo Format::name($listener['title'], $listener['preferredName'], $listener['surname'], 'Staff', false, true);
-                    echo '</td>';
-                    echo '<td>';
-                    echo ynExpander($guid, $listener['receiveNotificationEmails']);
-                    echo '</td>';
-                    echo '<td>';
+            $table->modifyRows(function ($listener, $row) {
+                if ($listener['status'] <> 'Full') $row->addClass('error');
+                if ($listener['receiveNotificationEmails'] == 'N') $row->addClass('warning');
+                return $row;
+            });
 
-                    if ($listener['scopeType'] == 'All') {
-                        echo __('All');
-                    } else {
-                        switch($listener['scopeType']) {
-                            case 'gibbonPersonIDStudent':   $data = array('gibbonPersonID' => $listener['scopeID']);
-                                                            $sql = "SELECT 'Student' as scopeTypeName, CONCAT(surname, ' ', preferredName) as scopeIDName FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID";
-                                                            break;
+            $table->addColumn('name', __('Name'))
+                ->sortable(['surname', 'preferredName'])
+                ->format(function ($person) {
+                    return Format::name($person['title'], $person['preferredName'], $person['surname'], 'Staff', false, true)
+                        .'<br/>'.Format::small(Format::userStatusInfo($person));
+                });
 
-                            case 'gibbonYearGroupID':       $data = array('gibbonYearGroupID' => $listener['scopeID']);
-                                                            $sql = "SELECT 'Year Group' as scopeTypeName, name as scopeIDName FROM gibbonYearGroup WHERE gibbonYearGroupID=:gibbonYearGroupID";
-                                                            break;
+            $table->addColumn('receiveNotificationEmails', __('Receive Email Notifications?'))
+                ->setTitle(__('Notifications can always be viewed on screen.'))
+                ->width('15%')
+                ->format(Format::using('yesNo', 'receiveNotificationEmails'));
 
-                            default:                        $data = array();
-                                                            $sql = "SELECT 'Scope' as scopeTypeName, 'Unknown' as scopeIDName";
-                        }
+            $table->addColumn('scope', __('Scope'))->format(function ($listener) use (&$pdo) {
+                if ($listener['scopeType'] == 'All') {
+                    return __('All');
+                } else {
+                    switch($listener['scopeType']) {
+                        case 'gibbonPersonIDStudent':   $data = array('gibbonPersonID' => $listener['scopeID']);
+                                                        $sql = "SELECT 'Student' as scopeTypeName, CONCAT(surname, ' ', preferredName) as scopeIDName FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID";
+                                                        break;
 
-                        $resultScope = $pdo->executeQuery($data, $sql);
-                        if ($resultScope && $resultScope->rowCount() > 0) {
-                            $scopeDetails = $resultScope->fetch();
-                            echo __($scopeDetails['scopeTypeName']).' - '.$scopeDetails['scopeIDName'];
-                        }
+                        case 'gibbonYearGroupID':       $data = array('gibbonYearGroupID' => $listener['scopeID']);
+                                                        $sql = "SELECT 'Year Group' as scopeTypeName, name as scopeIDName FROM gibbonYearGroup WHERE gibbonYearGroupID=:gibbonYearGroupID";
+                                                        break;
+
+                        default:                        $data = array();
+                                                        $sql = "SELECT 'Scope' as scopeTypeName, 'Unknown' as scopeIDName";
                     }
 
-                    echo '</td>';
-                    echo '<td>';
-                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/notificationSettings_manage_listener_deleteProcess.php?gibbonNotificationEventID=".$listener['gibbonNotificationEventID']."&gibbonNotificationListenerID=".$listener['gibbonNotificationListenerID']."&address=".$_SESSION[$guid]['address']."'><img title='".__('Delete')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/garbage.png'/></a>";
-                    echo '</td>';
-                    echo '</tr>';
+                    $resultScope = $pdo->executeQuery($data, $sql);
+                    if ($resultScope && $resultScope->rowCount() > 0) {
+                        $scopeDetails = $resultScope->fetch();
+                        return __($scopeDetails['scopeTypeName']).' - '.$scopeDetails['scopeIDName'];
+                    }
+                    return'';
                 }
-                echo '</table>';
-            }
+            });
+
+            // ACTIONS
+            $table->addActionColumn()
+                ->addParam('gibbonNotificationEventID')
+                ->addParam('gibbonNotificationListenerID')
+                ->format(function ($listener, $actions) {
+                    $actions->addAction('deleteDirect', __('Delete'))
+                            ->setIcon('garbage')
+                            ->directLink()
+                            ->addParam('address', $_GET['q'])
+                            ->setURL('/modules/System Admin/notificationSettings_manage_listener_deleteProcess.php');
+                });
+
+            echo $table->render($result->toDataSet());
+            echo '<br/>';
 
             // Filter users who can have permissions for the notification event action
             $staffMembers = array();

--- a/src/Domain/System/NotificationGateway.php
+++ b/src/Domain/System/NotificationGateway.php
@@ -119,7 +119,7 @@ class NotificationGateway
     public function selectAllNotificationListeners($gibbonNotificationEventID, $groupByPerson = true)
     {
         $data = array('gibbonNotificationEventID' => $gibbonNotificationEventID);
-        $sql = "SELECT gibbonNotificationListener.*, gibbonPerson.surname, gibbonPerson.preferredName, gibbonPerson.title, gibbonPerson.receiveNotificationEmails
+        $sql = "SELECT gibbonNotificationListener.*, gibbonPerson.surname, gibbonPerson.preferredName, gibbonPerson.title, gibbonPerson.receiveNotificationEmails, gibbonPerson.status
                 FROM gibbonNotificationListener
                 JOIN gibbonNotificationEvent ON (gibbonNotificationListener.gibbonNotificationEventID=gibbonNotificationEvent.gibbonNotificationEventID)
                 JOIN gibbonPerson ON (gibbonNotificationListener.gibbonPersonID=gibbonPerson.gibbonPersonID)
@@ -140,8 +140,13 @@ class NotificationGateway
 
     public function selectNotificationListenersByScope($gibbonNotificationEventID, $scopes = array())
     {
-        $data = array('gibbonNotificationEventID' => $gibbonNotificationEventID);
-        $sql = "SELECT DISTINCT gibbonPersonID FROM gibbonNotificationListener WHERE gibbonNotificationEventID=:gibbonNotificationEventID";
+        $data = array('gibbonNotificationEventID' => $gibbonNotificationEventID, 'today' => date('Y-m-d'));
+        $sql = "SELECT DISTINCT gibbonPerson.gibbonPersonID FROM gibbonNotificationListener 
+                JOIN gibbonPerson ON (gibbonNotificationListener.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                WHERE gibbonNotificationEventID=:gibbonNotificationEventID
+                AND gibbonPerson.status='Full'
+                AND (gibbonPerson.dateStart IS NULL OR gibbonPerson.dateStart<=:today) 
+                AND (gibbonPerson.dateEnd IS NULL  OR gibbonPerson.dateEnd>=:today)";
 
         if (is_array($scopes) && count($scopes) > 0) {
             $sql .= " AND (scopeType='All' ";

--- a/src/Domain/System/NotificationGateway.php
+++ b/src/Domain/System/NotificationGateway.php
@@ -127,7 +127,7 @@ class NotificationGateway
                 JOIN gibbonPermission ON (gibbonRole.gibbonRoleID=gibbonPermission.gibbonRoleID)
                 JOIN gibbonAction ON (gibbonPermission.gibbonActionID=gibbonAction.gibbonActionID)
                 WHERE gibbonNotificationListener.gibbonNotificationEventID=:gibbonNotificationEventID
-                AND gibbonNotificationEvent.actionName=gibbonAction.name";
+                AND (gibbonNotificationEvent.actionName=gibbonAction.name OR gibbonAction.name LIKE CONCAT(gibbonNotificationEvent.actionName, '_%'))";
 
         if ($groupByPerson) {
             $sql .= " GROUP BY gibbonNotificationListener.gibbonPersonID";


### PR DESCRIPTION
- Fixes an issue where notification events were sending emails to non-Full users (oops!)
- Adjusts the handling of Permission Required to allow for grouped actions.
- OOifies the Edit Subscribers table, highlights left users so they can be removed.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
<img width="804" alt="Screen Shot 2019-09-09 at 12 08 43 PM" src="https://user-images.githubusercontent.com/897700/64502780-98e03c00-d2fa-11e9-92b0-5594dfc282cb.png">

