### PR TITLE
Reports: add an option to select the PDF rendering library in Template Builder

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ v20.0.00
     Tweaks & Additions
         Departments: added drag-drop ordering to Departments in School Admin
         Reports: added a Proof Read by Form Group option
+        Reports: added an option to select the PDF rendering library in Template Builder
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
 
     Bug Fixes

--- a/modules/Reports/src/Renderer/HtmlRenderer.php
+++ b/modules/Reports/src/Renderer/HtmlRenderer.php
@@ -1,0 +1,160 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\Reports\Renderer;
+
+use Gibbon\Module\Reports\Renderer\ReportRendererInterface;
+use Gibbon\Module\Reports\ReportData;
+use Gibbon\Module\Reports\ReportTemplate;
+use Gibbon\Module\Reports\ReportSection;
+use Twig_Environment;
+
+class HtmlRenderer implements ReportRendererInterface
+{
+    protected $template;
+    protected $twig;
+
+    protected $absolutePath;
+    protected $absoluteURL;
+
+    protected $mode = 0;
+
+    protected $preProcess = [];
+    protected $postProcess = [];
+
+    public function __construct(Twig_Environment $templateEngine)
+    {
+        $this->microtime = microtime(true);
+
+        $this->twig = $templateEngine;
+    }
+
+    public function setMode(int $bitmask)
+    {
+        $this->mode |= $bitmask;
+    }
+
+    public function hasMode(int $bitmask)
+    {
+        return ($this->mode & $bitmask) == $bitmask;
+    }
+
+    public function render(ReportTemplate $template, array $input, string $output = '')
+    {
+        $this->template = $template;
+        $this->absolutePath = $template->getData('absolutePath');
+        $this->absoluteURL = $template->getData('absoluteURL');
+        $this->customAssetPath = $template->getData('customAssetPath');
+
+        $customTemplatePath = $this->absolutePath.$this->customAssetPath.'/templates';
+        if (is_dir($customTemplatePath)) {
+            $this->twig->getLoader()->prependPath($customTemplatePath);
+        }
+
+        $reports = (is_array($input))? $input : array($input);
+        $html = '';
+        $pages = [];
+        $pageNum = 1;
+        $this->template->addData([
+            'pageNum' => $pageNum,
+            'basePath' => $this->absoluteURL,
+            'assetPath' => $this->absoluteURL.$this->customAssetPath,
+            'isDraft' => $this->template->getIsDraft(),
+        ]);
+
+        foreach ($reports as $reportData) {
+            
+            if ($header = $this->template->getHeader($pageNum)) {
+                $html .= '<header style="height: '.$header->height.'mm">'.$this->renderSectionToHTML($header, $reportData).'</header>';
+            }
+
+            $pageBreak = function ($html) use (&$pages, &$pageNum, &$reportData) {
+                if ($footer = $this->template->getFooter($pageNum)) {
+                    $html .= '<footer style="height: '.$footer->height.'mm">'.$this->renderSectionToHTML($footer, $reportData).'</footer>';
+                }
+
+                $pages[$pageNum] = $html;
+                $html = '';
+                $pageNum++;
+                $this->template->addData(['pageNum' => $pageNum]);
+                
+                if ($header = $this->template->getHeader($pageNum)) {
+                    $html .= '<header style="height: '.$header->height.'mm">'.$this->renderSectionToHTML($header, $reportData).'</header>';
+                }
+
+                return $html;
+            };
+
+            $sections = $this->template->getSections();
+            foreach ($sections as $section) {
+
+                if ($section->hasFlag(ReportSection::PAGE_BREAK_BEFORE)) {
+                    $html = $pageBreak($html);
+                }
+
+                $html .= '<section>'.$this->renderSectionToHTML($section, $reportData).'</section>';
+
+                if ($section->hasFlag(ReportSection::PAGE_BREAK_AFTER)) {
+                    $html = $pageBreak($html);
+                }
+            }
+
+            if ($footer = $this->template->getFooter($pageNum, true)) {
+                $html .= '<footer style="height: '.$footer->height.'mm">'.$this->renderSectionToHTML($footer, $reportData).'</footer>';
+            }
+            
+            $pages[$pageNum] = $html;
+        }
+
+        return $pages;
+    }
+
+    public function addPreProcess(string $name, callable $callable)
+    {
+        if (is_callable($callable)) {
+            $this->preProcess[$name] = $callable;
+        }
+    }
+
+    public function addPostProcess(string $name, callable $callable)
+    {
+        if (is_callable($callable)) {
+            $this->postProcess[$name] = $callable;
+        }
+    }
+
+    protected function renderSectionToHTML(ReportSection &$section, ReportData &$reportData)
+    {
+        $data = $reportData->getData(array_keys($section->sources));
+        $data = array_merge($data, $this->template->getData(), $section->getData());
+        
+        // Render .twig templates using Twig
+        if (stripos($section->template, '.twig') !== false) {
+            return $this->twig->render($section->template, $data);
+        }
+        
+        // Render .php templates by including the file, data is shared by scope
+        if (stripos($section->template, '.php') !== false) {
+            $pdf = $this->pdf;
+            return include 'templates/'.$section->template;
+        }
+
+        return '';
+    }
+}

