### PR TITLE
Reports: add hooks for custom criteria types in the report writing screen

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -628,4 +628,5 @@ UPDATE `gibboni18n` SET `name` = 'Español - España' WHERE `code` = 'es_ES';end
 INSERT INTO `gibboni18n` (`code`, `name`, `active`, `installed`, `systemDefault`, `dateFormat`, `dateFormatRegEx`, `dateFormatPHP`, `rtl`) VALUES ('es_MX', 'Español - Mexico', 'Y', 'N', 'N', 'dd/mm/yyyy', '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i', 'd/m/Y', 'N');end
 ALTER TABLE `gibbonReportingValue` DROP INDEX `gibbonReportingCriteriaID`, ADD UNIQUE `gibbonReportingCriteriaID` (`gibbonReportingCriteriaID`, `gibbonPersonIDStudent`, `gibbonCourseClassID`) USING BTREE;end
 ALTER TABLE `gibbonHook` CHANGE `type` `type` ENUM('Public Home Page','Student Profile','Parental Dashboard','Staff Dashboard','Student Dashboard','Report Writing') CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
+ALTER TABLE `gibbonReportingCriteriaType` ADD UNIQUE(`name`);end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -627,4 +627,5 @@ ALTER TABLE `gibbonDepartment` ADD `sequenceNumber` INT(4) UNSIGNED NULL AFTER `
 UPDATE `gibboni18n` SET `name` = 'Español - España' WHERE `code` = 'es_ES';end
 INSERT INTO `gibboni18n` (`code`, `name`, `active`, `installed`, `systemDefault`, `dateFormat`, `dateFormatRegEx`, `dateFormatPHP`, `rtl`) VALUES ('es_MX', 'Español - Mexico', 'Y', 'N', 'N', 'dd/mm/yyyy', '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i', 'd/m/Y', 'N');end
 ALTER TABLE `gibbonReportingValue` DROP INDEX `gibbonReportingCriteriaID`, ADD UNIQUE `gibbonReportingCriteriaID` (`gibbonReportingCriteriaID`, `gibbonPersonIDStudent`, `gibbonCourseClassID`) USING BTREE;end
+ALTER TABLE `gibbonHook` CHANGE `type` `type` ENUM('Public Home Page','Student Profile','Parental Dashboard','Staff Dashboard','Student Dashboard','Report Writing') CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ v20.0.00
         Planner: removed bold from Chat comment in lesson plan view
         Reports: added a Proof Read by Form Group option
         Reports: added an option to select the PDF rendering library in Template Builder
+        Reports: added hooks for custom criteria types in the report writing screen
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
 
     Bug Fixes

--- a/modules/Reports/reporting_write_byStudent.php
+++ b/modules/Reports/reporting_write_byStudent.php
@@ -198,6 +198,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_write_by
         if ($criteria['valueType'] == 'Hook' && isset($hooks[$criteria['criteriaName']])) {
             // Attempt to load a hook, otherwise display an alert.
             if (!$hookInclude($hooks[$criteria['criteriaName']], $criteria)) {
+                $form->addHiddenValue($fieldName, $criteria['value']);
                 $form->addRow()->addAlert(__('Failed to load {name}', [
                     'name' => $criteria['criteriaName'],
                 ]), 'error');

--- a/modules/Rubrics/src/Visualise.php
+++ b/modules/Rubrics/src/Visualise.php
@@ -77,9 +77,10 @@ class Visualise
      * @param   $legend should the legend be included?
      * @param   $image should the chart be saved as an image
      * @param   $path if image is saved, where should it be saved (defaults to standard upload location)
+     * @param   $id optionally outputs the image path to the value of the given id
      * @return   void
      */
-    public function renderVisualise($legend = true, $image = false, $path = '')
+    public function renderVisualise($legend = true, $image = false, $path = '', $id = '')
     {
         //Filter out columns to ignore from visualisation
         $this->columns = array_filter($this->columns, function ($item) {
@@ -143,13 +144,15 @@ class Visualise
                 ]
             ];
             if ($image) {
-                $path = ($path != '') ? ", path: '$path'" : '';
                 $options['animation'] = [
                     'duration' => 0,
                     'onComplete' => $chart->addFunction('function(e) {
                         var img = visualisation'.$this->gibbonPersonID.'.toDataURL("image/png");
-                        $.ajax({ url: "'.$this->absoluteURL.'/modules/Rubrics/src/visualise_saveAjax.php", type: "POST", data: {img: img, gibbonPersonID: \''.$this->gibbonPersonID.$path.'\'}, dataType: "html"})
-                        $.ajax({ url: "./"});
+                        $.ajax({ url: "'.$this->absoluteURL.'/modules/Rubrics/src/visualise_saveAjax.php", type: "POST", data: {img: img, gibbonPersonID: \''.$this->gibbonPersonID.'\', path: \''.$path.'\'}, dataType: "html", success: function (data) {
+                            '.( $id ? '$("#'.$id.'").val(data);' : '' ).'
+                        } });
+
+                        this.options.animation.onComplete = null;
                     }'),
                 ];
             }

--- a/src/Domain/Rubrics/RubricGateway.php
+++ b/src/Domain/Rubrics/RubricGateway.php
@@ -73,4 +73,39 @@ class RubricGateway extends QueryableGateway
         
         return $this->runQuery($query, $criteria);
     }
+
+    public function selectRowsByRubric($gibbonRubricID)
+    {
+        $data = ['gibbonRubricID' => $gibbonRubricID];
+        $sql = "SELECT *, (CASE WHEN gibbonOutcome.name IS NOT NULL THEN gibbonOutcome.name ELSE title END) as title FROM gibbonRubricRow LEFT JOIN gibbonOutcome ON (gibbonRubricRow.gibbonOutcomeID=gibbonOutcome.gibbonOutcomeID) WHERE gibbonRubricID=:gibbonRubricID ORDER BY sequenceNumber";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectColumnsByRubric($gibbonRubricID)
+    {
+        $data = ['gibbonRubricID' => $gibbonRubricID];
+        $sql = "SELECT * FROM gibbonRubricColumn WHERE gibbonRubricID=:gibbonRubricID ORDER BY sequenceNumber";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectCellsByRubric($gibbonRubricID)
+    {
+        $data = ['gibbonRubricID' => $gibbonRubricID];
+        $sql = "SELECT * FROM gibbonRubricCell WHERE gibbonRubricID=:gibbonRubricID";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectGradeScalesByRubric($gibbonRubricID)
+    {
+        $data = ['gibbonRubricID' => $gibbonRubricID];
+        $sql = "SELECT gibbonScaleGrade.gibbonScaleGradeID, gibbonScaleGrade.*, gibbonScale.name FROM gibbonRubricColumn
+        JOIN gibbonScaleGrade ON (gibbonRubricColumn.gibbonScaleGradeID=gibbonScaleGrade.gibbonScaleGradeID)
+        JOIN gibbonScale ON (gibbonScale.gibbonScaleID=gibbonScaleGrade.gibbonScaleID)
+        WHERE gibbonRubricColumn.gibbonRubricID=:gibbonRubricID";
+
+        return $this->db()->select($sql, $data);
+    }
 }

--- a/src/Domain/System/HookGateway.php
+++ b/src/Domain/System/HookGateway.php
@@ -1,0 +1,46 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\System;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * Hook Gateway
+ *
+ * @version v20
+ * @since   v20
+ */
+class HookGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonHook';
+    private static $primaryKey = 'gibbonHookID';
+
+    public function selectHooksByType($type)
+    {
+        $data = ['type' => $type];
+        $sql = "SELECT name, options FROM gibbonHook WHERE type=:type ORDER BY name";
+
+        return $this->db()->select($sql, $data);
+    }
+}


### PR DESCRIPTION
This PR adds a "Report Writing" hook type, which can be used to display custom form fields in the report writing screen. For example, some schools may want to use a custom layout for certain inputs, generate an image, or display a diagram inside the report writing screen. Any hook that matches the name of a Criteria Type will be included as custom code instead of the default form fields.

For example, a custom hook can used to display a Chart.js diagram and save it as an image during report writing:
<img width="793" alt="Screen Shot 2020-03-05 at 2 30 37 PM" src="https://user-images.githubusercontent.com/897700/75954394-8c761e00-5eee-11ea-83fd-a490f5b30acc.png">

This PR also tweaks the Visualize.php code to optionally return the filename of the image it generated (related to the image above, should not affect any other core features).
