### PR TITLE
User Admin: add departure reason for final year students in Rollover

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,7 @@ v20.0.00
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
         Students: added option allowing the referee email field in the Application Form to be set to option
         User Admin: added rich text editors to the Application Form Settings
+        User Admin: added an option to enter a departure reason for final year students in Rollover
 
     Bug Fixes
         System: fixed module uninstall to also remove notification events

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -453,17 +453,18 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                         $row->addColumn()->addContent(__('Primary Role'));
                         $row->addColumn()->addContent(__('Current Status'));
                         $row->addColumn()->addContent(__('New Status'));
+                        $row->addColumn()->addContent(__('Departure Reason'));
 
                     $count = 0;
                     while ($rowFinal = $resultFinal->fetch()) {
                         $count++;
                         $form->addHiddenValue($count."-final-gibbonPersonID", $rowFinal['gibbonPersonID']);
                         $row = $form->addRow();
-                            $row->addColumn()->addContent(Format::name('', $rowFinal['preferredName'], $rowFinal['surname'], 'Student', true));
-                            $row->addColumn()->addContent(__($rowFinal['name']));
-                            $row->addColumn()->addContent(__('Full'));
-                            $column = $row->addColumn();
-                                $column->addSelect($count."-final-status")->fromArray($statuses)->required()->setClass('shortWidth floatNone')->selected('Left');
+                            $row->addContent(Format::name('', $rowFinal['preferredName'], $rowFinal['surname'], 'Student', true));
+                            $row->addContent(__($rowFinal['name']));
+                            $row->addContent(__('Full'));
+                            $row->addSelect($count."-final-status")->fromArray($statuses)->required()->setClass('shortWidth floatNone')->selected('Left');
+                            $row->addTextField($count.'-departureReason')->setValue(__('Graduated'))->setSize(12);
                     }
                     $form->addHiddenValue("final-count", $count);
                 }
@@ -1030,12 +1031,13 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                             for ($i = 1; $i <= $count; ++$i) {
                                 $gibbonPersonID = $_POST["$i-final-gibbonPersonID"];
                                 $status = $_POST["$i-final-status"];
+                                $departureReason = $_POST["$i-departureReason"];
 
                                 //Write to database
                                 $left = true;
                                 try {
-                                    $data = array('gibbonPersonID' => $gibbonPersonID, 'dateEnd' => $dateEnd, 'status' => $status);
-                                    $sql = 'UPDATE gibbonPerson SET status=:status, dateEnd=:dateEnd WHERE gibbonPersonID=:gibbonPersonID';
+                                    $data = array('gibbonPersonID' => $gibbonPersonID, 'dateEnd' => $dateEnd, 'status' => $status, 'departureReason' => $departureReason);
+                                    $sql = 'UPDATE gibbonPerson SET status=:status, dateEnd=:dateEnd, departureReason=:departureReason WHERE gibbonPersonID=:gibbonPersonID';
                                     $result = $connection2->prepare($sql);
                                     $result->execute($data);
                                 } catch (PDOException $e) {


### PR DESCRIPTION
Adds the option to enter a departure reason for final year students in Rollover.

**Motivation and Context**
Without entering this value at this step, the students are often marked as Left with no departure reason, and it can be difficult for staff to infer if they left with the year incomplete or if they graduated. The "Class of" field is helpful for this, but doesn't _specifically_ indicate if a student has graduated.

**Screenshots**

<img width="775" alt="Screen Shot 2020-04-01 at 4 56 02 PM" src="https://user-images.githubusercontent.com/897700/78119024-5c149780-743a-11ea-8330-1cec42eec0d7.png">
