### PR TITLE
Staff: add an option to edit or delete staff coverage dates

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -633,4 +633,6 @@ UPDATE `gibbonReportTemplateFont` SET fontFamily=fontName WHERE fontFamily IS NU
 ALTER TABLE `gibbonReportTemplate` ADD `config` TEXT NULL AFTER `flags`;end
 ALTER TABLE `gibbonHook` CHANGE `type` `type` ENUM('Public Home Page','Student Profile','Parental Dashboard','Staff Dashboard','Student Dashboard','Report Writing') CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL;end
 ALTER TABLE `gibbonReportingCriteriaType` ADD UNIQUE(`name`);end
+ALTER TABLE `gibbonStaffCoverageDate` CHANGE `value` `value` DECIMAL(3,2) NOT NULL DEFAULT '1.00';end
+ALTER TABLE `gibbonStaffAbsenceDate` CHANGE `value` `value` DECIMAL(3,2) NOT NULL DEFAULT '1.00';end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ v20.0.00
         Reports: added an option to select the PDF rendering library in Template Builder
         Reports: added hooks for custom criteria types in the report writing screen
         Reports: added the ability to select fonts in Template Builder
+        Staff: added an option to edit or delete staff coverage dates
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
         User Admin: added rich text editors to the Application Form Settings
 

--- a/modules/Staff/coverage_manage_edit.php
+++ b/modules/Staff/coverage_manage_edit.php
@@ -25,6 +25,7 @@ use Gibbon\Domain\User\UserGateway;
 use Gibbon\Domain\Staff\StaffCoverageGateway;
 use Gibbon\Domain\Staff\StaffCoverageDateGateway;
 use Gibbon\Module\Staff\View\StaffCard;
+use Gibbon\Module\Staff\Tables\CoverageDates;
 
 if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_edit.php') == false) {
     // Access denied
@@ -134,35 +135,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_edit
     }
 
     // DATA TABLE
-    $coverageDates = $container->get(StaffCoverageDateGateway::class)->selectDatesByCoverage($gibbonStaffCoverageID);
-    
-    $table = DataTable::create('staffCoverageDates');
-    $table->setTitle(__('Dates'));
+    $table = $container->get(CoverageDates::class)->create($gibbonStaffCoverageID);
 
-    $table->addColumn('date', __('Date'))
-        ->format(Format::using('dateReadable', 'date'));
-
-    $table->addColumn('timeStart', __('Time'))
-        ->format(function ($coverage) {
-            if ($coverage['allDay'] == 'N') {
-                return Format::small(Format::timeRange($coverage['timeStart'], $coverage['timeEnd']));
-            } else {
-                return Format::small(__('All Day'));
-            }
-        });
-
-    $table->addColumn('coverage', __('Coverage'))
-        ->format(function ($coverage) {
-            if (empty($coverage['coverage'])) {
-                return Format::small(__('N/A'));
-            }
-
-            return $coverage['coverage'] == 'Accepted'
-                    ? Format::name($coverage['titleCoverage'], $coverage['preferredNameCoverage'], $coverage['surnameCoverage'], 'Staff', false, true)
-                    : '<span class="tag message">'.__('Pending').'</span>';
-        });
-
-    $row = $form->addRow()->addContent($table->render($coverageDates->toDataSet()));
+    $row = $form->addRow()->addContent($table->getOutput());
 
     $row = $form->addRow();
         $row->addFooter();

--- a/modules/Staff/coverage_manage_edit_deleteProcess.php
+++ b/modules/Staff/coverage_manage_edit_deleteProcess.php
@@ -1,0 +1,56 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Staff\StaffCoverageDateGateway;
+
+$_POST['address'] = '/modules/Staff/coverage_manage_edit.php';
+$gibbonStaffCoverageID = $_GET['gibbonStaffCoverageID'] ?? '';
+$gibbonStaffCoverageDateID = $_GET['gibbonStaffCoverageDateID'] ?? '';
+
+require_once '../../gibbon.php';
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Staff/coverage_manage_edit.php&gibbonStaffCoverageID='.$gibbonStaffCoverageID;
+
+if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_edit.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} elseif (empty($gibbonStaffCoverageID) || empty($gibbonStaffCoverageDateID)) {
+    $URL .= '&return=error1';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $staffCoverageDateGateway = $container->get(StaffCoverageDateGateway::class);
+
+    $values = $staffCoverageDateGateway->getByID($gibbonStaffCoverageDateID);
+
+    if (empty($values)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $deleted = $staffCoverageDateGateway->delete($gibbonStaffCoverageDateID);
+
+    $URL .= !$deleted
+        ? '&return=error2'
+        : '&return=success0';
+
+    header("Location: {$URL}");
+}

--- a/modules/Staff/coverage_manage_edit_edit.php
+++ b/modules/Staff/coverage_manage_edit_edit.php
@@ -20,44 +20,44 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Services\Format;
-use Gibbon\Domain\Staff\StaffAbsenceDateGateway;
+use Gibbon\Domain\Staff\StaffCoverageDateGateway;
 
-if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_manage_edit.php') == false) {
+if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_edit.php') == false) {
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    $gibbonStaffAbsenceID = $_GET['gibbonStaffAbsenceID'] ?? '';
-    $gibbonStaffAbsenceDateID = $_GET['gibbonStaffAbsenceDateID'] ?? '';
+    $gibbonStaffCoverageID = $_GET['gibbonStaffCoverageID'] ?? '';
+    $gibbonStaffCoverageDateID = $_GET['gibbonStaffCoverageDateID'] ?? '';
 
     // Proceed!
     $page->breadcrumbs
-        ->add(__('Manage Staff Absences'), 'absences_manage.php')
-        ->add(__('Edit Absence'), 'absences_manage_edit.php', ['gibbonStaffAbsenceID' => $gibbonStaffAbsenceID])
+        ->add(__('Manage Staff Coverage'), 'coverage_manage.php')
+        ->add(__('Edit Coverage'), 'coverage_manage_edit.php', ['gibbonStaffCoverageID' => $gibbonStaffCoverageID])
         ->add(__('Edit'));
 
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);
     }
 