--- a/modules/Reports/src/Renderer/MpdfRenderer.php
+++ b/modules/Reports/src/Renderer/MpdfRenderer.php
@@ -179,7 +179,7 @@ class MpdfRenderer implements ReportRendererInterface
 
         $config = [
             'mode' => 'utf-8',
-            'format' => [210, 297],
+            'format' => $this->template->getData('pageSize', 'A4') == 'letter' ? [215.9, 279.4] : [210, 297],
             'orientation' => $this->template->getData('orientation', 'P'),
             'useOddEven' => $this->hasMode(self::OUTPUT_TWO_SIDED) ? '1' : '0',
             'mirrorMargins' => $this->hasMode(self::OUTPUT_TWO_SIDED) ? '1' : '0',

--- a/modules/Reports/src/Renderer/MpdfRenderer.php
+++ b/modules/Reports/src/Renderer/MpdfRenderer.php
@@ -1,0 +1,370 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\Reports\Renderer;
+
+use Gibbon\Module\Reports\ReportData;
+use Gibbon\Module\Reports\ReportTemplate;
+use Gibbon\Module\Reports\ReportSection;
+use Gibbon\Module\Reports\Renderer\ReportRendererInterface;
+use Mpdf\Mpdf as Mpdf;
+use Mpdf\Config\ConfigVariables;
+use Mpdf\Config\FontVariables;
+use Twig_Environment;
+
+class MpdfRenderer implements ReportRendererInterface
+{
+    protected $template;
+    protected $pdf;
+    protected $twig;
+
+    protected $absolutePath;
+    protected $filename;
+
+    protected $mode = 0;
+    protected $firstPage = true;
+    protected $lastPage = false;
+
+    protected $preProcess = array();
+    protected $postProcess = array();
+
+    public function __construct(Twig_Environment $templateEngine)
+    {
+        $this->twig = $templateEngine;
+    }
+
+    public function setMode(int $bitmask)
+    {
+        $this->mode |= $bitmask;
+    }
+
+    public function hasMode(int $bitmask)
+    {
+        return ($this->mode & $bitmask) == $bitmask;
+    }
+
+    public function addPreProcess(string $name, callable $callable)
+    {
+        if (is_callable($callable)) {
+            $this->preProcess[$name] = $callable;
+        }
+    }
+
+    public function addPostProcess(string $name, callable $callable)
+    {
+        if (is_callable($callable)) {
+            $this->postProcess[$name] = $callable;
+        }
+    }
+
+    public function render(ReportTemplate $template, array $input, string $output = '') 
+    {
+        $this->template = $template;
+        $this->absolutePath = $template->getData('absolutePath');
+        $this->customAssetPath = $template->getData('customAssetPath');
+
+        $customTemplatePath = $this->absolutePath.$this->customAssetPath.'/templates';
+        if (is_dir($customTemplatePath)) {
+            $this->twig->getLoader()->prependPath($customTemplatePath);
+        }
+
+        $reports = (is_array($input))? $input : array($input);
+        $this->filename = $output;
+
+        $this->setupDocument();
+        
+        foreach ($reports as $reportData) {
+            if ($reportData instanceof ReportData) {
+                $this->setupReport($reportData);
+                $this->renderReport($reportData);
+                $this->finishReport($reportData);
+            }
+        }
+
+        if ($this->hasMode(self::OUTPUT_CONTINUOUS)) {
+            $finalReport = end($reports);
+            $outputPath = $this->getFilePath($finalReport);
+            $this->finishDocument($outputPath);
+        }
+    }
+
+    protected function renderReport(ReportData &$reportData)
+    {
+        $sections = $this->template->getSections();
+
+        if (!empty($sections)) {
+            foreach ($sections as $section) {
+                $this->renderSection($section, $reportData);
+            }
+        }
+    }
+
+    protected function renderSection(ReportSection &$section, ReportData &$reportData)
+    {
+        if ($section->hasFlag(ReportSection::SKIP_IF_EMPTY)) {
+            $data = array_filter($reportData->getData(array_keys($section->sources)));
+
+            if (empty($data)) {
+                return;
+            }
+        }
+
+        $this->lastPage = $section->lastPage || $this->lastPage;
+
+        $this->setHeader();
+
+        if ($section->hasFlag(ReportSection::PAGE_BREAK_BEFORE) || $this->firstPage) {
+            $this->pdf->AddPageByArray(['suppress' => 'off']);
+        }
+        
+        $this->setFooter();
+
+        $html = $this->renderSectionToHTML($section, $reportData);
+
+        if ($section->x != null && $section->y != null) {
+            $this->pdf->WriteFixedPosHTML($html, floatval($section->x), floatval($section->y), !empty($section->width) ? $section->width : '100%', !empty($section->height) ? $section->height : '100%', 'visible');
+        } else {
+            $this->pdf->writeHTML($html.'<br/>');
+        }
+
+        $this->firstPage = false;
+
+        if ($section->hasFlag(ReportSection::PAGE_BREAK_AFTER)) {
+            $this->pdf->AddPageByArray([]);
+        }
+    }
+
+    protected function renderSectionToHTML(ReportSection &$section, ReportData &$reportData)
+    {
+        $data = $reportData->getData(array_keys($section->sources));
+        $data = array_merge($data, $this->template->getData(), $section->getData());
+        
+        // Render .twig templates using Twig
+        if (stripos($section->template, '.twig') !== false) {
+            return $this->twig->render($section->template, $data);
+        }
+        
+        // Render .php templates by including the file, data is shared by scope
+        if (stripos($section->template, '.php') !== false) {
+            $pdf = $this->pdf;
+            return include 'templates/'.$section->template;
+        }
+
+        return '';
+    }
+
+    protected function setupDocument()
+    {
+        $defaultConfig = (new ConfigVariables())->getDefaults();
+        $fontDirs = $defaultConfig['fontDir'] ?? [];
+
+        $defaultFontConfig = (new FontVariables())->getDefaults();
+        $fontData = $defaultFontConfig['fontdata'] ?? [];
+
+        $config = [
+            'mode' => 'utf-8',
+            'format' => [210, 297],
+            'orientation' => $this->template->getData('orientation', 'P'),
+            'useOddEven' => $this->hasMode(self::OUTPUT_TWO_SIDED) ? '1' : '0',
+            'mirrorMargins' => $this->hasMode(self::OUTPUT_TWO_SIDED) ? '1' : '0',
+
+            'margin_top' => $this->template->getData('marginY', '10'),
+            'margin_bottom' => $this->template->getData('marginY', '10'),
+            'margin_left' => $this->template->getData('marginX', '10'),
+            'margin_right' => $this->template->getData('marginX', '10'),
+
+            'setAutoTopMargin' => 'stretch',
+            'setAutoBottomMargin' => 'stretch',
+            'autoMarginPadding' => 1,
+
+            'shrink_tables_to_fit' => 0,
+            'defaultPagebreakType' => 'cloneall',
+            
+            'fontDir' => array_merge($fontDirs, [
+                $this->absolutePath.'/resources/reports/fonts',
+            ]),
+
+            'tempDir' =>  $this->absolutePath.'/uploads/reports/temp',
+            'default_font' => 'sans-serif',
+        ];
+
+        $stylesheetPath = $this->absolutePath.'/modules/Reports/templates/'.$this->template->getData('stylesheet');
+        if (is_file($stylesheetPath)) {
+            $config['defaultCssFile'] = $stylesheetPath;
+        } else {
+            $stylesheetPath = $this->absolutePath.$this->customAssetPath.'/templates/'.$this->template->getData('stylesheet');
+            if (is_file($stylesheetPath)) {
+                $config['defaultCssFile'] = $stylesheetPath;
+            }
+        }
+
+        $this->pdf = new Mpdf($config);
+
+        $this->template->addData([
+            'basePath' => $this->absolutePath,
+            'assetPath' => $this->absolutePath.$this->customAssetPath,
+            'isDraft' => $this->template->getIsDraft(),
+            'stylesheet' => ''
+        ]);
+    }
+
+    protected function setupReport(ReportData &$reportData)
+    {
+        if (empty($this->pdf)) {
+            $this->setupDocument();
+        }
+
+        $this->runPreProcess($reportData);
+
+        // Define Headers
+        $this->headers = $this->template->getHeaders();
+        
+        foreach ($this->headers as $index => $header) {
+            $data = $reportData->getData(array_keys($header->sources));
+            $data = array_merge($data, $this->template->getData(), $header->getData());
+
+            $this->pdf->DefHTMLHeaderByName('html_header'.$index, $this->twig->render($header->template, $data));
+        }
+
+        // Define Footers
+        $this->footers = $this->template->getFooters();
+
+        foreach ($this->footers as $index => $footer) {
+            $data = $reportData->getData(array_keys($footer->sources));
+            $data = array_merge($data, $this->template->getData(), $footer->getData());
+
+            $this->pdf->DefHTMLFooterByName('html_footer'.$index, $this->twig->render($footer->template, $data));
+        }
+
+        // Watermark
+        if ($this->template->getIsDraft()) {
+            $this->pdf->SetWatermarkText(__('DRAFT COPY. THIS IS NOT A FINAL REPORT.'), 0.05);
+            $this->pdf->showWatermarkText = true;
+        }
+
+        
+    }
+
+    protected function finishDocument($outputPath)
+    {
+        if (!empty($this->pdf)) {
+            if (!file_exists(dirname($outputPath))) {
+                mkdir(dirname($outputPath), 0755, true);
+            }
+
+            $this->pdf->Output($outputPath, 'F');
+            unset($this->pdf);
+        }
+    }
+
+    protected function finishReport(ReportData &$reportData)
+    {
+        $this->template->addData(['lastPage' => true]);
+        $this->lastPage = true;
+        
+        $this->setHeader();
+        $this->setFooter();
+
+        $this->runPostProcess($reportData);
+
+        // Add a page with odd-numbered reports for two-sided printing
+        if ($this->hasMode(self::OUTPUT_TWO_SIDED)) {
+            $this->pdf->AddPageByArray([
+                'type' => 'ODD',
+                'resetpagenum' => 1,
+                'suppress' => 'on',
+                'odd-header-name' => '',
+                'even-header-name' => '',
+                'odd-footer-name' => '',
+                'even-footer-name' => '',
+            ]);
+        }
+        
+        // Continue the current document after a report for continuous output
+        if ($this->hasMode(self::OUTPUT_CONTINUOUS)) {
+            $this->firstPage = true;
+            $this->lastPage = false;
+        } else {
+            $outputPath = $this->getFilePath($reportData);
+            $this->finishDocument($outputPath);
+        }
+    }
+
+    protected function setHeader()
+    {
+        $pageNum = $this->lastPage ? -1 : $this->pdf->getPageNumber() + 1;
+        $defaultHeader = isset($this->headers[0])? 'html_header0' : false;
+        $headerName = isset($this->headers[$pageNum])? 'html_header'.$pageNum : $defaultHeader;
+
+        $this->pdf->SetHTMLHeaderByName($headerName, $pageNum % 2 == 0 || $this->firstPage ? 'O' : 'E', $this->lastPage);
+    }
+
+    protected function setFooter()
+    {
+        $pageNum = $this->lastPage ? -1 : $this->pdf->getPageNumber();
+        $defaultFooter = isset($this->footers[0])? 'html_footer0' : false;
+        $footerName = isset($this->footers[$pageNum])? 'html_footer'.$pageNum : $defaultFooter;
+
+        $this->pdf->SetHTMLFooterByName($footerName, $pageNum % 2 == 0 ? 'E' : 'O');
+    }
+
+    protected function runPreProcess(ReportData &$reportData)
+    {
+        if (empty($reportData)) return;
+
+        foreach ($this->preProcess as $name => $callable) {
+            try {
+                call_user_func($callable, $reportData);
+            } catch (\Exception $e) {
+                echo 'Error calling pre-process '.$name;
+                return;
+            }
+        }
+    }
+
+    protected function runPostProcess(ReportData &$reportData)
+    {
+        if (empty($reportData)) return;
+
+        foreach ($this->postProcess as $name => $callable) {
+            try {
+                $outputPath = $this->getFilePath($reportData);
+                call_user_func($callable, $reportData, $outputPath);
+            } catch (\Exception $e) {
+                echo 'Error calling post-process '.$name;
+                return;
+            }
+        }
+    }
+
+    protected function getFilePath(ReportData &$reportData)
+    {
+        $filename = 'output.pdf';
+
+        if (is_callable($this->filename)) {
+            $filename = call_user_func($this->filename, $this, $reportData);
+        }
+
+        if (is_string($this->filename)) {
+            $filename = $this->filename;
+        }
+
+        return $filename;
+    }
+}

--- a/modules/Reports/src/Renderer/MpdfRenderer.php
+++ b/modules/Reports/src/Renderer/MpdfRenderer.php
@@ -312,7 +312,11 @@ class MpdfRenderer implements ReportRendererInterface
         $defaultHeader = isset($this->headers[0])? 'html_header0' : false;
         $headerName = isset($this->headers[$pageNum])? 'html_header'.$pageNum : $defaultHeader;
 
-        $this->pdf->SetHTMLHeaderByName($headerName, $pageNum % 2 == 0 || $this->firstPage ? 'O' : 'E', $this->lastPage);
+        if ($this->hasMode(self::OUTPUT_TWO_SIDED)) {
+            $this->pdf->SetHTMLHeaderByName($headerName, $pageNum % 2 == 0 || $this->firstPage ? 'O' : 'E', $this->lastPage);
+        } else {
+            $this->pdf->SetHTMLHeaderByName($headerName, 'O', $this->lastPage);
+        }
     }
 
     protected function setFooter()
