### PR TITLE
Messenger: adjust the default sending options for non-staff users

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,7 +47,7 @@ v19.0.00
         Messenger: added a Copy to Next Year bulk-option for Manage Groups
         Messenger: eliminated non-recipient siblings from Send Report
         Messenger: addition of student name(s) to emails sent to parents
-        Messenger: adjust the default sending options for non-staff users
+        Messenger: adjusted the default sending options for non-staff users
         Staff: added a Weekly View and Daily View to Substitute Availability report
         Staff: added a Substitute Information setting for displaying text on My Coverage page
         Staff: added a Staff Coverage Summary report with total days covered per substitute
@@ -74,6 +74,7 @@ v19.0.00
         Finance: fixed missing payment info in invoice receipt email for multiple partial payments
         Library: set Bookable to No by default on Add record screen
         Messenger: fixed bug when sending parent and student SMS for Attendance status
+        Messenger: fixed bug where users could create a message with no available delivery options
         Planner: fixed non-functional Smart Block Template setting
         Planner: fixed Unit Planner bug causing actions to appear in Classes table for newly created units
         Staff: fixed Cancel Coverage button not available for future coverage

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ v19.0.00
         Messenger: added a Copy to Next Year bulk-option for Manage Groups
         Messenger: eliminated non-recipient siblings from Send Report
         Messenger: addition of student name(s) to emails sent to parents
+        Messenger: adjust the default sending options for non-staff users
         Staff: added a Weekly View and Daily View to Substitute Availability report
         Staff: added a Substitute Information setting for displaying text on My Coverage page
         Staff: added a Staff Coverage Summary report with total days covered per substitute


### PR DESCRIPTION
This PR makes some usability changes to the New Message screen:

- Adds a check to ensure that the user sending a message has at least one delivery mode available: Email, Wall or SMS. If they do not have a delivery mode, they cannot send a message, which prevents an odd behaviour where messages can be created but go nowhere.
- Adds a `$roleCategory == 'Staff'` check to the new Individual Naming feature. It feels like it may not be as useful for other users to have this option, and it helps reduce the overall interface clutter for non-staff users.
- Flips the default staff/student/parent values for Parent users. By default, parents will have Include Staff = N, Include Students = N, and Include Parents = Y. 
  <img width="787" alt="Screen Shot 2019-10-21 at 3 30 10 PM" src="https://user-images.githubusercontent.com/897700/67185310-1af27300-f418-11e9-9cd6-b8201dcc5b0d.png">


