### PR TITLE
Formal Assessment: add a bulk action for External Assessment Data

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ v21.0.00
 
     Tweaks & Additions
         System: added Romanian Leu as currency option
+        Formal Assessment: added a bulk action for External Assessment Data
         Library: added ID column to View Overdue Items report
         Messenger: tied messages to school year
         Reports: display the download link after a batch PDF has completed

--- a/modules/Formal Assessment/externalAssessment.php
+++ b/modules/Formal Assessment/externalAssessment.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
+use Gibbon\Forms\Prefab\BulkActionForm;
 use Gibbon\Domain\Students\StudentGateway;
 
 //Module includes
@@ -33,15 +34,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
 } else {
     $page->breadcrumbs->add(__('View All Assessments'));
 
+    $highestAction = getHighestGroupedAction($guid, $_GET['q'], $connection2);
+    if (empty($highestAction)) {
+        echo Format::alert(__('The highest grouped action cannot be determined.'));
+        return;
+    }
+
+    if (isset($_GET['return'])) {
+        returnProcess($guid, $_GET['return'], null, null);
+    }
+
     $search = $_GET['search'] ?? '';
     $allStudents = $_GET['allStudents'] ??  '';
     $gibbonSchoolYearID = $_SESSION[$guid]['gibbonSchoolYearID'];
 
-    echo '<h2>';
-    echo __('Search');
-    echo '</h2>';
-
     $form = Form::create('searchForm', $_SESSION[$guid]['absoluteURL'].'/index.php', 'get');
+    $form->setTitle(__('Search'));
     $form->setClass('noIntBorder fullWidth standardForm');
     
     $form->addHiddenValue('q', '/modules/Formal Assessment/externalAssessment.php');
@@ -59,27 +67,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
         
     echo $form->getOutput();
 
-    echo '<h2>';
-    echo __('Choose A Student');
-    echo '</h2>';
-
     $studentGateway = $container->get(StudentGateway::class);
-
-    $searchColumns = $studentGateway->getSearchableColumns();
-
     $criteria = $studentGateway->newQueryCriteria(true)
-        ->searchBy($searchColumns, $search)
+        ->searchBy($studentGateway->getSearchableColumns(), $search)
         ->sortBy(['surname', 'preferredName'])
         ->filterBy('all',$allStudents)
         ->fromPOST();
     
     $students = $studentGateway->queryStudentsBySchoolYear($criteria, $gibbonSchoolYearID);
 
-    // DATA TABLE
-    $table = DataTable::createPaginated('students', $criteria);
+    // FORM
+    $form = BulkActionForm::create('bulkAction', $_SESSION[$guid]['absoluteURL'].'/modules/Formal Assessment/externalAssessment_manage_processBulk.php');
+    $form->setTitle(__('Choose A Student'));
+    $form->addHiddenValue('search', $search);
     
-    $table->modifyRows($studentGateway->getSharedUserRowHighlighter());
 
+    // DATA TABLE
+    $table = $form->addRow()->addDataTable('students', $criteria)->withData($students);
+    $table->modifyRows($studentGateway->getSharedUserRowHighlighter());
             
     $table->addMetaData('filterOptions', [
         'all:on'        => __('All Students')
@@ -92,6 +97,33 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
             'date:starting'   => __('Before Start Date'),
             'date:ended'      => __('After End Date'),
         ]);
+    }
+
+    // BULK ACTION
+    if ($highestAction == 'External Assessment Data_manage') {
+        $bulkActions = array(
+            'Add' => __('Add'),
+        );
+
+        $col = $form->createBulkActionColumn($bulkActions);
+            $sql = "SELECT gibbonExternalAssessmentID as value, name FROM gibbonExternalAssessment WHERE active='Y' ORDER BY name";
+            $col->addSelect('gibbonExternalAssessmentID')
+                ->fromQuery($pdo, $sql)
+                ->required()
+                ->placeholder()
+                ->setClass('w-32');
+            $col->addDate('date')
+                ->placeholder(__('Date'))
+                ->setClass('w-32');
+            $col->addYesNo('copyToGCSECheck')
+                ->required()
+                ->placeholder(__('Copy Target Grades?'))
+                ->setClass('w-32 copyToGCSE');
+            $col->addSubmit(__('Go'));
+
+        $form->toggleVisibilityByClass('copyToGCSE')->onSelect('gibbonExternalAssessmentID')->when('0002');
+
+        $table->addMetaData('bulkActions', $col);
     }
             
     // COLUMNS
