### PR TITLE
Students: add a grid view of teachers to student profile

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ v20.0.00
         Staff: added Family and Activities subpages to Staff Profile
         Students: added an Exclude Left Students checkbox to Student Enrolment Trends, off by default
         Students: added option allowing the referee email field in the Application Form to be set to option
+        Students: added a grid view of student's teachers to Student Profile
         User Admin: added rich text editors to the Application Form Settings
 
     Bug Fixes

--- a/modules/Students/css/module.css
+++ b/modules/Students/css/module.css
@@ -80,3 +80,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 .dayNoData {
 	border: 1px solid #555;
 }
+
+.unselectable {
+    -webkit-user-select: none; /* Safari */        
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE10+/Edge */
+    user-select: none; /* Standard */
+}

--- a/resources/templates/components/listOptions.twig.html
+++ b/resources/templates/components/listOptions.twig.html
@@ -7,7 +7,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 -->#}
 
 {% if listOptions %}
-<div class="flex-1 flex justify-end items-top font-sans">
+<div class="flex-1 flex justify-end items-top font-sans mb-2">
     {% set buttonClass = 'h-8 text-sm bg-white text-gray-700 border-gray-500 hover:bg-blue-500 hover:border-blue-700 hover:text-white border -ml-px px-3 md:px-5 py-1 leading-normal overflow-hidden' %}
 
     {% for view, label in listOptions %}

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -237,4 +237,57 @@ class StudentGateway extends QueryableGateway
 
         return $this->db()->selectOne($sql, $data);
     }
+
+    public function selectAllRelatedUsersByStudent($gibbonSchoolYearID, $gibbonYearGroupID, $gibbonRollGroupID, $gibbonPersonID)
+    {
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonID' => $gibbonPersonID, 'gibbonYearGroupID' => $gibbonYearGroupID, 'gibbonRollGroupID' => $gibbonRollGroupID);
+        $sql = "
+            (
+                SELECT DISTINCT gibbonCourseClass.gibbonCourseClassID as classID, teacher.gibbonPersonID, teacher.surname, teacher.preferredName, teacher.email, teacher.image_240, gibbonCourse.name as type, 4 as listOrder 
+                FROM gibbonPerson AS teacher 
+                JOIN gibbonCourseClassPerson AS teacherClass ON (teacherClass.gibbonPersonID=teacher.gibbonPersonID)
+                JOIN gibbonCourseClassPerson AS studentClass ON (studentClass.gibbonCourseClassID=teacherClass.gibbonCourseClassID)
+                JOIN gibbonPerson AS student ON (studentClass.gibbonPersonID=student.gibbonPersonID)
+                JOIN gibbonCourseClass ON (studentClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
+                JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID)
+                WHERE teacher.status='Full' AND teacherClass.role='Teacher' AND studentClass.role='Student' AND student.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID 
+                ORDER BY teacher.preferredName, teacher.surname, teacher.email
+            )
+            UNION
+            (
+                SELECT DISTINCT '' as classID, gibbonPerson.gibbonPersonID, surname, preferredName, email, image_240, 'Head of Year' as type, 1 as listOrder 
+                FROM gibbonPerson 
+                JOIN gibbonYearGroup ON (gibbonYearGroup.gibbonPersonIDHOY=gibbonPersonID) 
+                WHERE status='Full' AND gibbonYearGroupID=:gibbonYearGroupID
+            )
+            UNION
+            (
+                SELECT DISTINCT '' as classID, gibbonPerson.gibbonPersonID, surname, preferredName, email, image_240, 'IN Assistant' as type, 2 as listOrder
+                FROM gibbonPerson
+                    JOIN gibbonINAssistant ON (gibbonINAssistant.gibbonPersonIDAssistant=gibbonPerson.gibbonPersonID)
+                WHERE status='Full'
+                    AND gibbonPersonIDStudent=:gibbonPersonID
+            )
+            UNION
+            (
+                SELECT DISTINCT '' as classID, gibbonPerson.gibbonPersonID, surname, preferredName, email, image_240,  'Educational Assistant' as type, 2 as listOrder
+                FROM gibbonPerson
+                JOIN gibbonRollGroup ON (gibbonRollGroup.gibbonPersonIDEA=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDEA2=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDEA3=gibbonPerson.gibbonPersonID)
+                JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
+                WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID
+                AND gibbonStudentEnrolment.gibbonPersonID=:gibbonPersonID
+                AND gibbonPerson.status='Full'
+            )
+            UNION
+            (
+                SELECT DISTINCT '' as classID, gibbonPerson.gibbonPersonID, surname, preferredName, email, image_240, 'Form Tutor' as type, 0 as listOrder 
+                FROM gibbonRollGroup 
+                JOIN gibbonPerson ON (gibbonRollGroup.gibbonPersonIDTutor=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor2=gibbonPerson.gibbonPersonID OR gibbonRollGroup.gibbonPersonIDTutor3=gibbonPerson.gibbonPersonID) 
+                WHERE gibbonRollGroupID=:gibbonRollGroupID AND gibbonPerson.status='Full'
+            )
+            ORDER BY listOrder, preferredName, surname, email";
+
+        return $this->db()->select($sql, $data);
+    }
 }


### PR DESCRIPTION
- Refactors the list of student's teachers into a data table
- Adds a grid view of teachers which have links to staff profiles and classes
- Adds an updated list view that also includes the class names
- Uses some css to ensure the list view can still be copy-pasted into an email

**Motivation and Context**
This feature request emerged after the addition of the new staff directory. The idea was that adding photos can help new parents and students see who their teachers are, and a visual list with photos can be more inviting than a text list. For staff, it also gives people an easier way to lookup the teacher of a student by subject. The original text list is preserved, including the copy-paste functionality.

I've refactored a bit of the code along the way, boyscout-rule, but the student profile will oneday need a full refactoring to templates and gateways.

**How Has This Been Tested?**
Tested locally and in production.

**Screenshots**

Grid view:
<img width="799" alt="Screen Shot 2020-04-02 at 10 38 36 AM" src="https://user-images.githubusercontent.com/897700/78206305-0a6b1c00-74d1-11ea-8ca3-c09f99a1102b.png">

List view:
<img width="802" alt="Screen Shot 2020-04-02 at 11 00 39 AM" src="https://user-images.githubusercontent.com/897700/78206371-37b7ca00-74d1-11ea-8a73-61a375bebf47.png">

