### PR TITLE
OOification: Library Lending Item

### DIFF
--- a/modules/Library/library_lending_item.php
+++ b/modules/Library/library_lending_item.php
@@ -17,7 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
+use Gibbon\Domain\Library\LibraryGateway;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -147,151 +149,100 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
-            echo "<div class='linkTop'>";
-            if ($row['status'] == 'Available') {
-                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/library_lending_item_signout.php&gibbonLibraryItemID=$gibbonLibraryItemID&name=".$name.'&gibbonLibraryTypeID='.$gibbonLibraryTypeID.'&gibbonSpaceID='.$gibbonSpaceID.'&status='.$status."'>".__('Sign Out')." <img  style='margin: 0 0 -4px 3px' title='".__('Sign Out')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_right.png'/></a>";
-            } else {
-                echo '<i>'.__('This item has already been signed out.').'</i>';
-            }
-            echo '</div>';
-
-            if ($resultEvent->rowCount() < 1) {
-                echo "<div class='error'>";
-                echo __('There are no records to display.');
-                echo '</div>';
-            } else {
-                if ($resultEvent->rowCount() > $_SESSION[$guid]['pagination']) {
-                    printPagination($guid, $resultEvent->rowCount(), $page, $_SESSION[$guid]['pagination'], 'top', '');
+            $gateway = $container->get(LibraryGateway::class);
+            $criteria = $gateway->newQueryCriteria(true)
+               ->filterBy('gibbonLibraryItemID',$gibbonLibraryItemID)
+               ->filterBy('name',$name)
+               ->filterBy('gibbonLibraryTypeID',$gibbonLibraryTypeID)
+               ->filterBy('gibbonSpaceID',$gibbonSpaceID)
+               ->filterBy('status',$status)
+                                ->fromPOST();
+            $item = $gateway->queryLendingDetail($criteria); 
+            $table = DataTable::createPaginated('lendingLog',$criteria);
+            $table
+              ->addColumn('user',__('User'))
+              ->format(function($item) {
+                if($item['gibbonPersonIDStatusResponsible'] != '')
+                {
+                  return sprintf('%1$s<div style="margin-top: 3px; font-weight: bold">%2$s</div>', Format::userPhoto($item['responsiblePersonImage']),Format::name($item['responsiblePersonTitle'], $item['responsiblePersonPreferredName'], $item['responsiblePersonSurname'], 'Staff', false, true));
+                } else {
+                  return null;
                 }
-
-                echo "<table cellspacing='0' style='width: 100%'>";
-                echo "<tr class='head'>";
-                echo "<th style='text-align: center; min-width: 90px'>";
-                echo __('User');
-                echo '</th>';
-                echo '<th>';
-                echo __('Status').'<br/>';
-                echo "<span style='font-size: 85%; font-style: italic'>".__('Date Out & In').'</span><br/>';
-                echo '</th>';
-                echo '<th>';
-                echo __('Due Date');
-                echo '</th>';
-                echo '<th>';
-                echo __('Return Action');
-                echo '</th>';
-                echo '<th>';
-                echo __('Recorded By');
-                echo '</th>';
-                echo "<th style='width: 110px'>";
-                echo __('Actions');
-                echo '</th>';
-                echo '</tr>';
-
-                $count = 0;
-                $rowNum = 'odd';
-                try {
-                    $resultEventPage = $connection2->prepare($sqlEventPage);
-                    $resultEventPage->execute($dataEvent);
-                } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
+              });
+            $table->addColumn('status',__('Status (Date In/Out)'))
+                  ->format(function($event) {
+                    $timeInOut = Format::date($event['timestampOut']);
+                    if($event['timestampReturn'] != '')
+                    {
+                      $timeInOut .= ' - ' . Format::date($event['timestampReturn']);
+                    }
+                    return sprintf('%1$s<br/>%2$s',$event['status'],Format::small($timeInOut));
+                  });;
+            $table
+              ->addColumn('dueDate',__('Due Date'))
+              ->format(function($event) {
+                if($event['status'] != 'Returned' && $event['returnExpected'] != '')
+                {
+                  return Format::date($event['returnExpected']);
                 }
-                while ($rowEvent = $resultEventPage->fetch()) {
-                    if ($count % 2 == 0) {
-                        $rowNum = 'even';
-                    } else {
-                        $rowNum = 'odd';
-                    }
-                    ++$count;
-
-					//COLOR ROW BY STATUS!
-					echo "<tr class=$rowNum>";
-                    if ($rowEvent['gibbonPersonIDStatusResponsible'] != '') {
-                        try {
-                            $dataPerson = array('gibbonPersonID' => $rowEvent['gibbonPersonIDStatusResponsible']);
-                            $sqlPerson = 'SELECT title, preferredName, surname, image_240 FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID';
-                            $resultPerson = $connection2->prepare($sqlPerson);
-                            $resultPerson->execute($dataPerson);
-                        } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
-                        }
-                        if ($resultPerson->rowCount() == 1) {
-                            $rowPerson = $resultPerson->fetch();
-                        }
-                    }
-                    echo '<td style=\'text-align: center\'>';
-                    if (is_array($rowPerson)) {
-                        echo getUserPhoto($guid, $rowPerson['image_240'], 75);
-                    }
-                    if (is_array($rowPerson)) {
-                        echo "<div style='margin-top: 3px; font-weight: bold'>".Format::name($rowPerson['title'], $rowPerson['preferredName'], $rowPerson['surname'], 'Staff', false, true).'</div>';
-                    }
-                    echo '</td>';
-                    echo '<td>';
-                    echo $rowEvent['status'].'<br/>';
-                    if ($rowEvent['timestampOut'] != '') {
-                        echo "<span style='font-size: 85%; font-style: italic'>".dateConvertBack($guid, substr($rowEvent['timestampOut'], 0, 10));
-
-                        if ($rowEvent['timestampReturn'] != '') {
-                            echo ' - '.dateConvertBack($guid, substr($rowEvent['timestampReturn'], 0, 10));
-                        }
-                        echo '</span>';
-                    }
-                    echo '</td>';
-                    echo '<td>';
-                    if ($rowEvent['status'] != 'Returned' and $rowEvent['returnExpected'] != '') {
-                        echo dateConvertBack($guid, substr($rowEvent['returnExpected'], 0, 10)).'<br/>';
-                    }
-                    echo '</td>';
-                    echo '<td>';
-                    if ($rowEvent['status'] != 'Returned' and  $rowEvent['returnAction'] != '') {
-                        echo $rowEvent['returnAction'];
-                    }
-                    echo '</td>';
-                    echo '<td>';
-                    if ($rowEvent['gibbonPersonIDOut'] != '') {
-                        try {
-                            $dataPerson = array('gibbonPersonID' => $rowEvent['gibbonPersonIDOut']);
-                            $sqlPerson = 'SELECT title, preferredName, surname, image_240 FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID';
-                            $resultPerson = $connection2->prepare($sqlPerson);
-                            $resultPerson->execute($dataPerson);
-                        } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
-                        }
-                        if ($resultPerson->rowCount() == 1) {
-                            $rowPerson = $resultPerson->fetch();
-                        }
-                        echo __('Out:').' '.Format::name($rowPerson['title'], $rowPerson['preferredName'], $rowPerson['surname'], 'Staff', false, true).'<br/>';
-                    }
-                    if ($rowEvent['gibbonPersonIDIn'] != '') {
-                        try {
-                            $dataPerson = array('gibbonPersonID' => $rowEvent['gibbonPersonIDIn']);
-                            $sqlPerson = 'SELECT title, preferredName, surname, image_240 FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID';
-                            $resultPerson = $connection2->prepare($sqlPerson);
-                            $resultPerson->execute($dataPerson);
-                        } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
-                        }
-                        if ($resultPerson->rowCount() == 1) {
-                            $rowPerson = $resultPerson->fetch();
-                        }
-                        echo __('In:').' '.Format::name($rowPerson['title'], $rowPerson['preferredName'], $rowPerson['surname'], 'Staff', false, true);
-                    }
-                    echo '</td>';
-                    echo '<td>';
-                    if ($count == 1 and $rowEvent['status'] != 'Returned') {
-                        echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/library_lending_item_edit.php&gibbonLibraryItemID=$gibbonLibraryItemID&gibbonLibraryItemEventID=".$rowEvent['gibbonLibraryItemEventID'].'&name='.$name.'&gibbonLibraryTypeID='.$gibbonLibraryTypeID.'&gibbonSpaceID='.$gibbonSpaceID.'&status='.$status."'><img title='".__('Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
-                        echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/library_lending_item_return.php&gibbonLibraryItemID=$gibbonLibraryItemID&gibbonLibraryItemEventID=".$rowEvent['gibbonLibraryItemEventID'].'&name='.$name.'&gibbonLibraryTypeID='.$gibbonLibraryTypeID.'&gibbonSpaceID='.$gibbonSpaceID.'&status='.$status."'><img title='Return' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_left.png'/></a>";
-                        echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.$_SESSION[$guid]['module']."/library_lending_item_renew.php&gibbonLibraryItemID=$gibbonLibraryItemID&gibbonLibraryItemEventID=".$rowEvent['gibbonLibraryItemEventID'].'&name='.$name.'&gibbonLibraryTypeID='.$gibbonLibraryTypeID.'&gibbonSpaceID='.$gibbonSpaceID.'&status='.$status."'><img style='margin-left: 3px' title='Renew' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/page_right.png'/></a>";
-                    }
-                    echo '</td>';
-                    echo '</tr>';
+              });
+            $table
+              ->addColumn('returnAction',__('Return Action'))
+              ->format(function($event) {
+                if($event['status'] != 'Returned' && $event['returnAction'] != ''){
+                  return Format::date($event['returnAction']);
                 }
-                echo '</table>';
-
-                if ($result->rowCount() > $_SESSION[$guid]['pagination']) {
-                    printPagination($guid, $result->rowCount(), $page, $_SESSION[$guid]['pagination'], 'bottom', '');
+              });
+            $table
+              ->addColumn('recordedBy',__('Recorded By'))
+              ->format(function($event) {
+                $outPerson = "";
+                $inPerson = "";
+                if($event['outPersonID'])
+                {
+                  $outPerson .= 'Out: ' . Format::name($event['outPersonTitle'],$event['outPersonPreferredName'],$event['outPersonSurname'],'Staff',false,true);
                 }
-            }
+                if($event['inPersonID'])
+                {
+                  $inPerson .= 'In: ' . Format::name($event['inPersonTitle'],$event['inPersonPreferredName'],$event['inPersonSurname'],'Staff',false,true);
+                }
+                return sprintf('%1$s<br/>%2$s',$outPerson,$inPerson);
+              });
+            $table
+              ->addActionColumn()
+              ->addParam('gibbonLibraryItemID')
+              ->addParam('name',$name)
+              ->addParam('gibbonLibraryTypeID',$gibbonLibraryTypeID)
+              ->addParam('gibbonSpaceID',$gibbonSpaceID)
+              ->addParam('gibbonLibraryItemEventID')
+              ->addParam('status',$status)
+              ->format(function($event,$actions) {
+                if($event['rowNum'] == 1 && $event['status'] != 'Returned')
+                {
+                  //Edit function cannot be used unless the responsible person ID is set
+                  if($event['responsiblePersonID'] != null)
+                  {
+                    $actions
+                      ->addAction('edit',__('Edit'))
+                      ->setURL('/modules/Library/library_lending_item_edit.php');
+                  }
+
+                  $actions
+                    ->addAction('return',__('Return'))
+                    ->setIcon('page_left')
+                    ->setURL('/modules/Library/library_lending_item_return.php');
+
+                  //Renew feature is only usable when the responsible person ID is set
+                  if($event['responsiblePersonID'] != null)
+                  {
+                    $actions
+                      ->addAction('renew',__('Renew'))
+                      ->setIcon('page_right')
+                      ->setURL('/modules/Library/library_lending_item_renew.php');
+                  }
+                }
+              });
+            echo $table->render($item);
 
             $_SESSION[$guid]['sidebarExtra'] = '';
             $_SESSION[$guid]['sidebarExtra'] .= getImage($guid, $row['imageType'], $row['imageLocation']);

