### PR TITLE
Students: Fix emergency data report not showing parents column

### DIFF
--- a/src/Domain/Students/StudentReportGateway.php
+++ b/src/Domain/Students/StudentReportGateway.php
@@ -44,15 +44,15 @@ class StudentReportGateway extends QueryableGateway
     public function queryStudentDetails(QueryCriteria $criteria, $gibbonPersonID)
     {
         $gibbonPersonIDList = is_array($gibbonPersonID) ? implode(',', $gibbonPersonID) : $gibbonPersonID;
-        $data = array('gibbonPersonIDList' => $gibbonPersonIDList);
 
         $query = $this
             ->newQuery()
             ->from('gibbonPerson')
             ->cols([
-                'gibbonPerson.gibbonPersonID', 'gibbonPerson.*', 'gibbonPersonMedical.*',
+                'gibbonPerson.*', 'gibbonPersonMedical.*',
                 "(SELECT timestamp FROM gibbonPersonUpdate WHERE gibbonPersonID=gibbonPerson.gibbonPersonID AND status='Complete' ORDER BY timestamp DESC LIMIT 1) as lastPersonalUpdate",
-                "(SELECT timestamp FROM gibbonPersonMedicalUpdate WHERE gibbonPersonID=gibbonPerson.gibbonPersonID AND status='Complete' ORDER BY timestamp DESC LIMIT 1) as lastMedicalUpdate"
+                "(SELECT timestamp FROM gibbonPersonMedicalUpdate WHERE gibbonPersonID=gibbonPerson.gibbonPersonID AND status='Complete' ORDER BY timestamp DESC LIMIT 1) as lastMedicalUpdate",
+                'gibbonPerson.gibbonPersonID'
             ])
             ->leftJoin('gibbonPersonMedical', 'gibbonPersonMedical.gibbonPersonID=gibbonPerson.gibbonPersonID')
             ->where('FIND_IN_SET(gibbonPerson.gibbonPersonID, :gibbonPersonIDList)')


### PR DESCRIPTION
**Description**
People -> Students -> Reports -> Emergency Data Summary
The report is showing empty parents column.

gibbonPersonID get's replaced with blank which when passed to FamilyGateway produced nothing. Moving gibbonPersonID to the end solve the problem.

Besides that, I removed $data variable since it's not used.