### PR TITLE
Timetable Day & Column Bulk Duplicate

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ v21.0.00
         School Admin: added Email Summary Settings to manage daily and weekly email CLI scripts
         System Admin: added an Email Templates section to customize emails sent by Gibbon
         Reports: added a Send Reports tool to bulk-send templated emails with download links
+        Timetable Admin: added ability to duplicate Columns and Days
 
     Changes With Important Notices
         System: renamed planner_parentWeeklyEmailSummary.php to schoolAdmin_parentWeeklyEmailSummary.php

--- a/modules/Timetable Admin/ttColumn.php
+++ b/modules/Timetable Admin/ttColumn.php
@@ -17,37 +17,56 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\Form;
-use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Forms\Prefab\BulkActionForm;
 use Gibbon\Domain\Timetable\TimetableColumnGateway;
 
-if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.php') == false) {
-    //Acess denied
-    echo "<div class='error'>";
-    echo __('You do not have access to this action.');
-    echo '</div>';
-} else {
-    //Proceed!
-    $page->breadcrumbs->add(__('Manage Columns'));
+$page->breadcrumbs->add(__('Manage Columns'));
     echo '<p>';
     echo __('In Gibbon a column is a holder for the structure of a day. A number of columns can be defined, and these can be tied to particular timetable days in the timetable interface.');
     echo '</p>';
 
+if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.php') == false) {
+    //Acess denied
+    echo '<div class="error">';
+    echo __('You do not have access to this action.');
+    echo '</div>';
+} else {
+    //Proceed!
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);
     }
 
-    $ttColumnGateway = $container->get(TimetableColumnGateway::class);
-    $columns = $ttColumnGateway->selectTTColumns();
+    $timetableColumnGateway = $container->get(TimetableColumnGateway::class);
+
+    $criteria = $timetableColumnGateway->newQueryCriteria(true)
+        ->sortBy(['name'])
+        ->fromPOST();
+
+    $columns = $timetableColumnGateway->queryTTColumns($criteria);
+
+    // FORM
+    $form = BulkActionForm::create('bulkAction', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/ttColumnProcessBulk.php');
+    $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+
+    // BULK ACTIONS
+    $bulkActions = array(
+        'Duplicate' => __('Duplicate')
+    );
+    $col = $form->createBulkActionColumn($bulkActions);
+        $col->addSubmit(__('Go'));
 
     // DATA TABLE
-    $table = DataTable::create('timetableColumns');
+    $table = $form->addRow()->addDataTable('columnsManage', $criteria)->withData($columns);
+
+    $table->addMetaData('bulkActions', $col);
 
     $table->addHeaderAction('add', __('Add'))
         ->setURL('/modules/Timetable Admin/ttColumn_add.php')
         ->displayLabel();
 
+    // COLUMNS
     $table->addColumn('name', __('Name'));
     $table->addColumn('nameShort', __('Short Name'));
     $table->addColumn('rowCount', __('Rows'));
@@ -63,5 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.p
                 ->setURL('/modules/Timetable Admin/ttColumn_delete.php');
         });
 
-    echo $table->render($columns->toDataSet());
+    $table->addCheckboxColumn('gibbonTTColumnIDList', 'gibbonTTColumnID');
+
+    echo $form->getOutput();
 }

--- a/modules/Timetable Admin/ttColumnProcessBulk.php
+++ b/modules/Timetable Admin/ttColumnProcessBulk.php
@@ -1,0 +1,80 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Timetable\TimetableColumnGateway;
+
+include '../../gibbon.php';
+
+$action = $_POST['action'];
+
+$URL = $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Timetable Admin/ttColumn.php";
+
+if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else if ($action == '') {
+    $URL .= '&return=error1';
+    header("Location: {$URL}");
+} else {
+
+    $columns = isset($_POST['gibbonTTColumnIDList']) ? $_POST['gibbonTTColumnIDList'] : array();
+
+    //Proceed!
+    if (count($columns) < 1) {
+        $URL .= '&return=error3';
+        header("Location: {$URL}");
+    } else {
+        $timetableColumnGateway = $container->get(TimetableColumnGateway::class);
+        $partialFail = false;
+
+        foreach ($columns as $gibbonTTColumnID) {
+            $data = $timetableColumnGateway->getByID($gibbonTTColumnID);
+            $data['name'] .= " Copy";
+
+            // Copy columns
+            $inserted = $timetableColumnGateway->insert($data);
+            $partialFail &= !$inserted;
+
+            //Copy rows
+            $rows = $timetableColumnGateway->selectTTColumnRowsByID($gibbonTTColumnID)->fetchAll();
+            if (empty($rows)) continue;
+
+            foreach ($rows as $row) {
+                $insertedRow = $timetableColumnGateway->insertColumnRow([
+                    'gibbonTTColumnID' => $inserted,
+                    'name' => $row['name'],
+                    'nameShort' => $row['nameShort'],
+                    'timeStart' => $row['timeStart'],
+                    'timeEnd' => $row['timeEnd'],
+                    'type' => $row['type'],
+                ]);
+                $partialFail &= !$insertedRow;
+            }
+        }
+
+        if ($partialFail == true) {
+            $URL .= '&return=warning1';
+            header("Location: {$URL}");
+        } else {
+            $URL .= '&return=success0';
+            header("Location: {$URL}");
+        }
+    }
+
+}