@@ -321,7 +325,11 @@ class MpdfRenderer implements ReportRendererInterface
         $defaultFooter = isset($this->footers[0])? 'html_footer0' : false;
         $footerName = isset($this->footers[$pageNum])? 'html_footer'.$pageNum : $defaultFooter;
 
-        $this->pdf->SetHTMLFooterByName($footerName, $pageNum % 2 == 0 ? 'E' : 'O');
+        if ($this->hasMode(self::OUTPUT_TWO_SIDED)) {
+            $this->pdf->SetHTMLFooterByName($footerName, $pageNum % 2 == 0 ? 'E' : 'O');
+        } else {
+            $this->pdf->SetHTMLFooterByName($footerName);
+        }
     }
 
     protected function runPreProcess(ReportData &$reportData)

--- a/modules/Reports/src/Renderer/ReportRendererInterface.php
+++ b/modules/Reports/src/Renderer/ReportRendererInterface.php
@@ -1,0 +1,36 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\Reports\Renderer;
+
+use Gibbon\Module\Reports\ReportTemplate;
+
+interface ReportRendererInterface
+{
+    const OUTPUT_TWO_SIDED = 0b0001;
+    const OUTPUT_CONTINUOUS = 0b0010;
+    
+    public function setMode(int $bitmask);
+    public function hasMode(int $bitmask);
+
+    public function addPreProcess(string $name, callable $callable);
+    public function addPostProcess(string $name, callable $callable);
+
+    public function render(ReportTemplate $template, array $input, string $output = '');
+}

