### PR TITLE
Tables: add sticky header to DataTables without breaking legacy tables

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ v19.0.00
         System: updated TinyMCE allowable HTML to include details, summary and code blocks
         System: improved the display of checkbox and radio list items in forms
         System: added Malagasy as a selectable Language
+        System: added a sticky header to refactored data tables
         Activities: added a Year Group filter in Manage Activities
         Activities: fixed bug preventing viewing activity details in Activity Choices by Student when listing closed
         Attendance: added an option to record the first class attendance in a day as school-wide attendance

--- a/resources/templates/components/dataTable.twig.html
+++ b/resources/templates/components/dataTable.twig.html
@@ -30,7 +30,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
         {% endblock header %}
     </header>
 
-    <div id="{{ table.getID }}" class="dataTable overflow-x-auto overflow-y-visible">
+    <div id="{{ table.getID }}" class="dataTable {{ not preventOverflow ? 'overflow-x-auto overflow-y-visible' }}">
 
    
     {% if not rows and not isFiltered and dataSet.getResultCount == 0 %}
@@ -52,7 +52,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     {% block tableInner %}
     
         <table class="{{ class }} w-full" cellspacing=0 {% if draggable %}data-drag-url="{{ draggable.url }}" data-drag-data="{{ draggable.data }}"{% endif %}>
-            <thead>
+            <thead class="sticky top-0 z-10">
             {% for headerRow in headers %}
                 <tr class="head text-xs">
                 {% for columnIndex, column in columns %}

--- a/resources/templates/index.twig.html
+++ b/resources/templates/index.twig.html
@@ -51,7 +51,7 @@ TODO: add template variable details.
                         <br style="clear: both">
                     {% endif %}
 
-                    <div id="content" class="w-full {{ not sidebar ?'pt-0 sm:pt-6' }} lg:flex-1  p-6 lg:pt-0 overflow-x-scroll sm:overflow-x-auto">
+                    <div id="content" class="w-full max-w-full {{ not sidebar ?'pt-0 sm:pt-6' }} lg:flex-1  p-6 lg:pt-0 {{ not preventOverflow ? 'overflow-x-scroll sm:overflow-x-auto' }}">
 
                         {% block page %}
 

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -75,6 +75,11 @@ class DataTable implements OutputableInterface
         global $container;
 
         $renderer = !empty($renderer) ? $renderer : $container->get(DataTableView::class);
+
+        // This is a temporary workaround to prevent overflow on pages that have a refactored table.
+        // This enables the sticky headers to work for DataTables without breaking legacy tables.
+        $container->get('page')->addData('preventOverflow', true);
+        $renderer->addData('preventOverflow', true);
         
         return (new static($renderer))->setID($id);
     }
@@ -89,8 +94,13 @@ class DataTable implements OutputableInterface
     public static function createPaginated($id, QueryCriteria $criteria)
     {
         global $container;
-
+        
         $renderer = $container->get(PaginatedView::class)->setCriteria($criteria);
+
+        // This is a temporary workaround to prevent overflow on pages that have a refactored table.
+        // This enables the sticky headers to work for DataTables without breaking legacy tables.
+        $container->get('page')->addData('preventOverflow', true);
+        $renderer->addData('preventOverflow', true);
 
         return (new static($renderer))->setID($id)->setRenderer($renderer);
     }


### PR DESCRIPTION
**Description**
I've whipped up a small tweak that enables us to use sticky headers on tables that have been refactored, ideally without breaking any legacy tables. Sticky headers are quite handy for long data tables, but don't work if any of the containing divs have a css overflow property. 

This workaround uses a Page template variable to disable the overflow properties once a data table is created. The workaround can be removed once we've ooified all the tables, but for now I think it gives us the best of both worlds.

**How Has This Been Tested?**
Locally and in production.

**Screenshots**
Sticky header on Manage Users:
<img width="868" alt="Screen Shot 2019-12-03 at 12 54 54 PM" src="https://user-images.githubusercontent.com/897700/70021856-113e5c80-15cd-11ea-8a22-389447ff24db.png">

