### PR TITLE
Reports: add a Proof Read by Form Group option

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ v20.0.00
     Security
 
     Tweaks & Additions
+        Reports: added a Proof Read by Homeroom option
 
     Bug Fixes
 

--- a/modules/Reports/reporting_proofreadProcess.php
+++ b/modules/Reports/reporting_proofreadProcess.php
@@ -22,9 +22,11 @@ use Gibbon\Module\Reports\Domain\ReportingValueGateway;
 
 require_once '../../gibbon.php';
 
+$mode = $_POST['mode'] ?? '';
 $gibbonPersonID = $_POST['gibbonPersonID'] ?? '';
+$gibbonRollGroupID = $_POST['gibbonRollGroupID'] ?? '';
 
-$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Reports/reporting_proofread.php&gibbonPersonID='.$gibbonPersonID;
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Reports/reporting_proofread.php&mode='.$mode.'&gibbonPersonID='.$gibbonPersonID.'&gibbonRollGroupID='.$gibbonRollGroupID;
 
 if (!empty($_POST['override'])) {
     $URL .= '&override='.$_POST['override'];

--- a/modules/Reports/src/Domain/ReportingAccessGateway.php
+++ b/modules/Reports/src/Domain/ReportingAccessGateway.php
@@ -172,6 +172,24 @@ class ReportingAccessGateway extends QueryableGateway
         return $this->runQuery($query, $criteria);
     }
     
+
+    public function selectAccessibleRollGroupsByReportingScope($gibbonReportingScopeID)
+    {
+        $query = $this
+            ->newSelect()
+            ->from('gibbonReportingScope')
+            ->cols(['gibbonRollGroup.gibbonRollGroupID', 'gibbonRollGroup.name'])
+            ->innerJoin('gibbonReportingCycle', 'gibbonReportingCycle.gibbonReportingCycleID=gibbonReportingScope.gibbonReportingCycleID')
+            ->innerJoin('gibbonStudentEnrolment', 'FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, gibbonReportingCycle.gibbonYearGroupIDList) AND gibbonStudentEnrolment.gibbonSchoolYearID=gibbonReportingCycle.gibbonSchoolYearID')
+            ->innerJoin('gibbonRollGroup', 'gibbonRollGroup.gibbonRollGroupID=gibbonStudentEnrolment.gibbonRollGroupID')
+            ->where('gibbonReportingScope.gibbonReportingScopeID=:gibbonReportingScopeID')
+            ->bindValue('gibbonReportingScopeID', $gibbonReportingScopeID)
+            ->groupBy(['gibbonRollGroup.gibbonRollGroupID'])
+            ->orderBy(['LENGTH(gibbonRollGroup.name)', 'gibbonRollGroup.name']);
+    
+        return $this->runSelect($query);
+    }
+
     public function selectAccessibleStaffByReportingScope($gibbonReportingScopeID)
     {
         // COURSE

--- a/modules/Reports/src/Domain/ReportingProofGateway.php
+++ b/modules/Reports/src/Domain/ReportingProofGateway.php
@@ -52,6 +52,85 @@ class ReportingProofGateway extends QueryableGateway
         return $this->runSelect($query);
     }
 
