### PR TITLE
Staff: fix View Absences to only show the current year by default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -83,6 +83,7 @@ v19.0.00
         Staff: limited open coverage requests to the type of sub requested
         Staff: fixed staff coverage date not removed when deleting absence date
         Staff: fixed multi-day coverage only showing one day on the timetable
+        Staff: fixed View Absences to only show the current year by default
         Students: adjusted official name size in ID card for long-named students
         Students: fixed timetable chooser not working on student profile pages
 

--- a/modules/Staff/absences_view_byPerson.php
+++ b/modules/Staff/absences_view_byPerson.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_view_byPers
     }
 
     
-    $absences = $staffAbsenceDateGateway->selectApprovedAbsenceDatesByPerson($gibbonPersonID)->fetchGrouped();
+    $absences = $staffAbsenceDateGateway->selectApprovedAbsenceDatesByPerson($gibbonSchoolYearID, $gibbonPersonID)->fetchGrouped();
     $schoolYear = $schoolYearGateway->getSchoolYearByID($gibbonSchoolYearID);
 
     // CALENDAR VIEW
@@ -100,6 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_view_byPers
     // QUERY
     $criteria = $staffAbsenceGateway->newQueryCriteria()
         ->sortBy('date', 'DESC')
+        ->filterBy('schoolYear', $gibbonSchoolYearID)
         ->fromPOST();
 
     $absences = $staffAbsenceGateway->queryAbsencesByPerson($criteria, $gibbonPersonID);
@@ -118,6 +119,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_view_byPers
         if ($absence['status'] == 'Declined') $row->addClass('dull');
         return $row;
     });
+
+    $table->addMetaData('filterOptions', [
+        'schoolYear:'.$gibbonSchoolYearID => __('School Year').': '.__('Current'),
+    ]);
 
     $table->addHeaderAction('add', __('New Absence'))
         ->setURL('/modules/Staff/absences_add.php')

--- a/src/Domain/Staff/StaffAbsenceDateGateway.php
+++ b/src/Domain/Staff/StaffAbsenceDateGateway.php
@@ -53,14 +53,15 @@ class StaffAbsenceDateGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
-    public function selectApprovedAbsenceDatesByPerson($gibbonPersonID)
+    public function selectApprovedAbsenceDatesByPerson($gibbonSchoolYearID, $gibbonPersonID)
     {
-        $data = ['gibbonPersonID' => $gibbonPersonID];
+        $data = ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonID' => $gibbonPersonID];
         $sql = "SELECT gibbonStaffAbsenceDate.date as groupBy, gibbonStaffAbsence.*, gibbonStaffAbsenceDate.*, gibbonStaffAbsenceType.name as type, gibbonStaffAbsenceType.sequenceNumber
                 FROM gibbonStaffAbsence 
                 JOIN gibbonStaffAbsenceDate ON (gibbonStaffAbsenceDate.gibbonStaffAbsenceID=gibbonStaffAbsence.gibbonStaffAbsenceID) 
                 JOIN gibbonStaffAbsenceType ON (gibbonStaffAbsenceType.gibbonStaffAbsenceTypeID=gibbonStaffAbsence.gibbonStaffAbsenceTypeID)
-                WHERE gibbonStaffAbsence.gibbonPersonID=:gibbonPersonID
+                WHERE gibbonStaffAbsence.gibbonSchoolYearID=:gibbonSchoolYearID
+                AND gibbonStaffAbsence.gibbonPersonID=:gibbonPersonID
                 AND gibbonStaffAbsence.status='Approved'
                 ORDER BY gibbonStaffAbsenceDate.date";
 

--- a/src/Domain/Staff/StaffAbsenceGateway.php
+++ b/src/Domain/Staff/StaffAbsenceGateway.php
@@ -102,6 +102,14 @@ class StaffAbsenceGateway extends QueryableGateway
 
         $criteria->addFilterRules($this->getSharedFilterRules());
 
+        $criteria->addFilterRules([
+            'schoolYear' => function ($query, $gibbonSchoolYearID) {
+                return $query
+                    ->where('gibbonStaffAbsence.gibbonSchoolYearID = :gibbonSchoolYearID')
+                    ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID);
+            }
+        ]);
+
         return $this->runQuery($query, $criteria);
     }
 


### PR DESCRIPTION
View Absences was accidentally showing all absences, regardless of the school year. This fixes it so the calendar and tally view display only the current school year. The table below with a list of absences has a new `School Year: Current` filter, which shows current absences by default but can be cleared to allow staff to see their past absences too.

<img width="379" alt="Screen Shot 2019-10-23 at 11 35 32 AM" src="https://user-images.githubusercontent.com/897700/67355257-6aa47c00-f589-11e9-83cb-24e525da489c.png">
