### PR TITLE
Reports: add an option to bulk upload existing report PDFs

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -643,4 +643,7 @@ INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `typ
 INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Staff Left', 'Staff', 'Staff Directory_full', 'Core', 'All', 'Y');end
 ALTER TABLE `gibbonTTImport` CHANGE `courseNameShort` `courseNameShort` VARCHAR(12) NOT NULL DEFAULT '';end
 ALTER TABLE `gibbonTTImport` CHANGE `classNameShort` `classNameShort` VARCHAR(8) NOT NULL DEFAULT '';end
+INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, `description`, `URLList`, `entryURL`, `entrySidebar`, `menuShow`, `defaultPermissionAdmin`, `defaultPermissionTeacher`, `defaultPermissionStudent`, `defaultPermissionParent`, `defaultPermissionSupport`, `categoryPermissionStaff`, `categoryPermissionStudent`, `categoryPermissionParent`, `categoryPermissionOther`) VALUES((SELECT gibbonModuleID FROM gibbonModule WHERE name='Reports'), 'Upload Reports', 0, 'Archive', 'Enables users to upload reports from a ZIP archive.', 'archive_manage_upload.php,archive_manage_uploadPreview.php', 'archive_manage_upload.php', 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N');end
+INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Reports' AND gibbonAction.name='Upload Reports'));end
+
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,6 +48,7 @@ v20.0.00
         Reports: added auto resize to comment text boxes in Write Reports
         Reports: change criteria status to Locked/Unlocked for better clarity
         Reports: added a progress bar to the sidebar in Write Reports
+        Reports: added an option to bulk upload existing report PDFs
         Staff: added an option to edit or delete staff coverage dates
         Staff: added Family and Activities subpages to Staff Profile
         Staff: added notificaton events for New and Left staff

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ v20.0.00
     Significant Changes
         Added Español - Mexico as an available locale
         Students: added a Withdraw Student page with the option to notify staff
+        Reports: added an option to bulk upload existing report PDFs
 
     Security
 
@@ -48,7 +49,6 @@ v20.0.00
         Reports: added auto resize to comment text boxes in Write Reports
         Reports: change criteria status to Locked/Unlocked for better clarity
         Reports: added a progress bar to the sidebar in Write Reports
-        Reports: added an option to bulk upload existing report PDFs
         Staff: added an option to edit or delete staff coverage dates
         Staff: added Family and Activities subpages to Staff Profile
         Staff: added notificaton events for New and Left staff

--- a/modules/Reports/archive_manage.php
+++ b/modules/Reports/archive_manage.php
@@ -53,12 +53,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage.php
     $table->addHeaderAction('import', __('Import Reports'))
         ->setIcon('upload')
         ->setURL('/modules/Reports/archive_manage_import.php')
-        ->displayLabel()
-        ->append(' | ');
-
-    $table->addHeaderAction('upload', __('Upload Reports'))
-        ->setIcon('upload')
-        ->setURL('/modules/Reports/archive_manage_upload.php')
         ->displayLabel();
 
     $table->addColumn('name', __('Name'));

--- a/modules/Reports/archive_manage.php
+++ b/modules/Reports/archive_manage.php
@@ -53,6 +53,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage.php
     $table->addHeaderAction('import', __('Import Reports'))
         ->setIcon('upload')
         ->setURL('/modules/Reports/archive_manage_import.php')
+        ->displayLabel()
+        ->append(' | ');
+
+    $table->addHeaderAction('upload', __('Upload Reports'))
+        ->setIcon('upload')
+        ->setURL('/modules/Reports/archive_manage_upload.php')
         ->displayLabel();
 
     $table->addColumn('name', __('Name'));

--- a/modules/Reports/archive_manage_import.php
+++ b/modules/Reports/archive_manage_import.php
@@ -21,14 +21,14 @@ use Gibbon\Domain\System\ModuleGateway;
 use Gibbon\Forms\Form;
 use Gibbon\Module\Reports\Domain\ReportArchiveGateway;
 
-if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_add.php') == false) {
+if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_import.php') == false) {
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
     // Proceed!
     $page->breadcrumbs
         ->add(__('Manage Archives'), 'archive_manage.php')
-        ->add(__('Import'));
+        ->add(__('Import Reports'));
 
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);

--- a/modules/Reports/archive_manage_upload.php
+++ b/modules/Reports/archive_manage_upload.php
@@ -1,0 +1,67 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\System\ModuleGateway;
+use Gibbon\Forms\Form;
+use Gibbon\Module\Reports\Domain\ReportArchiveGateway;
+use Gibbon\Forms\DatabaseFormFactory;
+
+if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_add.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $page->breadcrumbs
+        ->add(__('Manage Archives'), 'archive_manage.php')
+        ->add(__('Upload'));
+
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
+    $form = Form::create('archiveImport', $gibbon->session->get('absoluteURL').'/modules/Reports/archive_manage_uploadProcess.php');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+    $form->setTitle(__('Select ZIP File'));
+    $form->setDescription(__('This page allows you to bulk import reports, in the form of a ZIP file containing PDFs named with individual usernames.'));
+    
+    $form->addHiddenValue('address', $gibbon->session->get('address'));
+
+    $row = $form->addRow();
+        $row->addLabel('file', __('ZIP File'))->description(__('See Notes below for specification.'));
+        $row->addFileUpload('file')->required();
+
+    $archives = $container->get(ReportArchiveGateway::class)->selectWriteableArchives()->fetchKeyPair();
+    $row = $form->addRow();
+        $row->addLabel('gibbonReportArchiveID', __('Archive'))->description(__('The selected archive determines where files are saved and who can access them.'));
+        $row->addSelect('gibbonReportArchiveID')->fromArray($archives)->required()->placeholder();
+
+    $row = $form->addRow();
+        $row->addLabel('gibbonSchoolYearID', __('School Year'));
+        $row->addSelectSchoolYear('gibbonSchoolYearID')->required()->selected($gibbon->session->get('gibbonSchoolYearID'));
+
+    $row = $form->addRow();
+        $row->addLabel('reportIdentifier', __('Report Name'));
+        $row->addTextField('reportIdentifier')->required()->maxLength(255);
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
+}

--- a/modules/Reports/archive_manage_upload.php
+++ b/modules/Reports/archive_manage_upload.php
@@ -28,7 +28,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
 } else {
     // Proceed!
     $page->breadcrumbs
-        ->add(__('Manage Archives'), 'archive_manage.php')
         ->add(__('Upload Reports'), 'archive_manage_upload.php')
         ->add(__('Step {number}', ['number' => 1]));
 

--- a/modules/Reports/archive_manage_uploadPreview.php
+++ b/modules/Reports/archive_manage_uploadPreview.php
@@ -1,0 +1,184 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+use Gibbon\FileUploader;
+use Gibbon\Services\Format;
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Domain\DataSet;
+use Gibbon\Domain\Students\StudentGateway;
+use Gibbon\Domain\School\SchoolYearGateway;
+use Gibbon\Module\Reports\Domain\ReportArchiveGateway;
+use Gibbon\Module\Reports\Domain\ReportArchiveEntryGateway;
+
+if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_uploadPreview.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $page->breadcrumbs
+        ->add(__('Manage Archives'), 'archive_manage.php')
+        ->add(__('Upload Reports'), 'archive_manage_upload.php')
+        ->add(__('Step {number}', ['number' => 2]));
+
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
+    $gibbonReportArchiveID = $_POST['gibbonReportArchiveID'] ?? '';
+    $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
+    $reportIdentifier = $_POST['reportIdentifier'] ?? '';
+    $reportDate = $_POST['reportDate'] ?? '';
+    $tempFile = $_FILES['file'] ?? '';
+    $fileSeparator = $_POST['fileSeparator'] ?? '';
+    $fileSection = $_POST['fileSection'] ?? '';
+
+    if (empty($gibbonReportArchiveID) || empty($gibbonSchoolYearID) || empty($reportIdentifier) || empty($tempFile)) {
+        $page->addError(__('You have not specified one or more required parameters.'));
+        return;
+    }
+
+    $reportArchiveGateway = $container->get(ReportArchiveGateway::class);
+    $archive = $reportArchiveGateway->getByID($gibbonReportArchiveID);
+    if (empty($archive)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+    // Open the zip archive
+    $zip = new ZipArchive();
+    if ($zip->open($tempFile['tmp_name']) === false) {
+        $page->addError(__('The import file could not be decompressed.'));
+        return;
+    }
+
+    // Grab any existing reports so we can check if they will be overwritten
+    $reportArchiveEntryGateway = $container->get(ReportArchiveEntryGateway::class);
+    $existingReports = $reportArchiveEntryGateway->selectArchiveEntriesByReportIdentifier($gibbonSchoolYearID, $reportIdentifier)->fetchGroupedUnique();
+
+    // Peek into the zip file and check the contents
+    $studentGateway = $container->get(StudentGateway::class);
+    $reports = [];
+    for ($i = 0; $i < $zip->numFiles; ++$i) {
+        if (substr($zip->getNameIndex($i), 0, 8) == '__MACOSX') continue;
+        
+        $filename = $zip->getNameIndex($i);
+        $extension = mb_substr(mb_strrchr(strtolower($filename), '.'), 1);
+        
+        if ($extension != 'pdf') continue;
+
+        // Optionally split the filenames by a separator character
+        if (!empty($fileSeparator) && !empty($fileSection)) {
+            $fileParts = explode($fileSeparator, mb_strstr($filename, '.', true));
+            $username = $fileParts[$fileSection-1] ?? '';
+        } else {
+            $username = mb_strstr($filename, '.', true);
+        }
+
+        // Ensure the file info matches a student enrolment in the selected year
+        $studentEnrolment = $studentGateway->getStudentByUsername($gibbonSchoolYearID, $username);
+        if (!empty($username) && !empty($studentEnrolment)) {
+            $studentEnrolment['report'] = $existingReports[$studentEnrolment['gibbonPersonID']] ?? [];
+            $studentEnrolment['filename'] = $filename;
+            $reports[] = $studentEnrolment;
+        }
+    }
+
+    // Cancel out if there's nothing to do
+    if (empty($reports)) {
+        $page->addError(__('Import cannot proceed. The uploaded ZIP archive did not contain any valid {filetype} files.', ['filetype' => 'pdf']));
+        return;
+    }
+
+    // Upload the temporary file to the archive
+    if (!empty($tempFile['tmp_name'])) {
+        $fileUploader = new FileUploader($pdo, $gibbon->session);
+        $file = $fileUploader->upload($tempFile['name'], $tempFile['tmp_name'], $archive['path'].'/temp');
+    } else {
+        $page->addError(__('Failed to write file to disk.'));
+        return;
+    }
+
+    $form = Form::create('archiveImport', $gibbon->session->get('absoluteURL').'/modules/Reports/archive_manage_uploadProcess.php');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+    $form->setTitle(__('Step 2 - Data Check & Confirm'));
+    
+    $form->addHiddenValue('address', $gibbon->session->get('address'));
+    $form->addHiddenValue('gibbonReportArchiveID', $gibbonReportArchiveID);
+    $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
+    $form->addHiddenValue('reportIdentifier', $reportIdentifier);
+    $form->addHiddenValue('reportDate', Format::dateConvert($reportDate));
+    $form->addHiddenValue('fileSeparator', $fileSeparator);
+    $form->addHiddenValue('fileSection', $fileSection);
+    $form->addHiddenValue('file', $file);
+
+    $form->addRow()->addHeading(__('Report Info'));
+
+    $row = $form->addRow();
+        $row->addLabel('archiveName', __('Archive'));
+        $row->addTextField('archiveName')->readonly()->setValue($archive['name']);
+
+    $schoolYear = $container->get(SchoolYearGateway::class)->getSchoolYearByID($gibbonSchoolYearID);
+    $row = $form->addRow();
+        $row->addLabel('schoolYearName', __('School Year'));
+        $row->addTextField('schoolYearName')->readonly()->setValue($schoolYear['name']);
+
+    $row = $form->addRow();
+        $row->addLabel('reportName', __('Report Name'));
+        $row->addTextField('reportName')->readonly()->setValue($reportIdentifier);
+
+    $row = $form->addRow();
+        $row->addLabel('reportDateName', __('Report Date'));
+        $row->addTextField('reportDateName')->readonly()->setValue($reportDate);
+
+    if (!empty($existingReports)) {
+        $row = $form->addRow();
+            $row->addLabel('overwrite', __('Overwrite'))->description(__('Should uploaded files overwrite any existing files?'));
+            $row->addYesNo('overwrite')->selected('N');
+    }
+
+    // DATA TABLE
+    $table = $form->addRow()->addDataTable('reportFiles')->withData(new DataSet($reports));
+
+    $table->modifyRows($studentGateway->getSharedUserRowHighlighter());
+
+    $table->addColumn('student', __('Student'))
+        ->sortable(['surname', 'preferredName'])
+        ->width('25%')
+        ->format(function ($person) {
+            return Format::name('', $person['preferredName'], $person['surname'], 'Student', true)
+                   .'<br/>'.Format::small(Format::userStatusInfo($person));
+        });
+    $table->addColumn('rollGroup', __('Roll Group'));
+    $table->addColumn('username', __('Username'));
+    $table->addColumn('filename', __('File Name'));
+    $table->addColumn('status', __('Status'))
+        ->format(function ($values) {
+            return !empty($values['report'])
+                ? '<span class="tag warning">'.__('Exists').'</span>'
+                : '<span class="tag success">'.__('New').'</span>';
+        });
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
+}

--- a/modules/Reports/archive_manage_uploadPreview.php
+++ b/modules/Reports/archive_manage_uploadPreview.php
@@ -34,7 +34,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
 } else {
     // Proceed!
     $page->breadcrumbs
-        ->add(__('Manage Archives'), 'archive_manage.php')
         ->add(__('Upload Reports'), 'archive_manage_upload.php')
         ->add(__('Step {number}', ['number' => 2]));
 

--- a/modules/Reports/archive_manage_uploadProcess.php
+++ b/modules/Reports/archive_manage_uploadProcess.php
@@ -1,0 +1,128 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Module\Reports\Domain\ReportArchiveEntryGateway;
+use Gibbon\Module\Reports\Domain\ReportArchiveGateway;
+use Gibbon\FileUploader;
+
+require_once '../../gibbon.php';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Reports/archive_manage.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_import.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $gibbonReportArchiveID = $_POST['gibbonReportArchiveID'] ?? '';
+    $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
+    $reportIdentifier = $_POST['reportIdentifier'] ?? '';
+
+    if (empty($_FILES['file']) || empty($gibbonReportArchiveID) || empty($gibbonSchoolYearID) || empty($reportIdentifier) ) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $absolutePath = $gibbon->session->get('absolutePath');
+    $reportArchiveGateway = $container->get(ReportArchiveGateway::class);
+    $reportArchiveEntryGateway = $container->get(ReportArchiveEntryGateway::class);
+
+    $archive = $reportArchiveGateway->getByID($gibbonReportArchiveID);
+    if (empty($archive)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $partialFail = false;
+    $path = str_replace('\\', '/', $_FILES['file']['tmp_name']);
+    $zip = new ZipArchive();
+
+    if ($zip->open($path) === true) { // Success
+        $fileUploader = new FileUploader($pdo, $gibbon->session);
+        $count = 0;
+        $total = $zip->numFiles;
+
+        for ($i = 0; $i < $zip->numFiles; ++$i) {
+            if (substr($zip->getNameIndex($i), 0, 8) == '__MACOSX') continue;
+            
+            $filename = $zip->getNameIndex($i);
+            $username = strstr($filename, '.', true);
+            $extension = mb_substr(mb_strrchr(strtolower($filename), '.'), 1);
+
+            if ($extension != 'pdf') {
+                $partialFail = true;
+            }
+
+            // Ensure the file info matches a user and student enrolment
+            $data = ['username' => $username, 'gibbonSchoolYearID' => $gibbonSchoolYearID];
+            $sql = "SELECT * FROM gibbonStudentEnrolment JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID) WHERE gibbonPerson.username=:username AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID";
+            $studentEnrolment = $pdo->selectOne($sql, $data);
+
+            if (!empty($username) && !empty($studentEnrolment)) {
+                // Get or make a folder to upload into
+                $reportFolder = preg_replace('/[^a-zA-Z0-9]/', '', $reportIdentifier);
+                $destinationFolder = $absolutePath.$archive['path'].'/'.$reportFolder;
+
+                if (!is_dir($destinationFolder)) {
+                    mkdir($destinationFolder, 0755, true);
+                }
+
+                // Upload the file, grab the /uploads relative path
+                $destinationName = $fileUploader->getRandomizedFilename($filename, $destinationFolder);
+                $filePathRelative = $reportFolder.'/'.$destinationName;
+
+                if (!(@copy('zip://'.$path.'#'.$filename, $destinationFolder.'/'.$destinationName))) {
+                    $partialFail = true;
+                }
+
+                // Create an archive entry for this file
+                $archiveEntry = [
+                    'gibbonReportID' => 0,
+                    'gibbonReportArchiveID' => $gibbonReportArchiveID,
+                    'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                    'gibbonYearGroupID' => $studentEnrolment['gibbonYearGroupID'],
+                    'gibbonRollGroupID' => $studentEnrolment['gibbonRollGroupID'],
+                    'gibbonPersonID' => $studentEnrolment['gibbonPersonID'],
+                    'type' => 'Single',
+                    'status' => 'Final',
+                    'reportIdentifier' => $reportIdentifier,
+                    'filePath' => $filePathRelative,
+                    'timestampCreated' => date('Y-m-d H:i:s'),
+                    'timestampModified' => date('Y-m-d H:i:s'),
+                ];
+
+                $inserted = $reportArchiveEntryGateway->insertAndUpdate($archiveEntry, $archiveEntry);
+                if ($inserted) $count++;
+            }
+        }
+    } else {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $URL .= $partialFail
+        ? "&return=warning1"
+        : "&return=success1";
+
+    header("Location: {$URL}&imported={$count}&total={$total}");
+}

--- a/modules/Reports/src/Domain/ReportArchiveEntryGateway.php
+++ b/modules/Reports/src/Domain/ReportArchiveEntryGateway.php
@@ -259,6 +259,21 @@ class ReportArchiveEntryGateway extends QueryableGateway
         return $this->runSelect($query)->fetch();
     }
 
+    public function selectArchiveEntriesByReportIdentifier($gibbonSchoolYearID, $reportIdentifier)
+    {
+        $query = $this
+            ->newSelect()
+            ->from($this->getTableName())
+            ->cols(['gibbonReportArchiveEntry.gibbonPersonID as groupBy', 'gibbonReportArchiveEntry.*'])
+            ->where('gibbonReportArchiveEntry.gibbonSchoolYearID=:gibbonSchoolYearID')
+            ->bindValue('gibbonSchoolYearID', $gibbonSchoolYearID)
+            ->where('gibbonReportArchiveEntry.reportIdentifier=:reportIdentifier')
+            ->bindValue('reportIdentifier', $reportIdentifier)
+            ->where("gibbonReportArchiveEntry.type='Single'");
+
+        return $this->runSelect($query);
+    }
+
     protected function applyArchiveAccessLogic(&$query, $roleCategory = 'Other', $viewDraft = false, $viewPast = false)
     {
         if (!$viewDraft) {

--- a/resources/templates/components/form.twig.html
+++ b/resources/templates/components/form.twig.html
@@ -11,6 +11,10 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     {% if form.getTitle %}
         <h2>{{ form.getTitle }}</h2>
     {% endif %}
+    
+    {% if form.getDescription %}
+        <p>{{ form.getDescription }}</p>
+    {% endif %}
 
     {% for values in form.getHiddenValues %}
         <input type="hidden" name="{{ values.name }}" value="{{ values.value }}">

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -198,7 +198,7 @@ class StudentGateway extends QueryableGateway
     public function selectActiveStudentByPerson($gibbonSchoolYearID, $gibbonPersonID)
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonID' => $gibbonPersonID, 'today' => date('Y-m-d'));
-        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, image_240, gender, gibbonStudentEnrolment.gibbonSchoolYearID, gibbonYearGroup.gibbonYearGroupID, gibbonYearGroup.nameShort AS yearGroup, gibbonRollGroup.gibbonRollGroupID, gibbonRollGroup.nameShort AS rollGroup, 'Student' as roleCategory, gibbonPerson.privacy
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, image_240, gender, gibbonStudentEnrolment.gibbonStudentEnrolmentID, gibbonStudentEnrolment.gibbonSchoolYearID, gibbonYearGroup.gibbonYearGroupID, gibbonYearGroup.nameShort AS yearGroup, gibbonRollGroup.gibbonRollGroupID, gibbonRollGroup.nameShort AS rollGroup, 'Student' as roleCategory, gibbonPerson.privacy
                 FROM gibbonPerson
                 JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
                 JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
@@ -210,6 +210,20 @@ class StudentGateway extends QueryableGateway
                 AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID";
 
         return $this->db()->select($sql, $data);
+    }
+
+    public function getStudentByUsername($gibbonSchoolYearID, $username)
+    {
+        $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'username' => $username);
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, image_240, gender, gibbonStudentEnrolment.gibbonStudentEnrolmentID, gibbonStudentEnrolment.gibbonSchoolYearID, gibbonYearGroup.gibbonYearGroupID, gibbonYearGroup.nameShort AS yearGroup, gibbonRollGroup.gibbonRollGroupID, gibbonRollGroup.nameShort AS rollGroup, 'Student' as roleCategory, gibbonPerson.privacy, gibbonPerson.username
+                FROM gibbonPerson
+                JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
+                JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
+                JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
+                WHERE gibbonPerson.username=:username 
+                AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID";
+
+        return $this->db()->selectOne($sql, $data);
     }
 
     public function selectAllStudentEnrolmentsByPerson($gibbonPersonID)

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -34,6 +34,7 @@ class Form implements OutputableInterface
     use BasicAttributesTrait;
 
     protected $title;
+    protected $description;
     protected $factory;
     protected $renderer;
 
@@ -95,6 +96,26 @@ class Form implements OutputableInterface
     public function setTitle($title)
     {
         $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Get the form description.
+     * @return  string 
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set the form description.
+     * @param  string  $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
 
         return $this;
     }

--- a/src/Gibbon/FileUploader.php
+++ b/src/Gibbon/FileUploader.php
@@ -187,11 +187,12 @@ class FileUploader
     }
 
     /**
-     * Convenience function for handling file uploads from
+     * Convenience function for handling file uploads from ZIP archives.
      *
      * @param string $file
      * @param string $destinationFolder
-     * @return array
+     * @param array $allowedExtensions
+     * @return array  Returns an array of info about uploaded files
      */
     public function uploadFromZIP($path, $destinationFolder = '', $allowedExtensions = [])
     {


### PR DESCRIPTION
Adds an Upload Reports option under Archives. This enables a user to upload a ZIP file of report PDFs that include student usernames, which are then added to the View Reports by Student page. This is similar to the user photo upload, with a few extra features:

- Includes a preview page to display which reports will be uploaded, and which already exist.
- Optionally overwrite existing reports when importing.
- The uploader can handle filenames inside the ZIP archive that have a separator character.
- The report name and date can be specified, which controls how the report displays in the student archive.
- Adds a uploadFromZIP method to the FileUploader class.
- Adds a setDescription method to the Form class, to match the functionality in the DataTable class.

**Motivation and Context**
This enables schools to upload reports that may have originated from other systems and make them available for staff, students, and/or parents to access through View Reports by Student. This can also be useful when migrating data and getting up and running with the reports module for the first time.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
Step 1:
<img width="819" alt="Screenshot 2020-04-29 at 12 13 02 PM" src="https://user-images.githubusercontent.com/897700/80560419-73cc4500-8a13-11ea-9b2b-31bfd583411f.png">

Step 2:
<img width="811" alt="Screenshot 2020-04-29 at 12 13 41 PM" src="https://user-images.githubusercontent.com/897700/80560422-77f86280-8a13-11ea-969a-f3dd58a5261e.png">

View by Student:
<img width="805" alt="Screenshot 2020-04-29 at 12 19 56 PM" src="https://user-images.githubusercontent.com/897700/80560509-c574cf80-8a13-11ea-905a-6bc9c7e026df.png">
