### PR TITLE
System: add a system setting to disable background processing

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -603,5 +603,6 @@ INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, 
 INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('002', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Reports' AND gibbonAction.name='Write Reports_mine'));end
 INSERT INTO `gibbonReportingCriteriaType` (`name`, `valueType`, `active`, `characterLimit`, `gibbonScaleID`) VALUES('Comment, Short', 'Comment', 'Y', 500, NULL);end
 INSERT INTO `gibbonReportingCriteriaType` (`name`, `valueType`, `active`, `characterLimit`, `gibbonScaleID`) VALUES('Comment Long', 'Comment', 'Y', 1000, NULL);end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('System', 'backgroundProcessing', 'Background Processing', 'Should the system start an external process for long-running commands?', 'Y');end
 
 ";

--- a/modules/System Admin/systemSettings.php
+++ b/modules/System Admin/systemSettings.php
@@ -117,6 +117,11 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
+    $setting = getSettingByScope($connection2, 'System', 'backgroundProcessing', true);
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addYesNo($setting['name'])->selected($setting['value'])->required();
+
     // ORGANISATION
     $form->addRow()->addHeading(__('Organisation Settings'));
 

--- a/modules/System Admin/systemSettingsProcess.php
+++ b/modules/System Admin/systemSettingsProcess.php
@@ -64,6 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $currency = $_POST['currency'];
     $gibboneduComOrganisationName = $_POST['gibboneduComOrganisationName'];
     $gibboneduComOrganisationKey = $_POST['gibboneduComOrganisationKey'];
+    $backgroundProcessing = $_POST['backgroundProcessing'] ?? 'Y';
 
     //Validate Inputs
     if ($absoluteURL == '' or $systemName == '' or $organisationLogo == '' or $indexText == '' or $organisationName == '' or $organisationNameShort == '' or $organisationEmail == '' or $organisationAdministrator == '' or $organisationDBA == '' or $organisationHR == '' or $organisationAdmissions == '' or $pagination == '' or (!(is_numeric($pagination))) or $timezone == '' or $installType == '' or $statsCollection == '' or $passwordPolicyMinLength == '' or $passwordPolicyAlpha == '' or $passwordPolicyNumeric == '' or $passwordPolicyNonAlphaNumeric == '' or $firstDayOfTheWeek == '' or ($firstDayOfTheWeek != 'Monday' and $firstDayOfTheWeek != 'Sunday') or $currency == '') {
@@ -426,6 +427,14 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
         try {
             $data = array('sessionDuration' => $sessionDuration);
             $sql = "UPDATE gibbonSetting SET value=:sessionDuration WHERE scope='System' AND name='sessionDuration'";
+            $result = $connection2->prepare($sql);
+            $result->execute($data);
+        } catch (PDOException $e) {
+            $fail = true;
+        }
+        try {
+            $data = array('backgroundProcessing' => $backgroundProcessing);
+            $sql = "UPDATE gibbonSetting SET value=:backgroundProcessing WHERE scope='System' AND name='backgroundProcessing'";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {

--- a/src/Services/BackgroundProcessor.php
+++ b/src/Services/BackgroundProcessor.php
@@ -102,6 +102,12 @@ class BackgroundProcessor implements ContainerAwareInterface
             'serialisedArray'    => serialize($processData),
         ]);
 
+        // Allow systems to disable background processing
+        if ($this->session->get('backgroundProcessing') == 'N') {
+            $this->runProcess($processID, $processData['key']);
+            return $processID;
+        }
+
         // Create and escape the set of args used in the php command.
         // These should always be non-user-supplied values.
         $args = [$phpFile, $processID, $processData['key'], $this->session->get('module')];


### PR DESCRIPTION
Not all systems may support using the `exec` function for background processing, so this adds a system setting to manually disable all background processing system-wide. Also useful for testing.