### PR TITLE
Departments: added drag-drop ordering to Departments in School Admin

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -622,4 +622,6 @@ UPDATE gibbonScaleGrade SET descriptor='1%' WHERE value='1%' AND descriptor='2%'
 //v20.0.00
 ++$count;
 $sql[$count][0] = '20.0.00';
-$sql[$count][1] = "";
+$sql[$count][1] = "
+ALTER TABLE `gibbonDepartment` ADD `sequenceNumber` INT(4) UNSIGNED NULL AFTER `logo`;end
+";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ v20.0.00
     Security
 
     Tweaks & Additions
+        Departments: added drag-drop ordering to Departments in School Admin
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
 
     Bug Fixes

--- a/modules/Departments/departments.php
+++ b/modules/Departments/departments.php
@@ -21,6 +21,7 @@ use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Tables\View\GridView;
 use Gibbon\Domain\DataSet;
+use Gibbon\Domain\Departments\DepartmentGateway;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -34,6 +35,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/departments.ph
 } else {
     $page->breadcrumbs->add(__('View All'));
 
+    $departmentGateway = $container->get(DepartmentGateway::class);
+    
     // Data Table
     $gridRenderer = new GridView($container->get('twig'));
     $table = $container->get(DataTable::class)->setRenderer($gridRenderer);
@@ -51,9 +54,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/departments.ph
             return Format::link($url, $department['name']);
         });
 
+    // QUERY
+    $criteria = $departmentGateway->newQueryCriteria(true)
+        ->sortBy(['sequenceNumber', 'name']);
+
     // Learning Areas
-    $sql = "SELECT * FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
-    $learningAreas = $pdo->select($sql)->toDataSet();
+    $learningAreas = $departmentGateway->queryDepartments($criteria, 'Learning Area');
 
     if (count($learningAreas) > 0) {
         $tableLA = clone $table;
@@ -63,8 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/departments.ph
     }
     
     // Administration
-    $sql = "SELECT * FROM gibbonDepartment WHERE type='Administration' ORDER BY name";
-    $administration = $pdo->select($sql)->toDataSet();
+    $administration = $departmentGateway->queryDepartments($criteria, 'Administration');
 
     if (count($administration) > 0) {
         $tableAdmin = clone $table;

--- a/modules/School Admin/department_manage.php
+++ b/modules/School Admin/department_manage.php
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
 
     // QUERY
     $criteria = $departmentGateway->newQueryCriteria(true)
-        ->sortBy('name')
+        ->sortBy(['sequenceNumber', 'name'])
         ->fromPOST();
 
     $departments = $departmentGateway->queryDepartments($criteria);
@@ -75,6 +75,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
     $table->addHeaderAction('add', __('Add'))
         ->setURL('/modules/School Admin/department_manage_add.php')
         ->displayLabel();
+
+    $table->addDraggableColumn('gibbonDepartmentID', $gibbon->session->get('absoluteURL').'/modules/School Admin/department_manage_editOrderAjax.php');
 
     $table->addColumn('name', __('Name'));
     $table->addColumn('type', __('Type'))->translatable();

--- a/modules/School Admin/department_manage_editOrderAjax.php
+++ b/modules/School Admin/department_manage_editOrderAjax.php
@@ -1,0 +1,44 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Departments\DepartmentGateway;
+
+$_POST['address'] = '/modules/School Admin/department_manage.php';
+
+require_once '../../gibbon.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_manage.php') == false) {
+    exit;
+} else {
+    // Proceed!
+    $data = $_POST['data'] ?? [];
+    $order = json_decode($_POST['order']);
+
+    if (empty($order)) {
+        exit;
+    } else {
+        $departmentGateway = $container->get(DepartmentGateway::class);
+
+        $count = 1;
+        foreach ($order as $gibbonDepartmentID) {
+            $updated = $departmentGateway->update($gibbonDepartmentID, ['sequenceNumber' => $count]);
+            $count++;
+        }
+    }
+}

--- a/src/Domain/Departments/DepartmentGateway.php
+++ b/src/Domain/Departments/DepartmentGateway.php
@@ -40,14 +40,19 @@ class DepartmentGateway extends QueryableGateway
      * @param QueryCriteria $criteria
      * @return DataSet
      */
-    public function queryDepartments(QueryCriteria $criteria)
+    public function queryDepartments(QueryCriteria $criteria, $type = null)
     {
         $query = $this
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonDepartmentID', 'name', 'nameShort', 'type'
+                'gibbonDepartmentID', 'name', 'nameShort', 'type', 'subjectListing', 'blurb', 'logo'
             ]);
+
+        if (!empty($type)) {
+            $query->where('gibbonDepartment.type = :type')
+                  ->bindValue('type', $type);
+        }
 
         return $this->runQuery($query, $criteria);
     }


### PR DESCRIPTION
Currently the order of departments is alphabetical. For larger schools this order may end up with a very mixed-up list of departments. This PR adds the option to drag-drop sort the order of departments. They will fall back to the original numeric order by default.