### PR TITLE
Attendance: fix Set Future Absence to only allow future dates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,7 @@ v19.0.00
         System: fixed Notification Events to only send to users who have status Full
         Activities: improved interface string advising users of disabled external activity registration
         Attendance: fixed missing data in printable view of Student History
+        Attendance: fixed Set Future Absence to only allow future dates
         Finance: fixed missing payment info in invoice receipt email for multiple partial payments
         Library: set Bookable to No by default on Add record screen
         Messenger: fixed bug when sending parent and student SMS for Attendance status

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
         $form->toggleVisibilityByClass('partialDateRow')->onSelect('absenceType')->when('partial');
         $row = $form->addRow()->addClass('partialDateRow');
             $row->addLabel('date', __('Date'));
-            $row->addDate('date')->required()->setValue($date);
+            $row->addDate('date')->required()->setValue($date)->minimum(date('Y-m-d', strtotime('today +1 day')));
     }
 
     $form->addRow()->addSearchSubmit($gibbon->session);
@@ -108,6 +108,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
     if(!empty($gibbonPersonID)) {
         $today = date('Y-m-d');
         $attendanceLog = '';
+
+        if (!empty($date) && Format::dateConvert($date) <= $today) {
+            echo Format::alert(__('The specified date is not in the future, or is not a school day.'), 'error');
+            return;
+        }
 
         if ($scope == 'single') {
             $attendanceLog .= "<div id='attendanceLog'>";
@@ -204,7 +209,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
         if ($absenceType == 'full') {
             $row = $form->addRow();
                 $row->addLabel('dateStart', __('Start Date'));
-                $row->addDate('dateStart')->required();
+                $row->addDate('dateStart')->required()->minimum(date('Y-m-d', strtotime('today +1 day')));
 
             $row = $form->addRow();
                 $row->addLabel('dateEnd', __('End Date'));

--- a/modules/Attendance/attendance_future_byPersonProcess.php
+++ b/modules/Attendance/attendance_future_byPersonProcess.php
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
             $today = date('Y-m-d');
 
             //Check to see if date is in the future and is a school day.
-            if ($dateStart == '' or ($dateEnd != '' and $dateEnd < $dateStart) or $dateStart < $today ) {
+            if ($dateStart == '' or ($dateEnd != '' and $dateEnd < $dateStart) or $dateStart <= $today) {
                 $URL .= '&return=error8';
                 header("Location: {$URL}");
             } else {


### PR DESCRIPTION
- Fixes the date check in attendance_future_byPersonProcess to not allow the current date.
- Applies the Date class `minimum()` method to the dates in Set Future Absence to ensure they only allow future dates:
  Eg:
  <img width="222" alt="Screen Shot 2019-09-12 at 2 29 08 PM" src="https://user-images.githubusercontent.com/897700/64760743-0b585280-d56d-11e9-9a9b-c7075aa64e73.png">

