### PR TITLE
Staff: add a Weekly View and Daily View to Substitute Availability

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ v19.0.00
         Behaviour: new Copy To Notes feature
         Form Groups: added staff-only summary of Year Groups after Form Group listing
         Messenger: added a Copy to Next Year bulk-option for Manage Groups
+        Staff: added a Weekly View and Daily View to Substitute Availability report
         Students: improved display of Teachers' emails in student profile
         Students: added extra permission allowing editing of all Notes
         Students: adjusted Privacy options to display even if blurb is not set

--- a/modules/Staff/report_subs_availability.php
+++ b/modules/Staff/report_subs_availability.php
@@ -20,8 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
-use Gibbon\Domain\Staff\SubstituteGateway;
 use Gibbon\Domain\DataSet;
+use Gibbon\Domain\Staff\SubstituteGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availability.php') == false) {
     // Access denied
@@ -30,20 +30,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     echo '</div>';
 } else {
     // Proceed!
-    $page->breadcrumbs->add(__('Substitute Availability'));
+    $page->breadcrumbs
+        ->add(__('Substitute Availability'), 'report_subs_availability.php')
+        ->add(__('Daily'));
 
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);
     }
 
     $date = isset($_GET['date']) ? Format::dateConvert($_GET['date']) : date('Y-m-d');
+    $dateObject = new DateTimeImmutable($date);
+    $dateFormat = $_SESSION[$guid]['i18n']['dateFormatPHP'];
+
     $allDay = $_GET['allDay'] ?? null;
     $timeStart = $_GET['timeStart'] ?? null;
     $timeEnd = $_GET['timeEnd'] ?? null;
     $allStaff = $_GET['allStaff'] ?? false;
 
     $subGateway = $container->get(SubstituteGateway::class);
-
+    
     // CRITERIA
     $criteria = $subGateway->newQueryCriteria()
         ->sortBy('gibbonSubstitute.priority', 'DESC')
@@ -58,6 +63,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     $form->setClass('noIntBorder fullWidth');
 
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+    $form->addHiddenValue('sidebar', $_GET['sidebar'] ?? '');
     $form->addHiddenValue('q', '/modules/'.$_SESSION[$guid]['module'].'/report_subs_availability.php');
 
     $row = $form->addRow();
@@ -105,11 +111,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     }
 
     $subs = $subGateway->queryAvailableSubsByDate($criteria, $date, $timeStart, $timeEnd);
-
     
     // DATA TABLE
     $table = DataTable::createPaginated('subsManage', $criteria);
     $table->setTitle(__('Substitute Availability'));
