### PR TITLE
Theme change message fixed and added translation support

### DIFF
--- a/modules/System Admin/theme_manage.php
+++ b/modules/System Admin/theme_manage.php
@@ -32,8 +32,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/theme_manage.
 
     $returns = array(
         'warning0' => __("Uninstall was successful. You will still need to remove the theme's files yourself."),
-        'success0' => __('Uninstall was successful.'),
         'success1' => __('Install was successful.'),
+        'success2' => __('Uninstall was successful.'),
         'error3'   => __('Your request failed because your manifest file was invalid.'),
         'error4'   => __('Your request failed because a theme with the same name is already installed.'),
     );

--- a/modules/System Admin/theme_manage_uninstall.php
+++ b/modules/System Admin/theme_manage_uninstall.php
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/theme_manage_
 
         if ($result->rowCount() != 1) {
             echo "<div class='error'>";
-            echo 'The specified theme cannot be found or is active and so cannot be removed.';
+            echo __('The specified theme cannot be found or is active and so cannot be removed.');
             echo '</div>';
         } else {
             $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/theme_manage_uninstallProcess.php?gibbonThemeID=$gibbonThemeID&orphaned=$orphaned");

--- a/modules/System Admin/theme_manage_uninstallProcess.php
+++ b/modules/System Admin/theme_manage_uninstallProcess.php
@@ -67,9 +67,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/theme_manage_
             }
 
             if ($orphaned != 'true') {
-                $URLDelete = $URLDelete.'&return=success0';
-            } else {
                 $URLDelete = $URLDelete.'&return=warning0';
+            } else {
+                $URLDelete = $URLDelete.'&return=success2';
             }
             header("Location: {$URLDelete}");
         }


### PR DESCRIPTION
**Motivation and Context**
When I changed active theme the message was "Uninstall was successful" and I changed for the default [success0] "Your request was completed successfully." and add translation support to message "The specified theme cannot be found or is active and so cannot be removed."

**How Has This Been Tested?**
Travis and Local
