### PR TITLE
Reports: add the ability to select fonts in Template Builder

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -627,4 +627,8 @@ ALTER TABLE `gibbonDepartment` ADD `sequenceNumber` INT(4) UNSIGNED NULL AFTER `
 UPDATE `gibboni18n` SET `name` = 'Español - España' WHERE `code` = 'es_ES';end
 INSERT INTO `gibboni18n` (`code`, `name`, `active`, `installed`, `systemDefault`, `dateFormat`, `dateFormatRegEx`, `dateFormatPHP`, `rtl`) VALUES ('es_MX', 'Español - Mexico', 'Y', 'N', 'N', 'dd/mm/yyyy', '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i', 'd/m/Y', 'N');end
 ALTER TABLE `gibbonReportingValue` DROP INDEX `gibbonReportingCriteriaID`, ADD UNIQUE `gibbonReportingCriteriaID` (`gibbonReportingCriteriaID`, `gibbonPersonIDStudent`, `gibbonCourseClassID`) USING BTREE;end
+ALTER TABLE `gibbonReportTemplateFont` ADD `fontType` ENUM('R','B','I','BI') NOT NULL DEFAULT 'R' AFTER `fontPath`;end
+ALTER TABLE `gibbonReportTemplateFont` ADD `fontFamily` VARCHAR(60) NULL AFTER `fontType`;end
+UPDATE `gibbonReportTemplateFont` SET fontFamily=fontName WHERE fontFamily IS NULL;end
+ALTER TABLE `gibbonReportTemplate` ADD `config` TEXT NULL AFTER `flags`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ v20.0.00
         Planner: removed bold from Chat comment in lesson plan view
         Reports: added a Proof Read by Form Group option
         Reports: added an option to select the PDF rendering library in Template Builder
+        Reports: added the ability to select fonts in Template Builder
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
 
     Bug Fixes

--- a/modules/Reports/src/Domain/ReportTemplateFontGateway.php
+++ b/modules/Reports/src/Domain/ReportTemplateFontGateway.php
@@ -64,7 +64,7 @@ class ReportTemplateFontGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
-    public function selectFontsByFamily()
+    public function selectFontFamilies()
     {
         $sql = "SELECT fontFamily as value, CONCAT(fontFamily, ' (', COUNT(*), ')') as name FROM gibbonReportTemplateFont GROUP BY fontFamily ORDER BY fontFamily";
 

--- a/modules/Reports/src/Domain/ReportTemplateFontGateway.php
+++ b/modules/Reports/src/Domain/ReportTemplateFontGateway.php
@@ -52,4 +52,22 @@ class ReportTemplateFontGateway extends QueryableGateway
 
         return $this->db()->select($sql);
     }
+
+    public function selectFontListByFamily($fontFamilies)
+    {
+        $data = ['fontFamilies' => is_array($fontFamilies)? implode(',', $fontFamilies) : $fontFamilies];
+        $sql = "SELECT fontFamily, fontType, fontPath 
+                FROM gibbonReportTemplateFont 
+                WHERE FIND_IN_SET(fontFamily, :fontFamilies)
+                ORDER BY fontFamily, fontType";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectFontsByFamily()
+    {
+        $sql = "SELECT fontFamily as value, CONCAT(fontFamily, ' (', COUNT(*), ')') as name FROM gibbonReportTemplateFont GROUP BY fontFamily ORDER BY fontFamily";
+
+        return $this->db()->select($sql);
+    }
 }

--- a/modules/Reports/src/Renderer/MpdfRenderer.php
+++ b/modules/Reports/src/Renderer/MpdfRenderer.php
@@ -196,11 +196,12 @@ class MpdfRenderer implements ReportRendererInterface
             'shrink_tables_to_fit' => 0,
             'defaultPagebreakType' => 'cloneall',
             
+            'tempDir' =>  $this->absolutePath.'/uploads/reports/temp',
             'fontDir' => array_merge($fontDirs, [
-                $this->absolutePath.'/resources/reports/fonts',
+                $this->absolutePath.$this->customAssetPath.'/fonts',
             ]),
 
-            'tempDir' =>  $this->absolutePath.'/uploads/reports/temp',
+            'fontdata' => $fontData + $this->template->getData('fonts', []),
             'default_font' => 'sans-serif',
         ];
 

--- a/modules/Reports/src/ReportBuilder.php
+++ b/modules/Reports/src/ReportBuilder.php
@@ -13,6 +13,7 @@ use Gibbon\Module\Reports\Domain\ReportTemplateGateway;
 use Gibbon\Module\Reports\Domain\ReportTemplateSectionGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Module\Reports\ReportSection;
+use Gibbon\Module\Reports\Domain\ReportTemplateFontGateway;
 
 class ReportBuilder
 {
@@ -21,18 +22,20 @@ class ReportBuilder
     protected $reportGateway;
     protected $reportTemplateGateway;
     protected $templateSectionGateway;
+    protected $templateFontGateway;
     protected $settingGateway;
 
     protected $absolutePath;
     protected $customAssetPath;
 
-    public function __construct(Connection $db, DataFactory $dataFactory, ReportGateway $reportGateway, ReportTemplateGateway $templateGateway, ReportTemplateSectionGateway $templateSectionGateway, SettingGateway $settingGateway)
+    public function __construct(Connection $db, DataFactory $dataFactory, ReportGateway $reportGateway, ReportTemplateGateway $templateGateway, ReportTemplateSectionGateway $templateSectionGateway, ReportTemplateFontGateway $templateFontGateway, SettingGateway $settingGateway)
     {
         $this->db = $db;
         $this->dataFactory = $dataFactory;
         $this->reportGateway = $reportGateway;
         $this->templateGateway = $templateGateway;
         $this->templateSectionGateway = $templateSectionGateway;
+        $this->templateFontGateway = $templateFontGateway;
         $this->settingGateway = $settingGateway;
 
         $this->absolutePath = $this->settingGateway->getSettingByScope('System', 'absolutePath');
@@ -69,6 +72,20 @@ class ReportBuilder
             'stylesheet'  => $templateData['stylesheet'] ?? '',
             'flags'       => $templateData['flags'] ?? '',
         ]);
+
+        $config = json_decode($templateData['config'] ?? '', true);
+        if (!empty($config['fonts'])) {
+            $fonts = $this->templateFontGateway->selectFontListByFamily($config['fonts'])->fetchAll();
+            $fonts = array_reduce($fonts, function ($group, $font) {
+                $fontPath = $this->absolutePath.$this->customAssetPath.'/fonts/'.basename($font['fontPath']);
+                if (!is_file($fontPath)) return $group;
+
+                $group[$font['fontFamily']][$font['fontType']] = basename($font['fontPath']);
+                return $group;
+            }, []);
+
+            $template->addData(['fonts' => $fonts]);
+        }
 
         $criteria = $this->templateSectionGateway->newQueryCriteria()
             ->sortBy('sequenceNumber', 'ASC')

--- a/modules/Reports/templates/preview.twig.html
+++ b/modules/Reports/templates/preview.twig.html
@@ -13,6 +13,17 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
   src: url('./resources/assets/fonts/DroidSansFallback.ttf')  format('truetype'); /* Safari, Android, iOS */
 }
 
+{% for fontFamily, fonts in fontList %}
+    {% for fontType, fontPath in fonts %}
+        @font-face {
+            font-family: '{{ fontFamily }}';
+            src: url('{{ fontURL }}/{{ fontPath }}')  format('truetype');
+            font-style: {{ 'I' in fontType ? 'italic' : 'normal' }};
+            font-weight: {{ 'B' in fontType ? '700' : 'normal' }};
+        }
+    {% endfor %}
+{% endfor %}
+
 body {
     margin: 0;
     padding: 0;

--- a/modules/Reports/templates_assets_fonts_edit.php
+++ b/modules/Reports/templates_assets_fonts_edit.php
@@ -60,6 +60,20 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_f
         $row->addTextField('fontName')->maxLength(90)->required();
 
     $row = $form->addRow();
+        $row->addLabel('fontFamily', __('Font Family'));
+        $row->addTextField('fontFamily')->maxLength(60)->required();
+
+    $types = [
+        'R' => __('Regular'),
+        'B' => __('Bold'),
+        'I' => __('Italic'),
+        'BI' => __('Bold & Italic'),
+    ];
+    $row = $form->addRow();
+        $row->addLabel('fontType', __('Type'));
+        $row->addSelect('fontType')->fromArray($types);
+
+    $row = $form->addRow();
         $row->addLabel('fontTCPDF', __('File Name'));
         $row->addTextField('fontTCPDF')->readonly();
 

--- a/modules/Reports/templates_assets_fonts_editProcess.php
+++ b/modules/Reports/templates_assets_fonts_editProcess.php
@@ -35,6 +35,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_f
 
     $data = [
         'fontName' => $_POST['fontName'] ?? '',
+        'fontFamily' => $_POST['fontFamily'] ?? '',
+        'fontType' => $_POST['fontType'] ?? 'R',
     ];
 
     // Validate the required values are present

--- a/modules/Reports/templates_assets_scanProcess.php
+++ b/modules/Reports/templates_assets_scanProcess.php
@@ -85,14 +85,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets.p
 
         foreach ($directoryFiles as $filePath) {
             $fontTCPDF = \TCPDF_FONTS::addTTFfont($filePath, 'TrueTypeUnicode', '', 32);
-            
-            if (empty($fontTCPDF)) continue;
+            $fontName = str_replace(['.ttf'], [''], basename($filePath));
+
+            if (empty($fontTCPDF) || empty($fontName)) continue;
 
             // Update the font details in the database
             $data = [
-                'fontName' => str_replace(['.ttf'], [''], basename($filePath)),
+                'fontName' => $fontName,
+                'fontFamily' => $fontName,
                 'fontPath' => str_replace($absolutePath.'/', '', $filePath),
                 'fontTCPDF' => $fontTCPDF,
+                'fontType' => 'R',
             ];
 
             $inserted = $fontGateway->insertAndUpdate($data, [

--- a/modules/Reports/templates_manage_edit.php
+++ b/modules/Reports/templates_manage_edit.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Module\Reports\Domain\ReportTemplateGateway;
+use Gibbon\Module\Reports\Domain\ReportTemplateFontGateway;
 use Gibbon\Module\Reports\Domain\ReportTemplateSectionGateway;
 use Gibbon\Module\Reports\Domain\ReportPrototypeSectionGateway;
 use Gibbon\Tables\View\GridView;
@@ -49,6 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
 
     $gibbonReportTemplateID = $_GET['gibbonReportTemplateID'] ?? '';
     $templateGateway = $container->get(ReportTemplateGateway::class);
+    $templateFontGateway = $container->get(ReportTemplateFontGateway::class);
     $templateSectionGateway = $container->get(ReportTemplateSectionGateway::class);
     $prototypeSectionGateway = $container->get(ReportPrototypeSectionGateway::class);
 
@@ -58,6 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
     }
 
     $values = $templateGateway->getByID($gibbonReportTemplateID);
+    $config = json_decode($values['config'] ?? '', true);
 
     if (empty($values)) {
         $page->addError(__('The specified record cannot be found.'));
@@ -83,6 +86,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
     $row = $form->addRow();
         $row->addLabel('stylesheet', __('Stylesheet'));
         $row->addSelect('stylesheet')->fromResults($stylesheets)->placeholder();
+
+    $fontFamilies = $templateFontGateway->selectFontsByFamily();
+    $row = $form->addRow();
+        $row->addLabel('fonts', __('Fonts'));
+        $row->addSelect('fonts')
+            ->fromResults($fontFamilies)
+            ->selectMultiple()
+            ->setSize(4)
+            ->selected($config['fonts'] ?? []);
 
     $flags = ['000' => __('TCPDF Renderer - Faster, Limited HTML'), '001' => __('mPDF Renderer - Slower, Better HTML Support')];
     $row = $form->addRow();

--- a/modules/Reports/templates_manage_edit.php
+++ b/modules/Reports/templates_manage_edit.php
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
         $row->addLabel('stylesheet', __('Stylesheet'));
         $row->addSelect('stylesheet')->fromResults($stylesheets)->placeholder();
 
-    $fontFamilies = $templateFontGateway->selectFontsByFamily();
+    $fontFamilies = $templateFontGateway->selectFontFamilies();
     $row = $form->addRow();
         $row->addLabel('fonts', __('Fonts'));
         $row->addSelect('fonts')

--- a/modules/Reports/templates_manage_editProcess.php
+++ b/modules/Reports/templates_manage_editProcess.php
@@ -44,6 +44,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
         'flags'       => $_POST['flags'] ?? '',
     ];
 
+    $config = [
+        'fonts' => $_POST['fonts'] ?? [],
+    ];
+
+    $data['config'] = json_encode($config);
+
     // Validate the required values are present
     if (empty($data['name'])) {
         $URL .= '&return=error1';

--- a/modules/Reports/templates_preview.php
+++ b/modules/Reports/templates_preview.php
@@ -63,6 +63,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_preview.
 
         echo $twig->render('preview.twig.html', $values + [
             'pages' => $renderer->render($template, $reports),
+            'fontList' => $template->getData('fonts', []),
+            'fontURL' => $template->getData('absoluteURL').$template->getData('customAssetPath').'/fonts',
             'debugData' => $debugMode ? print_r($reports[0], true) : null,
         ]);
     } else {


### PR DESCRIPTION
This PR adds the ability to define which fonts should be included in a template. 
- Fonts can be discovered and configured though the Manage Assets screen, then added to a template in Edit Template.
- Fonts are included in the HTML preview using the `@font-face` css rule, and in the MpdfRenderer as configuration data. Fonts in the TCPDFRenderer are implicitly included.
- Fonts can be grouped in to Font Families using the Edit option in Manage Assets to set the font family name and font type.

Font selector:
<img width="1106" alt="Screen Shot 2020-03-05 at 2 30 59 PM" src="https://user-images.githubusercontent.com/897700/75956085-1d9ac400-5ef2-11ea-8d38-e1cb6dcce040.png">

Font preview:
<img width="884" alt="Screen Shot 2020-03-05 at 2 56 54 PM" src="https://user-images.githubusercontent.com/897700/75956116-3014fd80-5ef2-11ea-82b5-54efb9cbb397.png">