+    $table->setDescription(Format::dateReadable($dateObject->format('Y-m-d'), '%A, %b %e'));
+
+    $table->addHeaderAction('calendar', __('Weekly').' '.__('View'))
+        ->setIcon('planner')
+        ->setURL('/modules/Staff/report_subs_availabilityWeekly.php')
+        ->addParam('sidebar', 'false')
+        ->addParam('date', Format::date($date))
+        ->displayLabel();
 
     $table->modifyRows(function ($values, $row) {
         if ($values['available'] == false) $row->addClass('error');
@@ -118,11 +131,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
 
     // COLUMNS
     $table->addColumn('image_240', __('Photo'))
+        ->context('primary')
         ->width('10%')
         ->notSortable()
         ->format(Format::using('userPhoto', 'image_240'));
 
     $table->addColumn('fullName', __('Name'))
+        ->context('primary')
         ->description(__('Priority'))
         ->sortable(['surname', 'preferredName'])
         ->format(function ($person) use ($guid) {
@@ -137,6 +152,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     $table->addColumn('details', __('Details'));
 
     $table->addColumn('contact', __('Contact'))
+        ->context('primary')
         ->notSortable()
         ->format(function ($person) {
             $output = '';

--- a/modules/Staff/report_subs_availabilityWeekly.php
+++ b/modules/Staff/report_subs_availabilityWeekly.php
@@ -1,0 +1,182 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Tables\DataTable;
+use Gibbon\Services\Format;
+use Gibbon\Domain\DataSet;
+use Gibbon\Domain\Staff\SubstituteGateway;
+
+if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availability.php') == false) {
+    // Access denied
+    echo "<div class='error'>";
+    echo __('You do not have access to this action.');
+    echo '</div>';
+} else {
+    // Proceed!
+    $page->breadcrumbs
+        ->add(__('Substitute Availability'), 'report_subs_availability.php')
+        ->add(__('Weekly'));
+
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
+    $date = isset($_GET['date']) ? Format::dateConvert($_GET['date']) : date('Y-m-d');
+    $dateObject = new DateTimeImmutable($date);
+    $dateFormat = $_SESSION[$guid]['i18n']['dateFormatPHP'];
+
+    $subGateway = $container->get(SubstituteGateway::class);
+    
+    // DATE SELECTOR
+    $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Staff/report_subs_availabilityWeekly.php&sidebar=false');
+    $form->setClass('blank fullWidth');
+    $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+
+    $row = $form->addRow()->addClass('flex flex-wrap');
+
+    $link = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Staff/report_subs_availabilityWeekly.php&sidebar=false';
+
+    $lastWeek = $dateObject->modify('-1 week')->format($dateFormat);
+    $thisWeek = (new DateTimeImmutable('Today'))->format($dateFormat);
+    $nextWeek = $dateObject->modify('+1 week')->format($dateFormat);
+
+    $col = $row->addColumn()->addClass('flex items-center ');
+        $col->addButton(__('Last Week'))->addClass('')->onClick("window.location.href='{$link}&date={$lastWeek}'");
+        $col->addButton(__('This Week'))->addClass('ml-px')->onClick("window.location.href='{$link}&date={$thisWeek}'");
+        $col->addButton(__('Next Week'))->addClass('ml-px')->onClick("window.location.href='{$link}&date={$nextWeek}'");
+
+    $col = $row->addColumn()->addClass('flex items-center justify-end');
+        $col->addDate('date')->setValue($dateObject->format($dateFormat))->setClass('shortWidth');
+        $col->addSubmit(__('Go'));
+
+    // DATA
+    $firstDayOfTheWeek = getSettingByScope($connection2, 'System', 'firstDayOfTheWeek');
+    $dateStart = $dateObject->modify($firstDayOfTheWeek == 'Monday' ? "Monday this week" : "Sunday last week");
+    $dateEnd = $dateObject->modify($firstDayOfTheWeek == 'Monday' ? "Monday next week" : "Sunday this week");
+
+    $criteria = $subGateway->newQueryCriteria()
+        ->sortBy('priority', 'DESC')
+        ->sortBy(['type', 'surname', 'preferredName'])
+        ->filterBy('active', 'Y')
+        ->fromPOST();
+
+    // Get all subs
+    $subs = $subGateway->queryAllSubstitutes($criteria)->toArray();
+    $subs = array_reduce($subs, function ($group, $item) {
+        $group[$item['gibbonPersonID']] = $item;
+        return $group;
+    }, []);
+
+    // Attach availability info to each sub
+    $availability = $subGateway->selectUnavailableDatesByDateRange($dateStart->format('Y-m-d'), $dateEnd->format('Y-m-d'))->fetchAll();
+    $subsAvailability = array_reduce($availability, function ($group, $item) {
+        $gibbonPersonID = str_pad($item['gibbonPersonID'], 10, '0', STR_PAD_LEFT);
+        $group[$gibbonPersonID]['dates'][$item['date']][] = $item;
+        return $group;
+    }, $subs);
+
+    // CALENDAR VIEW
+    $table = DataTable::createPaginated('subsManage', $criteria);
+    $table->setTitle(__('Substitute Availability'));
+    $table->setDescription($form->getOutput());
+
+    $table->addHeaderAction('daily', __('Daily').' '.__('View'))
+        ->setIcon('rubric')
+        ->setURL('/modules/Staff/report_subs_availability.php')
+        ->addParam('date', Format::date($date))
+        ->displayLabel();
+
+    $table->addColumn('image_240', __('Photo'))
+        ->context('primary')
+        ->width('6%')
+        ->notSortable()
+        ->format(Format::using('userPhoto', ['image_240', '125', 'w-12 p-px']));
+
+    $table->addColumn('fullName', __('Name'))
+        ->context('primary')
+        ->description(__('Type'))
+        ->width('10%')
+        ->sortable(['surname', 'preferredName'])
+        ->format(function ($person) {
+            $name = Format::name($person['title'], $person['preferredName'], $person['surname'], 'Staff', true, true);
+            $url = './index.php?q=/modules/Staff/coverage_manage.php&search='.$person['username'].'+date:upcoming';
+
+            return Format::link($url, $name).'<br/>'.Format::small($person['type']);
+        });
+
+    $dateRange = new DatePeriod($dateStart, new DateInterval('P1D'), $dateEnd);
+
+    foreach ($dateRange as $weekday) {
+        if (!isSchoolOpen($guid, $weekday->format('Y-m-d'), $connection2)) continue;
+
+        $url = './index.php?q=/modules/Staff/report_subs_availability.php&date='.Format::date($weekday);
+        $columnTitle = Format::link($url, Format::dateReadable($weekday->format('Y-m-d'), '%a, %b %e'));
+
+        $table->addColumn($weekday->format('D'), $columnTitle)
+            ->context('primary')
+            ->notSortable()
+            ->description(Format::date($weekday))
+            ->format(function ($values) use ($weekday) {
+                $availabilityByDate = $values['dates'][$weekday->format('Y-m-d')] ?? [];
+
+                $title = '';
+                foreach ($availabilityByDate as $availability) {
+                    $title .= $availability['status'].': ';
+                    $title .= $availability['allDay'] == 'N'
+                        ? Format::timeRange($availability['timeStart'], $availability['timeEnd'])
+                        : __('All Day');
+                    $title .= '<br/>';
+                }
+
+                $output = '<div class="flex h-12 border" style="min-width: 8rem;" title="'.$title.'">';
+
+                $timeRange = new DatePeriod($weekday->modify('8:30am'), new DateInterval('PT10M'), $weekday->modify('4pm'));
+
+                foreach ($timeRange as $time) {
+                    $class = 'bg-white';
+
+                    $timeStart = $time->format('H:i:s');
+                    $timeEnd = $time->modify('+9 minutes')->format('H:i:s');
+
+                    foreach ($availabilityByDate as $availability) {
+                        switch ($availability['status']) {
+                            case 'Not Available':   $highlight = 'bg-gray-500'; break;
+                            case 'Absent':          $highlight = 'bg-gray-500'; break;
+                            case 'Teaching':        $highlight = 'bg-blue-500'; break;
+                            default:                $highlight = 'bg-purple-500';
+                        }
+
+                        if ($availability['allDay'] == 'Y') $class = $highlight;
+                        if ($timeStart <= $availability['timeEnd'] && $timeEnd >= $availability['timeStart']) $class = $highlight;
+                    }
+                    $output .= '<div class="flex-1 '.$class.'"></div>';
+                }
+                $output .= '</div>';
+
+                return $output;
+            })
+            ->modifyCells(function ($values, $cell) use ($weekday) {
+                if ($weekday->format('Y-m-d') == date('Y-m-d')) $cell->addClass('bg-yellow-100');
+                return $cell;
+            });
+    }
+
+    echo $table->render(new DataSet($subsAvailability));
+}

--- a/modules/Staff/report_subs_availabilityWeekly.php
+++ b/modules/Staff/report_subs_availabilityWeekly.php
@@ -22,6 +22,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\DataSet;
 use Gibbon\Domain\Staff\SubstituteGateway;
+use Gibbon\Module\Staff\Tables\CoverageMiniCalendar;
 
 if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availability.php') == false) {
     // Access denied
@@ -134,43 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
             ->notSortable()
             ->description(Format::date($weekday))
             ->format(function ($values) use ($weekday) {
-                $availabilityByDate = $values['dates'][$weekday->format('Y-m-d')] ?? [];
-
-                $title = '';
-                foreach ($availabilityByDate as $availability) {
-                    $title .= $availability['status'].': ';
-                    $title .= $availability['allDay'] == 'N'
-                        ? Format::timeRange($availability['timeStart'], $availability['timeEnd'])
-                        : __('All Day');
-                    $title .= '<br/>';
-                }
-
-                $output = '<div class="flex h-12 border" style="min-width: 8rem;" title="'.$title.'">';
-
-                $timeRange = new DatePeriod($weekday->modify('8:30am'), new DateInterval('PT10M'), $weekday->modify('4pm'));
-
-                foreach ($timeRange as $time) {
-                    $class = 'bg-white';
-
-                    $timeStart = $time->format('H:i:s');
-                    $timeEnd = $time->modify('+9 minutes')->format('H:i:s');
-
-                    foreach ($availabilityByDate as $availability) {
-                        switch ($availability['status']) {
-                            case 'Not Available':   $highlight = 'bg-gray-500'; break;
-                            case 'Absent':          $highlight = 'bg-gray-500'; break;
-                            case 'Teaching':        $highlight = 'bg-blue-500'; break;
-                            default:                $highlight = 'bg-purple-500';
-                        }
-
-                        if ($availability['allDay'] == 'Y') $class = $highlight;
-                        if ($timeStart <= $availability['timeEnd'] && $timeEnd >= $availability['timeStart']) $class = $highlight;
-                    }
-                    $output .= '<div class="flex-1 '.$class.'"></div>';
-                }
-                $output .= '</div>';
-
-                return $output;
+                return CoverageMiniCalendar::renderTimeRange($values['dates'][$weekday->format('Y-m-d')] ?? [], $weekday);
             })
             ->modifyCells(function ($values, $cell) use ($weekday) {
                 if ($weekday->format('Y-m-d') == date('Y-m-d')) $cell->addClass('bg-yellow-100');

--- a/modules/Staff/src/Tables/CoverageMiniCalendar.php
+++ b/modules/Staff/src/Tables/CoverageMiniCalendar.php
@@ -31,8 +31,8 @@ use DatePeriod;
  *
  * A reusable DataTable class for displaying coverage and availability in a colour-coded calendar view.
  *
- * @version v18
- * @since   v18
+ * @version v19
+ * @since   v19
  */
 class CoverageMiniCalendar
 {

--- a/modules/Staff/src/Tables/CoverageMiniCalendar.php
+++ b/modules/Staff/src/Tables/CoverageMiniCalendar.php
@@ -1,0 +1,77 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\Staff\Tables;
+
+use Gibbon\Services\Format;
+use Gibbon\Domain\DataSet;
+use Gibbon\Tables\DataTable;
+use DateTime;
+use DateInterval;
+use DatePeriod;
+
+/**
+ * CoverageMiniCalendar
+ *
+ * A reusable DataTable class for displaying coverage and availability in a colour-coded calendar view.
+ *
+ * @version v18
+ * @since   v18
+ */
+class CoverageMiniCalendar
+{
+    public static function renderTimeRange($availabilityByDate, $date)
+    {
+        $title = '';
+        foreach ($availabilityByDate as $availability) {
+            $title .= $availability['status'].': ';
+            $title .= $availability['allDay'] == 'N'
+                ? Format::timeRange($availability['timeStart'], $availability['timeEnd'])
+                : __('All Day');
+            $title .= '<br/>';
+        }
+
+        $output = '<div class="flex h-12 border" style="min-width: 8rem;" title="'.$title.'">';
+
+        $timeRange = new DatePeriod($date->modify('8:30am'), new DateInterval('PT10M'), $date->modify('4pm'));
+
+        foreach ($timeRange as $time) {
+            $class = 'bg-white';
+
+            $timeStart = $time->format('H:i:s');
+            $timeEnd = $time->modify('+9 minutes')->format('H:i:s');
+
+            foreach ($availabilityByDate as $availability) {
+                switch ($availability['status']) {
+                    case 'Not Available':   $highlight = 'bg-gray-500'; break;
+                    case 'Absent':          $highlight = 'bg-gray-500'; break;
+                    case 'Teaching':        $highlight = 'bg-blue-500'; break;
+                    default:                $highlight = 'bg-purple-500';
+                }
+
+                if ($availability['allDay'] == 'Y') $class = $highlight;
+                if ($timeStart <= $availability['timeEnd'] && $timeEnd >= $availability['timeStart']) $class = $highlight;
+            }
+            $output .= '<div class="flex-1 '.$class.'"></div>';
+        }
+        $output .= '</div>';
+
+        return $output;
+    }
+}

--- a/src/Domain/Staff/StaffCoverageGateway.php
+++ b/src/Domain/Staff/StaffCoverageGateway.php
@@ -36,7 +36,7 @@ class StaffCoverageGateway extends QueryableGateway
     private static $tableName = 'gibbonStaffCoverage';
     private static $primaryKey = 'gibbonStaffCoverageID';
 
-    private static $searchableColumns = ['absence.preferredName', 'absence.surname', 'coverage.preferredName', 'coverage.surname', 'status.preferredName', 'status.surname', 'gibbonStaffCoverage.status'];
+    private static $searchableColumns = ['absence.username', 'absence.preferredName', 'absence.surname', 'coverage.username', 'coverage.preferredName', 'coverage.surname', 'status.preferredName', 'status.surname', 'gibbonStaffCoverage.status'];
 
     /**
      * @param QueryCriteria $criteria

--- a/src/Domain/Staff/SubstituteGateway.php
+++ b/src/Domain/Staff/SubstituteGateway.php
@@ -51,7 +51,8 @@ class SubstituteGateway extends QueryableGateway
             ->from($this->getTableName())
             ->cols([
                 'gibbonSubstitute.gibbonSubstituteID', 'gibbonSubstitute.type', 'gibbonSubstitute.details', 'gibbonSubstitute.priority', 'gibbonSubstitute.active',
-                'gibbonPerson.gibbonPersonID', 'gibbonPerson.title', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonPerson.status', 'gibbonPerson.image_240', 'gibbonStaff.gibbonStaffID'
+                'gibbonPerson.gibbonPersonID', 'gibbonPerson.title', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonPerson.status', 'gibbonPerson.image_240', 'gibbonPerson.username',
+                'gibbonStaff.gibbonStaffID'
                 
             ])
             ->innerJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonSubstitute.gibbonPersonID')
@@ -230,7 +231,7 @@ class SubstituteGateway extends QueryableGateway
                   ->where('unavailable.gibbonStaffCoverageDateID IS NULL');
         } else {
             $query->groupBy(['gibbonPerson.gibbonPersonID']);
-            $query->orderBy(['available DESC']);
+            $query->orderBy(['available DESC', 'priority DESC']);
         }
 
         $criteria->addFilterRules([
@@ -278,6 +279,47 @@ class SubstituteGateway extends QueryableGateway
                     AND gibbonTTDay.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID)
                 WHERE gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassPerson.role = 'Teacher'
             )";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectUnavailableDatesByDateRange($dateStart, $dateEnd)
+    {
+        $data = ['dateStart' => $dateStart, 'dateEnd' => $dateEnd];
+        $sql = "(
+                SELECT gibbonStaffCoverageDate.gibbonPersonIDUnavailable as gibbonPersonID, gibbonStaffCoverageDate.date, 'Not Available' as status, allDay, timeStart, timeEnd, gibbonSubstitute.type, gibbonSubstitute.priority
+                FROM gibbonStaffCoverageDate 
+                JOIN gibbonSubstitute ON (gibbonSubstitute.gibbonPersonID=gibbonStaffCoverageDate.gibbonPersonIDUnavailable AND gibbonSubstitute.active='Y')
+                WHERE gibbonStaffCoverageDate.date BETWEEN :dateStart AND :dateEnd
+                AND gibbonSubstitute.gibbonSubstituteID IS NOT NULL
+            ) UNION ALL (
+                SELECT gibbonStaffCoverage.gibbonPersonIDCoverage as gibbonPersonID, gibbonStaffCoverageDate.date, 'Covering' as status, allDay, timeStart, timeEnd, gibbonSubstitute.type, gibbonSubstitute.priority
+                FROM gibbonStaffCoverage
+                JOIN gibbonStaffCoverageDate ON (gibbonStaffCoverageDate.gibbonStaffCoverageID=gibbonStaffCoverage.gibbonStaffCoverageID)
+                JOIN gibbonSubstitute ON (gibbonSubstitute.gibbonPersonID=gibbonStaffCoverage.gibbonPersonIDCoverage AND gibbonSubstitute.active='Y')
+                WHERE gibbonStaffCoverageDate.date BETWEEN :dateStart AND :dateEnd
+                AND (gibbonStaffCoverage.status='Accepted')
+                AND gibbonSubstitute.gibbonSubstituteID IS NOT NULL
+            ) UNION ALL (
+                SELECT gibbonStaffAbsence.gibbonPersonID as gibbonPersonID, gibbonStaffAbsenceDate.date, 'Absent' as status, allDay, timeStart, timeEnd, gibbonSubstitute.type, gibbonSubstitute.priority
+                FROM gibbonStaffAbsence
+                JOIN gibbonStaffAbsenceDate ON (gibbonStaffAbsenceDate.gibbonStaffAbsenceID=gibbonStaffAbsence.gibbonStaffAbsenceID)
+                JOIN gibbonSubstitute ON (gibbonSubstitute.gibbonPersonID=gibbonStaffAbsence.gibbonPersonID AND gibbonSubstitute.active='Y')
+                WHERE gibbonStaffAbsenceDate.date BETWEEN :dateStart AND :dateEnd
+                AND gibbonStaffAbsence.status <> 'Declined'
+                AND gibbonSubstitute.gibbonSubstituteID IS NOT NULL
+            ) UNION ALL (
+                SELECT DISTINCT gibbonCourseClassPerson.gibbonPersonID as gibbonPersonID, gibbonTTDayDate.date, 'Teaching' as status, 'N', timeStart, timeEnd, gibbonSubstitute.type, gibbonSubstitute.priority
+                FROM gibbonCourseClassPerson 
+                JOIN gibbonSubstitute ON (gibbonSubstitute.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonSubstitute.active='Y')
+                JOIN gibbonTTDayRowClass ON (gibbonTTDayRowClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID)
+                JOIN gibbonTTDayDate ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID)
+                JOIN gibbonTTDay ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayDate.gibbonTTDayID)
+                JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID 
+                    AND gibbonTTDay.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID)
+                WHERE gibbonTTDayDate.date BETWEEN :dateStart AND :dateEnd AND gibbonCourseClassPerson.role = 'Teacher'
+                AND gibbonSubstitute.gibbonSubstituteID IS NOT NULL
+            ) ORDER BY priority DESC, type DESC, date, timeStart, timeEnd";
 
         return $this->db()->select($sql, $data);
     }


### PR DESCRIPTION
The current Substitute Availability page only shows one day at a time. This PR updates it to have two views: a Daily View and a Weekly View. It also updates both views to have a fine-grained visual of the time a sub is booked and available for.

In this PR:
- Adds a CoverageMiniCalendar class to handle the display of availability by time.
  <img width="797" alt="Screen Shot 2019-09-16 at 2 37 31 PM" src="https://user-images.githubusercontent.com/897700/64938574-f2afab80-d890-11e9-99c3-a62cd0a8db19.png">
- Adds a Weekly View button to the original Substitute Availability report:
  <img width="126" alt="Screen Shot 2019-09-16 at 2 45 21 PM" src="https://user-images.githubusercontent.com/897700/64938473-a49aa800-d890-11e9-97cb-b9182a4d0a67.png">
- Adds a Weekly View page, with the option to switch back to Daily View:
  <img width="1132" alt="Screen Shot 2019-09-16 at 2 36 44 PM" src="https://user-images.githubusercontent.com/897700/64938506-b8460e80-d890-11e9-90e0-576092e46b7d.png">


**Motivation and Context**
Booking and managing subs in a large school can be hard! This PR aims to give school admins a more visual view of substitute coverage so they can easily spot availability.

**How Has This Been Tested?**
Locally and in production.