### PR TITLE
Activities: add a Year Group filter in Manage Activities

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ v19.0.00
     Tweaks & Additions
         System: added Maldivian Rufiyaa as a currency option
         System: update DatePicker to use gibboni18n date format
+        Activities: added a Year Group filter in Manage Activities
         Attendance: added an option to record the first class attendance in a day as school-wide attendance
         Attendance: added an option to disable prefilling by attendance code, applied to Present - Late by default
         Attendance: added Consecutive Absence report to list all students who have been absent for the last N school days

--- a/modules/Activities/activities_manage.php
+++ b/modules/Activities/activities_manage.php
@@ -22,6 +22,7 @@ use Gibbon\Forms\Prefab\BulkActionForm;
 use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
+use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -39,8 +40,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         returnProcess($guid, $_GET['return'], null, null);
     }
 
-    $search = isset($_GET['search'])? $_GET['search'] : '';
-    $gibbonSchoolYearTermID = isset($_GET['gibbonSchoolYearTermID'])? $_GET['gibbonSchoolYearTermID'] : '';
+    $search = $_GET['search'] ?? '';
+    $gibbonSchoolYearTermID = $_GET['gibbonSchoolYearTermID'] ?? '';
+    $gibbonYearGroupID = $_GET['gibbonYearGroupID'] ?? '';
     $dateType = getSettingByScope($connection2, 'Activities', 'dateType');
     $enrolmentType = getSettingByScope($connection2, 'Activities', 'enrolmentType');
     $schoolTerms = getTerms($connection2, $_SESSION[$guid]['gibbonSchoolYearID']);
@@ -52,6 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     $criteria = $activityGateway->newQueryCriteria()
         ->searchBy($activityGateway->getSearchableColumns(), $search)
         ->filterBy('term', $gibbonSchoolYearTermID)
+        ->filterBy('yearGroup', $gibbonYearGroupID)
         ->sortBy($dateType != 'Date' ? 'gibbonSchoolYearTermIDList' : 'programStart', $dateType != 'Date' ? 'ASC' : 'DESC')
         ->sortBy('name');
 
@@ -64,6 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     $paymentOn = getSettingByScope($connection2, 'Activities', 'payment') != 'None' and getSettingByScope($connection2, 'Activities', 'payment') != 'Single';
 
     $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->setClass('noIntBorder fullWidth');
 
     $form->addHiddenValue('q', "/modules/".$_SESSION[$guid]['module']."/activities_manage.php");
@@ -79,6 +83,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             $row->addLabel('gibbonSchoolYearTermID', __('Term'));
             $row->addSelect('gibbonSchoolYearTermID')->fromQuery($pdo, $sql, $data)->selected($gibbonSchoolYearTermID)->placeholder();
     }
+
+    $row = $form->addRow();
+        $row->addLabel('gibbonYearGroupID', __('Year Group'));
+        $row->addSelectYearGroup('gibbonYearGroupID')->placeholder()->selected($gibbonYearGroupID);
 
     $row = $form->addRow();
         $row->addSearchSubmit($gibbon->session, __('Clear Search'));

--- a/modules/Activities/activities_manage.php
+++ b/modules/Activities/activities_manage.php
@@ -205,7 +205,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
     $table->addColumn('enrolment', __('Enrolment'))
         ->format(function($activity) {
-            return $activity['enrolment'] 
+            return $activity['enrolment'] .' / '. $activity['maxParticipants']
                 . (!empty($activity['waiting'])? '<br><small><i>' .$activity['waiting'].' '.__('Waiting') .'</i></small>' : '')
                 . (!empty($activity['pending'])? '<br><small><i>' .$activity['pending'].' '.__('Pending') .'</i></small>' : '');
         });

--- a/src/Domain/Activities/ActivityGateway.php
+++ b/src/Domain/Activities/ActivityGateway.php
@@ -87,6 +87,11 @@ class ActivityGateway extends QueryableGateway
                 if ($status == 'pending') $query->having('pending > 0');
                 return $query;
             },
+            'yearGroup' => function ($query, $gibbonYearGroupID) {
+                return $query
+                    ->where('FIND_IN_SET(:gibbonYearGroupID, gibbonActivity.gibbonYearGroupIDList)')
+                    ->bindValue('gibbonYearGroupID', $gibbonYearGroupID);
+            },
         ]);
 
         return $this->runQuery($query, $criteria);


### PR DESCRIPTION
In large schools with many year levels, it can become hard to manage a large number of activities. This filter helps those who manage activities to quickly filter the list down by year group. It also adds the max participant count next to the enrolment count, so it's easier to see available spaces.

**Screenshots**
<img width="803" alt="Screen Shot 2019-09-10 at 2 54 51 PM" src="https://user-images.githubusercontent.com/897700/64590809-f6e45080-d3da-11e9-934e-0c625974d416.png">