--- a/modules/Reports/src/ReportBuilder.php
+++ b/modules/Reports/src/ReportBuilder.php
@@ -67,6 +67,7 @@ class ReportBuilder
             'marginX'     => $templateData['marginX'],
             'marginY'     => $templateData['marginY'],
             'stylesheet'  => $templateData['stylesheet'] ?? '',
+            'flags'       => $templateData['flags'] ?? '',
         ]);
 
         $criteria = $this->templateSectionGateway->newQueryCriteria()

--- a/modules/Reports/src/ReportTemplate.php
+++ b/modules/Reports/src/ReportTemplate.php
@@ -70,6 +70,11 @@ class ReportTemplate
         }, array()));
     }
 
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
     public function addHeader($section, $pageNum = self::ALL_PAGES)
     {
         if ($section = $this->getOrCreateSection($section)) {
@@ -95,6 +100,11 @@ class ReportTemplate
         }
 
         return false;
+    }
+
+    public function getFooters()
+    {
+        return $this->footers;
     }
 
     public function addFooter($section, $pageNum = self::ALL_PAGES)

--- a/modules/Reports/src/Sources/CustomFields.php
+++ b/modules/Reports/src/Sources/CustomFields.php
@@ -1,0 +1,53 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\Reports\Sources;
+
+use Gibbon\Module\Reports\DataSource;
+
+class CustomFields extends DataSource
+{
+    public function getSchema()
+    {
+        return [
+            'Field Name'   => ['sentence'],
+        ];
+    }
+
+    public function getData($ids = [])
+    {
+        $data = ['gibbonStudentEnrolmentID' => $ids['gibbonStudentEnrolmentID']];
+        $sql = "SELECT gibbonPerson.fields
+                FROM gibbonStudentEnrolment 
+                JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
+                WHERE gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID";
+
+        $fieldData = $this->db()->selectOne($sql, $data);
+        $personFields = unserialize($fieldData ?? '');
+
+        $sql = "SELECT name, gibbonPersonFieldID FROM gibbonPersonField WHERE active='Y' AND activePersonStudent=1";
+        $fields = $this->db()->select($sql)->fetchKeyPair();
+        
+        $personFields = array_map(function ($id) use ($personFields) {
+            return $personFields[$id] ?? '';
+        }, $fields);
+
+        return $personFields;
+    }
+}

