### PR TITLE
OO: Individual Needs moduleFunctions

### DIFF
--- a/modules/Individual Needs/moduleFunctions.php
+++ b/modules/Individual Needs/moduleFunctions.php
@@ -15,127 +15,117 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-*/
+ */
+
+use Gibbon\Domain\IndividualNeeds\INGateway;
+use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Domain\DataSet;
 
 //$mode can be blank or "disabled". $archive is a serialized array of values previously archived
 function printINStatusTable($connection2, $guid, $gibbonPersonID, $mode = '', $archive = '')
 {
-    $output = false;
-
-    try {
-        $dataDescriptors = array();
-        $sqlDescriptors = 'SELECT * FROM gibbonINDescriptor ORDER BY sequenceNumber, nameShort';
-        $resultDescriptors = $connection2->prepare($sqlDescriptors);
-        $resultDescriptors->execute($dataDescriptors);
-    } catch (PDOException $e) {
-        $output .= "<div class='error'>".$e->getMessage().'</div>';
-    }
-
-    try {
-        $dataSeverity = array();
-        $sqlSeverity = 'SELECT * FROM gibbonAlertLevel ORDER BY sequenceNumber, nameShort';
-        $resultSeverity = $connection2->prepare($sqlSeverity);
-        $resultSeverity->execute($dataSeverity);
-    } catch (PDOException $e) {
-        $output .= "<div class='error'>".$e->getMessage().'</div>';
-    }
-
-    if ($resultDescriptors->rowCount() < 1 or $resultSeverity->rowCount() < 1) {
-        $output .= "<div class='error'>";
-        $output .= __('Individual needs descriptors or severity levels have not been set.');
-        $output .= '</div>';
-    } else {
-        $descriptors = array();
-        $count = 0;
-        while ($rowDescriptors = $resultDescriptors->fetch()) {
-            $descriptors[$count][0] = $rowDescriptors['gibbonINDescriptorID'];
-            $descriptors[$count][1] = $rowDescriptors['name'];
-            $descriptors[$count][2] = $rowDescriptors['nameShort'];
-            $descriptors[$count][3] = $rowDescriptors['description'];
-            ++$count;
+    $output = "";
+    global $container;
+    $gateway = $container->get(INGateway::class);
+    if ($archive == '') { //Use live data
+        $criteria = $gateway
+          ->newQueryCriteria()
+          ->filterBy('gibbonPersonID', $gibbonPersonID)
+          ->fromPOST();
+        $personalDescriptors = $gateway->queryIndividualNeedsPersonDescriptors($criteria)->toArray();
+    } else //Use archived data
+    {
+        $archive = unserialize($archive);
+        $personalDescriptors = [];
+        foreach ($archive as $archiveEntry) {
+            array_push($personalDescriptors, [
+            'gibbonINDescriptorID' => $archiveEntry['gibbonINDescriptorID'],
+            'gibbonAlertLevelID' => $archiveEntry['gibbonAlertLevelID']
+            ]);
         }
+    }
+    $allDescriptors = $gateway->queryIndividualNeedsDescriptors($gateway->newQueryCriteria())->toArray();
+    $alertLevels = $gateway->queryAlertLevels($gateway->newQueryCriteria())->toArray();
 
-        $severity = array();
-        $count = 0;
-        while ($rowSeverity = $resultSeverity->fetch()) {
-            $severity[$count][0] = $rowSeverity['gibbonAlertLevelID'];
-            $severity[$count][1] = __($rowSeverity['name']);
-            $severity[$count][2] = $rowSeverity['nameShort'];
-            $severity[$count][3] = __($rowSeverity['description']);
-            $severity[$count][4] = $rowSeverity['color'];
-            ++$count;
-        }
-
-        $personDescriptors = array();
-        $count = 0;
-        if ($archive == '') { //Not an archive, get live data
-            try {
-                $dataPersonDescriptors = array('gibbonPersonID' => $gibbonPersonID);
-                $sqlPersonDescriptors = 'SELECT * FROM gibbonINPersonDescriptor WHERE gibbonPersonID=:gibbonPersonID';
-                $resultPersonDescriptors = $connection2->prepare($sqlPersonDescriptors);
-                $resultPersonDescriptors->execute($dataPersonDescriptors);
-            } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
-            }
-            while ($rowPersonDescriptors = $resultPersonDescriptors->fetch()) {
-                $personDescriptors[$count][0] = $rowPersonDescriptors['gibbonINDescriptorID'];
-                $personDescriptors[$count][1] = $rowPersonDescriptors['gibbonAlertLevelID'];
-                ++$count;
-            }
-        } else { //It is an archive, so populate array
-            $archive = unserialize($archive);
-            if (count($archive) > 0) {
-                foreach ($archive as $archiveEntry) {
-                    $personDescriptors[$count][0] = $archiveEntry['gibbonINDescriptorID'];
-                    $personDescriptors[$count][1] = $archiveEntry['gibbonAlertLevelID'];
-                    ++$count;
+    if ($archive != '') {
+      /*
+       * Given this is archived data, there's a possibility some of the data
+       * may no longer exist. Display an error message if this data no longer
+       * exists.
+       */
+        $missingDescriptor = false;
+        $missingAlert = false;
+        foreach ($personalDescriptors as $pDescriptor) {
+            $foundDescriptor = false;
+            $foundAlert = false;
+            foreach ($allDescriptors as $descriptor) {
+                if ($descriptor['gibbonINDescriptorID'] == $pDescriptor['gibbonINDescriptorID']) {
+                    $foundDescriptor = true;
                 }
             }
-        }
-
-        //Print IN Status table
-        $output .= "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-        $output .= "<tr class='head'>";
-        $output .= '<th>';
-        $output .= __('Descriptor');
-        $output .= '<th>';
-        for ($i = 0; $i < count($severity); ++$i) {
-            $output .= '<th>';
-            $output .= "<span title='".$severity[$i][3]."'>".$severity[$i][1].'</span>';
-            $output .= '<th>';
-        }
-        $output .= '</tr>';
-        for ($n = 0; $n < count($descriptors); ++$n) {
-            if ($n % 2 == 0) {
-                $rowNum = 'even';
-            } else {
-                $rowNum = 'odd';
+            foreach ($alertLevels as $level) {
+                if ($level['gibbonAlertLevelID'] == $pDescriptor['gibbonAlertLevelID']) {
+                    $foundAlert = true;
+                }
             }
+            if ($foundDescriptor == false) {
+                $missingDescriptor = true;
+            }
+            if ($foundAlert == false) {
+                $missingAlert = true;
+            }
+        }
+        if ($missingAlert) {
+            $output .= Format::alert(__('Some of the alert levels present in your provided archive can no longer be found. These alert levels will no longer show in the table below.'));
+        }
+        if ($missingDescriptor) {
+            $output .= Format::alert(__('Some of the descriptors present in your provided archive can no longer be found. These descriptors will no longer show in the table below.'));
+        }
+    }
 
-            $output .= "<tr class=$rowNum>";
-            $output .= '<td>';
-            $output .= "<span title='".__($descriptors[$n][3])."'>".__($descriptors[$n][1]).'</span>';
-            $output .= '<td>';
-            for ($i = 0; $i < count($severity); ++$i) {
-                $output .= "<td style='width: 10%'>";
-                $checked = '';
-                for ($j = 0; $j < count($personDescriptors); ++$j) {
-                    if ($personDescriptors[$j][0] == $descriptors[$n][0] and $personDescriptors[$j][1] == $severity[$i][0]) {
-                        $checked = 'checked';
+    $results = array_map(function ($descriptor) use ($alertLevels, $personalDescriptors) {
+        $result = [
+        'gibbonINDescriptorID' => $descriptor['gibbonINDescriptorID'],
+        'gibbonINDescriptorName' => $descriptor['name'],
+        'gibbonINDescriptorNameShort' => $descriptor['nameShort'],
+        'gibbonINDescriptorDescription' => $descriptor['description'],
+        'gibbonINDescriptorSequenceNumber' => $descriptor['sequenceNumber']
+        ];
+        foreach ($alertLevels as $alertLevel) {
+            $pDescriptorAssigned = false;
+            foreach ($personalDescriptors as $pDescriptor) {
+                if ($pDescriptor['gibbonINDescriptorID'] == $descriptor['gibbonINDescriptorID']) {
+                    if ($pDescriptor['gibbonAlertLevelID'] == $alertLevel['gibbonAlertLevelID']) {
+                        $pDescriptorAssigned = true;
                     }
                 }
-                $output .= "<input $mode $checked type='checkbox' name='status[]' value='".$descriptors[$n][0].'-'.$severity[$i][0]."'>";
-                $output .= '<td>';
             }
-            $output .= '</tr>';
+            $result["alert_${alertLevel['name']}"] = $pDescriptorAssigned;
         }
-        $output .= '</table>';
-    }
+        return $result;
+    }, $allDescriptors);
 
+  //Results array needs to be a dataset so it can be rendered by the table;
+    $dataset = new DataSet($results);
+
+    $table = DataTable::create('descriptors');
+    $table->addColumn('gibbonINDescriptorName', __('Descriptor'));
+    foreach ($alertLevels as $alertLevel) {
+        $table
+        ->addColumn("alert_${alertLevel['name']}", $alertLevel['name'])
+        ->format(function ($level) use ($alertLevel) {
+            $checked = $level["alert_${alertLevel['name']}"] == true ? "checked" : "";
+            $value = "${level['gibbonINDescriptorID']}-${alertLevel['gibbonAlertLevelID']}";
+            return "<input type='checkbox' name='status[]' value=${value} ${checked}></input>";
+        });
+    }
+    $output .= $table->render($dataset);
     return $output;
 }
 
-function getInvestigationCriteriaArray($strand) {
+function getInvestigationCriteriaArray($strand)
+{
     $options = array();
 
     if ($strand == 'Cognition') {
@@ -145,16 +135,14 @@ function getInvestigationCriteriaArray($strand) {
             'Simple concepts and processes with one or two steps can be understood and applied to classroom learning' => __('Simple concepts and processes with one or two steps can be understood and applied to classroom learning'),
             'New concepts can be understood with ease and used consistently in a structured learning environment' => __('New concepts can be understood with ease and used consistently in a structured learning environment')
         );
-    }
-    else if ($strand == 'Memory') {
+    } elseif ($strand == 'Memory') {
         $options = array(
             'The ability to hold and use important information in work­ing mem­ory over a short period of time' => __('The ability to hold and use important information in work­ing mem­ory over a short period of time'),
             'The ability to hold several ideas in mind at once' => __('The ability to hold several ideas in mind at once'),
             'The ability to remember what has been learnt in recent lessons' => __('The ability to remember what has been learnt in recent lessons'),
             'The ability to retrieve information from long-term memory' => __('The ability to retrieve information from long-term memory'),
         );
-    }
-    else if ($strand == 'Self-Management') {
+    } elseif ($strand == 'Self-Management') {
         $options = array(
             'Setting goals' => __('Setting goals'),
             'Managing time' => __('Managing time'),
@@ -162,8 +150,7 @@ function getInvestigationCriteriaArray($strand) {
             'Monitoring, controlling and self directing aspects of learning for themselves' => __('Monitoring, controlling and self directing aspects of learning for themselves'),
             'Emotional self-regulation' => __('Emotional self-regulation'),
         );
-    }
-    else if ($strand == 'Attention') {
+    } elseif ($strand == 'Attention') {
         $options = array(
             'Sus­taining con­cen­tra­tion and attention in lessons' => __('Sus­taining con­cen­tra­tion and attention in lessons'),
             'Paying attention to relevant information' => __('Paying attention to relevant information'),
@@ -171,16 +158,14 @@ function getInvestigationCriteriaArray($strand) {
             'Monitoring, controlling and self directing aspects of learning for themselves' => __('Monitoring, controlling and self directing aspects of learning for themselves'),
             'Resisting distraction and internal urges to do other things than the task at hand' => __('Resisting distraction and internal urges to do other things than the task at hand'),
         );
-    }
-    else if ($strand == 'Social Interaction') {
+    } elseif ($strand == 'Social Interaction') {
         $options = array(
             'Approaching others and making friends' => __('Approaching others and making friends'),
             'Ability to hold a conversation' => __('Ability to hold a conversation'),
             'Ability to use appropriate non-verbal communication (eye contact, facial expressions, gestures, body language)' => __('Ability to use appropriate non-verbal communication (eye contact, facial expressions, gestures, body language)'),
             'Adjusting behaviour to suit contexts' => __('Adjusting behaviour to suit contexts'),
         );
-    }
-    else if ($strand == 'Communication') {
+    } elseif ($strand == 'Communication') {
         $options = array(
             'Word reading accuracy (ability to sound out words)' => __('Word reading accuracy (ability to sound out words)'),
             'Reading rate or fluency (speed)' => __('Reading rate or fluency (speed)'),
@@ -195,7 +180,8 @@ function getInvestigationCriteriaArray($strand) {
     return $options;
 }
 
-function getInvestigationCriteriaStrands($includeCognition = false) {
+function getInvestigationCriteriaStrands($includeCognition = false)
+{
     $options = array(
         0 => array('name' => 'memory', 'nameHuman' => 'Memory'),
         1 => array('name' => 'selfManagement', 'nameHuman' => 'Self-Management'),

--- a/src/Domain/IndividualNeeds/INGateway.php
+++ b/src/Domain/IndividualNeeds/INGateway.php
@@ -86,11 +86,38 @@ class INGateway extends QueryableGateway
         return $this->runQuery($query, $criteria);
     }
 
+    public function queryIndividualNeedsPersonDescriptors(QueryCriteria $criteria)
+    {
+      $query = $this
+        ->newQuery()
+        ->from('gibbonINPersonDescriptor')
+        ->innerJoin('gibbonAlertLevel','gibbonAlertLevel.gibbonAlertLevelID = gibbonINPersonDescriptor.gibbonAlertLevelID')
+        ->cols([
+          'gibbonINPersonDescriptor.gibbonINPersonDescriptorID',
+          'gibbonINPersonDescriptor.gibbonPersonID',
+          'gibbonINPersonDescriptor.gibbonINDescriptorID',
+          'gibbonINPersonDescriptor.gibbonAlertLevelID',
+          'gibbonAlertLevel.gibbonAlertLevelID'
+        ]);
+
+      $criteria->addFilterRules([
+        'gibbonPersonID' => function($query,$gibbonPersonID)
+        {
+          return $query
+            ->where('gibbonINPersonDescriptor.gibbonPersonID = :gibbonPersonID')
+            ->bindValue('gibbonPersonID',$gibbonPersonID);
+        }
+      ]);
+
+      return $this->runQuery($query,$criteria);
+    }
+
     public function queryIndividualNeedsDescriptors(QueryCriteria $criteria)
     {
         $query = $this
             ->newQuery()
             ->from('gibbonINDescriptor')
+            ->orderBy(['gibbonINDescriptor.sequenceNumber'])
             ->cols([
                 'gibbonINDescriptorID', 'name', 'nameShort', 'description', 'sequenceNumber'
             ]);
@@ -143,5 +170,24 @@ class INGateway extends QueryableGateway
         }
 
         return $this->runQuery($query, $criteria);
+    }
+
+    public function queryAlertLevels(QueryCriteria $criteria)
+    {
+      $query = $this
+        ->newQuery()
+        ->distinct()
+        ->from('gibbonAlertLevel')
+        ->orderBy(['sequenceNumber'])
+        ->cols([
+          'gibbonAlertLevel.gibbonAlertLevelID',
+          'gibbonAlertLevel.name',
+          'gibbonAlertLevel.nameShort',
+          'gibbonAlertLevel.description',
+          'gibbonAlertLevel.color',
+          'gibbonAlertLevel.sequenceNumber'
+        ]);
+
+      return $this->runQuery($query,$criteria);
     }
 }


### PR DESCRIPTION
This PR contains the OOified version of the moduleFunctions script for Individual Needs with a number of improvements.

- Now using DataTables in place of inline HTML for the most part.
- Error handling for archives (see note below)
- Gateway functions for alert levels and descriptors for students have been added. 
- sequenceNumber within alert and descriptor tables is now used as part of the IN gateway. This does affect other pages but will only order them based on the ingrained sequenceNumber instead of whatever order SQL outputs it in.

**Archives**
It was previously possible to have an archive show which would not actually tick any of the boxes giving the appearance that the student never had any IN attributes. The table will now check that the relevant descriptor and alert level exist and, if not, will display an error message (created using Format::alert) depending on what couldn't be found. An example of how this shows is below where both descriptor and alert cannot be found:

![image](https://user-images.githubusercontent.com/12417556/84802273-4275fb80-aff8-11ea-97ad-3b6668f88681.png)

The archive functionality was tested using the following snippet at the top of the printINStatusTable function:

```
   $archiveArray = [
    [
      'gibbonINDescriptorID' => '005',
      'gibbonAlertLevelID' => '005'
    ]
  ];
  $archive = serialize($archiveArray);
```
I did test these side-by-side by resetting the archive using `$archive = serialize($archiveArray);` after echoing the table to make sure the format would be read as expected on both versions of the table.

**Suggestions**
- There is currently an inline formatter for checkboxes, this might be something worthwhile changing into a Format function instead, it may be a bit more universal that way.