### PR TITLE
Students: add a Withdraw Student page with the option to notify staff

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -636,5 +636,8 @@ ALTER TABLE `gibbonReportingCriteriaType` ADD UNIQUE(`name`);end
 ALTER TABLE `gibbonStaffCoverageDate` CHANGE `value` `value` DECIMAL(3,2) NOT NULL DEFAULT '1.00';end
 ALTER TABLE `gibbonStaffAbsenceDate` CHANGE `value` `value` DECIMAL(3,2) NOT NULL DEFAULT '1.00';end
 INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Students', 'applicationFormRefereeRequired', 'Application Form Referee Required', 'Should the referee email address field be required?', 'Y');end
+INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, `description`, `URLList`, `entryURL`, `entrySidebar`, `menuShow`, `defaultPermissionAdmin`, `defaultPermissionTeacher`, `defaultPermissionStudent`, `defaultPermissionParent`, `defaultPermissionSupport`, `categoryPermissionStaff`, `categoryPermissionStudent`, `categoryPermissionParent`, `categoryPermissionOther`) VALUES((SELECT gibbonModuleID FROM gibbonModule WHERE name='Students'), 'Withdraw Student', 0, 'Admissions', 'Enables admin to set a student to left and notify other users.', 'student_withdraw.php', 'student_withdraw.php', 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N');end
+INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Students' AND gibbonAction.name='Withdraw Student'));end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Student Withdrawn', 'Students', 'View Student Profile_full', 'Core', 'All,gibbonYearGroupID', 'Y');end
 
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ v20.0.00
 
     Significant Changes
         Added Español - Mexico as an available locale
+        Students: added a Withdraw Student page with the option to notify staff
 
     Security
 

--- a/modules/Students/student_withdraw.php
+++ b/modules/Students/student_withdraw.php
@@ -1,0 +1,94 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+
+if (isActionAccessible($guid, $connection2, '/modules/Students/student_withdraw.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $page->breadcrumbs->add(__('Withdraw Student'));
+
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
+    $form = Form::create('studentWithdraw', $_SESSION[$guid]['absoluteURL'].'/modules/Students/student_withdrawProcess.php');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+
+    $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+
+    $form->addRow()->addHeading(__('Basic Information'));
+
+    $row = $form->addRow();
+        $row->addLabel('gibbonPersonID', __('Student'));
+        $row->addSelectStudent('gibbonPersonID', $gibbon->session->get('gibbonSchoolYearID'), ['showRoll' => true])->required()->placeholder();
+
+    $row = $form->addRow();
+        $row->addLabel('status', __('Status'))->description(__("Set this to Left unless the student's withdraw date is in the future."));
+        $row->addSelect('status')->fromArray(['Left' => __('Left'), 'Full' => __('Full')])->required()->selected('Left');
+
+    $row = $form->addRow();
+        $row->addLabel('dateEnd', __('End Date'))->description(__("Users's last day at school."));
+        $row->addDate('dateEnd')->required();
+
+    $departureReasonsList = getSettingByScope($connection2, 'User Admin', 'departureReasons');
+    $row = $form->addRow();
+        $row->addLabel('departureReason', __('Departure Reason'));
+        if (!empty($departureReasonsList)) {
+            $row->addSelect('departureReason')->fromString($departureReasonsList)->required()->placeholder();
+        } else {
+            $row->addTextField('departureReason')->maxLength(30)->required();
+        }
+
+    // NOTES
+    $form->addRow()->addHeading(__('Notes'));
+
+    $col = $form->addRow()->addColumn();
+        $col->addLabel('withdrawNote', __('Withdraw Note'))->description(__('If provided, these will be saved in student notes, as well as shared with notification recipients.'));
+        $col->addTextArea('withdrawNote');
+
+    // NOTIFICATIONS
+    $form->addRow()->addHeading(__('Notifications'));
+
+    $row = $form->addRow();
+        $row->addLabel('notify', __('Automatically Notify'));
+        $row->addCheckbox('notify')->fromArray([
+            'admin'    => __('Admissions Administrator'),
+            'HOY'      => __('Head of Year'),
+            'tutors'   => __('Form Tutors'),
+            'teachers' => __('Class Teachers'),
+            'EAs'      => __('Educational Assistants'),
+        ])->checkAll();
+
+    $row = $form->addRow();
+        $row->addLabel('notificationList', __('Notify Additional People'));
+        $row->addFinder('notificationList')
+            ->fromAjax($gibbon->session->get('absoluteURL').'/modules/Staff/staff_searchAjax.php')
+            ->setParameter('resultsLimit', 10)
+            ->resultsFormatter('function(item){ return "<li class=\'\'><div class=\'inline-block bg-cover w-12 h-12 ml-2 rounded-full bg-gray-200 border border-gray-400 bg-no-repeat\' style=\'background-image: url(" + item.image + ");\'></div><div class=\'inline-block px-4 truncate\'>" + item.name + "<br/><span class=\'inline-block opacity-75 truncate text-xxs\'>" + item.jobTitle + "</span></div></li>"; }');
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
+}

--- a/modules/Students/student_withdrawProcess.php
+++ b/modules/Students/student_withdrawProcess.php
@@ -149,7 +149,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_withdraw.
             }
 
             // Add event listeners to the notification sender
