### PR TITLE
Partial PHP 7.4 Test Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@
 language: php
 
 # The platforms you wants to test on
-dist: trusty
+dist: xenial
 os:
   - linux
+
+services:
+  - mysql
 
 # list any PHP version you want to test against
 php:

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,10 @@
             "cd tests && codecept run install --env $CI_PLATFORM",
             "cd tests && codecept run acceptance --env $CI_PLATFORM"
         ],
+        "test:codeceptiondebug": [
+            "cd tests && codecept run install --debug --env $CI_PLATFORM",
+            "cd tests && codecept run acceptance --debug --env $CI_PLATFORM"
+        ],
         "test:phpunit": [
             "cd tests && ../vendor/bin/phpunit --verbose --configuration phpunit.xml"
         ]

--- a/tests/install/InstallCept.php
+++ b/tests/install/InstallCept.php
@@ -29,6 +29,8 @@ try {
     // STEP 3 --------------------------------------
     $I->see('Installation - Step 3', 'h2');
 
+    $I->dontSee('A database connection could not be established.');
+
     $formValues = array(
         'title'                 => 'Mr.',
         'surname'               => 'CI',


### PR DESCRIPTION
Previously, the Travis test was failing on PHP 7.4 because there's no version of PHP 7.4 on Ubuntu Trusty which includes the zip extension. This PR does a couple of things to remedy this:

- We're now testing on Ubuntu Xenial
- Due to Ubuntu Xenial image not enabling mysql by default, the service is now enabled directly in the `.travis.yml`

Additionally, to partially assist with any future issues where mysql doesn't start or isn't accessible, there's now a Codeception test to make sure that the install page doesn't show the connection failed test.

Finally, a debug version of the Codeception test has been added to the composer.json which doesn't run as a default test, it's just there for convenience.