--- a/modules/Reports/src/Sources/Report.php
+++ b/modules/Reports/src/Sources/Report.php
@@ -29,7 +29,7 @@ class Report extends DataSource
             'name'       => "Sample Report",
             'status'     => "Final",
             'date'       => ['date', 'Y-m-d'],
-            'schoolYear' => ['date', 'Y-m-d'],
+            'schoolYear' => '2019-2020',
         ];
     }
 

--- a/modules/Reports/src/Sources/YearGroupCriteria.php
+++ b/modules/Reports/src/Sources/YearGroupCriteria.php
@@ -43,8 +43,21 @@ class YearGroupCriteria extends DataSource
                     'officialName'        => ['sameAs', 'firstName surname'],
                 ],
             ],
-            'perStudent' => [
 
+            'perStudent' => [
+                0 => [
+                    'scopeName'           => 'Year Group',
+                    'criteriaName'        => 'Student Comment',
+                    'criteriaDescription' => ['sentence'],
+                    'value'               => ['randomDigit'],
+                    'comment'             => ['paragraph', 6],
+                    'valueType'           => 'Comment',
+                    'title'               => ['title', $gender],
+                    'surname'             => ['lastName'],
+                    'firstName'           => ['firstName', $gender],
+                    'preferredName'       => ['sameAs', 'firstName'],
+                    'officialName'        => ['sameAs', 'firstName surname'],
+                ],
             ],
         ];
     }

