### PR TITLE
Finance: apply email template to invoices, receipts, and reminders

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ v20.0.00
         System: added target option to Alert Bar
         Departments: added drag-drop ordering to Departments in School Admin
         Finance: added Student ID, where set, to invoices and receipts
+        Finance: apply email template to invoices, receipts, and reminders
         Planner: enhanced Smart Block display in Lesson Planner
         Planner: removed bold from Chat comment in lesson plan view
         Reports: added a Proof Read by Form Group option

--- a/modules/Finance/invoices_manage_editProcess.php
+++ b/modules/Finance/invoices_manage_editProcess.php
@@ -248,19 +248,22 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
 
                                 //Prep message
                                 $body = receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true, $receiptCount-1)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
-                                $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the receipt. Please reply to this email if you have any questions.';
 
                                 $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);
                                 }
-                                $mail->CharSet = 'UTF-8';
-                                $mail->Encoding = 'base64';
-                                $mail->IsHTML(true);
-                                $mail->Subject = 'Receipt From '.$_SESSION[$guid]['organisationNameShort'].' via '.$_SESSION[$guid]['systemName'];
-                                $mail->Body = $body;
-                                $mail->AltBody = $bodyPlain;
+
+                                $mail->Subject = __('Receipt from {organisation} via {system}', [
+                                    'organisation' => $_SESSION[$guid]['organisationNameShort'],
+                                    'system' => $_SESSION[$guid]['systemName'],
+                                ]);
+
+                                $mail->renderBody('mail/email.twig.html', [
+                                    'title'  => $mail->Subject,
+                                    'body'   => $body,
+                                ]);
 
                                 if (!$mail->Send()) {
                                     $emailFail = true;
@@ -311,7 +314,6 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                                     $body .= '<p>Reminder '.$reminderOutput.': '.$reminderText.'</p><br/>';
                                 }
                                 $body .= invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
-                                $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the reminder. Please reply to this email if you have any questions.';
 
                                 //Update reminder count
                                 if ($row['reminderCount'] < 3) {
@@ -329,12 +331,16 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);
                                 }
