### PR TITLE
Messenger: add a Copy to Next Year bulk-option for Manage Groups

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ v19.0.00
         Attendance: updated Student History to still display class attendance when countClassAsSchool in N
         Behaviour: new Copy To Notes feature
         Form Groups: added staff-only summary of Year Groups after Form Group listing
+        Messenger: added a Copy to Next Year bulk-option for Manage Groups
         Students: improved display of Teachers' emails in student profile
         Students: added extra permission allowing editing of all Notes
         Timetable Admin: included student reportable flag in student enrolment

--- a/modules/Messenger/groups_manageProcessBulk.php
+++ b/modules/Messenger/groups_manageProcessBulk.php
@@ -1,0 +1,73 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Messenger\GroupGateway;
+
+include '../../gibbon.php';
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage.php";
+
+if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $action = $_POST['action'] ?? '';
+    $gibbonGroupIDList = $_POST['gibbonGroupIDList'] ?? '';
+    $gibbonSchoolYearIDCopyTo = $_POST['gibbonSchoolYearIDCopyTo'] ?? array();
+
+    if (empty($action) || empty($gibbonSchoolYearIDCopyTo) || empty($gibbonGroupIDList)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    } else {
+        $groupGateway = $container->get(GroupGateway::class);
+        $partialFail = false;
+
+        foreach ($gibbonGroupIDList as $gibbonGroupID) {
+            $data = $groupGateway->getByID($gibbonGroupID);
+            $data['gibbonSchoolYearID'] = $gibbonSchoolYearIDCopyTo;
+
+            // Copy groups to selected year
+            $inserted = $groupGateway->insert($data);
+            $partialFail &= !$inserted;
+
+            // Optionally add members to new group
+            if ($inserted && $action == 'CopyMembers') {
+                $members = $groupGateway->selectPersonIDsByGroup($gibbonGroupID)->fetchAll();
+                if (empty($members)) continue;
+
+                foreach ($members as $member) {
+                    $insertedMember = $groupGateway->insertGroupPerson([
+                        'gibbonGroupID' => $inserted,
+                        'gibbonPersonID' => $member['gibbonPersonID'],
+                    ]);
+                    $partialFail &= !$insertedMember;
+                }
+            }
+        }
+
+        $URL .= $partialFail
+            ? "&return=warning1"
+            : "&return=success0";
+
+        header("Location: {$URL}");
+    }
+}

--- a/src/Domain/Messenger/GroupGateway.php
+++ b/src/Domain/Messenger/GroupGateway.php
@@ -34,6 +34,7 @@ class GroupGateway extends QueryableGateway
     use TableAware;
 
     private static $tableName = 'gibbonGroup';
+    private static $primaryKey = 'gibbonGroupID';
     private static $searchableColumns = ['gibbonGroup.name'];
     
     /**


### PR DESCRIPTION
Adds a bulk action to Manage Groups so they can be selectively copied to future years. Currently, groups are tied to a particular school year, and it's handy to be able to bump them forward to a new year, particularly when they're being used in conjunction with the staff absence notification feature.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="802" alt="Screen Shot 2019-09-10 at 3 46 22 PM" src="https://user-images.githubusercontent.com/897700/64594220-2ea2c680-d3e2-11e9-97a0-adeb8c8ed339.png">

