### PR TITLE
School Admin: add drag-drop Year Group ordering

### DIFF
--- a/modules/School Admin/yearGroup_manage.php
+++ b/modules/School Admin/yearGroup_manage.php
@@ -39,6 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
     // QUERY
     $criteria = $yearGroupGateway->newQueryCriteria()
         ->sortBy(['sequenceNumber'])
+        ->pageSize(0)
         ->fromPOST();
 
     $yearGroups = $yearGroupGateway->queryYearGroups($criteria);
@@ -50,7 +51,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
         ->setURL('/modules/School Admin/yearGroup_manage_add.php')
         ->displayLabel();
 
-    $table->addColumn('sequenceNumber', __('sequenceNumber'));
+    $table->addDraggableColumn('gibbonYearGroupID', $gibbon->session->get('absoluteURL').'/modules/School Admin/yearGroup_manage_editOrderAjax.php');
+
     $table->addColumn('name', __('Name'));
     $table->addColumn('nameShort', __('Short Name'));
     $table->addColumn('gibbonPersonIDHOY', __('Head of Year'))

--- a/modules/School Admin/yearGroup_manage_editOrderAjax.php
+++ b/modules/School Admin/yearGroup_manage_editOrderAjax.php
@@ -1,0 +1,44 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\School\YearGroupGateway;
+
+$_POST['address'] = '/modules/School Admin/yearGroup_manage.php';
+
+require_once '../../gibbon.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_manage.php') == false) {
+    exit;
+} else {
+    // Proceed!
+    $data = $_POST['data'] ?? [];
+    $order = json_decode($_POST['order']);
+
+    if (empty($order)) {
+        exit;
+    } else {
+        $yearGroupGateway = $container->get(YearGroupGateway::class);
+
+        $count = 1;
+        foreach ($order as $gibbonYearGroupID) {
+            $updated = $yearGroupGateway->update($gibbonYearGroupID, ['sequenceNumber' => $count]);
+            $count++;
+        }
+    }
+}

--- a/src/Domain/School/YearGroupGateway.php
+++ b/src/Domain/School/YearGroupGateway.php
@@ -34,6 +34,7 @@ class YearGroupGateway extends QueryableGateway
     use TableAware;
 
     private static $tableName = 'gibbonYearGroup';
+    private static $primaryKey = 'gibbonYearGroupID';
     private static $searchableColumns = [];
 
     public function queryYearGroups(QueryCriteria $criteria)

--- a/src/Tables/Columns/DraggableColumn.php
+++ b/src/Tables/Columns/DraggableColumn.php
@@ -38,7 +38,7 @@ class DraggableColumn extends Column
         parent::__construct('draggable');
         $this->sortable(false)
              ->context('action')
-             ->width('1%; max-width: 1.8rem;');
+             ->width('3%; max-width: 1.8rem; min-width: 1.8rem;');
 
         $this->format(function ($values) {
             return '<div class="drag-handle w-2 h-6 ml-3 px-px border-4 border-dotted cursor-move"></div>';

--- a/src/Tables/View/PaginatedView.php
+++ b/src/Tables/View/PaginatedView.php
@@ -57,7 +57,8 @@ class PaginatedView extends DataTableView implements RendererInterface
     {
         $this->addData('table', $table);
         $this->addData('blankSlate', $table->getMetaData('blankSlate'));
-
+        $this->addData('draggable', $table->getMetaData('draggable'));
+        
         $this->preProcessTable($table);
         
         $filters = $table->getMetaData('filterOptions', []);


### PR DESCRIPTION
Updates the Manage Year Groups page as an example of drag-drop row ordering.

**Screenshots**
<img width="816" alt="Screen Shot 2019-09-27 at 3 29 54 PM" src="https://user-images.githubusercontent.com/897700/65750799-d129ac00-e13b-11e9-90dd-12e9a5fc1b52.png">