@@ -111,7 +143,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
             $actions->addAction('view', __('View Details'))
                 ->setURL('/modules/Formal Assessment/externalAssessment_details.php');
         });
+
+    if ($highestAction == 'External Assessment Data_manage') {
+        $table->addCheckboxColumn('gibbonPersonID');
+    }
     
-    echo $table->render($students);
+    echo $form->getOutput();
 }
-?>

--- a/modules/Formal Assessment/externalAssessment_manage_processBulk.php
+++ b/modules/Formal Assessment/externalAssessment_manage_processBulk.php
@@ -1,0 +1,121 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Services\Format;
+use Gibbon\Domain\FormalAssessment\ExternalAssessmentStudentGateway;
+use Gibbon\Domain\FormalAssessment\ExternalAssessmentStudentEntryGateway;
+
+include '../../gibbon.php';
+
+$action = $_POST['action'] ?? '';
+$search = $_POST['search'] ?? '';
+$gibbonPersonID = $_POST['gibbonPersonID'] ?? '';
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Formal Assessment/externalAssessment.php&search='.$search;
+
+if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/externalAssessment_manage_details_add.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} elseif (empty($action) || empty($gibbonPersonID)) {
+    $URL .= '&return=error1';
+    header("Location: {$URL}");
+} else {
+    // Proceed!
+    $gibbonPersonIDList = is_array($gibbonPersonID)? $gibbonPersonID : [$gibbonPersonID];
+    $eaStudentGateway = $container->get(ExternalAssessmentStudentGateway::class);
+    $eaStudentEntryGateway = $container->get(ExternalAssessmentStudentEntryGateway::class);
+    $partialFail = false;
+
+    if ($action == 'Add') {
+        $gibbonExternalAssessmentID = $_POST['gibbonExternalAssessmentID'] ?? '';
+        $copyToGCSECheck = $_POST['copyToGCSECheck'] ?? 'N';
+        $date = $_POST['date'] ?? '';
+
+        if (empty($gibbonExternalAssessmentID) || empty($copyToGCSECheck) || empty($date)) {
+            $URL .= '&return=error1';
+            header("Location: {$URL}");
+            exit();
+        }
+    
+        foreach ($gibbonPersonIDList as $gibbonPersonID) {
+            $data = [
+                'gibbonExternalAssessmentID' => $gibbonExternalAssessmentID,
+                'gibbonPersonID' => $gibbonPersonID,
+                'date' => Format::dateConvert($date),
+            ];
+
+            // Do not create a record if it already exists
+            $isUnique = $eaStudentGateway->unique($data, ['gibbonExternalAssessmentID', 'gibbonPersonID', 'date']);
+            if (!$isUnique) continue;
+
+            // Insert the student, then add the entries
+            if ($gibbonExternalAssessmentStudentID = $eaStudentGateway->insert($data)) {
+
+                // Optionally copy CAT data to GCSE
+                if ($gibbonExternalAssessmentID == 2 && $copyToGCSECheck == 'Y') {
+                    $data = [
+                        'gibbonExternalAssessmentStudentID' => $gibbonExternalAssessmentStudentID,
+                        'gibbonExternalAssessmentID' => $gibbonExternalAssessmentID,
+                        'gibbonPersonID' => $gibbonPersonID,
+                    ];
+
+                    $sql = "INSERT INTO gibbonExternalAssessmentStudentEntry 
+                            (`gibbonExternalAssessmentStudentID`, `gibbonExternalAssessmentFieldID`, `gibbonScaleGradeID`) 
+                            SELECT :gibbonExternalAssessmentStudentID, field.gibbonExternalAssessmentFieldID, 
+                            (
+                                SELECT gibbonExternalAssessmentStudentEntry.gibbonScaleGradeID FROM gibbonExternalAssessment 
+                                JOIN gibbonExternalAssessmentField ON (gibbonExternalAssessmentField.gibbonExternalAssessmentID=gibbonExternalAssessment.gibbonExternalAssessmentID) 
+                                JOIN gibbonExternalAssessmentStudent ON (gibbonExternalAssessmentStudent.gibbonExternalAssessmentID=gibbonExternalAssessment.gibbonExternalAssessmentID)
+                                JOIN gibbonExternalAssessmentStudentEntry ON (gibbonExternalAssessmentStudentEntry.gibbonExternalAssessmentFieldID=gibbonExternalAssessmentField.gibbonExternalAssessmentFieldID AND gibbonExternalAssessmentStudentEntry.gibbonExternalAssessmentStudentID=gibbonExternalAssessmentStudent.gibbonExternalAssessmentStudentID) 
+                                WHERE gibbonExternalAssessment.name='Cognitive Abilities Test' 
+                                    AND gibbonExternalAssessmentStudent.gibbonPersonID=:gibbonPersonID
+                                    AND gibbonExternalAssessmentField.name=field.name
+                                    AND gibbonExternalAssessmentField.category LIKE '%GCSE Target Grades' 
+                                    AND NOT (gibbonScaleGradeID IS NULL)
+                                LIMIT 1
+                            )
+                            FROM gibbonExternalAssessmentField as field
+                            WHERE field.gibbonExternalAssessmentID=:gibbonExternalAssessmentID
+                            AND field.category='0_Target Grade'";
+                } else {
+                    $data = [
+                        'gibbonExternalAssessmentStudentID' => $gibbonExternalAssessmentStudentID,
+                        'gibbonExternalAssessmentID' => $gibbonExternalAssessmentID,
+                    ];
+
+                    $sql = "INSERT INTO gibbonExternalAssessmentStudentEntry 
+                            (`gibbonExternalAssessmentStudentID`, `gibbonExternalAssessmentFieldID`, `gibbonScaleGradeID`) 
+                            SELECT :gibbonExternalAssessmentStudentID, gibbonExternalAssessmentFieldID, NULL
+                            FROM gibbonExternalAssessmentField
+                            WHERE gibbonExternalAssessmentField.gibbonExternalAssessmentID=:gibbonExternalAssessmentID";
+                }
+
+                $inserted = $pdo->insert($sql, $data);
+                $partialFail &= !$inserted;
+            }
+        }
+
+        $URL .= $partialFail
+            ? '&return=warning1'
+            : '&return=success0';
+        header("Location: {$URL}");
+    } else {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+    }
+}