--- a/modules/Timetable Admin/tt_editProcessBulk.php
+++ b/modules/Timetable Admin/tt_editProcessBulk.php
@@ -1,0 +1,92 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Timetable\TimetableDayGateway;
+
+include '../../gibbon.php';
+
+$gibbonTTID = $_GET['gibbonTTID'] ?? '';
+$gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
+$action = $_POST['action'];
+
+$URL = $_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/Timetable Admin/tt_edit.php&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID";
+
+if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else if ($action == '') {
+    $URL .= '&return=error1';
+    header("Location: {$URL}");
+} else {
+    $days = isset($_POST['gibbonTTDayIDList']) ? $_POST['gibbonTTDayIDList'] : array();
+
+    //Proceed!
+    if (count($days) < 1) {
+        $URL .= '&return=error3';
+        header("Location: {$URL}");
+    } else {
+        $timetableDayGateway = $container->get(TimetableDayGateway::class);
+        $partialFail = false;
+
+        foreach ($days as $gibbonTTDayID) {
+            $data = $timetableDayGateway->getByID($gibbonTTDayID);
+            $data['name'] .= " Copy";
+
+            //Copy gibbonTTDay
+            $inserted = $timetableDayGateway->insert($data);
+            $partialFail &= !$inserted;
+
+            //Copy gibbonTTDayRowClass
+            $classes = $timetableDayGateway->selectTTDayRowClassesByID($gibbonTTDayID)->fetchAll();
+
+            if (empty($classes)) continue;
+
+            foreach ($classes as $class) {
+                $insertedClass = $timetableDayGateway->insertDayRowClass([
+                    'gibbonTTDayID' => $inserted,
+                    'gibbonTTColumnRowID' => $class['gibbonTTColumnRowID'],
+                    'gibbonCourseClassID' => $class['gibbonCourseClassID'],
+                    'gibbonSpaceID' => $class['gibbonSpaceID'],
+                ]);
+                $partialFail &= !$insertedClass;
+
+                //Copy gibbonTTDayRowClassException
+                $exceptions = $timetableDayGateway->selectTTDayRowClassExceptionsByID($class['gibbonTTDayRowClassID'])->fetchAll();
+
+                if (empty($exceptions)) continue;
+
+                foreach ($exceptions as $exception) {
+                    $insertedExceptions = $timetableDayGateway->insertDayRowClassException([
+                        'gibbonTTDayRowClassID' => $insertedClass,
+                        'gibbonPersonID' => $exception['gibbonPersonID']
+                    ]);
+                    $partialFail &= !$insertedExceptions;
+                }
+            }
+        }
+
+        if ($partialFail == true) {
+            $URL .= '&return=warning1';
+            header("Location: {$URL}");
+        } else {
+            $URL .= '&return=success0';
+            header("Location: {$URL}");
+        }
+    }
+}


### PR DESCRIPTION
**Description**
Adds the ability to bulk duplicate timetable days and columns

**Motivation and Context**
Makes rescheduling for school closures considerably easier, as you can duplicate days and columns to created editable versions, without losing your regular schedule.

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="813" alt="Screenshot 2020-09-12 at 5 07 06 PM" src="https://user-images.githubusercontent.com/5436438/92992096-d0d81b80-f51a-11ea-9135-300e3c9f4c25.png">

<img width="804" alt="Screenshot 2020-09-12 at 5 07 16 PM" src="https://user-images.githubusercontent.com/5436438/92992098-d33a7580-f51a-11ea-8c04-55adbb9b14b4.png">