### PR TITLE
System: split Daily Attendance CLI into two separate scripts

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ v19.0.00
     Headlines
 
     Changes With Important Notices
+        System: split Daily Attendance CLI into separate form group and class scripts
 
     Significant Changes
         System: added Year Switcher to staff homepage sidebar


### PR DESCRIPTION
This PR splits the class attendance from the `attendance_dailyIncompleteEmail.php` script into a separate script `attendance_dailyIncompleteEmail_byClass.php`. This enables schools to schedule these CLI scripts to run at different times of the day. Generally, class attendance notifications must run at the end of the day to catch all classes, and form group attendance could optionally run earlier in the day.

Added under the "Changes With Important Notices" section in the CHANGELOG to let admins know to update their CLI schedule (if needed).