--- a/modules/Library/library_lending_item.php
+++ b/modules/Library/library_lending_item.php
@@ -128,9 +128,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             echo '</tr>';
             echo '</table>';
 
-            echo '<h3>';
-            echo __('Lending & Activity Log');
-            echo '</h3>';
             
             $gateway = $container->get(LibraryGateway::class);
             $criteria = $gateway->newQueryCriteria(true)

--- a/modules/Library/library_lending_item.php
+++ b/modules/Library/library_lending_item.php
@@ -214,7 +214,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
               ->format(function($event,$actions) {
                 if($event['rowNum'] == 1 && $event['status'] != 'Returned')
                 {
-                  var_dump($event);
                   //Edit function cannot be used unless the responsible person ID is set
                   if($event['responsiblePersonID'] != null)
                   {

--- a/modules/Library/library_lending_item.php
+++ b/modules/Library/library_lending_item.php
@@ -139,7 +139,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                                 ->fromPOST();
             $item = $gateway->queryLendingDetail($criteria); 
             $table = DataTable::createPaginated('lendingLog',$criteria);
-
+            $table->setTitle(__('Lending & Activity Log'));
             if($status == 'Available') {
               $table
                 ->addHeaderAction('signout',__('Sign Out'))

--- a/src/Domain/Library/LibraryGateway.php
+++ b/src/Domain/Library/LibraryGateway.php
@@ -14,6 +14,56 @@ class LibraryGateway extends QueryableGateway
     private static $primaryKey = 'gibbonLibraryItemID';
     private static $searchableColumns = [];
 
+    public function queryLendingDetail(QueryCriteria $criteria)
+    {
+      $query = $this
+        ->newQuery()
+        ->from('gibbonLibraryItemEvent')
+        ->join('left','gibbonPerson as gibbonPersonResponsible','gibbonLibraryItemEvent.gibbonPersonIDStatusResponsible = gibbonPersonResponsible.gibbonPersonID')
+        ->join('left','gibbonPerson as gibbonPersonOut','gibbonLibraryItemEvent.gibbonPersonIDOut = gibbonPersonOut.gibbonPersonID')
+        ->join('left','gibbonPerson as gibbonPersonIn','gibbonLibraryItemEvent.gibbonPersonIDIn = gibbonPersonIn.gibbonPersonID')
+        ->cols([
+          'ROW_NUMBER() OVER (ORDER BY gibbonLibraryItemEvent.timestampOut DESC) AS rowNum',
+          'gibbonPersonResponsible.title as responsiblePersonTitle',
+          'gibbonPersonResponsible.preferredName as responsiblePersonPreferredName',
+          'gibbonPersonResponsible.surname as responsiblePersonSurname',
+          'gibbonPersonResponsible.image_240 as responsiblePersonImage',
+          'gibbonPersonOut.gibbonPersonId as outPersonID',
+          'gibbonPersonOut.title as outPersonTitle',
+          'gibbonPersonOut.preferredName as outPersonPreferredName',
+          'gibbonPersonOut.surname as outPersonSurname',
+          'gibbonPersonOut.image_240 as outPersonImage',
+          'gibbonPersonIn.gibbonPersonID as inPersonID',
+          'gibbonPersonIn.title as inPersonTitle',
+          'gibbonPersonIn.preferredName as inPersonPreferredName',
+          'gibbonPersonIn.surname as inPersonSurname',
+          'gibbonPersonIn.image_240 as inPersonImage',
+          'gibbonLibraryItemEvent.gibbonPersonIDStatusResponsible',
+          'gibbonLibraryItemEvent.gibbonLibraryItemID',
+          'gibbonLibraryItemEvent.gibbonLibraryItemEventID',
+          'CONVERT(gibbonLibraryItemEvent.timestampOut,DATE) AS timestampOut',
+          'CONVERT(gibbonLibraryItemEvent.timestampReturn,DATE) AS timestampReturn',
+          'gibbonLibraryItemEvent.status',
+          'gibbonLibraryItemEvent.returnExpected',
+          'gibbonLibraryItemEvent.returnAction',
+          'gibbonLibraryItemEvent.gibbonPersonIDOut'
+        ])
+        ->orderBy([
+          'gibbonLibraryItemEvent.timestampOut DESC'
+        ]);
+
+
+      $criteria->addFilterRules([
+        'gibbonLibraryItemID' => function($query,$itemid) {
+          return $query
+            ->where('gibbonLibraryItemEvent.gibbonLibraryItemID = :itemid')
+            ->bindValue('itemid',$itemid);
+        }
+      ]);
+
+      return $this->runQuery($query,$criteria);
+    }
+
     public function queryLending(QueryCriteria $criteria)
     {
       


### PR DESCRIPTION
Finished a first pass of library_lending_item.php OOification. A couple of possibilities here still:

- There's another hard coded table above the log which shows the details of the item. I suspect this can be OOified too. Is this worthwhile? Would this need to be build through some kinda lower level DataTable class?
- There's a header on the log on the original version. Is there a way to add a title to those DataTables? I suspect there was but I didn't find anything on the docs.
- This table uses italicised text where the action header usually appears to show that the item is not available for sign out. I don't believe there's a way to do that with the current OO tables so in place of that I've used a div with error class. Is that best practice? Could switch it for a warning class maybe?

A couple of bugs I found too:

- When you try to open the library_lending_item_renew or _edit pages where no responsible person is set, an error occurs. As a workaround, I've set the actions to not show if this is the case since both the current version of those pages requires it.