### PR TITLE
Added Header Actions to Details Tables

### DIFF
--- a/resources/templates/components/detailsTable.twig.html
+++ b/resources/templates/components/detailsTable.twig.html
@@ -14,6 +14,20 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
 {% block table %}
 
+    <header class="relative">
+        {% block header %}
+    
+            {% if table.getHeader %}
+            <div class="linkTop">
+                {% for action in table.getHeader %}
+                    {{ action.getOutput|raw }}
+                {% endfor %}
+            </div>
+            {% endif %}
+            
+        {% endblock header %}
+    </header>
+
 {{ title }}
     
     {% for rowIndex, rowData in rows %}


### PR DESCRIPTION
**Description**
Implemented Header Action rendering for Details Tables. Detail Tables without Header Actions should look the same.

**How Has This Been Tested?**
Locally on Detail Tables with and without Header Actions, in both core and Help Desk module.

**Screenshots**
Example of simple details table with Header:
![image](https://user-images.githubusercontent.com/8520854/92071043-12691800-edf1-11ea-85f0-05aa389d9e45.png)
Example of simple details table without Header (i.e. no change):
![image](https://user-images.githubusercontent.com/8520854/92071068-2745ab80-edf1-11ea-98d8-e8290faa139b.png)