--- a/src/Domain/FormalAssessment/ExternalAssessmentStudentEntryGateway.php
+++ b/src/Domain/FormalAssessment/ExternalAssessmentStudentEntryGateway.php
@@ -1,0 +1,38 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\FormalAssessment;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * @version v21
+ * @since   v21
+ */
+class ExternalAssessmentStudentEntryGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonExternalAssessmentStudentEntry';
+    private static $primaryKey = 'gibbonExternalAssessmentStudentEntryID';
+
+    private static $searchableColumns = [];
+}

--- a/src/Domain/FormalAssessment/ExternalAssessmentStudentGateway.php
+++ b/src/Domain/FormalAssessment/ExternalAssessmentStudentGateway.php
@@ -1,0 +1,38 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\FormalAssessment;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * @version v21
+ * @since   v21
+ */
+class ExternalAssessmentStudentGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonExternalAssessmentStudent';
+    private static $primaryKey = 'gibbonExternalAssessmentStudentID';
+
+    private static $searchableColumns = [];
+}


### PR DESCRIPTION
This PR adds an Add bulk action for External Assessment Data, which can be used when setting up placeholders for a large number of students at once. It works with the Copy Target Grades option, which copies CAT targets into the GCSE/iGCSE assessment.

The bulk action is only available to users with the `External Assessment Data_manage` permission.

**How Has This Been Tested?**
Locally and in production.

**Screenshots**
<img width="803" alt="Screenshot 2020-08-26 at 12 22 20 PM" src="https://user-images.githubusercontent.com/897700/91255196-cede3080-e796-11ea-89be-218ec620fd14.png">

