### PR TITLE
Codesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,15 @@
         ],
         "test:phpunit": [
             "cd tests && ../vendor/bin/phpunit --verbose --configuration phpunit.xml"
+        ],
+        "test:codesniffer": [
+          "vendor/bin/phpcs --standard=PSR2 modules/Library/" 
         ]
     },
     "scripts-descriptions": {
         "test:codeception": "Initialize CI environment and run acceptance tests with Codeception.",
-        "test:phpunit": "Run unit tests with PHPUnit."
+        "test:phpunit": "Run unit tests with PHPUnit.",
+        "test:codesniffer": "Check code complies with PSR-2 standards"
     },
     "require": {
         "php" : "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "phpoffice/phpspreadsheet": "^1.6",
         "phpoffice/phpexcel": "1.8.1",
         "fzaninotto/faker": "^1.8",
-        "mpdf/mpdf": "^8.0"
+        "mpdf/mpdf": "^8.0",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "6.5.14"

--- a/composer.json
+++ b/composer.json
@@ -49,11 +49,11 @@
         "phpoffice/phpspreadsheet": "^1.6",
         "phpoffice/phpexcel": "1.8.1",
         "fzaninotto/faker": "^1.8",
-        "mpdf/mpdf": "^8.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "mpdf/mpdf": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "6.5.14"
+        "phpunit/phpunit": "6.5.14",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b87b5d0673638ea46a35911d6c427ab4",
+    "content-hash": "052969f1fef03d802db23b6ed852d109",
     "packages": [
         {
             "name": "aura/sqlquery",
@@ -1772,6 +1772,57 @@
             "time": "2018-09-16T10:54:21+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-04-17T01:09:41+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.9.0",
             "source": {
@@ -3509,5 +3560,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.0"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
I believe Sandra mentioned in passing that PSR-2 was something we could have some robot fix for us, this PR kind of spawned from that but also my own lack of tooling with a GUI-less editor. 

This PR introduces codesniffer alongside a composer script for testing for PSR-2 styling. In doing so, it also bumps a couple of other packages due to what I believe to be fuzzy package version references.

It bumps:

aura/sqlquery
container-interop/container-interop
league/container
tecnikcom/tcpdf
twig/twig

I'm not 100% on these packages so would appreciate if one of you guys could see if you can explain that change. I'm not exactly an expert with composer but I get the gist of it through the use of npm.

I can, by all means, revert those vendorfiles and look to add some kind of versionlock to composer.json. We might even find that the new packages work without a hitch and, in my short testing for my instance running, that checks out. Might be worth letting Travis do it's thing tbh! 🎉 