--- a/modules/Reports/src/Sources/YearGroupCriteria.php
+++ b/modules/Reports/src/Sources/YearGroupCriteria.php
@@ -79,7 +79,8 @@ class YearGroupCriteria extends DataSource
                     createdBy.surname,
                     createdBy.firstName,
                     createdBy.preferredName,
-                    createdBy.officialName
+                    createdBy.officialName,
+                    gibbonStaff.jobTitle
                 FROM gibbonStudentEnrolment 
                 JOIN gibbonReportingCriteria ON (gibbonReportingCriteria.gibbonYearGroupID=gibbonStudentEnrolment.gibbonYearGroupID)
                 JOIN gibbonReportingValue ON (gibbonReportingCriteria.gibbonReportingCriteriaID=gibbonReportingValue.gibbonReportingCriteriaID AND (gibbonReportingValue.gibbonPersonIDStudent=gibbonStudentEnrolment.gibbonPersonID OR gibbonReportingValue.gibbonPersonIDStudent=0))
@@ -89,6 +90,7 @@ class YearGroupCriteria extends DataSource
                 LEFT JOIN gibbonReportingProgress ON (gibbonReportingProgress.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID AND (gibbonReportingProgress.gibbonPersonIDStudent=gibbonStudentEnrolment.gibbonPersonID OR gibbonReportingProgress.gibbonPersonIDStudent=0))
                 LEFT JOIN gibbonScaleGrade ON (gibbonScaleGrade.gibbonScaleID=gibbonReportingCriteriaType.gibbonScaleID AND gibbonScaleGrade.gibbonScaleGradeID=gibbonReportingValue.gibbonScaleGradeID)
                 LEFT JOIN gibbonPerson as createdBy ON (createdBy.gibbonPersonID=gibbonReportingValue.gibbonPersonIDCreated)
