### PR TITLE
Messenger naming option

### DIFF
--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -144,7 +144,7 @@ else {
 				$form->toggleVisibilityByClass('sms')->onRadio('sms')->when('Y');
 
 				$smsAlert = __('SMS messages are sent to local and overseas numbers, but not all countries are supported. Please see the SMS Gateway provider\'s documentation or error log to see which countries are not supported. The subject does not get sent, and all HTML tags are removed. Each message, to each recipient, will incur a charge (dependent on your SMS gateway provider). Messages over 140 characters will get broken into smaller messages, and will cost more.');
-                
+
                 $sms = $container->get(SMS::class);
 
                 if ($smsCredits = $sms->getCreditBalance()) {
@@ -225,25 +225,31 @@ else {
 	        $col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true)->setValue($signature);
 
 
+		$form->addRow()->addHeading(__('Customisation'));
+
 		//READ RECEIPTS
 		if (!isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_readReceipts")) {
 			$form->addHiddenValue('emailReceipt', 'N');
 		}
 		else {
-			$form->addRow()->addHeading(__('Email Read Receipts'));
-			$form->addRow()->addContent(__('With read receipts enabled, the text [confirmLink] can be included in a message to add a unique, login-free read receipt link. If [confirmLink] is not included, the link will be appended to the end of the message.'));
-
 			$row = $form->addRow();
 				$row->addLabel('emailReceipt', __('Enable Read Receipts'))->description(__('Each email recipient will receive a personalised confirmation link.'));
 				$row->addYesNoRadio('emailReceipt')->checked('N')->required();
 
 			$form->toggleVisibilityByClass('emailReceipt')->onRadio('emailReceipt')->when('Y');
 
+			$form->addRow()->addClass('emailReceipt')
+				->addContent(__('With read receipts enabled, the text [confirmLink] can be included in a message to add a unique, login-free read receipt link. If [confirmLink] is not included, the link will be appended to the end of the message.'));
+
 			$row = $form->addRow()->addClass('emailReceipt');
 				$row->addLabel('emailReceiptText', __('Link Text'))->description(__('Confirmation link text to display to recipient.'));
 				$row->addTextArea('emailReceiptText')->setRows(4)->required()->setValue(__('By clicking on this link I confirm that I have read, and agree to, the text contained within this email, and give consent for my child to participate.'));
-
 		}
+
+		//Individual naming
+		$row = $form->addRow();
+			$row->addLabel('individualNaming', __('Individual Naming'))->description(__('the names of relevant students will be preppended to messages.'));
+			$row->addYesNoRadio('individualNaming')->checked('N')->required();
 
 
 		//TARGETS
@@ -558,7 +564,7 @@ else {
                 $row->addLabel('attendanceParents', __('Include Parents?'));
                 $row->addYesNo('attendanceParents')->selected('Y');
 		}
-		
+
 		 // Group
 		 if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_any")) {
             $row = $form->addRow();

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -249,7 +249,7 @@ else {
 		//Individual naming
 		$row = $form->addRow();
 			$row->addLabel('individualNaming', __('Individual Naming'))->description(__('the names of relevant students will be preppended to messages.'));
-			$row->addYesNoRadio('individualNaming')->checked('N')->required();
+			$row->addYesNoRadio('individualNaming')->checked('Y')->required();
 
 
 		//TARGETS

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -248,7 +248,7 @@ else {
 
 		//Individual naming
 		$row = $form->addRow();
-			$row->addLabel('individualNaming', __('Individual Naming'))->description(__('the names of relevant students will be preppended to messages.'));
+			$row->addLabel('individualNaming', __('Individual Naming'))->description(__('The names of relevant students will be prepended to messages.'));
 			$row->addYesNoRadio('individualNaming')->checked('Y')->required();
 
 

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -100,10 +100,12 @@ else {
 		$body=stripslashes($_POST["body"]) ;
 		$emailReceipt = $_POST["emailReceipt"] ;
 		$emailReceiptText = null;
-		if (isset($_POST["emailReceiptText"]))
+		if (isset($_POST["emailReceiptText"])) {
 			$emailReceiptText = $_POST["emailReceiptText"] ;
+		}
+		$individualNaming = $_POST["individualNaming"] ;
 
-		if ($subject == "" OR $body == "" OR ($email == "Y" AND $from == "") OR $emailReceipt == '' OR ($emailReceipt == "Y" AND $emailReceiptText == "")) {
+		if ($subject == "" OR $body == "" OR ($email == "Y" AND $from == "") OR $emailReceipt == '' OR ($emailReceipt == "Y" AND $emailReceiptText == "") OR $individualNaming == "") {
 			//Fail 3
 			$URL.="&addReturn=fail3" ;
 			header("Location: {$URL}");
@@ -2047,18 +2049,20 @@ else {
 						}
 
 						//Deal with student names
-						$studentNames = '';
-						if ($reportEntry[7] != '') {
-							$lastComma = strrpos($reportEntry[7], ',');
-							if ($lastComma != false) {
-								$reportEntry[7] = substr_replace($reportEntry[7], ' &', $lastComma, 1);
-								$studentNames = '<i>'.__('This email relates to the following students: ').$reportEntry[7].'</i><br/><br/>';
+						if ($individualNaming == "Y") {
+							$studentNames = '';
+							if ($reportEntry[7] != '') {
+								$lastComma = strrpos($reportEntry[7], ',');
+								if ($lastComma != false) {
+									$reportEntry[7] = substr_replace($reportEntry[7], ' &', $lastComma, 1);
+									$studentNames = '<i>'.__('This email relates to the following students: ').$reportEntry[7].'</i><br/><br/>';
+								}
+								else {
+									$studentNames = '<i>'.__('This email relates to the following student: ').$reportEntry[7].'</i><br/><br/>';
+								}
 							}
-							else {
-								$studentNames = '<i>'.__('This email relates to the following student: ').$reportEntry[7].'</i><br/><br/>';
-							}
+							$bodyOut = $studentNames.$bodyOut;
 						}
-						$bodyOut = $studentNames.$bodyOut;
 
 						$mail->renderBody('mail/email.twig.html', [
 							'title'  => $subject,


### PR DESCRIPTION
**Description**
Makes individual naming optional, on by default.

**Motivation and Context**
Some times naming is not needed.

**How Has This Been Tested?**
Locally and in production

**Screenshots**
<img width="822" alt="Screenshot 2019-10-18 at 11 55 59 AM" src="https://user-images.githubusercontent.com/5436438/67064749-479b5600-f19e-11e9-9ba6-cd67c57ce480.png">