+    public function selectProofReadingByRollGroup($gibbonSchoolYearID, $gibbonRollGroupID)
+    {
+        // COURSES
+        $query = $this
+            ->newSelect()
+            ->from('gibbonReportingCycle')
+            ->cols(['gibbonReportingValue.gibbonPersonIDStudent', 'gibbonReportingValue.gibbonReportingValueID', 'gibbonReportingCriteria.target as criteriaTarget', 'gibbonReportingCriteria.name as criteriaName', 'gibbonReportingCriteriaType.characterLimit', 'gibbonCourse.name', "CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as nameShort", 'gibbonReportingValue.comment', 'student.surname', 'student.preferredName', 'student.gender', 'writtenBy.surname as surnameWrittenBy',  'writtenBy.preferredName as preferredNameWrittenBy' ])
+            ->innerJoin('gibbonStudentEnrolment', 'gibbonReportingCycle.gibbonSchoolYearID=gibbonStudentEnrolment.gibbonSchoolYearID')
+            ->innerJoin('gibbonPerson as student', 'student.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
+            ->innerJoin('gibbonReportingValue', 'student.gibbonPersonID=gibbonReportingValue.gibbonPersonIDStudent AND gibbonReportingValue.gibbonReportingCycleID=gibbonReportingCycle.gibbonReportingCycleID')
+            ->innerJoin('gibbonReportingCriteria', 'gibbonReportingValue.gibbonReportingCriteriaID=gibbonReportingCriteria.gibbonReportingCriteriaID')
+            ->innerJoin('gibbonReportingCriteriaType', 'gibbonReportingCriteriaType.gibbonReportingCriteriaTypeID=gibbonReportingCriteria.gibbonReportingCriteriaTypeID')
+            ->innerJoin('gibbonReportingProgress', 'gibbonReportingProgress.gibbonReportingScopeID=gibbonReportingCriteria.gibbonReportingScopeID AND gibbonReportingProgress.gibbonCourseClassID=gibbonReportingValue.gibbonCourseClassID AND gibbonReportingProgress.gibbonPersonIDStudent=gibbonReportingValue.gibbonPersonIDStudent')
+            ->innerJoin('gibbonCourseClass', 'gibbonCourseClass.gibbonCourseClassID=gibbonReportingValue.gibbonCourseClassID')
+            ->innerJoin('gibbonCourse', 'gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID')
+            ->innerJoin('gibbonPerson as writtenBy', 'writtenBy.gibbonPersonID=gibbonReportingValue.gibbonPersonIDCreated')
+            ->where('gibbonReportingCycle.gibbonSchoolYearID=:gibbonSchoolYearID')
+            ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID)
+            ->where('gibbonStudentEnrolment.gibbonRollGroupID=:gibbonRollGroupID')
+            ->bindValue('gibbonRollGroupID', $gibbonRollGroupID)
+            ->where("gibbonReportingProgress.status='Complete'")
+            ->where("gibbonReportingCriteriaType.valueType='Comment'")
+            ->where("gibbonReportingValue.gibbonCourseClassID <> 0")
+            ->where("(gibbonReportingValue.comment <> '' AND gibbonReportingValue.comment IS NOT NULL)")
+            ->where('(:today BETWEEN gibbonReportingCycle.dateStart AND gibbonReportingCycle.dateEnd)')
+            ->bindValue('today', date('Y-m-d'));
+
+        // ROLL GROUP
+        $query->unionAll()
+            ->from('gibbonReportingCycle')
+            ->cols(['gibbonReportingValue.gibbonPersonIDStudent', 'gibbonReportingValue.gibbonReportingValueID', 'gibbonReportingCriteria.target as criteriaTarget', 'gibbonReportingCriteria.name as criteriaName', 'gibbonReportingCriteriaType.characterLimit', 'gibbonRollGroup.name', 'gibbonRollGroup.nameShort', 'gibbonReportingValue.comment', 'student.surname', 'student.preferredName', 'student.gender', 'writtenBy.surname as surnameWrittenBy',  'writtenBy.preferredName as preferredNameWrittenBy'])
+            ->innerJoin('gibbonStudentEnrolment', 'gibbonReportingCycle.gibbonSchoolYearID=gibbonStudentEnrolment.gibbonSchoolYearID')
+            ->innerJoin('gibbonPerson as student', 'student.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
+            ->innerJoin('gibbonReportingValue', 'student.gibbonPersonID=gibbonReportingValue.gibbonPersonIDStudent AND gibbonReportingValue.gibbonReportingCycleID=gibbonReportingCycle.gibbonReportingCycleID')
+            ->innerJoin('gibbonReportingCriteria', 'gibbonReportingValue.gibbonReportingCriteriaID=gibbonReportingCriteria.gibbonReportingCriteriaID')
+            ->innerJoin('gibbonReportingCriteriaType', 'gibbonReportingCriteriaType.gibbonReportingCriteriaTypeID=gibbonReportingCriteria.gibbonReportingCriteriaTypeID')
+            ->innerJoin('gibbonRollGroup', 'gibbonRollGroup.gibbonRollGroupID=gibbonReportingCriteria.gibbonRollGroupID')
+            ->innerJoin('gibbonReportingProgress', 'gibbonReportingProgress.gibbonReportingScopeID=gibbonReportingCriteria.gibbonReportingScopeID AND gibbonReportingProgress.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID AND gibbonReportingProgress.gibbonPersonIDStudent=gibbonReportingValue.gibbonPersonIDStudent')
+            ->innerJoin('gibbonPerson as writtenBy', 'writtenBy.gibbonPersonID=gibbonReportingValue.gibbonPersonIDCreated')
+            ->where('gibbonReportingCycle.gibbonSchoolYearID=:gibbonSchoolYearID')
+            ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID)
+            ->where('gibbonStudentEnrolment.gibbonRollGroupID=:gibbonRollGroupID')
+            ->bindValue('gibbonRollGroupID', $gibbonRollGroupID)
+            ->where("gibbonReportingProgress.status='Complete'")
+            ->where("gibbonReportingCriteriaType.valueType='Comment'")
+            ->where("gibbonReportingCriteria.gibbonRollGroupID IS NOT NULL")
+            ->where("(gibbonReportingValue.comment <> '' AND gibbonReportingValue.comment IS NOT NULL)")
+            ->where('(:today BETWEEN gibbonReportingCycle.dateStart AND gibbonReportingCycle.dateEnd)')
+            ->bindValue('today', date('Y-m-d'));
+
+        // YEAR GROUP
+        $query->unionAll()
+            ->from('gibbonReportingCycle')
+            ->cols(['gibbonReportingValue.gibbonPersonIDStudent', 'gibbonReportingValue.gibbonReportingValueID', 'gibbonReportingCriteria.target as criteriaTarget', 'gibbonReportingCriteria.name as criteriaName', 'gibbonReportingCriteriaType.characterLimit', 'gibbonYearGroup.name', 'gibbonYearGroup.nameShort', 'gibbonReportingValue.comment', 'student.surname', 'student.preferredName', 'student.gender', 'writtenBy.surname as surnameWrittenBy', 'writtenBy.preferredName as preferredNameWrittenBy'])
+            ->innerJoin('gibbonStudentEnrolment', 'gibbonReportingCycle.gibbonSchoolYearID=gibbonStudentEnrolment.gibbonSchoolYearID')
+            ->innerJoin('gibbonPerson as student', 'student.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')
+            ->innerJoin('gibbonReportingValue', 'student.gibbonPersonID=gibbonReportingValue.gibbonPersonIDStudent AND gibbonReportingValue.gibbonReportingCycleID=gibbonReportingCycle.gibbonReportingCycleID')
+            ->innerJoin('gibbonReportingCriteria', 'gibbonReportingValue.gibbonReportingCriteriaID=gibbonReportingCriteria.gibbonReportingCriteriaID')
+            ->innerJoin('gibbonReportingCriteriaType', 'gibbonReportingCriteriaType.gibbonReportingCriteriaTypeID=gibbonReportingCriteria.gibbonReportingCriteriaTypeID')
+            ->innerJoin('gibbonYearGroup', 'gibbonYearGroup.gibbonYearGroupID=gibbonReportingCriteria.gibbonYearGroupID')
+            ->innerJoin('gibbonReportingProgress', 'gibbonReportingProgress.gibbonReportingScopeID=gibbonReportingCriteria.gibbonReportingScopeID AND gibbonReportingProgress.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID AND gibbonReportingProgress.gibbonPersonIDStudent=gibbonReportingValue.gibbonPersonIDStudent')
+            ->innerJoin('gibbonPerson as writtenBy', 'writtenBy.gibbonPersonID=gibbonReportingValue.gibbonPersonIDCreated')
+            ->where('gibbonReportingCycle.gibbonSchoolYearID=:gibbonSchoolYearID')
+            ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID)
+            ->where('gibbonStudentEnrolment.gibbonRollGroupID=:gibbonRollGroupID')
+            ->bindValue('gibbonRollGroupID', $gibbonRollGroupID)
+            ->where("gibbonReportingProgress.status='Complete'")
+            ->where("gibbonReportingCriteriaType.valueType='Comment'")
+            ->where("gibbonReportingCriteria.gibbonYearGroupID IS NOT NULL")
+            ->where("(gibbonReportingValue.comment <> '' AND gibbonReportingValue.comment IS NOT NULL)")
+            ->where('(:today BETWEEN gibbonReportingCycle.dateStart AND gibbonReportingCycle.dateEnd)')
+            ->bindValue('today', date('Y-m-d'));
+
+        $query->orderBy(['criteriaTarget', 'surname', 'preferredName', 'nameShort']);
+
+        return $this->runSelect($query);
+
+    }
+
     public function selectProofReadingByPerson($gibbonSchoolYearID, $gibbonPersonID, $reportingScopeIDs = null)
     {
         $reportingScopeIDs = is_array($reportingScopeIDs)? implode(',', $reportingScopeIDs) : $reportingScopeIDs;


### PR DESCRIPTION
Currently, proof reading can be done by person, which shows all the comments that person has written. This adds an optional Proof Read Mode by form group/roll group, which shows all the comments that have been written for students in that form group. Teachers still receive edits and view their own overall progress on a per-person level.

<img width="813" alt="Screenshot 2020-01-22 at 9 05 58 AM" src="https://user-images.githubusercontent.com/897700/72856736-6f96da00-3cf6-11ea-84e6-3dd10e81d84b.png">