-            $event->sendNotificationsAsBcc($pdo, $gibbon->session);
+            $event->sendNotifications($pdo, $gibbon->session);
         }
     }
 

--- a/modules/Students/student_withdrawProcess.php
+++ b/modules/Students/student_withdrawProcess.php
@@ -1,0 +1,161 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Services\Format;
+use Gibbon\Domain\User\UserGateway;
+use Gibbon\Domain\Students\StudentGateway;
+use Gibbon\Domain\Students\StudentNoteGateway;
+use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\School\YearGroupGateway;
+use Gibbon\Domain\RollGroups\RollGroupGateway;
+use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
+use Gibbon\Domain\IndividualNeeds\INAssistantGateway;
+
+require_once '../../gibbon.php';
+
+$gibbonPersonID = $_POST['gibbonPersonID'] ?? '';
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Students/student_withdraw.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Students/student_withdraw.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $userGateway = $container->get(UserGateway::class);
+    $studentGateway = $container->get(StudentGateway::class);
+
+    $data = [
+        'status'          => $_POST['status'] ?? '',
+        'dateEnd'         => isset($_POST['dateEnd']) ? Format::dateConvert($_POST['dateEnd']) : null,
+        'departureReason' => $_POST['departureReason'] ?? '',
+    ];
+
+    // Validate the required values are present
+    if (empty($gibbonPersonID) || empty($data['status']) || empty($data['dateEnd']) || empty($data['departureReason'])) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Validate the database relationships exist
+    $person = $userGateway->getByID($gibbonPersonID);
+    $student = $studentGateway->selectActiveStudentByPerson($gibbon->session->get('gibbonSchoolYearID'), $gibbonPersonID)->fetch();
+
+    if (empty($person) || empty($student)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Update the user data
+    $updated = $userGateway->update($gibbonPersonID, $data);
+    $partialFail = !$updated;
+
+    if ($updated) {
+        $withdrawNote = $_POST['withdrawNote'] ?? '';
+        if (!empty($withdrawNote)) {
+            $noteGateway = $container->get(StudentNoteGateway::class);
+            $inserted = $noteGateway->insert([
+                'title'                       => __('Student Withdrawn'),
+                'note'                        => $withdrawNote,
+                'gibbonPersonID'              => $gibbonPersonID,
+                'gibbonPersonIDCreator'       => $gibbon->session->get('gibbonPersonID'),
+                'gibbonStudentNoteCategoryID' => $noteGateway->getNoteCategoryIDByName('Academic') ?? null,
+                'timestamp'                   => date('Y-m-d H:i:s', time()),
+            ]);
+
+            $partialFail &= !$inserted;
+        }
+
+        $notify = $_POST['notify'] ?? [];
+        $notificationList = isset($_POST['notificationList'])? explode(',', $_POST['notificationList']) : [];
+
+        if (!empty($notify) || !empty($notificationList)) {
+            // Create the notification body
+            $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, true);
+            $notificationString = __('{student} {rollGroup} has withdrawn from {school} on {date}.', [
+                'student'   => $studentName,
+                'rollGroup'   => $student['rollGroup'],
+                'school'    => $gibbon->session->get('organisationNameShort'),
+                'date'      => Format::date($data['dateEnd']),
+            ]);
+
+            if (!empty($withdrawNote)) {
+                $notificationString .= '<br/><br/>'.__('Withdraw Note').': '.$withdrawNote;
+            }
+
+            // Raise a new notification event
+            $event = new NotificationEvent('Students', 'Student Withdrawn');
+            $event->addScope('gibbonPersonIDStudent', $gibbonPersonID);
+            $event->addScope('gibbonYearGroupID', $student['gibbonYearGroupID']);
+            $event->setNotificationText($notificationString);
+            $event->setActionLink('/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID.'&search=&sort=&allStudents=on');
+
+            // Notify Additional People
+            foreach ($notificationList as $gibbonPersonIDNotify) {
+                $event->addRecipient($gibbonPersonIDNotify);
+            }
+
+            // Admissions Administrator
+            if (in_array('admin', $notify)) {
+                $event->addRecipient($gibbon->session->get('organisationAdmissions'));
+            }
+
+            // Head of Year
+            if (in_array('HOY', $notify)) {
+                $yearGroup = $container->get(YearGroupGateway::class)->getByID($student['gibbonYearGroupID']);
+                $event->addRecipient($yearGroup['gibbonPersonIDHOY']);
+            }
+
+            // Form Tutors
+            if (in_array('tutors', $notify)) {
+                $rollGroup = $container->get(RollGroupGateway::class)->getByID($student['gibbonRollGroupID']);
+                $event->addRecipient($rollGroup['gibbonPersonIDTutor']);
+                $event->addRecipient($rollGroup['gibbonPersonIDTutor2']);
+                $event->addRecipient($rollGroup['gibbonPersonIDTutor3']);
+            }
+
+            // Class Teachers
+            if (in_array('teachers', $notify)) {
+                $teachers = $container->get(CourseEnrolmentGateway::class)->selectClassTeachersByStudent($gibbon->session->get('gibbonSchoolYearID'), $gibbonPersonID);
+                foreach ($teachers as $teacher) {
+                    $event->addRecipient($teacher['gibbonPersonID']);
+                }
+            }
+
+            // Educational Assistants
+            if (in_array('EAs', $notify)) {
+                $EAs = $container->get(INAssistantGateway::class)->selectINAssistantsByStudent($gibbonPersonID);
+                foreach ($EAs as $EA) {
+                    $event->addRecipient($EA['gibbonPersonID']);
+                }
+            }
+
+            // Add event listeners to the notification sender
+            $event->sendNotificationsAsBcc($pdo, $gibbon->session);
+        }
+    }
+
+    $URL .= $partialFail
+        ? "&return=warning1"
+        : "&return=success0";
+
+    header("Location: {$URL}");
+}

