### PR TITLE
System: add a general-purpose DiscussionGateway class

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -615,4 +615,5 @@ UPDATE `gibbonPersonUpdate` SET citizenship1PassportExpiry=NULL WHERE citizenshi
 UPDATE `gibbonPersonUpdate` SET citizenship2PassportExpiry=NULL WHERE citizenship2PassportExpiry=0000-00-00;end
 UPDATE `gibbonAction` SET precedence=2 WHERE name='Write Reports_editAll' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Reports');end
 UPDATE `gibbonAction` SET precedence=1 WHERE name='Write Reports_mine' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Reports');end
+CREATE TABLE `gibbonDiscussion` (`gibbonDiscussionID` INT(12) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT, `foreignTable` VARCHAR(60) NOT NULL, `foreignTableID` INT(14) UNSIGNED ZEROFILL NOT NULL, `gibbonModuleID` INT(4) UNSIGNED ZEROFILL NOT NULL, `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL, `type` VARCHAR(60) NULL, `comment` TEXT NULL, `attachmentType` enum('File','Link') NULL, `attachmentLocation` text NULL, `gibbonDiscussionIDReplyTo` INT(12) UNSIGNED ZEROFILL NULL, `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonDiscussionID`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ v19.0.00
         System: added a sticky header to refactored data tables
         System: refactored the Sound Alarm system
         System: added a setting to toggle background processing
+        System: added a general-purpose DiscussionGateway class
         Activities: added a Year Group filter in Manage Activities
         Attendance: added an option to record the first class attendance in a day as school-wide attendance
         Attendance: added an option to disable prefilling by attendance code, applied to Present - Late by default

--- a/src/Domain/System/DiscussionGateway.php
+++ b/src/Domain/System/DiscussionGateway.php
@@ -1,0 +1,59 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\System;
+
+use Gibbon\Domain\QueryableGateway;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\Traits\TableAware;
+
+/**
+ * Discussion Gateway
+ *
+ * @version v19
+ * @since   v19
+ */
+class DiscussionGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonDiscussion';
+    private static $primaryKey = 'gibbonDiscussionID';
+
+    public function selectDiscussionByContext($foreignTable, $foreignTableID, $type = null)
+    {
+        $query = $this
+            ->newSelect()
+            ->cols(['gibbonDiscussion.*', 'gibbonPerson.title', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonPerson.image_240', 'gibbonPerson.username', 'gibbonPerson.email'])
+            ->from($this->getTableName())
+            ->innerJoin('gibbonPerson', 'gibbonDiscussion.gibbonPersonID=gibbonPerson.gibbonPersonID')
+            ->where('gibbonDiscussion.foreignTable = :foreignTable')
+            ->bindValue('foreignTable', $foreignTable)
+            ->where('gibbonDiscussion.foreignTableID = :foreignTableID')
+            ->bindValue('foreignTableID', $foreignTableID)
+            ->orderBy(['gibbonDiscussion.timestamp']);
+
+        if (!empty($type)) {
+            $query->where('gibbonDiscussion.type = :type')
+                ->bindValue('type', $type);
+        }
+
+        return $this->runSelect($query);
+    }
+}


### PR DESCRIPTION
This adds a new table and gateway class which can be used for feedback, evidence, discussion, etc. The idea is that by having a central location for discussion then we can then query and display recent comments in areas such as dashboards and student profiles. 

Some possible uses so-far include Planner, Mastery Transcript, Free Learning, Badges, House Points (when awarded individually).

**Description**
Adds a gibbonDiscussion table, linked to a foriegnTable by ID, with the following schema:
```
CREATE TABLE `gibbonDiscussion` (
  `gibbonDiscussionID` INT(12) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT,
  `foreignTable` VARCHAR(60) NOT NULL,
  `foreignTableID` INT(14) UNSIGNED ZEROFILL NOT NULL,
  `gibbonModuleID` INT(4) UNSIGNED ZEROFILL NOT NULL,
  `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL,
  `type` VARCHAR(60) NULL,
  `comment` TEXT NULL,
  `attachmentType` enum('File','Link') NULL,
  `attachmentLocation` text NULL,
  `gibbonDiscussionIDReplyTo` INT(12) UNSIGNED ZEROFILL NULL,
  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`gibbonDiscussionID`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

**How Has This Been Tested?**
Tested locally. No core changes.
