### PR TITLE
Data Updater: auto-accept data updates with no changes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ v21.0.00
         System: update complete homework to display in green on the Parent Dashboard
         Attendance: added an Offsite - Late option for attendance codes
         Departments: improved course/class naming in Class view
+        Data Updater: data updates with no changes will be automatically accepted
         Finance: added a setting to customize Payment Type options
         Formal Assessment: added a bulk action for External Assessment Data
         Individual Needs: removed Notes & Review from parent view of individual needs information

--- a/modules/Data Updater/data_familyProcess.php
+++ b/modules/Data Updater/data_familyProcess.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
 
                 try {
                     $dataCheck = array('gibbonFamilyID' => $gibbonFamilyID);
-                    $sqlCheck = 'SELECT name, gibbonFamily.gibbonFamilyID FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
+                    $sqlCheck = 'SELECT gibbonFamily.* FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
                     $resultCheck = $connection2->prepare($sqlCheck);
                     $resultCheck->execute($dataCheck);
                 } catch (PDOException $e) {
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
 
                 try {
                     $dataCheck = array('gibbonFamilyID' => $gibbonFamilyID, 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID']);
-                    $sqlCheck = "SELECT name, gibbonFamily.gibbonFamilyID FROM gibbonFamily JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID) WHERE gibbonPersonID=:gibbonPersonID AND childDataAccess='Y' AND gibbonFamily.gibbonFamilyID=:gibbonFamilyID";
+                    $sqlCheck = "SELECT gibbonFamily.* FROM gibbonFamily JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID) WHERE gibbonPersonID=:gibbonPersonID AND childDataAccess='Y' AND gibbonFamily.gibbonFamilyID=:gibbonFamilyID";
                     $resultCheck = $connection2->prepare($sqlCheck);
                     $resultCheck->execute($dataCheck);
                 } catch (PDOException $e) {
@@ -67,41 +67,59 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
                 $URL .= '&return=warning';
                 header("Location: {$URL}");
             } else {
+                $values = $resultCheck->fetch();
+
                 //Proceed!
-                $nameAddress = $_POST['nameAddress'];
-                $homeAddress = $_POST['homeAddress'];
-                $homeAddressDistrict = $_POST['homeAddressDistrict'];
-                $homeAddressCountry = $_POST['homeAddressCountry'];
-                $languageHomePrimary = $_POST['languageHomePrimary'];
-                $languageHomeSecondary = $_POST['languageHomeSecondary'];
+                $data = [
+                    'gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'],
+                    'nameAddress' => $_POST['nameAddress'] ?? '',
+                    'homeAddress' => $_POST['homeAddress'] ?? '',
+                    'homeAddressDistrict' => $_POST['homeAddressDistrict'] ?? '',
+                    'homeAddressCountry' => $_POST['homeAddressCountry'] ?? '',
+                    'languageHomePrimary' => $_POST['languageHomePrimary'] ?? '',
+                    'languageHomeSecondary' => $_POST['languageHomeSecondary'] ?? '',
+                    'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID'],
+                ];
 
-                //Write to database
-                $existing = $_POST['existing'];
+                // COMPARE VALUES: Has the data changed?
+                $dataChanged = false;
+                foreach ($values as $key => $value) {
+                    if (!isset($data[$key])) continue; // Skip fields we don't plan to update
 
-                try {
-                    if ($existing != 'N') {
-                        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'nameAddress' => $nameAddress, 'homeAddress' => $homeAddress, 'homeAddressDistrict' => $homeAddressDistrict, 'homeAddressCountry' => $homeAddressCountry, 'languageHomePrimary' => $languageHomePrimary, 'languageHomeSecondary' => $languageHomeSecondary, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonFamilyUpdateID' => $existing);
-                        $sql = 'UPDATE gibbonFamilyUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, nameAddress=:nameAddress, homeAddress=:homeAddress, homeAddressDistrict=:homeAddressDistrict, homeAddressCountry=:homeAddressCountry, languageHomePrimary=:languageHomePrimary, languageHomeSecondary=:languageHomeSecondary, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=NOW() WHERE gibbonFamilyUpdateID=:gibbonFamilyUpdateID';
-                    } else {
-                        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonFamilyID' => $gibbonFamilyID, 'nameAddress' => $nameAddress, 'homeAddress' => $homeAddress, 'homeAddressDistrict' => $homeAddressDistrict, 'homeAddressCountry' => $homeAddressCountry, 'languageHomePrimary' => $languageHomePrimary, 'languageHomeSecondary' => $languageHomeSecondary, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID']);
-                        $sql = 'INSERT INTO gibbonFamilyUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonFamilyID=:gibbonFamilyID, nameAddress=:nameAddress, homeAddress=:homeAddress, homeAddressDistrict=:homeAddressDistrict, homeAddressCountry=:homeAddressCountry, languageHomePrimary=:languageHomePrimary, languageHomeSecondary=:languageHomeSecondary, gibbonPersonIDUpdater=:gibbonPersonIDUpdater';
+                    if ($data[$key] != $value) {
+                        $dataChanged = true;
                     }
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
-                    exit();
                 }
 
-                // Raise a new notification event
-                $event = new NotificationEvent('Data Updater', 'Family Data Updates');
+                // Auto-accept updates where no data had changed
+                $data['status'] = $dataChanged ? 'Pending' : 'Complete';
 
-                $event->addRecipient($_SESSION[$guid]['organisationDBA']);
-                $event->setNotificationText(__('A family data update request has been submitted.'));
-                $event->setActionLink('/index.php?q=/modules/Data Updater/data_family_manage.php');
+                //Write to database
+                $existing = $_POST['existing'] ?? 'N';
+                $data['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
+                $data['gibbonPersonIDUpdater'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['timestamp'] = date('Y-m-d H:i:s');
 
-                $event->sendNotifications($pdo, $gibbon->session);
+                if ($existing != 'N') {
+                    $data['gibbonFamilyUpdateID'] = $existing;
+                    $sql = 'UPDATE gibbonFamilyUpdate SET `status`=:status, gibbonSchoolYearID=:gibbonSchoolYearID, nameAddress=:nameAddress, homeAddress=:homeAddress, homeAddressDistrict=:homeAddressDistrict, homeAddressCountry=:homeAddressCountry, languageHomePrimary=:languageHomePrimary, languageHomeSecondary=:languageHomeSecondary, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp WHERE gibbonFamilyUpdateID=:gibbonFamilyUpdateID';
+                } else {
+                    $data['gibbonFamilyID'] = $gibbonFamilyID;
+                    $sql = 'INSERT INTO gibbonFamilyUpdate SET `status`=:status, gibbonSchoolYearID=:gibbonSchoolYearID, gibbonFamilyID=:gibbonFamilyID, nameAddress=:nameAddress, homeAddress=:homeAddress, homeAddressDistrict=:homeAddressDistrict, homeAddressCountry=:homeAddressCountry, languageHomePrimary=:languageHomePrimary, languageHomeSecondary=:languageHomeSecondary, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp';
+                }
+                $pdo->statement($sql, $data);
+
+
+                if ($dataChanged) {
+                    // Raise a new notification event
+                    $event = new NotificationEvent('Data Updater', 'Family Data Updates');
+
+                    $event->addRecipient($_SESSION[$guid]['organisationDBA']);
+                    $event->setNotificationText(__('A family data update request has been submitted.'));
+                    $event->setActionLink('/index.php?q=/modules/Data Updater/data_family_manage.php');
+
+                    $event->sendNotifications($pdo, $gibbon->session);
+                }
 
                 $URLSuccess .= '&return=success0';
                 header("Location: {$URLSuccess}");

--- a/modules/Data Updater/data_financeProcess.php
+++ b/modules/Data Updater/data_financeProcess.php
@@ -47,12 +47,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
                 
                 try {
                     $dataSelect = array('gibbonFinanceInvoiceeID' => $gibbonFinanceInvoiceeID);
-                    $sqlSelect = "SELECT surname, preferredName, gibbonPerson.gibbonPersonID, gibbonFinanceInvoiceeID FROM gibbonFinanceInvoicee JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE status='Full' AND gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID ORDER BY surname, preferredName";
+                    $sqlSelect = "SELECT surname, preferredName, gibbonPerson.gibbonPersonID, gibbonFinanceInvoicee.* FROM gibbonFinanceInvoicee JOIN gibbonPerson ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE status='Full' AND gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID ORDER BY surname, preferredName";
                     $resultSelect = $connection2->prepare($sqlSelect);
                     $resultSelect->execute($dataSelect);
                 } catch (PDOException $e) {
                 }
                 $checkCount = $resultSelect->rowCount();
+                $values = $resultSelect->fetch();
             } else {
                 $URLSuccess = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Data Updater/data_updates.php&gibbonFinanceInvoiceeID='.$gibbonFinanceInvoiceeID;
                 
@@ -66,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
                 while ($rowCheck = $resultCheck->fetch()) {
                     try {
                         $dataCheck2 = array('gibbonFamilyID' => $rowCheck['gibbonFamilyID']);
-                        $sqlCheck2 = "SELECT surname, preferredName, gibbonPerson.gibbonPersonID, gibbonFamilyID, gibbonFinanceInvoiceeID FROM gibbonFamilyChild JOIN gibbonPerson ON (gibbonFamilyChild.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonPerson.status='Full' AND gibbonFamilyID=:gibbonFamilyID";
+                        $sqlCheck2 = "SELECT surname, preferredName, gibbonPerson.gibbonPersonID, gibbonFamilyID, gibbonFinanceInvoicee.* FROM gibbonFamilyChild JOIN gibbonPerson ON (gibbonFamilyChild.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonPerson.status='Full' AND gibbonFamilyID=:gibbonFamilyID";
                         $resultCheck2 = $connection2->prepare($sqlCheck2);
                         $resultCheck2->execute($dataCheck2);
                     } catch (PDOException $e) {
@@ -74,6 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
                     while ($rowCheck2 = $resultCheck2->fetch()) {
                         if ($gibbonFinanceInvoiceeID == $rowCheck2['gibbonFinanceInvoiceeID']) {
                             ++$checkCount;
+                            $values = $rowCheck2;
                         }
                     }
                 }
@@ -84,64 +86,77 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
                 header("Location: {$URL}");
             } else {
                 //Proceed!
-                $invoiceTo = $_POST['invoiceTo'];
+                $invoiceTo = $_POST['invoiceTo'] ?? '';
                 if ($invoiceTo == 'Company') {
-                    $companyName = $_POST['companyName'];
-                    $companyContact = $_POST['companyContact'];
-                    $companyAddress = $_POST['companyAddress'];
-                    $companyEmail = $_POST['companyEmail'];
-                    $companyCCFamily = $_POST['companyCCFamily'];
-                    $companyPhone = $_POST['companyPhone'];
-                    $companyAll = $_POST['companyAll'];
-                    $gibbonFinanceFeeCategoryIDList = null;
-                    if ($companyAll == 'N') {
-                        $gibbonFinanceFeeCategoryIDList == '';
-                        $gibbonFinanceFeeCategoryIDArray = $_POST['gibbonFinanceFeeCategoryIDList'];
-                        if (count($gibbonFinanceFeeCategoryIDArray) > 0) {
-                            foreach ($gibbonFinanceFeeCategoryIDArray as $gibbonFinanceFeeCategoryID) {
-                                $gibbonFinanceFeeCategoryIDList .= $gibbonFinanceFeeCategoryID.',';
-                            }
-                            $gibbonFinanceFeeCategoryIDList = substr($gibbonFinanceFeeCategoryIDList, 0, -1);
-                        }
+                    $data = [
+                        'invoiceTo' => $invoiceTo,
+                        'companyName' => $_POST['companyName'] ?? '',
+                        'companyContact' => $_POST['companyContact'] ?? '',
+                        'companyAddress' => $_POST['companyAddress'] ?? '',
+                        'companyEmail' => $_POST['companyEmail'] ?? '',
+                        'companyCCFamily' => $_POST['companyCCFamily'] ?? '',
+                        'companyPhone' => $_POST['companyPhone'] ?? '',
+                        'companyAll' => $_POST['companyAll'] ?? '',
+                        'gibbonFinanceFeeCategoryIDList' => $_POST['gibbonFinanceFeeCategoryIDList'] ?? '',
+                    ];
+
+                    if ($data['companyAll'] == 'N') {
+                        $data['gibbonFinanceFeeCategoryIDList'] = is_array($data['gibbonFinanceFeeCategoryIDList'])
+                            ? implode(',', $data['gibbonFinanceFeeCategoryIDList'])
+                            : $data['gibbonFinanceFeeCategoryIDList'];
                     }
                 } else {
-                    $companyName = null;
-                    $companyContact = null;
-                    $companyAddress = null;
-                    $companyEmail = null;
-                    $companyCCFamily = null;
-                    $companyPhone = null;
-                    $companyAll = null;
-                    $gibbonFinanceFeeCategoryIDList = null;
+                    $data = [
+                        'invoiceTo' => $invoiceTo,
+                        'companyName' => '',
+                        'companyContact' => '',
+                        'companyAddress' => '',
+                        'companyEmail' => '',
+                        'companyCCFamily' => '',
+                        'companyPhone' => '',
+                        'companyAll' => '',
+                        'gibbonFinanceFeeCategoryIDList' => '',
+                    ];
                 }
+
+                // COMPARE VALUES: Has the data changed?
+                $dataChanged = false;
+                foreach ($values as $key => $value) {
+                    if (!isset($data[$key])) continue; // Skip fields we don't plan to update
+
+                    if ($data[$key] != $value) {
+                        $dataChanged = true;
+                    }
+                }
+
+                // Auto-accept updates where no data had changed
+                $data['status'] = $dataChanged ? 'Pending' : 'Complete';
+                $data['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
+                $data['gibbonPersonIDUpdater'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['timestamp'] = date('Y-m-d H:i:s');
 
                 //Write to database
                 $existing = $_POST['existing'];
 
-                try {
-                    if ($existing != 'N') {
-                        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'invoiceTo' => $invoiceTo, 'companyName' => $companyName, 'companyContact' => $companyContact, 'companyAddress' => $companyAddress, 'companyEmail' => $companyEmail, 'companyCCFamily' => $companyCCFamily, 'companyPhone' => $companyPhone, 'companyAll' => $companyAll, 'gibbonFinanceFeeCategoryIDList' => $gibbonFinanceFeeCategoryIDList, 'gibbonFinanceInvoiceeUpdateID' => $existing);
-                        $sql = 'UPDATE gibbonFinanceInvoiceeUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, invoiceTo=:invoiceTo, companyName=:companyName, companyContact=:companyContact, companyAddress=:companyAddress, companyEmail=:companyEmail, companyCCFamily=:companyCCFamily, companyPhone=:companyPhone, companyAll=:companyAll, gibbonFinanceFeeCategoryIDList=:gibbonFinanceFeeCategoryIDList, timestamp=NOW() WHERE gibbonFinanceInvoiceeUpdateID=:gibbonFinanceInvoiceeUpdateID';
-                    } else {
-                        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonFinanceInvoiceeID' => $gibbonFinanceInvoiceeID, 'invoiceTo' => $invoiceTo, 'companyName' => $companyName, 'companyContact' => $companyContact, 'companyAddress' => $companyAddress, 'companyEmail' => $companyEmail, 'companyCCFamily' => $companyCCFamily, 'companyPhone' => $companyPhone, 'companyAll' => $companyAll, 'gibbonFinanceFeeCategoryIDList' => $gibbonFinanceFeeCategoryIDList, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID']);
-                        $sql = 'INSERT INTO gibbonFinanceInvoiceeUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID, invoiceTo=:invoiceTo, companyName=:companyName, companyContact=:companyContact, companyAddress=:companyAddress, companyEmail=:companyEmail, companyCCFamily=:companyCCFamily, companyPhone=:companyPhone, companyAll=:companyAll, gibbonFinanceFeeCategoryIDList=:gibbonFinanceFeeCategoryIDList, gibbonPersonIDUpdater=:gibbonPersonIDUpdater';
-                    }
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
-                    exit();
+                if ($existing != 'N') {
+                    $data['gibbonFinanceInvoiceeUpdateID'] = $existing;
+                    $sql = 'UPDATE gibbonFinanceInvoiceeUpdate SET `status`=:status, gibbonSchoolYearID=:gibbonSchoolYearID, invoiceTo=:invoiceTo, companyName=:companyName, companyContact=:companyContact, companyAddress=:companyAddress, companyEmail=:companyEmail, companyCCFamily=:companyCCFamily, companyPhone=:companyPhone, companyAll=:companyAll, gibbonFinanceFeeCategoryIDList=:gibbonFinanceFeeCategoryIDList, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp WHERE gibbonFinanceInvoiceeUpdateID=:gibbonFinanceInvoiceeUpdateID';
+                } else {
+                    $data['gibbonFinanceInvoiceeID'] = $gibbonFinanceInvoiceeID;
+                    $sql = 'INSERT INTO gibbonFinanceInvoiceeUpdate SET `status`=:status, gibbonSchoolYearID=:gibbonSchoolYearID, gibbonFinanceInvoiceeID=:gibbonFinanceInvoiceeID, invoiceTo=:invoiceTo, companyName=:companyName, companyContact=:companyContact, companyAddress=:companyAddress, companyEmail=:companyEmail, companyCCFamily=:companyCCFamily, companyPhone=:companyPhone, companyAll=:companyAll, gibbonFinanceFeeCategoryIDList=:gibbonFinanceFeeCategoryIDList, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp';
                 }
+                $pdo->statement($sql, $data);
 
-                // Raise a new notification event
-                $event = new NotificationEvent('Data Updater', 'Finance Data Updates');
+                if ($dataChanged) {
+                    // Raise a new notification event
+                    $event = new NotificationEvent('Data Updater', 'Finance Data Updates');
 
-                $event->addRecipient($_SESSION[$guid]['organisationDBA']);
-                $event->setNotificationText(__('A finance data update request has been submitted.'));
-                $event->setActionLink('/index.php?q=/modules/Data Updater/data_finance_manage.php');
+                    $event->addRecipient($_SESSION[$guid]['organisationDBA']);
+                    $event->setNotificationText(__('A finance data update request has been submitted.'));
+                    $event->setActionLink('/index.php?q=/modules/Data Updater/data_finance_manage.php');
 
-                $event->sendNotifications($pdo, $gibbon->session);
+                    $event->sendNotifications($pdo, $gibbon->session);
+                }
 
 
                 $URLSuccess .= '&return=success0';

--- a/modules/Data Updater/data_medicalProcess.php
+++ b/modules/Data Updater/data_medicalProcess.php
@@ -110,7 +110,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
                 $values = $medicalGateway->getByID($gibbonPersonMedicalID);
 
                 // COMPARE VALUES: Has the data changed?
-                $dataChanged = false;
+                $dataChanged = empty($values);
                 foreach ($values as $key => $value) {
                     if (!isset($data[$key])) continue; // Skip fields we don't plan to update
 

--- a/modules/Data Updater/data_medicalProcess.php
+++ b/modules/Data Updater/data_medicalProcess.php
@@ -17,7 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\Students\MedicalGateway;
+use Gibbon\Domain\DataUpdater\MedicalUpdateGateway;
 
 include '../../gibbon.php';
 
@@ -90,164 +93,136 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
                 $URL .= '&return=error2';
                 header("Location: {$URL}");
             } else {
-                $existing = $_POST['existing'];
-                if ($existing != 'N') {
-                    $AI = $existing;
-                }
+                // Proceed!
+                $gibbonPersonMedicalID = $_POST['gibbonPersonMedicalID'] ?? null;
+                $data = [
+                    'gibbonPersonMedicalID'     => $gibbonPersonMedicalID,
+                    'gibbonPersonID'            => $gibbonPersonID,
+                    'bloodType'                 => $_POST['bloodType'] ?? '',
+                    'longTermMedication'        => $_POST['longTermMedication'] ?? 'N',
+                    'longTermMedicationDetails' => $_POST['longTermMedicationDetails'] ?? '',
+                    'tetanusWithin10Years'      => $_POST['tetanusWithin10Years'] ?? '',
+                    'comment'                   => $_POST['comment'] ?? '',
+                ];
 
-                //Get medical form fields
-                //Proceed!
-                if ($_POST['gibbonPersonMedicalID'] != '') {
-                    $gibbonPersonMedicalID = $_POST['gibbonPersonMedicalID'];
-                } else {
-                    $gibbonPersonMedicalID = null;
-                }
-                $bloodType = $_POST['bloodType'];
-                $longTermMedication = $_POST['longTermMedication'];
-                $longTermMedicationDetails = isset($_POST['longTermMedicationDetails'])? $_POST['longTermMedicationDetails'] : '';
-                $tetanusWithin10Years = $_POST['tetanusWithin10Years'];
-                $comment = $_POST['comment'];
+                // Get medical form fields
+                $medicalGateway = $container->get(MedicalGateway::class);
+                $values = $medicalGateway->getByID($gibbonPersonMedicalID);
 
-                //Write to database
-                try {
-                    if ($existing != 'N') {
-                        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonMedicalID' => $gibbonPersonMedicalID, 'gibbonPersonID' => $gibbonPersonID, 'bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'comment' => $comment, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonPersonMedicalUpdateID' => $existing);
-                        $sql = 'UPDATE gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=NOW() WHERE gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID';
-                    } else {
-                        $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonMedicalID' => $gibbonPersonMedicalID, 'gibbonPersonID' => $gibbonPersonID, 'bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'comment' => $comment, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID']);
-                        $sql = 'INSERT INTO gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater';
+                // COMPARE VALUES: Has the data changed?
+                $dataChanged = false;
+                foreach ($values as $key => $value) {
+                    if (!isset($data[$key])) continue; // Skip fields we don't plan to update
+
+                    if ($data[$key] != $value) {
+                        $dataChanged = true;
                     }
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
-                    exit();
                 }
+
+                // Write to database
+                $existing = $_POST['existing'] ?? 'N';
+                $data['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
+                $data['gibbonPersonIDUpdater'] = $_SESSION[$guid]['gibbonPersonID'];
+                $data['timestamp'] = date('Y-m-d H:i:s');
                 
-                if ($existing == 'N') {
-                   $AI = $connection2->lastInsertID();
-                }
-
-                //Update existing medical conditions
-                $partialFail = false;
-                $count = 0;
-                if (isset($_POST['count'])) {
-                    $count = $_POST['count'];
-                }
-
                 if ($existing != 'N') {
-                    for ($i = 0; $i < $count; ++$i) {
-                        if ($AI != '') {
-                            $gibbonPersonMedicalUpdateID = $AI;
-                        } else {
-                            $gibbonPersonMedicalUpdateID = null;
-                        }
-                        $gibbonPersonMedicalConditionID = $_POST["gibbonPersonMedicalConditionID$i"];
-                        $gibbonPersonMedicalConditionUpdateID = $_POST["gibbonPersonMedicalConditionUpdateID$i"];
-                        $name = $_POST["name$i"];
-                        $gibbonAlertLevelID = $_POST["gibbonAlertLevelID$i"];
-                        $triggers = $_POST["triggers$i"];
-                        $reaction = $_POST["reaction$i"];
-                        $response = $_POST["response$i"];
-                        $medication = $_POST["medication$i"];
-                        if ($_POST["lastEpisode$i"] != '') {
-                            $lastEpisode = dateConvert($guid, $_POST["lastEpisode$i"]);
-                        } else {
-                            $lastEpisode = null;
-                        }
-                        $lastEpisodeTreatment = $_POST["lastEpisodeTreatment$i"];
-                        $commentCond = $_POST["commentCond$i"];
+                    $gibbonPersonMedicalUpdateID = $existing;
+                    $data['gibbonPersonMedicalUpdateID'] = $gibbonPersonMedicalUpdateID;
+                    $sql = 'UPDATE gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp WHERE gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID';
+                    $pdo->update($sql, $data);
+                } else {
+                    $sql = 'INSERT INTO gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp';
+                    $gibbonPersonMedicalUpdateID = $pdo->insert($sql, $data);
+                }
 
-                        try {
-                            $data = array('gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID, 'gibbonPersonMedicalID' => $gibbonPersonMedicalID, 'name' => $name, 'gibbonAlertLevelID' => $gibbonAlertLevelID, 'triggers' => $triggers, 'reaction' => $reaction, 'response' => $response, 'medication' => $medication, 'lastEpisode' => $lastEpisode, 'lastEpisodeTreatment' => $lastEpisodeTreatment, 'comment' => $commentCond, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonPersonMedicalConditionUpdateID' => $gibbonPersonMedicalConditionUpdateID);
-                            $sql = 'UPDATE gibbonPersonMedicalConditionUpdate SET gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID, gibbonPersonMedicalID=:gibbonPersonMedicalID, name=:name, gibbonAlertLevelID=:gibbonAlertLevelID, triggers=:triggers, reaction=:reaction, response=:response, medication=:medication, lastEpisode=:lastEpisode, lastEpisodeTreatment=:lastEpisodeTreatment, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater WHERE gibbonPersonMedicalConditionUpdateID=:gibbonPersonMedicalConditionUpdateID';
-                            $result = $connection2->prepare($sql);
-                            $result->execute($data);
-                        } catch (PDOException $e) {
-                            $partialFail = true;
+                // Update existing medical conditions
+                $partialFail = false;
+                $count = $_POST['count'] ?? 0;
+
+                for ($i = 0; $i < $count; ++$i) {
+                    $data = [
+                        'gibbonPersonMedicalID' => $gibbonPersonMedicalID,
+                        'gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID,
+                        'name'                  => $_POST["name$i"] ?? '',
+                        'gibbonAlertLevelID'    => $_POST["gibbonAlertLevelID$i"] ?? '',
+                        'triggers'              => $_POST["triggers$i"] ?? '',
+                        'reaction'              => $_POST["reaction$i"] ?? '',
+                        'response'              => $_POST["response$i"] ?? '',
+                        'medication'            => $_POST["medication$i"] ?? '',
+                        'lastEpisode'           => !empty($_POST["lastEpisode$i"]) ? Format::dateConvert($_POST["lastEpisode$i"]) : null,
+                        'lastEpisodeTreatment'  => $_POST["lastEpisodeTreatment$i"] ?? '',
+                        'comment'               => $_POST["commentCond$i"] ?? '',
+                        'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID'],
+                    ];
+
+                    // Get the values of the current condition
+                    $gibbonPersonMedicalConditionID = $_POST["gibbonPersonMedicalConditionID$i"] ?? null;
+                    $condition = $medicalGateway->getMedicalConditionByID($gibbonPersonMedicalConditionID);
+                    if (empty($condition)) {
+                        $dataChanged = true;
+                    }
+
+                    // Check for values that have changed
+                    foreach ($condition as $key => $value) {
+                        if (!isset($data[$key])) continue; // Skip fields we don't plan to update
+                        if ($data[$key] != $value) {
+                            $dataChanged = true;
                         }
                     }
-                } else {
-                    for ($i = 0; $i < $count; ++$i) {
-                        if ($AI != '') {
-                            $gibbonPersonMedicalUpdateID = $AI;
-                        } else {
-                            $gibbonPersonMedicalUpdateID = null;
-                        }
-                        $gibbonPersonMedicalConditionID = $_POST["gibbonPersonMedicalConditionID$i"];
-                        $name = $_POST["name$i"];
-                        $gibbonAlertLevelID = $_POST["gibbonAlertLevelID$i"];
-                        $triggers = $_POST["triggers$i"];
-                        $reaction = $_POST["reaction$i"];
-                        $response = $_POST["response$i"];
-                        $medication = $_POST["medication$i"];
-                        if ($_POST["lastEpisode$i"] != '') {
-                            $lastEpisode = dateConvert($guid, $_POST["lastEpisode$i"]);
-                        } else {
-                            $lastEpisode = null;
-                        }
-                        $lastEpisodeTreatment = $_POST["lastEpisodeTreatment$i"];
-                        $commentCond = $_POST["commentCond$i"];
 
-                        try {
-                            $data = array('gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID, 'gibbonPersonMedicalConditionID' => $gibbonPersonMedicalConditionID, 'gibbonPersonMedicalID' => $gibbonPersonMedicalID, 'name' => $name, 'gibbonAlertLevelID' => $gibbonAlertLevelID, 'triggers' => $triggers, 'reaction' => $reaction, 'response' => $response, 'medication' => $medication, 'lastEpisode' => $lastEpisode, 'lastEpisodeTreatment' => $lastEpisodeTreatment, 'comment' => $commentCond, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID']);
-                            $sql = 'INSERT INTO gibbonPersonMedicalConditionUpdate SET gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID, gibbonPersonMedicalConditionID=:gibbonPersonMedicalConditionID, gibbonPersonMedicalID=:gibbonPersonMedicalID, name=:name, gibbonAlertLevelID=:gibbonAlertLevelID, triggers=:triggers, reaction=:reaction, response=:response, medication=:medication, lastEpisode=:lastEpisode, lastEpisodeTreatment=:lastEpisodeTreatment, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater';
-                            $result = $connection2->prepare($sql);
-                            $result->execute($data);
-                        } catch (PDOException $e) {
-                            $partialFail = true;
-                        }
+                    $data['timestamp'] = date('Y-m-d H:i:s');
+
+                    if ($existing != 'N' && !empty($_POST["gibbonPersonMedicalConditionUpdateID$i"])) {
+                        $data['gibbonPersonMedicalConditionUpdateID'] = $_POST["gibbonPersonMedicalConditionUpdateID$i"] ?? '';
+                        $sql = 'UPDATE gibbonPersonMedicalConditionUpdate SET gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID, gibbonPersonMedicalID=:gibbonPersonMedicalID, name=:name, gibbonAlertLevelID=:gibbonAlertLevelID, triggers=:triggers, reaction=:reaction, response=:response, medication=:medication, lastEpisode=:lastEpisode, lastEpisodeTreatment=:lastEpisodeTreatment, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp WHERE gibbonPersonMedicalConditionUpdateID=:gibbonPersonMedicalConditionUpdateID';
+                        $pdo->update($sql, $data);
+                    } else {
+                        $data['gibbonPersonMedicalConditionID'] = $gibbonPersonMedicalConditionID;
+                        $sql = 'INSERT INTO gibbonPersonMedicalConditionUpdate SET gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID, gibbonPersonMedicalConditionID=:gibbonPersonMedicalConditionID, gibbonPersonMedicalID=:gibbonPersonMedicalID, name=:name, gibbonAlertLevelID=:gibbonAlertLevelID, triggers=:triggers, reaction=:reaction, response=:response, medication=:medication, lastEpisode=:lastEpisode, lastEpisodeTreatment=:lastEpisodeTreatment, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp';
+                        $gibbonPersonMedicalConditionUpdateID = $pdo->insert($sql, $data);
                     }
                 }
 
                 //Add new medical condition
-                if (isset($_POST['addCondition'])) {
-                    if ($_POST['addCondition'] == 'Yes') {
-                        if ($_POST['name'] != '' and $_POST['gibbonAlertLevelID'] != '') {
-                            if ($AI != '') {
-                                $gibbonPersonMedicalUpdateID = $AI;
-                            } else {
-                                $gibbonPersonMedicalUpdateID = null;
-                            }
-                            $name = $_POST['name'];
-                            $gibbonAlertLevelID = null;
-                            if ($_POST['gibbonAlertLevelID'] != 'Please select...') {
-                                $gibbonAlertLevelID = $_POST['gibbonAlertLevelID'];
-                            }
-                            $triggers = $_POST['triggers'];
-                            $reaction = $_POST['reaction'];
-                            $response = $_POST['response'];
-                            $medication = $_POST['medication'];
-                            if ($_POST['lastEpisode'] != '') {
-                                $lastEpisode = dateConvert($guid, $_POST['lastEpisode']);
-                            } else {
-                                $lastEpisode = null;
-                            }
-                            $lastEpisodeTreatment = $_POST['lastEpisodeTreatment'];
-                            $commentCond = $_POST['commentCond'];
+                if (isset($_POST['addCondition']) && $_POST['addCondition'] == 'Yes') {
+                    $dataChanged = true;
+                    $data = [
+                        'gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID,
+                        'gibbonPersonMedicalID'       => $gibbonPersonMedicalID,
+                        'name'                        => $_POST['name'] ?? '',
+                        'gibbonAlertLevelID'          => $_POST['gibbonAlertLevelID'] ?? '',
+                        'triggers'                    => $_POST['triggers'] ?? '',
+                        'reaction'                    => $_POST['reaction'] ?? '',
+                        'response'                    => $_POST['response'] ?? '',
+                        'medication'                  => $_POST['medication'] ?? '',
+                        'lastEpisode'                 => !empty($_POST['lastEpisode']) ? Format::dateConvert($_POST['lastEpisode']) :  null,
+                        'lastEpisodeTreatment'        => $_POST['lastEpisodeTreatment'] ?? '',
+                        'comment'                     => $_POST['commentCond'] ?? '',
+                        'gibbonPersonIDUpdater'       => $_SESSION[$guid]['gibbonPersonID'],
+                        'timestamp'                   => date('Y-m-d H:i:s'),
+                    ];
 
-                            try {
-                                $data = array('gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID, 'gibbonPersonMedicalID' => $gibbonPersonMedicalID, 'name' => $name, 'gibbonAlertLevelID' => $gibbonAlertLevelID, 'triggers' => $triggers, 'reaction' => $reaction, 'response' => $response, 'medication' => $medication, 'lastEpisode' => $lastEpisode, 'lastEpisodeTreatment' => $lastEpisodeTreatment, 'comment' => $commentCond, 'gibbonPersonIDUpdater' => $_SESSION[$guid]['gibbonPersonID']);
-                                $sql = 'INSERT INTO gibbonPersonMedicalConditionUpdate SET gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID, gibbonPersonMedicalID=:gibbonPersonMedicalID, name=:name, gibbonAlertLevelID=:gibbonAlertLevelID, triggers=:triggers, reaction=:reaction, response=:response, medication=:medication, lastEpisode=:lastEpisode, lastEpisodeTreatment=:lastEpisodeTreatment, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater';
-                                $result = $connection2->prepare($sql);
-                                $result->execute($data);
-                            } catch (PDOException $e) {
-                                $partialFail = true;
-                            }
-                        }
+                    if (!empty($data['name']) and !empty($data['gibbonAlertLevelID'])) {
+                        $sql = 'INSERT INTO gibbonPersonMedicalConditionUpdate SET gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID, gibbonPersonMedicalID=:gibbonPersonMedicalID, name=:name, gibbonAlertLevelID=:gibbonAlertLevelID, triggers=:triggers, reaction=:reaction, response=:response, medication=:medication, lastEpisode=:lastEpisode, lastEpisodeTreatment=:lastEpisodeTreatment, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp';
+                        $pdo->insert($sql, $data);
+                    } else {
+                        $partialFail = true;
                     }
                 }
 
-                // Raise a new notification event
-                $event = new NotificationEvent('Data Updater', 'Medical Form Updates');
+                // If no data has changed in the medical form and any conditions, then auto-accept the changes
+                if ($dataChanged == false) {
+                    $container->get(MedicalUpdateGateway::class)->update($gibbonPersonMedicalUpdateID, ['status' => 'Complete']);
+                } else {
+                    // Raise a new notification event
+                    $event = new NotificationEvent('Data Updater', 'Medical Form Updates');
 
-                $event->addRecipient($_SESSION[$guid]['organisationDBA']);
-                $event->setNotificationText(__('A medical data update request has been submitted.'));
-                $event->setActionLink('/index.php?q=/modules/Data Updater/data_medical_manage.php');
+                    $event->addRecipient($_SESSION[$guid]['organisationDBA']);
+                    $event->setNotificationText(__('A medical data update request has been submitted.'));
+                    $event->setActionLink('/index.php?q=/modules/Data Updater/data_medical_manage.php');
 
-                $event->sendNotifications($pdo, $gibbon->session);
-
+                    $event->sendNotifications($pdo, $gibbon->session);
+                }
 
                 if ($partialFail == true) {
                     $URL .= '&return=warning1';

--- a/modules/Data Updater/data_personalProcess.php
+++ b/modules/Data Updater/data_personalProcess.php
@@ -115,11 +115,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     header("Location: {$URL}");
                     exit();
                 } else {
-                    $row = $result->fetch();
+                    $values = $result->fetch();
 
                     //Get categories
                     $staff = $student = $parent = $other = false;
-                    $roles = explode(',', $row['gibbonRoleIDAll']);
+                    $roles = explode(',', $values['gibbonRoleIDAll']);
                     foreach ($roles as $role) {
                         $roleCategory = getRoleCategory($role, $connection2);
                         $staff = $staff || ($roleCategory == 'Staff');
@@ -130,62 +130,61 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
                     //Proceed!
                     $data = [
-                        'gibbonSchoolYearID'     => $_SESSION[$guid]['gibbonSchoolYearID'],
-                        'gibbonPersonID'         => $_POST['gibbonPersonID'] ?? $row['gibbonPersonID'],
-                        'title'                  => $_POST['title'] ?? $row['title'],
-                        'surname'                => $_POST['surname'] ?? $row['surname'],
-                        'firstName'              => $_POST['firstName'] ?? $row['firstName'],
-                        'preferredName'          => $_POST['preferredName'] ?? $row['preferredName'],
-                        'officialName'           => $_POST['officialName'] ?? $row['officialName'],
-                        'nameInCharacters'       => $_POST['nameInCharacters'] ?? $row['nameInCharacters'],
-                        'dob'                    => isset($_POST['dob']) ? Format::dateConvert($_POST['dob']) : $row['dob'],
-                        'email'                  => $_POST['email'] ?? $row['email'],
-                        'emailAlternate'         => $_POST['emailAlternate'] ?? $row['emailAlternate'],
-                        'address1'               => $_POST['address1'] ?? $row['address1'],
-                        'address1District'       => $_POST['address1District'] ?? $row['address1District'],
-                        'address1Country'        => $_POST['address1Country'] ?? $row['address1Country'],
-                        'address2'               => $_POST['address2'] ?? $row['address2'],
-                        'address2District'       => $_POST['address2District'] ?? $row['address2District'],
-                        'address2Country'        => $_POST['address2Country'] ?? $row['address2Country'],
-                        'phone1Type'             => $_POST['phone1Type'] ?? $row['phone1Type'],
-                        'phone1CountryCode'      => $_POST['phone1CountryCode'] ?? $row['phone1CountryCode'],
-                        'phone1'                 => $_POST['phone1'] ?? $row['phone1'],
-                        'phone2Type'             => $_POST['phone2Type'] ?? $row['phone2Type'],
-                        'phone2CountryCode'      => $_POST['phone2CountryCode'] ?? $row['phone2CountryCode'],
-                        'phone2'                 => $_POST['phone2'] ?? $row['phone2'],
-                        'phone3Type'             => $_POST['phone3Type'] ?? $row['phone3Type'],
-                        'phone3CountryCode'      => $_POST['phone3CountryCode'] ?? $row['phone3CountryCode'],
-                        'phone3'                 => $_POST['phone3'] ?? $row['phone3'],
-                        'phone4Type'             => $_POST['phone4Type'] ?? $row['phone4Type'],
-                        'phone4CountryCode'      => $_POST['phone4CountryCode'] ?? $row['phone4CountryCode'],
-                        'phone4'                 => $_POST['phone4'] ?? $row['phone4'],
-                        'languageFirst'          => $_POST['languageFirst'] ?? $row['languageFirst'],
-                        'languageSecond'         => $_POST['languageSecond'] ?? $row['languageSecond'],
-                        'languageThird'          => $_POST['languageThird'] ?? $row['languageThird'],
-                        'countryOfBirth'         => $_POST['countryOfBirth'] ?? $row['countryOfBirth'],
-                        'ethnicity'              => $_POST['ethnicity'] ?? $row['ethnicity'],
-                        'citizenship1'           => $_POST['citizenship1'] ?? $row['citizenship1'],
-                        'citizenship1Passport'   => $_POST['citizenship1Passport'] ?? $row['citizenship1Passport'],
-                        'citizenship1PassportExpiry'   => !empty($_POST['citizenship1PassportExpiry']) ? Format::dateConvert($_POST['citizenship1PassportExpiry']) : $row['citizenship1PassportExpiry'],
-                        'citizenship2'           => $_POST['citizenship2'] ?? $row['citizenship2'],
-                        'citizenship2Passport'   => $_POST['citizenship2Passport'] ?? $row['citizenship2Passport'],
-                        'citizenship2PassportExpiry'   => !empty($_POST['citizenship2PassportExpiry']) ? Format::dateConvert($_POST['citizenship2PassportExpiry']) : $row['citizenship2PassportExpiry'],
-                        'religion'               => $_POST['religion'] ?? $row['religion'],
-                        'nationalIDCardNumber'   => $_POST['nationalIDCardNumber'] ?? $row['nationalIDCardNumber'],
-                        'residencyStatus'        => $_POST['residencyStatus'] ?? $row['residencyStatus'],
-                        'visaExpiryDate'         => isset($_POST['visaExpiryDate']) ? Format::dateConvert($_POST['visaExpiryDate']) : $row['visaExpiryDate'],
-                        'emergency1Name'         => $_POST['emergency1Name'] ?? $row['emergency1Name'],
-                        'emergency1Number1'      => $_POST['emergency1Number1'] ?? $row['emergency1Number1'],
-                        'emergency1Number2'      => $_POST['emergency1Number2'] ?? $row['emergency1Number2'],
-                        'emergency1Relationship' => $_POST['emergency1Relationship'] ?? $row['emergency1Relationship'],
-                        'emergency2Name'         => $_POST['emergency2Name'] ?? $row['emergency2Name'],
-                        'emergency2Number1'      => $_POST['emergency2Number1'] ?? $row['emergency2Number1'],
-                        'emergency2Number2'      => $_POST['emergency2Number2'] ?? $row['emergency2Number2'],
-                        'emergency2Relationship' => $_POST['emergency2Relationship'] ?? $row['emergency2Relationship'],
-                        'profession'             => $_POST['profession'] ?? $row['profession'],
-                        'employer'               => $_POST['employer'] ?? $row['employer'],
-                        'jobTitle'               => $_POST['jobTitle'] ?? $row['jobTitle'],
-                        'vehicleRegistration'    => $_POST['vehicleRegistration'] ?? $row['vehicleRegistration'],
+                        'gibbonPersonID'             => $gibbonPersonID,
+                        'title'                      => $_POST['title'] ?? $values['title'],
+                        'surname'                    => $_POST['surname'] ?? $values['surname'],
+                        'firstName'                  => $_POST['firstName'] ?? $values['firstName'],
+                        'preferredName'              => $_POST['preferredName'] ?? $values['preferredName'],
+                        'officialName'               => $_POST['officialName'] ?? $values['officialName'],
+                        'nameInCharacters'           => $_POST['nameInCharacters'] ?? $values['nameInCharacters'],
+                        'dob'                        => isset($_POST['dob']) ? Format::dateConvert($_POST['dob']) : $values['dob'],
+                        'email'                      => $_POST['email'] ?? $values['email'],
+                        'emailAlternate'             => $_POST['emailAlternate'] ?? $values['emailAlternate'],
+                        'address1'                   => $_POST['address1'] ?? $values['address1'],
+                        'address1District'           => $_POST['address1District'] ?? $values['address1District'],
+                        'address1Country'            => $_POST['address1Country'] ?? $values['address1Country'],
+                        'address2'                   => $_POST['address2'] ?? $values['address2'],
+                        'address2District'           => $_POST['address2District'] ?? $values['address2District'],
+                        'address2Country'            => $_POST['address2Country'] ?? $values['address2Country'],
+                        'phone1Type'                 => $_POST['phone1Type'] ?? $values['phone1Type'],
+                        'phone1CountryCode'          => $_POST['phone1CountryCode'] ?? $values['phone1CountryCode'],
+                        'phone1'                     => $_POST['phone1'] ?? $values['phone1'],
+                        'phone2Type'                 => $_POST['phone2Type'] ?? $values['phone2Type'],
+                        'phone2CountryCode'          => $_POST['phone2CountryCode'] ?? $values['phone2CountryCode'],
+                        'phone2'                     => $_POST['phone2'] ?? $values['phone2'],
+                        'phone3Type'                 => $_POST['phone3Type'] ?? $values['phone3Type'],
+                        'phone3CountryCode'          => $_POST['phone3CountryCode'] ?? $values['phone3CountryCode'],
+                        'phone3'                     => $_POST['phone3'] ?? $values['phone3'],
+                        'phone4Type'                 => $_POST['phone4Type'] ?? $values['phone4Type'],
+                        'phone4CountryCode'          => $_POST['phone4CountryCode'] ?? $values['phone4CountryCode'],
+                        'phone4'                     => $_POST['phone4'] ?? $values['phone4'],
+                        'languageFirst'              => $_POST['languageFirst'] ?? $values['languageFirst'],
+                        'languageSecond'             => $_POST['languageSecond'] ?? $values['languageSecond'],
+                        'languageThird'              => $_POST['languageThird'] ?? $values['languageThird'],
+                        'countryOfBirth'             => $_POST['countryOfBirth'] ?? $values['countryOfBirth'],
+                        'ethnicity'                  => $_POST['ethnicity'] ?? $values['ethnicity'],
+                        'citizenship1'               => $_POST['citizenship1'] ?? $values['citizenship1'],
+                        'citizenship1Passport'       => $_POST['citizenship1Passport'] ?? $values['citizenship1Passport'],
+                        'citizenship1PassportExpiry' => !empty($_POST['citizenship1PassportExpiry']) ? Format::dateConvert($_POST['citizenship1PassportExpiry']) : $values['citizenship1PassportExpiry'],
+                        'citizenship2'               => $_POST['citizenship2'] ?? $values['citizenship2'],
+                        'citizenship2Passport'       => $_POST['citizenship2Passport'] ?? $values['citizenship2Passport'],
+                        'citizenship2PassportExpiry' => !empty($_POST['citizenship2PassportExpiry']) ? Format::dateConvert($_POST['citizenship2PassportExpiry']) : $values['citizenship2PassportExpiry'],
+                        'religion'                   => $_POST['religion'] ?? $values['religion'],
+                        'nationalIDCardNumber'       => $_POST['nationalIDCardNumber'] ?? $values['nationalIDCardNumber'],
+                        'residencyStatus'            => $_POST['residencyStatus'] ?? $values['residencyStatus'],
+                        'visaExpiryDate'             => isset($_POST['visaExpiryDate']) ? Format::dateConvert($_POST['visaExpiryDate']) : $values['visaExpiryDate'],
+                        'emergency1Name'             => $_POST['emergency1Name'] ?? $values['emergency1Name'],
+                        'emergency1Number1'          => $_POST['emergency1Number1'] ?? $values['emergency1Number1'],
+                        'emergency1Number2'          => $_POST['emergency1Number2'] ?? $values['emergency1Number2'],
+                        'emergency1Relationship'     => $_POST['emergency1Relationship'] ?? $values['emergency1Relationship'],
+                        'emergency2Name'             => $_POST['emergency2Name'] ?? $values['emergency2Name'],
+                        'emergency2Number1'          => $_POST['emergency2Number1'] ?? $values['emergency2Number1'],
+                        'emergency2Number2'          => $_POST['emergency2Number2'] ?? $values['emergency2Number2'],
+                        'emergency2Relationship'     => $_POST['emergency2Relationship'] ?? $values['emergency2Relationship'],
+                        'profession'                 => $_POST['profession'] ?? $values['profession'],
+                        'employer'                   => $_POST['employer'] ?? $values['employer'],
+                        'jobTitle'                   => $_POST['jobTitle'] ?? $values['jobTitle'],
+                        'vehicleRegistration'        => $_POST['vehicleRegistration'] ?? $values['vehicleRegistration'],
                     ];
  
                     $data = array_map('trim', $data);
@@ -195,6 +194,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     if (empty($data['visaExpiryDate'])) $data['visaExpiryDate'] = null;
                     if (empty($data['citizenship1PassportExpiry']) || $data['citizenship1PassportExpiry'] == '0000-00-00') $data['citizenship1PassportExpiry'] = null;
                     if (empty($data['citizenship2PassportExpiry']) || $data['citizenship2PassportExpiry'] == '0000-00-00') $data['citizenship2PassportExpiry'] = null;
+
+                    // Matching addresses
+                    $matchAddressCount = $_POST['matchAddressCount'] ?? 0;
 
                     // Phone number filtering
                     for ($i = 1; $i <= 4; $i++) {
@@ -208,17 +210,32 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     $data['privacy'] = isset($_POST['privacyOptions']) && is_array($_POST['privacyOptions'])
                         ? implode(', ', $_POST['privacyOptions'])
                         : null;
-                        
+
+                    // COMPARE VALUES: Has the data changed?
+                    $dataChanged = $matchAddressCount > 0 ? true : false;
+                    foreach ($values as $key => $value) {
+                        if (!isset($data[$key])) continue; // Skip fields we don't plan to update
+
+                        if ($data[$key] != $value) {
+                            $dataChanged = true;
+                        }
+                    }
 
                     //DEAL WITH CUSTOM FIELDS
                     //Prepare field values
                     $customRequireFail = false;
+                    $existingFields = unserialize($values['fields']);
                     $resultFields = getCustomFields($connection2, $guid, $student, $staff, $parent, $other, null, true);
                     $fields = [];
                     if ($resultFields->rowCount() > 0) {
                         while ($rowFields = $resultFields->fetch()) {
                             $fieldID = $rowFields['gibbonPersonFieldID'];
                             $fieldValue = $_POST['custom'.$fieldID] ?? null;
+                            $existingValue = $existingFields[$fieldID] ?? null;
+
+                            if ($existingValue != $fieldValue) {
+                                $dataChanged = true;
+                            }
 
                             if (!is_null($fieldValue)) {
                                 $fields[$fieldID] = ($rowFields['type'] == 'date')
@@ -241,28 +258,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                         //Write to database
                         $existing = $_POST['existing'] ?? 'N';
 
-                        try {
-                            $data['gibbonPersonIDUpdater'] = $_SESSION[$guid]['gibbonPersonID'];
-                            if ($existing != 'N') {
-                                $data['gibbonPersonUpdateID'] = $existing;
-                                $sql = 'UPDATE gibbonPersonUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonID=:gibbonPersonID, title=:title, surname=:surname, firstName=:firstName, preferredName=:preferredName, officialName=:officialName, nameInCharacters=:nameInCharacters, dob=:dob, email=:email, emailAlternate=:emailAlternate, address1=:address1, address1District=:address1District, address1Country=:address1Country, address2=:address2, address2District=:address2District, address2Country=:address2Country, phone1Type=:phone1Type, phone1CountryCode=:phone1CountryCode, phone1=:phone1, phone2Type=:phone2Type, phone2CountryCode=:phone2CountryCode, phone2=:phone2, phone3Type=:phone3Type, phone3CountryCode=:phone3CountryCode, phone3=:phone3, phone4Type=:phone4Type, phone4CountryCode=:phone4CountryCode, phone4=:phone4, languageFirst=:languageFirst, languageSecond=:languageSecond, languageThird=:languageThird, countryOfBirth=:countryOfBirth, ethnicity=:ethnicity, citizenship1=:citizenship1, citizenship1Passport=:citizenship1Passport, citizenship1PassportExpiry=:citizenship1PassportExpiry, citizenship2=:citizenship2, citizenship2Passport=:citizenship2Passport, citizenship2PassportExpiry=:citizenship2PassportExpiry, religion=:religion, nationalIDCardNumber=:nationalIDCardNumber, residencyStatus=:residencyStatus, visaExpiryDate=:visaExpiryDate, emergency1Name=:emergency1Name, emergency1Number1=:emergency1Number1, emergency1Number2=:emergency1Number2, emergency1Relationship=:emergency1Relationship, emergency2Name=:emergency2Name, emergency2Number1=:emergency2Number1, emergency2Number2=:emergency2Number2, emergency2Relationship=:emergency2Relationship, profession=:profession, employer=:employer, jobTitle=:jobTitle, vehicleRegistration=:vehicleRegistration, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, privacy=:privacy, fields=:fields, timestamp=NOW() WHERE gibbonPersonUpdateID=:gibbonPersonUpdateID';
-                            } else {
-                                $sql = 'INSERT INTO gibbonPersonUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonID=:gibbonPersonID, title=:title, surname=:surname, firstName=:firstName, preferredName=:preferredName, officialName=:officialName, nameInCharacters=:nameInCharacters, dob=:dob, email=:email, emailAlternate=:emailAlternate, address1=:address1, address1District=:address1District, address1Country=:address1Country, address2=:address2, address2District=:address2District, address2Country=:address2Country, phone1Type=:phone1Type, phone1CountryCode=:phone1CountryCode, phone1=:phone1, phone2Type=:phone2Type, phone2CountryCode=:phone2CountryCode, phone2=:phone2, phone3Type=:phone3Type, phone3CountryCode=:phone3CountryCode, phone3=:phone3, phone4Type=:phone4Type, phone4CountryCode=:phone4CountryCode, phone4=:phone4, languageFirst=:languageFirst, languageSecond=:languageSecond, languageThird=:languageThird, countryOfBirth=:countryOfBirth, ethnicity=:ethnicity, citizenship1=:citizenship1, citizenship1Passport=:citizenship1Passport, citizenship1PassportExpiry=:citizenship1PassportExpiry, citizenship2=:citizenship2, citizenship2Passport=:citizenship2Passport, citizenship2PassportExpiry=:citizenship2PassportExpiry, religion=:religion, nationalIDCardNumber=:nationalIDCardNumber, residencyStatus=:residencyStatus, visaExpiryDate=:visaExpiryDate, emergency1Name=:emergency1Name, emergency1Number1=:emergency1Number1, emergency1Number2=:emergency1Number2, emergency1Relationship=:emergency1Relationship, emergency2Name=:emergency2Name, emergency2Number1=:emergency2Number1, emergency2Number2=:emergency2Number2, emergency2Relationship=:emergency2Relationship, profession=:profession, employer=:employer, jobTitle=:jobTitle, vehicleRegistration=:vehicleRegistration, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, privacy=:privacy, fields=:fields';
-                            }
-                            $result = $connection2->prepare($sql);
-                            $result->execute($data);
-                        } catch (PDOException $e) {
-                            $URL .= '&return=error2';
-                            header("Location: {$URL}");
-                            exit();
+                        // Auto-accept updates where no data had changed
+                        $data['status'] = $dataChanged ? 'Pending' : 'Complete';
+                        $data['gibbonSchoolYearID'] = $_SESSION[$guid]['gibbonSchoolYearID'];
+                        $data['gibbonPersonIDUpdater'] = $_SESSION[$guid]['gibbonPersonID'];
+                        $data['timestamp'] = date('Y-m-d H:i:s');
+
+
+                        if ($existing != 'N') {
+                            $data['gibbonPersonUpdateID'] = $existing;
+                            $sql = 'UPDATE gibbonPersonUpdate SET `status`=:status, gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonID=:gibbonPersonID, title=:title, surname=:surname, firstName=:firstName, preferredName=:preferredName, officialName=:officialName, nameInCharacters=:nameInCharacters, dob=:dob, email=:email, emailAlternate=:emailAlternate, address1=:address1, address1District=:address1District, address1Country=:address1Country, address2=:address2, address2District=:address2District, address2Country=:address2Country, phone1Type=:phone1Type, phone1CountryCode=:phone1CountryCode, phone1=:phone1, phone2Type=:phone2Type, phone2CountryCode=:phone2CountryCode, phone2=:phone2, phone3Type=:phone3Type, phone3CountryCode=:phone3CountryCode, phone3=:phone3, phone4Type=:phone4Type, phone4CountryCode=:phone4CountryCode, phone4=:phone4, languageFirst=:languageFirst, languageSecond=:languageSecond, languageThird=:languageThird, countryOfBirth=:countryOfBirth, ethnicity=:ethnicity, citizenship1=:citizenship1, citizenship1Passport=:citizenship1Passport, citizenship1PassportExpiry=:citizenship1PassportExpiry, citizenship2=:citizenship2, citizenship2Passport=:citizenship2Passport, citizenship2PassportExpiry=:citizenship2PassportExpiry, religion=:religion, nationalIDCardNumber=:nationalIDCardNumber, residencyStatus=:residencyStatus, visaExpiryDate=:visaExpiryDate, emergency1Name=:emergency1Name, emergency1Number1=:emergency1Number1, emergency1Number2=:emergency1Number2, emergency1Relationship=:emergency1Relationship, emergency2Name=:emergency2Name, emergency2Number1=:emergency2Number1, emergency2Number2=:emergency2Number2, emergency2Relationship=:emergency2Relationship, profession=:profession, employer=:employer, jobTitle=:jobTitle, vehicleRegistration=:vehicleRegistration, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, privacy=:privacy, fields=:fields, timestamp=:timestamp WHERE gibbonPersonUpdateID=:gibbonPersonUpdateID';
+                        } else {
+                            $sql = 'INSERT INTO gibbonPersonUpdate SET `status`=:status, gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonID=:gibbonPersonID, title=:title, surname=:surname, firstName=:firstName, preferredName=:preferredName, officialName=:officialName, nameInCharacters=:nameInCharacters, dob=:dob, email=:email, emailAlternate=:emailAlternate, address1=:address1, address1District=:address1District, address1Country=:address1Country, address2=:address2, address2District=:address2District, address2Country=:address2Country, phone1Type=:phone1Type, phone1CountryCode=:phone1CountryCode, phone1=:phone1, phone2Type=:phone2Type, phone2CountryCode=:phone2CountryCode, phone2=:phone2, phone3Type=:phone3Type, phone3CountryCode=:phone3CountryCode, phone3=:phone3, phone4Type=:phone4Type, phone4CountryCode=:phone4CountryCode, phone4=:phone4, languageFirst=:languageFirst, languageSecond=:languageSecond, languageThird=:languageThird, countryOfBirth=:countryOfBirth, ethnicity=:ethnicity, citizenship1=:citizenship1, citizenship1Passport=:citizenship1Passport, citizenship1PassportExpiry=:citizenship1PassportExpiry, citizenship2=:citizenship2, citizenship2Passport=:citizenship2Passport, citizenship2PassportExpiry=:citizenship2PassportExpiry, religion=:religion, nationalIDCardNumber=:nationalIDCardNumber, residencyStatus=:residencyStatus, visaExpiryDate=:visaExpiryDate, emergency1Name=:emergency1Name, emergency1Number1=:emergency1Number1, emergency1Number2=:emergency1Number2, emergency1Relationship=:emergency1Relationship, emergency2Name=:emergency2Name, emergency2Number1=:emergency2Number1, emergency2Number2=:emergency2Number2, emergency2Relationship=:emergency2Relationship, profession=:profession, employer=:employer, jobTitle=:jobTitle, vehicleRegistration=:vehicleRegistration, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, privacy=:privacy, fields=:fields, timestamp=:timestamp';
                         }
+                        $pdo->statement($sql, $data);
+
 
                         //Update matching addresses
                         $partialFail = false;
-                        $matchAddressCount = 0;
-                        if (isset($_POST['matchAddressCount'])) {
-                            $matchAddressCount = $_POST['matchAddressCount'];
-                        }
+
                         if ($matchAddressCount > 0) {
                             for ($i = 0; $i < $matchAddressCount; ++$i) {
                                 if (!empty($_POST[$i.'-matchAddress'])) {
@@ -298,14 +312,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                             }
                         }
 
-                        // Raise a new notification event
-                        $event = new NotificationEvent('Data Updater', 'Personal Data Updates');
+                        if ($dataChanged) {
+                            // Raise a new notification event
+                            $event = new NotificationEvent('Data Updater', 'Personal Data Updates');
 
-                        $event->addRecipient($_SESSION[$guid]['organisationDBA']);
-                        $event->setNotificationText(__('A personal data update request has been submitted.'));
-                        $event->setActionLink('/index.php?q=/modules/Data Updater/data_personal_manage.php');
+                            $event->addRecipient($_SESSION[$guid]['organisationDBA']);
+                            $event->setNotificationText(__('A personal data update request has been submitted.'));
+                            $event->setActionLink('/index.php?q=/modules/Data Updater/data_personal_manage.php');
 
-                        $event->sendNotifications($pdo, $gibbon->session);
+                            $event->sendNotifications($pdo, $gibbon->session);
+                        }
 
 
                         if ($partialFail == true) {


### PR DESCRIPTION
This PR changes the data update process so that a data update with no changes is automatically accepted and does not generate a notification. It does this by comparing the new values to the old values when processing the request.

**Motivation and Context**
It is good to encourage people to submit a data update even if there are no changes, so that the system knows their data is up to date. However, accepting all these changes can be tedious. This PR aims to save some time for admin.

**How Has This Been Tested?**
Tested locally.
