### PR TITLE
Removing renewal from the Library domain as it is not used

### DIFF
--- a/src/Domain/Library/LibraryGateway.php
+++ b/src/Domain/Library/LibraryGateway.php
@@ -54,7 +54,7 @@ class LibraryGateway extends QueryableGateway
             ])
             ->innerJoin('gibbonLibraryType as glt', 'gli.gibbonLibraryTypeID = glt.gibbonLibraryTypeID')
             ->join('left', 'gibbonSpace as gs', 'gli.gibbonSpaceID = gs.gibbonSpaceID')
-            ->where("gli.status IN ('Available','On Loan','Repair','Renewal')")
+            ->where("gli.status IN ('Available','On Loan','Repair')")
             ->where("gli.ownershipType <> 'Individual'")
             ->where("gli.borrowable = 'Y'");
 


### PR DESCRIPTION
The enum within the mysql table for gibbonLibraryItem confirms that the renewal enum is not supported and therefore serves no purpose within the domain.