+                LEFT JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=createdBy.gibbonPersonID)
                 WHERE gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
                 AND gibbonReportingCriteria.gibbonReportingCycleID=:gibbonReportingCycleID
                 AND gibbonReportingScope.scopeType='Year Group'

--- a/modules/Reports/templates/preview.twig.html
+++ b/modules/Reports/templates/preview.twig.html
@@ -63,8 +63,8 @@ footer {
         {% set baseWidth = orientation == 'L' ? '279.4' : '215.9' %}
         {% set baseHeight = orientation == 'L' ? '215.9' : '279.4' %}
     {% else %}
-        {% set baseWidth = orientation == 'L' ? '297' : '190' %}
-        {% set baseHeight = orientation == 'L' ? '190' : '297' %}
+        {% set baseWidth = orientation == 'L' ? '297' : '210' %}
+        {% set baseHeight = orientation == 'L' ? '210' : '297' %}
     {% endif%}
     
     {% for page in pages %}

--- a/modules/Reports/templates_assets_components_preview.php
+++ b/modules/Reports/templates_assets_components_preview.php
@@ -25,6 +25,7 @@ use Gibbon\Module\Reports\ReportTemplate;
 use Gibbon\Module\Reports\ReportBuilder;
 use Gibbon\Module\Reports\Domain\ReportPrototypeSectionGateway;
 use Gibbon\Module\Reports\Domain\ReportTemplateGateway;
+use Gibbon\Module\Reports\Renderer\HtmlRenderer;
 
 if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_components_preview.php') == false) {
     // Access denied
@@ -71,11 +72,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_c
     $reports = $reportBuilder->buildReportMock($template);
 
     // Render
-    $renderer = new ReportRenderer($template, $twig);
+    $renderer = $container->get(HtmlRenderer::class);
 
     if (isset($page)) {
         echo $twig->render('preview.twig.html', $prototypeSection + [
-            'pages' => $renderer->renderToHTML($reports),
+            'pages' => $renderer->render($template, $reports),
             'prototype' => true,
             'marginX' => '10',
             'marginY' => '5',

--- a/modules/Reports/templates_assets_fonts_preview.php
+++ b/modules/Reports/templates_assets_fonts_preview.php
@@ -21,6 +21,7 @@ use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Module\Reports\ReportRenderer;
 use Gibbon\Module\Reports\ReportBuilder;
 use Gibbon\Module\Reports\Domain\ReportTemplateFontGateway;
+use Gibbon\Module\Reports\Renderer\HtmlRenderer;
 
 if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_components_preview.php') == false) {
     // Access denied
@@ -61,11 +62,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_c
     $reports = $reportBuilder->buildReportMock($template);
 
     // Render
-    $renderer = new ReportRenderer($template, $twig);
+    $renderer = $container->get(HtmlRenderer::class);
 
     if (isset($page)) {
         echo $twig->render('preview.twig.html', [
-            'pages'     => $renderer->renderToHTML($reports),
+            'pages'     => $renderer->render($template, $reports),
             'prototype' => true,
             'name'      => $font['fontName'],
             'marginX'   => '10',

--- a/modules/Reports/templates_manage_add.php
+++ b/modules/Reports/templates_manage_add.php
@@ -69,6 +69,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_a
         $row->addLabel('stylesheet', __('Stylesheet'));
         $row->addSelect('stylesheet')->fromResults($stylesheets)->placeholder();
 
+    $flags = ['000' => __('TCPDF Renderer - Faster, Limited HTML'), '001' => __('mPDF Renderer - Slower, Better HTML Support')];
+    $row = $form->addRow();
+        $row->addLabel('flags', __('Renderer'));
+        $row->addSelect('flags')->fromArray($flags)->required();
+
     $form->addRow()->addHeading(__('Document Setup'));
 
     $orientations = ['P' => __('Portrait'), 'L' => __('Landscape')];

--- a/modules/Reports/templates_manage_addProcess.php
+++ b/modules/Reports/templates_manage_addProcess.php
@@ -42,6 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_a
         'marginX'     => $_POST['marginX'] ?? '',
         'marginY'     => $_POST['marginY'] ?? '',
         'stylesheet'  => $_POST['stylesheet'] ?? '',
+        'flags'       => $_POST['flags'] ?? '',
     ];
 
     // Validate the required values are present

--- a/modules/Reports/templates_manage_edit.php
+++ b/modules/Reports/templates_manage_edit.php
@@ -84,6 +84,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
         $row->addLabel('stylesheet', __('Stylesheet'));
         $row->addSelect('stylesheet')->fromResults($stylesheets)->placeholder();
 
+    $flags = ['000' => __('TCPDF Renderer - Faster, Limited HTML'), '001' => __('mPDF Renderer - Slower, Better HTML Support')];
+    $row = $form->addRow();
+        $row->addLabel('flags', __('Renderer'));
+        $row->addSelect('flags')->fromArray($flags)->required();
+
     $form->addRow()->addHeading(__('Document Setup'));
 
     $orientations = ['P' => __('Portrait'), 'L' => __('Landscape')];

--- a/modules/Reports/templates_manage_editProcess.php
+++ b/modules/Reports/templates_manage_editProcess.php
@@ -41,6 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
         'marginX'     => $_POST['marginX'] ?? '',
         'marginY'     => $_POST['marginY'] ?? '',
         'stylesheet'  => $_POST['stylesheet'] ?? '',
+        'flags'       => $_POST['flags'] ?? '',
     ];
 
     // Validate the required values are present


### PR DESCRIPTION
Requires #988 

This PR adds an option to select the PDF renderer when setting up a report template. In the back-end, it introduces a `ReportRendererInterface` and separates the previous `ReportRenderer` into `HtmlRenderer`, `TcpdfRenderer` and `MpdfRenderer`.

<img width="1151" alt="Screenshot 2020-01-24 at 12 31 14 PM" src="https://user-images.githubusercontent.com/897700/73044778-2e452c80-3ea6-11ea-8856-d0f6a926c585.png">

By the end of v20 we may want set mPDF as the default. For now, I think support for both options is a reasonable way to go.