-    if (empty($gibbonStaffAbsenceID) || empty($gibbonStaffAbsenceDateID)) {
+    if (empty($gibbonStaffCoverageID) || empty($gibbonStaffCoverageDateID)) {
         $page->addError(__('You have not specified one or more required parameters.'));
         return;
     }
 
-    $staffAbsenceDateGateway = $container->get(StaffAbsenceDateGateway::class);
-    $values = $staffAbsenceDateGateway->getByID($gibbonStaffAbsenceDateID);
+    $staffCoverageDateGateway = $container->get(StaffCoverageDateGateway::class);
+    $values = $staffCoverageDateGateway->getByID($gibbonStaffCoverageDateID);
 
     if (empty($values)) {
         $page->addError(__('The specified record cannot be found.'));
         return;
     }
 
-    $form = Form::create('staffAbsenceEdit', $_SESSION[$guid]['absoluteURL'].'/modules/Staff/absences_manage_edit_editProcess.php');
+    $form = Form::create('staffCoverageEdit', $_SESSION[$guid]['absoluteURL'].'/modules/Staff/coverage_manage_edit_editProcess.php');
 
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
-    $form->addHiddenValue('gibbonStaffAbsenceID', $gibbonStaffAbsenceID);
-    $form->addHiddenValue('gibbonStaffAbsenceDateID', $gibbonStaffAbsenceDateID);
+    $form->addHiddenValue('gibbonStaffCoverageID', $gibbonStaffCoverageID);
+    $form->addHiddenValue('gibbonStaffCoverageDateID', $gibbonStaffCoverageDateID);
    
     $row = $form->addRow();
         $row->addLabel('dateLabel', __('Date'));

--- a/modules/Staff/coverage_manage_edit_editProcess.php
+++ b/modules/Staff/coverage_manage_edit_editProcess.php
@@ -1,0 +1,60 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Staff\StaffCoverageDateGateway;
+
+require_once '../../gibbon.php';
+
+$gibbonStaffCoverageID = $_POST['gibbonStaffCoverageID'] ?? '';
+$gibbonStaffCoverageDateID = $_POST['gibbonStaffCoverageDateID'] ?? '';
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Staff/coverage_manage_edit_edit.php&gibbonStaffCoverageID='.$gibbonStaffCoverageID.'&gibbonStaffCoverageDateID='.$gibbonStaffCoverageDateID;
+
+if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_edit.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} elseif (empty($gibbonStaffCoverageID) || empty($gibbonStaffCoverageDateID)) {
+    $URL .= '&return=error1';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $staffCoverageDateGateway = $container->get(StaffCoverageDateGateway::class);
+
+    if (!$staffCoverageDateGateway->exists($gibbonStaffCoverageDateID)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $data = [
+        'allDay'    => $_POST['allDay'] ?? 'N',
+        'timeStart' => $_POST['timeStart'] ?? null,
+        'timeEnd'   => $_POST['timeEnd'] ?? null,
+        'value'     => $_POST['value'] ?? '',
+    ];
+
+    $updated = $staffCoverageDateGateway->update($gibbonStaffCoverageDateID, $data);
+
+    $URL .= !$updated
+        ? '&return=error2'
+        : '&return=success0';
+
+    header("Location: {$URL}");
+}


### PR DESCRIPTION
Adds the option to edit the time and values of a coverage record, or delete a date from a coverage record spanning more than one day. Also adjusts the value fields to accept two decimal places (eg: 0.25).

**Motivation and Context**
Coverage details can change and admin occasionally need the ability to edit the exact timing of staff coverage, or adjust the calculated value of that coverage for the day.

**How Has This Been Tested?**
Tested locally and in production.

**Screenshots**
<img width="777" alt="Screen Shot 2020-03-27 at 11 08 53 AM" src="https://user-images.githubusercontent.com/897700/77717410-62120f00-701b-11ea-92e2-80c78494841f.png">