-                                $mail->CharSet = 'UTF-8';
-                                $mail->Encoding = 'base64';
-                                $mail->IsHTML(true);
-                                $mail->Subject = 'Reminder From '.$_SESSION[$guid]['organisationNameShort'].' via '.$_SESSION[$guid]['systemName'];
-                                $mail->Body = $body;
-                                $mail->AltBody = $bodyPlain;
+                               
+                                $mail->Subject = __('Reminder from {organisation} via {system}', [
+                                    'organisation' => $_SESSION[$guid]['organisationNameShort'],
+                                    'system' => $_SESSION[$guid]['systemName'],
+                                ]);
+
+                                $mail->renderBody('mail/email.twig.html', [
+                                    'title'  => $mail->Subject,
+                                    'body'   => $body,
+                                ]);
 
                                 if (!$mail->Send()) {
                                     $emailFail = true;

--- a/modules/Finance/invoices_manage_issueProcess.php
+++ b/modules/Finance/invoices_manage_issueProcess.php
@@ -199,19 +199,22 @@ if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') { echo 'Fatal er
                         if (count($emails) > 0) {
                             //Prep message
                             $body = invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
-                            $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the invoice. Please reply to this email if you have any questions.';
 
                             $mail = $container->get(Mailer::class);
                             $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                             foreach ($emails as $address) {
                                 $mail->AddBCC($address);
                             }
-                            $mail->CharSet = 'UTF-8';
-                            $mail->Encoding = 'base64';
-                            $mail->IsHTML(true);
-                            $mail->Subject = 'Invoice From '.$_SESSION[$guid]['organisationNameShort'].' via '.$_SESSION[$guid]['systemName'];
-                            $mail->Body = $body;
-                            $mail->AltBody = $bodyPlain;
+
+                            $mail->Subject = __('Invoice from {organisation} via {system}', [
+                                'organisation' => $_SESSION[$guid]['organisationNameShort'],
+                                'system' => $_SESSION[$guid]['systemName'],
+                            ]);
+
+                            $mail->renderBody('mail/email.twig.html', [
+                                'title'  => $mail->Subject,
+                                'body'   => $body,
+                            ]);
 
                             if (!$mail->Send()) {
                                 $emailFail = true;

--- a/modules/Finance/invoices_manage_processBulk.php
+++ b/modules/Finance/invoices_manage_processBulk.php
@@ -306,19 +306,22 @@ if ($gibbonSchoolYearID == '' or $action == '') { echo 'Fatal error loading this
                             } else {
                                 //Prep message
                                 $body = invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
-                                $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the invoice. Please reply to this email if you have any questions.';
 
                                 $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($from, sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                                 foreach ($emails as $address) {
                                     $mail->AddBCC($address);
                                 }
-                                $mail->CharSet = 'UTF-8';
-                                $mail->Encoding = 'base64';
-                                $mail->IsHTML(true);
-                                $mail->Subject = 'Invoice From '.$_SESSION[$guid]['organisationNameShort'].' via '.$_SESSION[$guid]['systemName'];
-                                $mail->Body = $body;
-                                $mail->AltBody = $bodyPlain;
+
+                                $mail->Subject = __('Invoice from {organisation} via {system}', [
+                                    'organisation' => $_SESSION[$guid]['organisationNameShort'],
+                                    'system' => $_SESSION[$guid]['systemName'],
+                                ]);
+    
+                                $mail->renderBody('mail/email.twig.html', [
+                                    'title'  => $mail->Subject,
+                                    'body'   => $body,
+                                ]);
 
                                 if (!$mail->Send()) {
                                     $emailFail = true;
@@ -447,7 +450,6 @@ if ($gibbonSchoolYearID == '' or $action == '') { echo 'Fatal error loading this
                             $body .= '<p>Reminder '.$reminderOutput.': '.$reminderText.'</p><br/>';
                         }
                         $body .= invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
-                        $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the reminder. Please reply to this email if you have any questions.';
 
                         //Update reminder count
                         if ($row['reminderCount'] < 3) {
@@ -465,12 +467,16 @@ if ($gibbonSchoolYearID == '' or $action == '') { echo 'Fatal error loading this
                         foreach ($emails as $address) {
                             $mail->AddBCC($address);
                         }
-                        $mail->CharSet = 'UTF-8';
-                        $mail->Encoding = 'base64';
-                        $mail->IsHTML(true);
-                        $mail->Subject = 'Reminder From '.$_SESSION[$guid]['organisationNameShort'].' via '.$_SESSION[$guid]['systemName'];
-                        $mail->Body = $body;
-                        $mail->AltBody = $bodyPlain;
+
+                        $mail->Subject = __('Reminder from {organisation} via {system}', [
+                            'organisation' => $_SESSION[$guid]['organisationNameShort'],
+                            'system' => $_SESSION[$guid]['systemName'],
+                        ]);
+
+                        $mail->renderBody('mail/email.twig.html', [
+                            'title'  => $mail->Subject,
+                            'body'   => $body,
+                        ]);
 
                         if (!$mail->Send()) {
                             $emailFail = true;

--- a/modules/Finance/invoices_payOnlineProcess.php
+++ b/modules/Finance/invoices_payOnlineProcess.php
@@ -284,19 +284,22 @@ if ($paid != 'Y') { //IF PAID IS NOT Y, LET'S REDIRECT TO MAKE PAYMENT
 
                 //Prep message
                 $body = receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSchoolYearID, $_SESSION[$guid]['currency'], true, $receiptCount)."<p style='font-style: italic;'>Email sent via ".$_SESSION[$guid]['systemName'].' at '.$_SESSION[$guid]['organisationName'].'.</p>';
-                $bodyPlain = 'This email is not viewable in plain text: enable rich text/HTML in your email client to view the receipt. Please reply to this email if you have any questions.';
 
                 $mail = $container->get(Mailer::class);
                 $mail->SetFrom(getSettingByScope($connection2, 'Finance', 'email'), sprintf(__('%1$s Finance'), $_SESSION[$guid]['organisationName']));
                 foreach ($emails as $address) {
                     $mail->AddBCC($address);
                 }
-                $mail->CharSet = 'UTF-8';
-                $mail->Encoding = 'base64';
-                $mail->IsHTML(true);
-                $mail->Subject = 'Receipt From '.$_SESSION[$guid]['organisationNameShort'].' via '.$_SESSION[$guid]['systemName'];
-                $mail->Body = $body;
-                $mail->AltBody = $bodyPlain;
+
+                $mail->Subject = __('Receipt from {organisation} via {system}', [
+                    'organisation' => $_SESSION[$guid]['organisationNameShort'],
+                    'system' => $_SESSION[$guid]['systemName'],
+                ]);
+
+                $mail->renderBody('mail/email.twig.html', [
+                    'title'  => $mail->Subject,
+                    'body'   => $body,
+                ]);
 
                 $mail->Send();
             }


### PR DESCRIPTION
Finance emails now use the same template as other emails in the system.

**Motivation and Context**
Hackathon! 

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="627" alt="Screen Shot 2020-04-18 at 5 12 59 PM" src="https://user-images.githubusercontent.com/897700/79633851-b4b59580-8199-11ea-9185-dee388899f40.png">