### PR TITLE
Messenger: low SMS credit notification when fewer than 1,000 credits …

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@ v19.0.00
         Messenger: eliminated non-recipient siblings from Send Report
         Messenger: addition of student name(s) to emails sent to parents
         Messenger: adjusted the default sending options for non-staff users
+        Messenger: low SMS credit notification when fewer than 1,000 credits remain
         School Admin: renamed IN Settings to Individual Needs Settings
         Staff: added a Weekly View and Daily View to Substitute Availability report
         Staff: added a Substitute Information setting for displaying text on My Coverage page

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -73,13 +73,13 @@ else {
 				print $addReturnMessage;
 			print "</div>" ;
 		}
-        
+
 		$form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/messenger_postProcess.php');
 		$form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
 		//DELIVERY MODE
         $form->addRow()->addHeading(__('Delivery Mode'));
-        
+
         $deliverByEmail = isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byEmail");
         $deliverByWall = isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byMessageWall");
         $deliverBySMS = isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_bySMS");
@@ -156,6 +156,7 @@ else {
 
                 if ($smsCredits = $sms->getCreditBalance()) {
                     $smsAlert .= "<br/><br/><b>" . sprintf(__('Current balance: %1$s credit(s).'), $smsCredits) . "</u></b>" ;
+					$form->addHiddenValue('smsCreditBalance', $smsCredits);
                 }
 
 				$form->addRow()->addAlert($smsAlert, 'error')->addClass('sms');
@@ -265,7 +266,7 @@ else {
 
 		//TARGETS
 		$form->addRow()->addHeading(__('Targets'));
-        
+
         $defaultSendStaff = ($roleCategory == 'Staff' || $roleCategory == 'Student')? 'Y' : 'N';
         $defaultSendStudents = ($roleCategory == 'Staff' || $roleCategory == 'Student')? 'Y' : 'N';
         $defaultSendParents = ($roleCategory == 'Parent')? 'Y' : 'N';

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -170,7 +170,7 @@ else {
 			if ($smsCreditBalance != null && $smsCreditBalance < 1000) {
 				$notificationGateway = new NotificationGateway($pdo);
 			    $notificationSender = new NotificationSender($notificationGateway, $gibbon->session);
-				echo $organisationAdministrator = getSettingByScope($connection2, 'System', 'organisationAdministrator');
+				$organisationAdministrator = getSettingByScope($connection2, 'System', 'organisationAdministrator');
 				$notificationString = __('Low SMS credit warning.');
 				$notificationSender->addNotification($organisationAdministrator, $notificationString, "Messenger", "/index.php?q=/modules/Messenger/messenger_post.php");
 				$notificationSender->sendNotifications();

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -20,6 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Contracts\Comms\SMS;
 use Gibbon\Services\Format;
+use Gibbon\Comms\NotificationSender;
+use Gibbon\Domain\System\NotificationGateway;
 
 include '../../gibbon.php';
 
@@ -96,6 +98,7 @@ else {
 		if ($sms!="Y") {
 			$sms="N" ;
 		}
+		$smsCreditBalance = ($sms == Y && !empty($_POST["smsCreditBalance"])) ? $_POST["smsCreditBalance"] : null;
 		$subject=$_POST["subject"] ;
 		$body=stripslashes($_POST["body"]) ;
 		$emailReceipt = $_POST["emailReceipt"] ;
@@ -163,6 +166,15 @@ else {
 				exit() ;
 			}
 
+			//SMS Credit notification
+			if ($smsCreditBalance != null && $smsCreditBalance < 1000) {
+				$notificationGateway = new NotificationGateway($pdo);
+			    $notificationSender = new NotificationSender($notificationGateway, $gibbon->session);
+				echo $organisationAdministrator = getSettingByScope($connection2, 'System', 'organisationAdministrator');
+				$notificationString = __('Low SMS credit warning.');
+				$notificationSender->addNotification($organisationAdministrator, $notificationString, "Messenger", "/index.php?q=/modules/Messenger/messenger_post.php");
+				$notificationSender->sendNotifications();
+			}
 			//TARGETS
 			$partialFail=FALSE ;
 			$report = array();


### PR DESCRIPTION
**Description**
Issues a notification to the system administrator when an SMS is sent and less than 1,000 SMS credits remain.

**Motivation and Context**
Aims to help avoiding running out of credits in an emergency.

**How Has This Been Tested?**
Locally, production