### PR TITLE
Students: turned First Aid Record Followup into a non-editable log

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -517,4 +517,5 @@ UPDATE gibbonAction SET name='Individual Needs Settings' WHERE name='IN Settings
 INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES ('Individual Needs', 'investigationNotificationsRole', 'Investigations Notification Role', 'Users to notify when an Investigation is complete.', '');end
 UPDATE gibbonSetting set name='investigationNotificationRole' WHERE scope='Individual Needs' AND name='investigationNotificationsRole';end
 INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES ('Students', 'firstAidDescriptionTemplate', 'First Aid Description Template', 'Template text to be included in the Description field of a First Aid Record.', '');end
+CREATE TABLE `gibbonFirstAidFollowUp` (`gibbonFirstAidFollowUpID` int(11) unsigned zerofill NOT NULL AUTO_INCREMENT, `gibbonFirstAidID` int(10) unsigned zerofill NOT NULL, `gibbonPersonID` int(10) unsigned zerofill NOT NULL, `followUp` text NOT NULL, `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonFirstAidFollowUpID`), KEY `gibbonFirstAidID` (`gibbonFirstAidID`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -61,7 +61,8 @@ v19.0.00
         Students: added extra permission allowing editing and deleting of all Notes
         Students: adjusted Privacy options to display even if blurb is not set
         Students: adjusted Application Form to allow showing of Language Selection blurb without fields
-        Students: added template setting for Description field in First Aid Record 
+        Students: added template setting for Description field in First Aid Record
+        Students: turned First Aid Record Followup into a non-editable log
         Timetable Admin: included student reportable flag in student enrolment
         Timetable Admin: enable users who can search All Users to also see Left students
         User Admin: increased Student ID field max length to 15

--- a/modules/Students/firstAidRecord.php
+++ b/modules/Students/firstAidRecord.php
@@ -103,11 +103,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.ph
             ->displayLabel();
 
         // COLUMNS
-        $table->addExpandableColumn('details')->format(function($person) {
+        $table->addExpandableColumn('details')->format(function($person) use ($firstAidGateway) {
             $output = '';
             if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2brr($person['description']).'<br/><br/>';
             if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2brr($person['actionTaken']).'<br/><br/>';
-            if ($person['followUp'] != '') $output .= '<b>'.__('Follow Up').'</b><br/>'.nl2brr($person['followUp']);
+            if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeReadable($person['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2brr($person['followUp']).'<br/><br/>';
+            $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
+            foreach ($resultLog AS $rowLog) {
+                $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeReadable($rowLog['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2brr($rowLog['followUp']).'<br/><br/>';
+            }
+
             return $output;
         });
 
@@ -140,7 +145,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.ph
                 $actions->addAction('edit', __('Edit'))
                     ->setURL('/modules/Students/firstAidRecord_edit.php');
             });
-        
+
         echo $table->render($firstAidRecords);
     }
 }

--- a/modules/Students/firstAidRecord_add.php
+++ b/modules/Students/firstAidRecord_add.php
@@ -60,6 +60,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ad
 
         $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
+        $row = $form->addRow()->addHeading(__('Basic Information'));
+
         $row = $form->addRow();
             $row->addLabel('gibbonPersonID', __('Patient'));
             $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->placeholder()->required();
@@ -87,6 +89,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ad
             $column->addLabel('actionTaken', __('Action Taken'));
             $column->addTextArea('actionTaken')->setRows(8)->setClass('fullWidth');
 
+        $row = $form->addRow()->addHeading(__('Follow Up'));
+        
         $row = $form->addRow();
             $column = $row->addColumn();
             $column->addLabel('followUp', __('Follow Up'));

--- a/modules/Students/firstAidRecord_editProcess.php
+++ b/modules/Students/firstAidRecord_editProcess.php
@@ -54,20 +54,33 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
             $URL .= '&return=error2';
             header("Location: {$URL}");
         } else {
-            $timeOut = null;
-            if ($_POST['timeOut'] != '')
-                $timeOut = $_POST['timeOut'];
+            $row = $result->fetch();
+            $gibbonPersonID = $row['gibbonPersonIDFirstAider'];
+            $timeOut = (!empty($_POST['timeOut'])) ? $_POST['timeOut'] : null;
             $followUp = $_POST['followUp'];
 
             try {
-                $data = array('timeOut' => $timeOut, 'followUp' => $followUp, 'gibbonFirstAidID' => $gibbonFirstAidID);
-                $sql = 'UPDATE gibbonFirstAid SET timeOut=:timeOut, followUp=:followUp WHERE gibbonFirstAidID=:gibbonFirstAidID';
+                $data = array('timeOut' => $timeOut, 'gibbonFirstAidID' => $gibbonFirstAidID);
+                $sql = 'UPDATE gibbonFirstAid SET timeOut=:timeOut WHERE gibbonFirstAidID=:gibbonFirstAidID';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
                 $URL .= '&return=error2';
                 header("Location: {$URL}");
                 exit();
+            }
+
+            if (!empty($followUp)) {
+                try {
+                    $data = array('gibbonFirstAidID' => $gibbonFirstAidID, 'gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'followUp' => $followUp);
+                    $sql = 'INSERT INTO gibbonFirstAidFollowUp SET gibbonFirstAidID=:gibbonFirstAidID, gibbonPersonID=:gibbonPersonID, followUp=:followUp';
+                    $result = $connection2->prepare($sql);
+                    $result->execute($data);
+                } catch (PDOException $e) {
+                    $URL .= '&return=error2';
+                    header("Location: {$URL}");
+                    exit();
+                }
             }
 
             $URL .= '&return=success0';

--- a/src/Domain/Students/FirstAidGateway.php
+++ b/src/Domain/Students/FirstAidGateway.php
@@ -34,7 +34,7 @@ class FirstAidGateway extends QueryableGateway
     private static $tableName = 'gibbonFirstAid';
 
     private static $searchableColumns = [''];
-    
+
     /**
      * @param QueryCriteria $criteria
      * @return DataSet
@@ -45,7 +45,7 @@ class FirstAidGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonFirstAidID', 'gibbonFirstAid.date', 'gibbonFirstAid.timeIn', 'gibbonFirstAid.timeOut', 'gibbonFirstAid.description', 'gibbonFirstAid.actionTaken', 'gibbonFirstAid.followUp', 'gibbonFirstAid.date', 'patient.surname AS surnamePatient', 'patient.preferredName AS preferredNamePatient', 'gibbonFirstAid.gibbonPersonIDPatient', 'gibbonRollGroup.name as rollGroup', 'firstAider.title', 'firstAider.surname AS surnameFirstAider', 'firstAider.preferredName AS preferredNameFirstAider'
+                'gibbonFirstAidID', 'gibbonFirstAid.date', 'gibbonFirstAid.timeIn', 'gibbonFirstAid.timeOut', 'gibbonFirstAid.description', 'gibbonFirstAid.actionTaken', 'gibbonFirstAid.followUp', 'gibbonFirstAid.date', 'patient.surname AS surnamePatient', 'patient.preferredName AS preferredNamePatient', 'gibbonFirstAid.gibbonPersonIDPatient', 'gibbonRollGroup.name as rollGroup', 'firstAider.title', 'firstAider.surname AS surnameFirstAider', 'firstAider.preferredName AS preferredNameFirstAider', 'timestamp'
             ])
             ->innerJoin('gibbonPerson AS patient', 'gibbonFirstAid.gibbonPersonIDPatient=patient.gibbonPersonID')
             ->innerJoin('gibbonStudentEnrolment', 'patient.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
@@ -76,5 +76,26 @@ class FirstAidGateway extends QueryableGateway
         ]);
 
         return $this->runQuery($query, $criteria);
+    }
+
+    public function queryFollowUpByFirstAidID($gibbonFirstAidID)
+    {
+        $dataLog = array('gibbonFirstAidID' => $gibbonFirstAidID);
+        $sqlLog = "SELECT gibbonFirstAidFollowUp.*, surname, preferredName FROM gibbonFirstAidFollowUp JOIN gibbonPerson ON (gibbonFirstAidFollowUp.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonFirstAidID=:gibbonFirstAidID";
+
+        $query = $this
+            ->newSelect()
+            ->from($this->getTableName())
+            ->cols([
+                'gibbonFirstAidFollowUp.*',
+                'surname',
+                'preferredName'
+            ])
+            ->innerJoin('gibbonFirstAidFollowUp', 'gibbonFirstAidFollowUp.gibbonFirstAidID=gibbonFirstAid.gibbonFirstAidID')
+            ->innerJoin('gibbonPerson', 'gibbonFirstAidFollowUp.gibbonPersonID=gibbonPerson.gibbonPersonID')
+            ->where('gibbonFirstAidFollowUp.gibbonFirstAidID=:gibbonFirstAidID')
+            ->bindValue('gibbonFirstAidID', $gibbonFirstAidID);
+
+        return $this->runSelect($query);
     }
 }


### PR DESCRIPTION
**Description**
Follow up on student First Aid Records is now no longer a single field, but a non-editable log that can be added to over time.

**Motivation and Context**
Concerns have arisen over editing and deletion of follow up details.

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="800" alt="Screenshot 2019-11-08 at 1 19 38 PM" src="https://user-images.githubusercontent.com/5436438/68451713-c843f400-022a-11ea-9514-3c827e6d58c7.png">