### PR TITLE
Attendance: update Student History to display class attendance

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ v19.0.00
         Attendance: added an option to record the first class attendance in a day as school-wide attendance
         Attendance: added an option to disable prefilling by attendance code, applied to Present - Late by default
         Attendance: added Consecutive Absence report to list all students who have been absent for the last N school days
+        Attendance: updated Student History to still display class attendance when countClassAsSchool in N
         Behaviour: new Copy To Notes feature
         Form Groups: added staff-only summary of Year Groups after Form Group listing
         Students: improved display of Teachers' emails in student profile

--- a/resources/templates/components/studentHistory.twig.html
+++ b/resources/templates/components/studentHistory.twig.html
@@ -89,7 +89,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
                         <div class="{{ blockWidth }} {{ dayClass }} bg-gray-400 border-gray-600 text-gray-500" title="{{ __('School Closed') }}">
                             {{ day.specialDay }}
                         </div>
-                    {% elseif day.logs is empty %}
+                    {% elseif day.logs is empty and day.classLogs is empty %}
                         <div class="{{ blockWidth }} {{ dayClass }} bg-gray-200 border-gray-600 text-gray-700" title="{{ __('No Data') }}">
                             {{ day.dateDisplay }}
                         </div>
@@ -139,13 +139,27 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
         {% endif %}
 
         <ul class='list-none ml-0 mt-4 text-xs text-left'>
-        {% for log in day.logs %}
-            <li class='{{ log.statusClass }} leading-relaxed'>
-                {{ log.timestampTaken|date( log.timestampTaken|date('Y-m-d') == day.date ? 'H:i' : 'H:i Y-m-d') }} -
-                {{ __(log.type) }} {{- log.reason ? ', ' ~ __(log.reason) }} - 
-                {{ log.contextName ? log.contextName : __(log.context) }}
-            </li>
-        {% endfor %}
+            <li class='text-xxs  font-bold'>{{ __('School Attendance') }}:</li>
+            {% for log in day.logs %}
+                <li class='{{ log.statusClass }} leading-relaxed'>
+                    {{ log.timestampTaken|date( log.timestampTaken|date('Y-m-d') == day.date ? 'H:i' : 'H:i Y-m-d') }} -
+                    {{ __(log.type) }} {{- log.reason ? ', ' ~ __(log.reason) }} - 
+                    {{ log.contextName ? log.contextName : __(log.context) }}
+                </li>
+            {% else %}
+                <li class='text-xxs'>{{ __('Not Available') }}</li>
+            {% endfor %}
+
+        {%if day.classLogs %}
+            <li class='text-xxs  font-bold mt-2'>{{ __('Class Attendance') }}:</li>
+            {% for log in day.classLogs %}
+                <li class='{{ log.statusClass }} leading-relaxed'>
+                    {{ log.timestampTaken|date( log.timestampTaken|date('Y-m-d') == day.date ? 'H:i' : 'H:i Y-m-d') }} -
+                    {{ __(log.type) }} {{- log.reason ? ', ' ~ __(log.reason) }} - 
+                    {{ log.contextName ? log.contextName : __(log.context) }}
+                </li>
+            {% endfor %}
+        {% endif %}
     </section>
 {% endmacro tooltip %}
 

--- a/src/Domain/Attendance/AttendanceLogPersonGateway.php
+++ b/src/Domain/Attendance/AttendanceLogPersonGateway.php
@@ -108,7 +108,7 @@ class AttendanceLogPersonGateway extends QueryableGateway
         return $this->runQuery($query, $criteria);
     }
 
-    public function selectAllAttendanceLogsByPerson($gibbonSchoolYearID, $gibbonPersonID, $countClassAsSchool)
+    public function selectAllAttendanceLogsByPerson($gibbonSchoolYearID, $gibbonPersonID)
     {
         $query = $this
             ->newSelect()
@@ -125,10 +125,6 @@ class AttendanceLogPersonGateway extends QueryableGateway
             ->where('gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID')
             ->bindValue('gibbonPersonID', $gibbonPersonID)
             ->orderBy(['timestampTaken ASC']);
-
-        if ($countClassAsSchool == 'N') {
-            $query->where("NOT gibbonAttendanceLogPerson.context='Class'");
-        }
 
         return $this->runSelect($query);
     }


### PR DESCRIPTION
Currently, student attendance history does not display class attendance when countClassAsSchool is N. This means taking class attendance for informational purposes is less useful. Even though it's not prefilled or counted as school attendance, it's still handy to be able to see that it exists. 

This PR:
- Highlights days as Incomplete when school attendance has not been taken, but class attendance has. Previously, these showed as No Data, even when there was class data.
- Adds a list of class attendance below school attendance if countClassAsSchool is N.
- Labels and visually separates School Attendance and Class Attendance.
- Enables the badge count when attendance logs differ from the end-of-day status.
- No change if countClassAsSchool is Y.

**Motivation and Context**
Even when class attendance doesn't count as school-wide, people are still interested in having a way to quickly see the class attendance, as well as spot inconsistencies between statuses (eg: Present school-wide and Absent from class). This PR doesn't change the logic for determining end of day, it just adds a visual display of the class attendance after the school attendance. 

**How Has This Been Tested?**
Locally and in production.

**Screenshots**
School attendance and class attendance are labelled and listed separately:
<img width="300" alt="Screen Shot 2019-09-09 at 12 39 24 PM" src="https://user-images.githubusercontent.com/897700/64505120-5bcd7700-d305-11e9-9eb9-f36f7fce5649.png">

An example of an incomplete record, where school-wide attendance was not recorded, but class attendance was:
<img width="308" alt="Screen Shot 2019-09-09 at 12 52 51 PM" src="https://user-images.githubusercontent.com/897700/64504863-3e4bdd80-d304-11e9-9fd8-17feac8379ee.png">