### PR TITLE
User Admin: add rich text editors to the Application Form Settings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ v20.0.00
         Reports: added hooks for custom criteria types in the report writing screen
         Reports: added the ability to select fonts in Template Builder
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
+        User Admin: added rich text editors to the Application Form Settings
 
     Bug Fixes
         System: fixed module uninstall to also remove notification events

--- a/modules/User Admin/applicationFormSettings.php
+++ b/modules/User Admin/applicationFormSettings.php
@@ -41,19 +41,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
     $row = $form->addRow()->addHeading(__('General Options'));
 
     $setting = getSettingByScope($connection2, 'Application Form', 'introduction', true);
-    $row = $form->addRow();
-        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value']);
+    $col = $form->addRow()->addColumn();
+        $col->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $col->addEditor($setting['name'], $guid)->setValue($setting['value'])->setRows(8);
+
+    $setting = getSettingByScope($connection2, 'Application Form', 'postscript', true);
+    $col = $form->addRow()->addColumn();
+        $col->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $col->addEditor($setting['name'], $guid)->setValue($setting['value'])->setRows(8);
 
     $setting = getSettingByScope($connection2, 'Students', 'applicationFormRefereeLink', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addURL($setting['name'])->setValue($setting['value']);
-
-    $setting = getSettingByScope($connection2, 'Application Form', 'postscript', true);
-    $row = $form->addRow();
-        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
-        $row->addTextArea($setting['name'])->setValue($setting['value']);
 
     $setting = getSettingByScope($connection2, 'Application Form', 'agreement', true);
     $row = $form->addRow();
@@ -225,4 +225,3 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
 
     echo $form->getOutput();
 }
-?>


### PR DESCRIPTION
This PR adds text editors for the Introduction and Postscript settings. Not many users have HTML skills and this is one area often updated by non-system-admin users. Should be backwards compatible for most HTML content already in those fields.

<img width="801" alt="Screen Shot 2020-03-26 at 1 45 59 PM" src="https://user-images.githubusercontent.com/897700/77615195-ae9d1200-6f69-11ea-89d2-457d8259b386.png">


