### PR TITLE
Fixed the first and last day of the selected school year

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ v20.0.00
         Reports: fixed Course scope Per Group criteria not saving per-class
         Reports: suppressed TCPDF deprecation messages when generating PDFs
         Reports: fixed pronoun switching not applied globally in some browsers
+        System: fixed the first and last day of the selected school year
 
 v19.0.00
 --------

--- a/yearSwitcherProcess.php
+++ b/yearSwitcherProcess.php
@@ -87,6 +87,8 @@ if (empty($gibbonSchoolYearID)) {
                     $gibbon->session->set('gibbonSchoolYearID', $rowYear['gibbonSchoolYearID']);
                     $gibbon->session->set('gibbonSchoolYearName', $rowYear['name']);
                     $gibbon->session->set('gibbonSchoolYearSequenceNumber', $rowYear['sequenceNumber']);
+                    $gibbon->session->set('gibbonSchoolYearFirstDay', $rowYear['firstDay']);
+                    $gibbon->session->set('gibbonSchoolYearLastDay', $rowYear['lastDay']);
 
                     // Reload cached FF actions
                     $gibbon->session->cacheFastFinderActions($gibbon->session->get('gibbonRoleIDCurrent'));


### PR DESCRIPTION
**Description**
Fixed the first and last day of the selected school year in session

**Motivation and Context**
When I switch the school year, I can't see the data for the selected school year because the system keeps the first day and last day of current school year. e.g modules/Attendance/report_summary_byDate.php

**How Has This Been Tested?**
Local and Travis
