### PR TITLE
System: update module uninstaller, tweak cache refresh in system updater

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ v20.0.00
     Tweaks & Additions
 
     Bug Fixes
+        System: fixed module uninstall to also remove notification events
 
 v19.0.00
 --------

--- a/modules/System Admin/updateProcess.php
+++ b/modules/System Admin/updateProcess.php
@@ -87,6 +87,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
                 // Clear the var/log folder
                 removeDirectoryContents($_SESSION[$guid]['absolutePath'].'/var/log');
 
+                //Reset cache to force top-menu reload
+                $gibbon->session->forget('pageLoads');
+
                 $URL .= '&return=success0';
                 header("Location: {$URL}");
             }
@@ -208,7 +211,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
                 removeDirectoryContents($_SESSION[$guid]['absolutePath'].'/var', true);
 
                 //Reset cache to force top-menu reload
-                $_SESSION[$guid]['pageLoads'] = null;
+                $gibbon->session->forget('pageLoads');
 
                 $URL .= '&return=success0';
                 header("Location: {$URL}");


### PR DESCRIPTION
One fix and one tweak:
- Update the module uninstaller to also remove notification events. This fixes a bug where uninstalling and installing the Trip Planner caused an SQL error. Tidied up the script a bit.
- Add a `pageLoads` refresh on update for non-cutting-edge installs.