--- a/src/Domain/Timetable/CourseEnrolmentGateway.php
+++ b/src/Domain/Timetable/CourseEnrolmentGateway.php
@@ -165,4 +165,23 @@ class CourseEnrolmentGateway extends QueryableGateway
 
         return $this->db()->select($sql, $data);
     }
+
+    public function selectClassTeachersByStudent($gibbonSchoolYearID, $gibbonPersonIDStudent)
+    {
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonIDStudent' => $gibbonPersonIDStudent);
+        $sql = "SELECT DISTINCT teacher.gibbonPersonID, teacher.surname, teacher.preferredName, teacher.email 
+                FROM gibbonCourseClassPerson AS studentClass
+                JOIN gibbonCourseClassPerson AS teacherClass ON (studentClass.gibbonCourseClassID=teacherClass.gibbonCourseClassID)
+                JOIN gibbonPerson AS teacher ON (teacherClass.gibbonPersonID=teacher.gibbonPersonID)
+                JOIN gibbonCourseClass ON (studentClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
+                JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID)
+                WHERE teacher.status='Full' 
+                AND teacherClass.role='Teacher' 
+                AND studentClass.role='Student' 
+                AND studentClass.gibbonPersonID=:gibbonPersonIDStudent 
+                AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID 
+                ORDER BY teacher.preferredName, teacher.surname, teacher.email";
+
+        return $this->db()->select($sql, $data);
+    }
 }


### PR DESCRIPTION
This PR adds an action under Admissions to allow privileged users to withdraw a student. 
<img width="255" alt="Screen Shot 2020-04-01 at 2 51 43 PM" src="https://user-images.githubusercontent.com/897700/78107578-53b36100-7428-11ea-9b48-f91063c690c7.png">

**Motivation and Context**
Currently the workflow to withdraw a student is to edit their status in User Admin. This can be counter-intuitive for some staff, or they may forget to update other fields such as end date and departure reason. 

This feature combines the student withdraw workflow into one page and adds optional student notes and notifications to help keep relevant parties informed. This includes a notification event, which allows admin to subscribe users to automatically receive all withdraw notifications.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
![Screenshot_2020-04-01 TEST - Gibbon - Students](https://user-images.githubusercontent.com/897700/78107356-e56e9e80-7427-11ea-9d54-8246623491ea.png)