### PR TITLE
Messenger: add a setting to display pinned messages above the dashboard

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -519,4 +519,5 @@ UPDATE gibbonSetting set name='investigationNotificationRole' WHERE scope='Indiv
 INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES ('Students', 'firstAidDescriptionTemplate', 'First Aid Description Template', 'Template text to be included in the Description field of a First Aid Record.', '');end
 CREATE TABLE `gibbonFirstAidFollowUp` (`gibbonFirstAidFollowUpID` int(11) unsigned zerofill NOT NULL AUTO_INCREMENT, `gibbonFirstAidID` int(10) unsigned zerofill NOT NULL, `gibbonPersonID` int(10) unsigned zerofill NOT NULL, `followUp` text NOT NULL, `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonFirstAidFollowUpID`), KEY `gibbonFirstAidID` (`gibbonFirstAidID`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;end
 ALTER TABLE `gibbonMessenger` ADD `messageWallPin` ENUM('N','Y') NOT NULL DEFAULT 'N' AFTER `messageWall`;end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`)VALUES ('Messenger', 'pinnedMessagesOnHome', 'Enable Pinned Messages on Home', 'Displays pinned messages on the home page, above the dashboard.', 'N');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -54,6 +54,7 @@ v19.0.00
         Messenger: adjusted the default sending options for non-staff users
         Messenger: low SMS credit notification when fewer than 1,000 credits remain
         Messenger: added ability to pin messages to the top of the message wall
+        Messenger: added a setting to display pinned messages above the dashboard
         School Admin: renamed IN Settings to Individual Needs Settings
         Staff: added a Weekly View and Daily View to Substitute Availability report
         Staff: added a Substitute Information setting for displaying text on My Coverage page

--- a/index.php
+++ b/index.php
@@ -548,6 +548,22 @@ if (!$session->has('address')) {
         $page->writeFromTemplate('welcome.twig.html', $templateData);
         
     } else {
+        // Pinned Messages
+        $pinnedMessagesOnHome = getSettingByScope($connection2, 'Messenger', 'pinnedMessagesOnHome');
+        if ($pinnedMessagesOnHome == 'Y') {
+            if ($cacheLoad || !$session->exists('pinnedMessages')) {
+                $pinnedMessages = array_filter(getMessages($guid, $connection2, 'array'), function ($item) {
+                    return $item['messageWallPin'] == 'Y';
+                });
+
+                $session->set('pinnedMessages', $pinnedMessages);
+            }
+
+            if ($session->has('pinnedMessages')) {
+                $page->writeFromTemplate('ui/pinnedMessages.twig.html', ['pinnedMessages' => $pinnedMessages]);
+            }
+        }
+
         // Custom content loader
         if (!$session->exists('index_custom.php')) {
             $globals = [

--- a/modules/Messenger/moduleFunctions.php
+++ b/modules/Messenger/moduleFunctions.php
@@ -97,7 +97,7 @@ function getMessages($guid, $connection2, $mode = '', $date = '')
     if ($date == '') {
         $date = date('Y-m-d');
     }
-    if ($mode != 'print' and $mode != 'count' and $mode != 'result') {
+    if ($mode != 'print' and $mode != 'count' and $mode != 'result' and $mode != 'array') {
         $mode = 'print';
     }
 
@@ -611,6 +611,12 @@ function getMessages($guid, $connection2, $mode = '', $date = '')
         $resultReturn[1] = $sqlPosts.' ORDER BY messageWallPin DESC, subject, gibbonMessengerID, source';
 
         return serialize($resultReturn);
+    } elseif ($mode == 'array') {
+        $sqlPosts = $sqlPosts.' ORDER BY messageWallPin DESC, subject, gibbonMessengerID, source';
+        $resultPosts = $connection2->prepare($sqlPosts);
+        $resultPosts->execute($dataPosts);
+
+        return  $resultPosts->rowCount() > 0 ? $resultPosts->fetchAll() : [];
     } else {
         $count = 0;
         try {

--- a/modules/School Admin/messengerSettings.php
+++ b/modules/School Admin/messengerSettings.php
@@ -70,6 +70,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/messengerSett
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
 		$row->addTextArea($setting['name'])->setValue($setting['value'])->setRows(2);
 
+    $setting = getSettingByScope($connection2, 'Messenger', 'pinnedMessagesOnHome', true);
+	$row = $form->addRow();
+    	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+    	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
 	$row = $form->addRow();
 		$row->addFooter();

--- a/modules/School Admin/messengerSettingsProcess.php
+++ b/modules/School Admin/messengerSettingsProcess.php
@@ -26,11 +26,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/messengerSett
     header("Location: {$URL}");
 } else {
     //Proceed!
-    $messageBubbleWidthType = $_POST['messageBubbleWidthType'];
-    $messageBubbleBGColor = $_POST['messageBubbleBGColor'];
-    $messageBubbleAutoHide = $_POST['messageBubbleAutoHide'];
-    $enableHomeScreenWidget = $_POST['enableHomeScreenWidget'];
-    $messageBcc = $_POST['messageBcc'];
+    $messageBubbleWidthType = $_POST['messageBubbleWidthType'] ?? '';
+    $messageBubbleBGColor = $_POST['messageBubbleBGColor'] ?? '';
+    $messageBubbleAutoHide = $_POST['messageBubbleAutoHide'] ?? '';
+    $enableHomeScreenWidget = $_POST['enableHomeScreenWidget'] ?? '';
+    $pinnedMessagesOnHome = $_POST['pinnedMessagesOnHome'] ?? 'N';
+    $messageBcc = $_POST['messageBcc'] ?? '';
 
     //Write to database
     $fail = false;
@@ -74,6 +75,15 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/messengerSett
     try {
         $data = array('value' => $messageBcc);
         $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='messageBcc'";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+    } catch (PDOException $e) {
+        $fail = true;
+    }
+
+    try {
+        $data = array('value' => $pinnedMessagesOnHome);
+        $sql = "UPDATE gibbonSetting SET value=:value WHERE scope='Messenger' AND name='pinnedMessagesOnHome'";
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {

--- a/resources/templates/ui/pinnedMessages.twig.html
+++ b/resources/templates/ui/pinnedMessages.twig.html
@@ -1,0 +1,26 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+{% if pinnedMessages %}
+<div class="mt-6 bg-white border border-gray-500 rounded p-4 overflow-y-auto" style="max-height: 20rem">
+    {% for index, message in pinnedMessages %}
+    <div class="{{ not loop.last ? 'mb-6'}}">
+        <a href="{{ absoluteURL }}/index.php?q=/modules/Messenger/messageWall_view.php#{{ index+1 }}" class="no-underline hover:underline hover:text-blue-600">
+            <h3 class="mt-0 p-0 border-0 hover:text-blue-600">{{ message.subject }}</h3>
+        </a>
+
+        {{ message.body|raw }}
+
+        <div class="-mt-2 text-xxs text-gray-600">
+            <u>{{ __('Posted By') }}</u>: {{ formatUsing('name', message.title, message.preferredName, message.surname)}},
+            <u>{{ __('Shared Via') }}</u>: {{ message.source }}
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}

--- a/src/UI/Dashboard/StaffDashboard.php
+++ b/src/UI/Dashboard/StaffDashboard.php
@@ -49,7 +49,7 @@ class StaffDashboard implements OutputableInterface
         $output = '<h2>'.
             __('Staff Dashboard').
             '</h2>'.
-            "<div style='margin-bottom: 30px; margin-left: 1%; float: left; width: 100%'>";
+            "<div style='margin-bottom: 30px; float: left; width: 100%'>";
 
         $dashboardContents = $this->renderDashboard();
 

--- a/src/UI/Dashboard/StudentDashboard.php
+++ b/src/UI/Dashboard/StudentDashboard.php
@@ -45,7 +45,7 @@ class StudentDashboard implements OutputableInterface
         $output = '<h2>'.
             __('Student Dashboard').
             '</h2>'.
-            "<div style='margin-bottom: 30px; margin-left: 1%; float: left; width: 100%'>";
+            "<div style='margin-bottom: 30px; float: left; width: 100%'>";
 
         $dashboardContents = $this->renderDashboard();
 


### PR DESCRIPTION
- Adds a new setting in School Admin > Messenger Settings called "Enable Pinned Messages on Home"
- Adds code to `index.php` which loads (and caches) pinned messages, displaying them at the top of the home page, above the dashboard.

Feel free to suggest any visual changes. I kept it pretty minimal, to not distract from the content or add too much vertical space to the page.

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="1131" alt="Screen Shot 2019-11-12 at 8 08 06 PM" src="https://user-images.githubusercontent.com/897700/68670704-7d0e4600-0588-11ea-925e-45ae5aecf711.png">

