### PR TITLE
Tables: add a DetailsTable view and template

### DIFF
--- a/modules/Staff/staff_view_details.php
+++ b/modules/Staff/staff_view_details.php
@@ -23,6 +23,7 @@ use Gibbon\Domain\Staff\StaffAbsenceDateGateway;
 use Gibbon\Domain\Activities\ActivityGateway;
 use Gibbon\Tables\DataTable;
 use Gibbon\Domain\User\FamilyGateway;
+use Gibbon\Domain\DataSet;
 
 //Module includes for User Admin (for custom fields)
 include './modules/User Admin/moduleFunctions.php';
@@ -208,35 +209,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view_details.p
                             echo '</div>';
                         }
 
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        echo '<tr>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Name').'</span><br/>';
-                        echo '<i>'.Format::name($row['title'], $row['preferredName'], $row['surname'], 'Parent').'</i>';
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Staff Type').'</span><br/>';
-                        echo '<i>'.__($row['type']).'</i>';
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Job Title').'</span><br/>';
-                        echo '<i>'.$row['jobTitle'].'</i>';
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Initials').'</span><br/>';
-                        echo $row['initials'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Gender').'</span><br/>';
-                        echo $row['gender'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
+                        $table = DataTable::createDetails('personal');
 
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '</table>';
+                        $table->addColumn('preferredName', __('Name'))
+                            ->format(Format::using('name', ['title', 'preferredName', 'surname', 'Parent']));
+                        $table->addColumn('type', __('Staff Type'));
+                        $table->addColumn('jobTitle', __('Job Title'));
+                        $table->addColumn('initials', __('Initials'));
+                        $table->addColumn('gender', __('Gender'));
+                        $table->addColumn('initials', __('Initials'));
+
+                        echo $table->render([$row]);
 
                         echo '<h4>';
                         echo 'Contacts';

--- a/resources/templates/components/dataTable.twig.html
+++ b/resources/templates/components/dataTable.twig.html
@@ -7,7 +7,9 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 -->#}
 
 {% if table.getTitle %}
+    {% block title %}
     <h2>{{ table.getTitle }}</h2>
+    {% endblock title %}
 {% endif %}
 
 {% if table.getDescription %}

--- a/resources/templates/components/detailsTable.twig.html
+++ b/resources/templates/components/detailsTable.twig.html
@@ -1,0 +1,33 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+{% extends "components/dataTable.twig.html" %}
+
+{% block title %}
+    <h4>{{ table.getTitle }}</h4>
+{% endblock title %}
+
+{% block table %}
+
+{{ title }}
+    
+    {% for rowIndex, rowData in rows %}
+        <div class="flex flex-wrap rounded border bg-gray-100">
+
+        {% for columnIndex, column in columns %}
+            <div class="w-full sm:w-1/2 lg:w-1/3 p-2 border-b -mb-px">
+                <span class="block text-sm text-gray-700 font-bold mb-1">{{ column.getLabel }}</span>
+                <span class="block text-xs text-gray-700 ">{{ column.getOutput(rowData) }}</span>
+            </div>
+        {% endfor %}
+
+        </div>
+    {% endfor %}
+
+{% endblock table %}
+

--- a/src/Services/ViewServiceProvider.php
+++ b/src/Services/ViewServiceProvider.php
@@ -28,6 +28,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Tables\View\DataTableView;
 use Gibbon\Tables\View\PaginatedView;
 use League\Container\ServiceProvider\AbstractServiceProvider;
+use Gibbon\Tables\View\DetailsView;
 use Twig_Environment;
 
 /**
@@ -54,6 +55,7 @@ class ViewServiceProvider extends AbstractServiceProvider
         DataTableView::class,
         PaginatedView::class,
         Twig_Environment::class,
+        DetailsView::class,
     ];
 
     /**
@@ -93,6 +95,10 @@ class ViewServiceProvider extends AbstractServiceProvider
 
         $container->add(PaginatedView::class, function () use ($container) {
             return new PaginatedView($container->get('twig'));
+        });
+
+        $container->add(DetailsView::class, function () use ($container) {
+            return new DetailsView($container->get('twig'));
         });
 
         $container->share(\Twig_Environment::class, function () {

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -32,6 +32,7 @@ use Gibbon\Tables\Renderer\RendererInterface;
 use Gibbon\Tables\View\DataTableView;
 use Gibbon\Tables\View\PaginatedView;
 use Gibbon\View\View;
+use Gibbon\Tables\View\DetailsView;
 
 /**
  * DataTable
@@ -104,6 +105,20 @@ class DataTable implements OutputableInterface
         if ($renderer instanceof View) $renderer->addData('preventOverflow', true);
 
         return (new static($renderer))->setID($id)->setRenderer($renderer);
+    }
+
+    /**
+     * Helper method to create a details table.
+     *
+     * @param string $id
+     * @return self
+     */
+    public static function createDetails($id)
+    {
+        global $container;
+
+        $renderer = $container->get(DetailsView::class);
+        return (new static($renderer))->setID($id);
     }
 
     /**
@@ -438,12 +453,13 @@ class DataTable implements OutputableInterface
     /**
      * Render the data table, either with the supplied renderer or default to the built-in one.
      *
-     * @param DataSet $dataSet
+     * @param DataSet|array $dataSet
      * @param RendererInterface $renderer
      * @return string
      */
-    public function render(DataSet $dataSet, RendererInterface $renderer = null)
+    public function render($dataSet, RendererInterface $renderer = null)
     {
+        $dataSet = is_array($dataSet) ? new DataSet($dataSet) : $dataSet;
         $renderer = isset($renderer)? $renderer : $this->renderer;
 
         return $renderer->renderTable($this, $dataSet);

--- a/src/Tables/View/DetailsView.php
+++ b/src/Tables/View/DetailsView.php
@@ -1,0 +1,56 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Tables\View;
+
+use Gibbon\View\View;
+use Gibbon\Domain\DataSet;
+use Gibbon\Tables\DataTable;
+use Gibbon\Tables\Renderer\RendererInterface;
+
+/**
+ * DetailsView
+ *
+ * @version v20
+ * @since   v20
+ */
+class DetailsView extends View implements RendererInterface
+{
+    /**
+     * Render the table to HTML.
+     *
+     * @param DataTable $table
+     * @param DataSet $dataSet
+     * @return string
+     */
+    public function renderTable(DataTable $table, DataSet $dataSet)
+    {
+        $this->addData('table', $table);
+
+        if ($dataSet->count() > 0) {
+            $this->addData([
+                'columns'    => $table->getColumns(),
+                'rows'       => $dataSet,
+                'blankSlate' => $table->getMetaData('blankSlate'),
+            ]);
+        }
+
+        return $this->render('components/detailsTable.twig.html');
+    }
+}


### PR DESCRIPTION
Adds a new renderer for details tables, which represent a set of labels and data to display. There are lots of random areas in the system where these types of tables are displayed, and currently a regular data table or form doesn't work well.

Includes an example details table on the Staff Profile:

<img width="791" alt="Screen Shot 2020-04-18 at 7 49 18 PM" src="https://user-images.githubusercontent.com/897700/79637017-5941d280-81ae-11ea-9155-3a6ea1c1015b.png">

With the following code:
```php
table = DataTable::createDetails('personal');

$table->addColumn('preferredName', __('Name'))
    ->format(Format::using('name', ['title', 'preferredName', 'surname', 'Parent']));
$table->addColumn('type', __('Staff Type'));
$table->addColumn('jobTitle', __('Job Title'));
$table->addColumn('initials', __('Initials'));
$table->addColumn('gender', __('Gender'));
$table->addColumn('initials', __('Initials'));
echo $table->render([$row]);
```
