### PR TITLE
System admin update

### DIFF
--- a/modules/System Admin/update.php
+++ b/modules/System Admin/update.php
@@ -223,7 +223,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
             $tablesInnoDB = 0;
             try {
                 $data = array();
-                $sql = 'SHOW TABLE STATUS';
+                $sql = "SELECT * FROM information_schema.tables WHERE table_schema = DATABASE() AND TABLE_TYPE = 'BASE TABLE';";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -235,7 +235,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
                 echo '</div>';
             } else {
                 while ($row = $result->fetch()) {
-                    if ($row['Engine'] == 'InnoDB') {
+                    if ($row['ENGINE'] == 'InnoDB') {
                         $tablesInnoDB++;
                     }
                     $tablesTotal++;
@@ -263,8 +263,4 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
             }
         }
     }
-
-    //echo "ALTER TABLE ".$row['Tables_in_'.$databaseName]." ENGINE=InnoDB;<br/>";
-
-
 }

--- a/modules/System Admin/updateProcess.php
+++ b/modules/System Admin/updateProcess.php
@@ -221,7 +221,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
         //Update DB line count
         try {
             $data = array();
-            $sql = 'SHOW TABLE STATUS';
+            $sql = "SELECT * FROM information_schema.tables WHERE table_schema = DATABASE() AND TABLE_TYPE = 'BASE TABLE';";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
@@ -230,10 +230,10 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
             exit();
         }
         while ($row = $result->fetch()) {
-            if ($row['Engine'] != 'InnoDB') {
+            if ($row['ENGINE'] != 'InnoDB') {
                 try {
                     $dataUpdate = array();
-                    $sqlUpdate = "ALTER TABLE ".$row['Name']." ENGINE=InnoDB;";
+                    $sqlUpdate = "ALTER TABLE ".$row['TABLE_NAME']." ENGINE=InnoDB;";
                     $resultUpdate = $connection2->prepare($sqlUpdate);
                     $resultUpdate->execute($dataUpdate);
                 } catch (PDOException $e) {


### PR DESCRIPTION
**Description**
Changed the method to identify tables with engine other than innodb

**Motivation and Context**
If I have a view in my database, the system identifies it as a table, but a view does not have the engine attribute, so we cannot update it either.

![Captura de Tela 2020-06-05 às 16 14 52](https://user-images.githubusercontent.com/1969911/83924474-2605d380-a75b-11ea-8903-bdbce6850d51.png)

View
![Captura de Tela 2020-06-04 às 20 19 15](https://user-images.githubusercontent.com/1969911/83924971-539f4c80-a75c-11ea-911a-8dece71047e9.png)



**How Has This Been Tested?**
Local