### PR TITLE
Staff: fix Delete Staff Absence to also delete any related coverage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -58,6 +58,7 @@ v19.0.00
         Planner: fixed non-functional Smart Block Template setting
         Planner: fixed Unit Planner bug causing actions to appear in Classes table for newly created units
         Staff: fixed Cancel Coverage button not available for future coverage
+        Staff: fixed Delete Staff Absence to also delete any related coverage
         Students: adjusted official name size in ID card for long-named students
 
 v18.0.01

--- a/modules/Staff/absences_manage_deleteProcess.php
+++ b/modules/Staff/absences_manage_deleteProcess.php
@@ -19,6 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Domain\Staff\StaffAbsenceGateway;
 use Gibbon\Domain\Staff\StaffAbsenceDateGateway;
+use Gibbon\Domain\Staff\StaffCoverageGateway;
+use Gibbon\Domain\Staff\StaffCoverageDateGateway;
 
 $_POST['address'] = '/modules/Staff/absences_manage.php';
 $gibbonStaffAbsenceID = $_GET['gibbonStaffAbsenceID'] ?? '';
@@ -50,7 +52,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_manage_dele
     $absenceDates = $staffAbsenceDateGateway->selectDatesByAbsence($gibbonStaffAbsenceID)->fetchAll();
     $partialFail = false;
 
-    // Delete each date first
+    // First delete any coverage attached to this absence
+    $partialFail &= $container->get(StaffCoverageDateGateway::class)->deleteCoverageDatesByAbsenceID($gibbonStaffAbsenceID);
+    $partialFail &= $container->get(StaffCoverageGateway::class)->deleteCoverageByAbsenceID($gibbonStaffAbsenceID);
+
+    // Delete each absence date
     foreach ($absenceDates as $log) {
         $partialFail &= $staffAbsenceDateGateway->delete($log['gibbonStaffAbsenceDateID']);
     }

--- a/src/Domain/Staff/StaffCoverageDateGateway.php
+++ b/src/Domain/Staff/StaffCoverageDateGateway.php
@@ -51,4 +51,14 @@ class StaffCoverageDateGateway extends QueryableGateway
 
         return $this->db()->select($sql, $data);
     }
+
+    public function deleteCoverageDatesByAbsenceID($gibbonStaffAbsenceID)
+    {
+        $data = ['gibbonStaffAbsenceID' => $gibbonStaffAbsenceID];
+        $sql = "DELETE gibbonStaffCoverageDate FROM gibbonStaffCoverageDate
+                JOIN gibbonStaffAbsenceDate ON (gibbonStaffAbsenceDate.gibbonStaffAbsenceDateID=gibbonStaffCoverageDate.gibbonStaffAbsenceDateID)
+                WHERE gibbonStaffAbsenceDate.gibbonStaffAbsenceID = :gibbonStaffAbsenceID";
+
+        return $this->db()->delete($sql, $data);
+    }
 }

--- a/src/Domain/Staff/StaffCoverageGateway.php
+++ b/src/Domain/Staff/StaffCoverageGateway.php
@@ -204,6 +204,15 @@ class StaffCoverageGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
+    public function deleteCoverageByAbsenceID($gibbonStaffAbsenceID)
+    {
+        $data = ['gibbonStaffAbsenceID' => $gibbonStaffAbsenceID];
+        $sql = "DELETE FROM gibbonStaffCoverage
+                WHERE gibbonStaffCoverage.gibbonStaffAbsenceID = :gibbonStaffAbsenceID";
+
+        return $this->db()->delete($sql, $data);
+    }
+
     protected function getSharedFilterRules()
     {
         return [


### PR DESCRIPTION
Bug fix. If a staff absence is removed the coverage attached to that absence also needs cleaned up so there's no orphaned records.