### PR TITLE
Timetable Admin: add a dateEnrolled and dateUnenrolled to class enrolments

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -700,5 +700,5 @@ UPDATE `gibbonPlannerEntry` SET homeworkSubmissionRequired='Required' WHERE home
 ALTER TABLE `gibbonPlannerEntry` CHANGE `homeworkSubmissionRequired` `homeworkSubmissionRequired` enum('Optional','Required') DEFAULT NULL;end
 ALTER TABLE `gibbonModule` CHANGE `version` `version` VARCHAR(8) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
 UPDATE gibbonStaff SET type='Support' WHERE NOT type='Teaching';end
-ALTER TABLE `gibbonCourseClassPerson` ADD `dateStart` DATE NULL DEFAULT NULL AFTER `role`, ADD `dateEnd` DATE NULL DEFAULT NULL AFTER `dateStart`;end
+ALTER TABLE `gibbonCourseClassPerson` ADD `dateEnrolled` DATE NULL DEFAULT NULL AFTER `role`, ADD `dateUnenrolled` DATE NULL DEFAULT NULL AFTER `dateEnrolled`;end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -700,4 +700,5 @@ UPDATE `gibbonPlannerEntry` SET homeworkSubmissionRequired='Required' WHERE home
 ALTER TABLE `gibbonPlannerEntry` CHANGE `homeworkSubmissionRequired` `homeworkSubmissionRequired` enum('Optional','Required') DEFAULT NULL;end
 ALTER TABLE `gibbonModule` CHANGE `version` `version` VARCHAR(8) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
 UPDATE gibbonStaff SET type='Support' WHERE NOT type='Teaching';end
+ALTER TABLE `gibbonCourseClassPerson` ADD `dateStart` DATE NULL DEFAULT NULL AFTER `role`, ADD `dateEnd` DATE NULL DEFAULT NULL AFTER `dateStart`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,6 +67,7 @@ v21.0.00
         Students: send notifications for student notes to the Head of Year, if available
         System Admin: adjusted View Log to show only current year's log entries
         System Admin: added a flag to import types to enable updating non-unique rows
+        Timetable Admin: added a dateStart and dateEnd to class enrolments
         Testing: Changed install suite admin username and password to be compliant with the default password requirements
 
     Bug Fixes
@@ -90,9 +91,9 @@ v21.0.00
         Students: fixed parent support link in application acceptance email
         Students: fixed students able to see other students in class lists
         Students: fixed issue preventing timetable edit link from working with left students and allStudent flag
-	Tests: Added fallback environment variables if .env is not defining DB details
-	Tests: Changed HTTP to HTTPs, so SSL enabled environments don't fail
-	Tests: Added Users group and changed reference in acceptance.suite.yml so that the acceptance suite does not fail
+	    Tests: added fallback environment variables if .env is not defining DB details
+	    Tests: changed HTTP to HTTPs, so SSL enabled environments don't fail
+	    Tests: added Users group and changed reference in acceptance.suite.yml so that the acceptance suite does not fail
 
 
 v20.0.00

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -67,7 +67,7 @@ v21.0.00
         Students: send notifications for student notes to the Head of Year, if available
         System Admin: adjusted View Log to show only current year's log entries
         System Admin: added a flag to import types to enable updating non-unique rows
-        Timetable Admin: added a dateStart and dateEnd to class enrolments
+        Timetable Admin: added a dateEnrolled and dateUnenrolled to class enrolments
         Testing: Changed install suite admin username and password to be compliant with the default password requirements
 
     Bug Fixes

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -505,10 +505,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 $data = array(
                                     'gibbonRollGroupID' => $values['gibbonRollGroupID'],
                                     'gibbonPersonID' => $gibbonPersonID,
+                                    'gibbonSchoolYearIDEntry' => $values['gibbonSchoolYearIDEntry'],
                                 );
 
-                                $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `reportable`)
-                                        SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, 'Student', 'Y'
+                                $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateEnrolled`, `reportable`)
+                                        SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, 'Student', GREATEST((SELECT firstDay FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearIDEntry), CURRENT_DATE), 'Y'
                                         FROM gibbonCourseClassMap
                                         WHERE gibbonCourseClassMap.gibbonRollGroupID=:gibbonRollGroupID";
                                 $pdo->executeQuery($data, $sql);

--- a/modules/Students/studentEnrolment_manage_addProcess.php
+++ b/modules/Students/studentEnrolment_manage_addProcess.php
@@ -114,9 +114,9 @@ if ($gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
                         // Handle automatic course enrolment if enabled
                         $autoEnrolStudent = (isset($_POST['autoEnrolStudent']))? $_POST['autoEnrolStudent'] : 'N';
                         if ($autoEnrolStudent == 'Y') {
-                            $data = array('gibbonRollGroupID' => $gibbonRollGroupID, 'gibbonPersonID' => $gibbonPersonID, 'dateStart' => date('Y-m-d'));
-                            $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateStart`, `reportable`)
-                                    SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, 'Student', :dateStart, 'Y'
+                            $data = array('gibbonRollGroupID' => $gibbonRollGroupID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnrolled' => date('Y-m-d'));
+                            $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateEnrolled`, `reportable`)
+                                    SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, 'Student', :dateEnrolled, 'Y'
                                     FROM gibbonCourseClassMap
                                     LEFT JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClassMap.gibbonCourseClassID AND gibbonCourseClassPerson.role='Student')
                                     WHERE gibbonCourseClassMap.gibbonRollGroupID=:gibbonRollGroupID

--- a/modules/Students/studentEnrolment_manage_addProcess.php
+++ b/modules/Students/studentEnrolment_manage_addProcess.php
@@ -114,9 +114,9 @@ if ($gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
                         // Handle automatic course enrolment if enabled
                         $autoEnrolStudent = (isset($_POST['autoEnrolStudent']))? $_POST['autoEnrolStudent'] : 'N';
                         if ($autoEnrolStudent == 'Y') {
-                            $data = array('gibbonRollGroupID' => $gibbonRollGroupID, 'gibbonPersonID' => $gibbonPersonID);
-                            $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `reportable`)
-                                    SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, 'Student', 'Y'
+                            $data = array('gibbonRollGroupID' => $gibbonRollGroupID, 'gibbonPersonID' => $gibbonPersonID, 'dateStart' => date('Y-m-d'));
+                            $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateStart`, `reportable`)
+                                    SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, 'Student', :dateStart, 'Y'
                                     FROM gibbonCourseClassMap
                                     LEFT JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClassMap.gibbonCourseClassID AND gibbonCourseClassPerson.role='Student')
                                     WHERE gibbonCourseClassMap.gibbonRollGroupID=:gibbonRollGroupID

--- a/modules/Students/studentEnrolment_manage_editProcess.php
+++ b/modules/Students/studentEnrolment_manage_editProcess.php
@@ -114,6 +114,17 @@ if ($gibbonStudentEnrolmentID == '' or $gibbonSchoolYearID == '') { echo 'Fatal 
                             exit;
                         }
 
+                        // Update existing course enrolments for new Roll Group
+                        $data = array('gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateEnrolled' => date('Y-m-d'));
+                        $sql = "UPDATE gibbonCourseClassPerson 
+                                JOIN gibbonStudentEnrolment ON (gibbonCourseClassPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
+                                JOIN gibbonCourseClassMap ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClassMap.gibbonCourseClassID 
+                                    AND gibbonCourseClassMap.gibbonRollGroupID=gibbonStudentEnrolment.gibbonRollGroupID)
+                                SET gibbonCourseClassPerson.role='Student', gibbonCourseClassPerson.dateEnrolled=:dateEnrolled, reportable='Y'
+                                WHERE gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
+                                AND gibbonCourseClassPerson.gibbonCourseClassPersonID IS NOT NULL";
+                        $pdo->executeQuery($data, $sql);
+
                         // Add course enrolments for new Roll Group
                         $data = array('gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateEnrolled' => date('Y-m-d'));
                         $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateEnrolled`, `reportable`)

--- a/modules/Students/studentEnrolment_manage_editProcess.php
+++ b/modules/Students/studentEnrolment_manage_editProcess.php
@@ -99,11 +99,11 @@ if ($gibbonStudentEnrolmentID == '' or $gibbonSchoolYearID == '') { echo 'Fatal 
                         // Remove existing auto-enrolment: moving a student from one Roll Group to another
                         $gibbonRollGroupIDOriginal = (isset($_POST['gibbonRollGroupIDOriginal']))? $_POST['gibbonRollGroupIDOriginal'] : 'N';
 
-                        $data = array('gibbonRollGroupIDOriginal' => $gibbonRollGroupIDOriginal, 'gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID);
+                        $data = array('gibbonRollGroupIDOriginal' => $gibbonRollGroupIDOriginal, 'gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateEnd' => date('Y-m-d'));
                         $sql = "UPDATE gibbonCourseClassPerson
                                 JOIN gibbonStudentEnrolment ON (gibbonCourseClassPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
                                 JOIN gibbonCourseClassMap ON (gibbonCourseClassMap.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID)
-                                SET role='Student - Left'
+                                SET role='Student - Left', dateEnd=:dateEnd
                                 WHERE gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
                                 AND gibbonCourseClassMap.gibbonRollGroupID=:gibbonRollGroupIDOriginal";
                         $pdo->executeQuery($data, $sql);
@@ -115,9 +115,9 @@ if ($gibbonStudentEnrolmentID == '' or $gibbonSchoolYearID == '') { echo 'Fatal 
                         }
 
                         // Add course enrolments for new Roll Group
-                        $data = array('gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID);
-                        $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `reportable`)
-                                SELECT gibbonCourseClassMap.gibbonCourseClassID, gibbonStudentEnrolment.gibbonPersonID, 'Student', 'Y'
+                        $data = array('gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateStart' => date('Y-m-d'));
+                        $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateStart`, `reportable`)
+                                SELECT gibbonCourseClassMap.gibbonCourseClassID, gibbonStudentEnrolment.gibbonPersonID, 'Student', :dateStart, 'Y'
                                 FROM gibbonStudentEnrolment
                                 JOIN gibbonCourseClassMap ON (gibbonCourseClassMap.gibbonRollGroupID=gibbonStudentEnrolment.gibbonRollGroupID)
                                 LEFT JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClassMap.gibbonCourseClassID AND gibbonCourseClassPerson.role='Student')

--- a/modules/Students/studentEnrolment_manage_editProcess.php
+++ b/modules/Students/studentEnrolment_manage_editProcess.php
@@ -99,11 +99,11 @@ if ($gibbonStudentEnrolmentID == '' or $gibbonSchoolYearID == '') { echo 'Fatal 
                         // Remove existing auto-enrolment: moving a student from one Roll Group to another
                         $gibbonRollGroupIDOriginal = (isset($_POST['gibbonRollGroupIDOriginal']))? $_POST['gibbonRollGroupIDOriginal'] : 'N';
 
-                        $data = array('gibbonRollGroupIDOriginal' => $gibbonRollGroupIDOriginal, 'gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateEnd' => date('Y-m-d'));
+                        $data = array('gibbonRollGroupIDOriginal' => $gibbonRollGroupIDOriginal, 'gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateUnenrolled' => date('Y-m-d'));
                         $sql = "UPDATE gibbonCourseClassPerson
                                 JOIN gibbonStudentEnrolment ON (gibbonCourseClassPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
                                 JOIN gibbonCourseClassMap ON (gibbonCourseClassMap.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID)
-                                SET role='Student - Left', dateEnd=:dateEnd
+                                SET role='Student - Left', dateUnenrolled=:dateUnenrolled
                                 WHERE gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
                                 AND gibbonCourseClassMap.gibbonRollGroupID=:gibbonRollGroupIDOriginal";
                         $pdo->executeQuery($data, $sql);
@@ -115,9 +115,9 @@ if ($gibbonStudentEnrolmentID == '' or $gibbonSchoolYearID == '') { echo 'Fatal 
                         }
 
                         // Add course enrolments for new Roll Group
-                        $data = array('gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateStart' => date('Y-m-d'));
-                        $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateStart`, `reportable`)
-                                SELECT gibbonCourseClassMap.gibbonCourseClassID, gibbonStudentEnrolment.gibbonPersonID, 'Student', :dateStart, 'Y'
+                        $data = array('gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateEnrolled' => date('Y-m-d'));
+                        $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateEnrolled`, `reportable`)
+                                SELECT gibbonCourseClassMap.gibbonCourseClassID, gibbonStudentEnrolment.gibbonPersonID, 'Student', :dateEnrolled, 'Y'
                                 FROM gibbonStudentEnrolment
                                 JOIN gibbonCourseClassMap ON (gibbonCourseClassMap.gibbonRollGroupID=gibbonStudentEnrolment.gibbonRollGroupID)
                                 LEFT JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClassMap.gibbonCourseClassID AND gibbonCourseClassPerson.role='Student')

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
@@ -58,8 +58,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         } else {
             foreach ($classes as $gibbonCourseClassID) {
                 try {
-                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnd' => date('Y-m-d'));
-                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left'), dateEnd=:dateEnd WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID AND (role = 'Student' OR role = 'Teacher')";
+                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateUnenrolled' => date('Y-m-d'));
+                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left'), dateUnenrolled=:dateUnenrolled WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID AND (role = 'Student' OR role = 'Teacher')";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
@@ -58,8 +58,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         } else {
             foreach ($classes as $gibbonCourseClassID) {
                 try {
-                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
-                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left') WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID AND (role = 'Student' OR role = 'Teacher')";
+                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnd' => date('Y-m-d'));
+                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left'), dateEnd=:dateEnd WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID AND (role = 'Student' OR role = 'Teacher')";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
@@ -56,8 +56,8 @@ if ($gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error load
                 //If student not in course, add them
                 if ($result->rowCount() == 0) {
                     try {
-                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role, 'dateStart' => date('Y-m-d'));
-                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateStart=:dateStart';
+                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role, 'dateEnrolled' => date('Y-m-d'));
+                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateEnrolled=:dateEnrolled';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
@@ -65,10 +65,10 @@ if ($gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error load
                     }
                 } else {
                     $values = $result->fetch();
-                    $dateStart = $values['role'] != $role ? date('Y-m-d') : $values['dateStart'];
+                    $dateEnrolled = $values['role'] != $role ? date('Y-m-d') : $values['dateEnrolled'];
                     try {
-                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role, 'dateStart' => $dateStart);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
+                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role, 'dateEnrolled' => $dateEnrolled);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
@@ -56,17 +56,19 @@ if ($gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error load
                 //If student not in course, add them
                 if ($result->rowCount() == 0) {
                     try {
-                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role);
-                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role';
+                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role, 'dateStart' => date('Y-m-d'));
+                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateStart=:dateStart';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
                         $update = false;
                     }
                 } else {
+                    $values = $result->fetch();
+                    $dateStart = $values['role'] != $role ? date('Y-m-d') : $values['dateStart'];
                     try {
-                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
+                        $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role, 'dateStart' => $dateStart);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
@@ -65,7 +65,7 @@ if ($gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error load
                     }
                 } else {
                     $values = $result->fetch();
-                    $dateEnrolled = $values['role'] != $role ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateEnrolled = $values['role'] != $role || empty($values['dateEnrolled']) ? date('Y-m-d') : $values['dateEnrolled'];
                     try {
                         $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonCourseClassID' => $t, 'role' => $role, 'dateEnrolled' => $dateEnrolled);
                         $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     } else {
         try {
             $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
-            $sql = "SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.reportable FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonPerson.gibbonPersonID=:gibbonPersonID";
+            $sql = "SELECT role, gibbonCourseClassPerson.dateEnrolled, gibbonCourseClassPerson.dateUnenrolled, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.reportable FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonPerson.gibbonPersonID=:gibbonPersonID";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
@@ -110,7 +110,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 			
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable'));
-				$row->addYesNo('reportable')->required()->selected($values['reportable']);
+                $row->addYesNo('reportable')->required()->selected($values['reportable']);
+                
+            if (!empty($values['dateEnrolled'])) {
+                $row = $form->addRow();
+                    $row->addLabel('dateEnrolled', __('Date Enrolled'));
+                    $row->addTextField('dateEnrolled')->readonly()->setValue(Format::date($values['dateEnrolled']));
+            }
+                
+            if (!empty($values['dateUnenrolled']) && stripos($values['role'], 'Left') !== false) {
+                $row = $form->addRow();
+                    $row->addLabel('dateUnenrolled', __('Date Unenrolled'));
+                    $row->addTextField('dateUnenrolled')->readonly()->setValue(Format::date($values['dateUnenrolled']));
+            }
 
 			$row = $form->addRow();
 				$row->addFooter();

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
@@ -42,7 +42,7 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
         } else {
             try {
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
-                $sql = "SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateStart, gibbonCourseClassPerson.dateEnd FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonPerson.gibbonPersonID=:gibbonPersonID";
+                $sql = "SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateEnrolled, gibbonCourseClassPerson.dateUnenrolled FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonPerson.gibbonPersonID=:gibbonPersonID";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -65,11 +65,11 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
                     header("Location: {$URL}");
                 } else {
                     //Write to database
-                    $dateStart = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateStart'];
-                    $dateEnd = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
+                    $dateEnrolled = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateUnenrolled = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
-                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateStart' => $dateStart, 'dateEnd' => $dateEnd);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=:dateEnd, reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
+                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnrolled' => $dateEnrolled, 'dateUnenrolled' => $dateUnenrolled);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=:dateUnenrolled, reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
@@ -42,7 +42,7 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
         } else {
             try {
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
-                $sql = "SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonPerson.gibbonPersonID=:gibbonPersonID";
+                $sql = "SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateStart, gibbonCourseClassPerson.dateEnd FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonPerson.gibbonPersonID=:gibbonPersonID";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -56,6 +56,7 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
                 header("Location: {$URL}");
             } else {
                 //Validate Inputs
+                $values = $result->fetch();
                 $role = $_POST['role'];
                 $reportable = $_POST['reportable'];
 
@@ -64,9 +65,11 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
                     header("Location: {$URL}");
                 } else {
                     //Write to database
+                    $dateStart = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateStart'];
+                    $dateEnd = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
-                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
+                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateStart' => $dateStart, 'dateEnd' => $dateEnd);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=:dateEnd, reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
@@ -65,8 +65,8 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
                     header("Location: {$URL}");
                 } else {
                     //Write to database
-                    $dateEnrolled = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
-                    $dateUnenrolled = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
+                    $dateEnrolled = $role != $values['role'] && stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateUnenrolled = $role != $values['role'] && stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
                         $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnrolled' => $dateEnrolled, 'dateUnenrolled' => $dateUnenrolled);
                         $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=:dateUnenrolled, reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';

--- a/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
@@ -73,8 +73,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                     // Insert new course participants
                     if ($resultCheck->rowCount() == 0) {
                         try {
-                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'gibbonCourseClassIDCopyTo' => $gibbonCourseClassIDCopyTo, 'dateStart' => date('Y-m-d'));
-                            $sql = 'INSERT INTO gibbonCourseClassPerson (gibbonCourseClassID, gibbonPersonID, role, dateStart, reportable) SELECT :gibbonCourseClassIDCopyTo, gibbonPersonID, role, :dateStart, reportable FROM gibbonCourseClassPerson WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
+                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'gibbonCourseClassIDCopyTo' => $gibbonCourseClassIDCopyTo, 'dateEnrolled' => date('Y-m-d'));
+                            $sql = 'INSERT INTO gibbonCourseClassPerson (gibbonCourseClassID, gibbonPersonID, role, dateEnrolled, reportable) SELECT :gibbonCourseClassIDCopyTo, gibbonPersonID, role, :dateEnrolled, reportable FROM gibbonCourseClassPerson WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
@@ -91,8 +91,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         } else if ($action == 'Mark as left') {
             foreach ($people as $gibbonCourseClassPersonID) {
                 try {
-                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'dateEnd' => date('Y-m-d'));
-                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left '), dateEnd=:dateEnd WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (role = 'Student' OR role = 'Teacher')";
+                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'dateUnenrolled' => date('Y-m-d'));
+                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left '), dateUnenrolled=:dateUnenrolled WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (role = 'Student' OR role = 'Teacher')";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
@@ -73,8 +73,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                     // Insert new course participants
                     if ($resultCheck->rowCount() == 0) {
                         try {
-                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'gibbonCourseClassIDCopyTo' => $gibbonCourseClassIDCopyTo);
-                            $sql = 'INSERT INTO gibbonCourseClassPerson (gibbonCourseClassID, gibbonPersonID, role, reportable) SELECT :gibbonCourseClassIDCopyTo, gibbonPersonID, role, reportable FROM gibbonCourseClassPerson WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
+                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'gibbonCourseClassIDCopyTo' => $gibbonCourseClassIDCopyTo, 'dateStart' => date('Y-m-d'));
+                            $sql = 'INSERT INTO gibbonCourseClassPerson (gibbonCourseClassID, gibbonPersonID, role, dateStart, reportable) SELECT :gibbonCourseClassIDCopyTo, gibbonPersonID, role, :dateStart, reportable FROM gibbonCourseClassPerson WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
@@ -91,8 +91,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         } else if ($action == 'Mark as left') {
             foreach ($people as $gibbonCourseClassPersonID) {
                 try {
-                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
-                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left ') WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (role = 'Student' OR role = 'Teacher')";
+                    $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'dateEnd' => date('Y-m-d'));
+                    $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left '), dateEnd=:dateEnd WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (role = 'Student' OR role = 'Teacher')";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
@@ -64,7 +64,7 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID =
                     }
                 } else {
                     $values = $result->fetch();
-                    $dateEnrolled = $values['role'] != $role ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateEnrolled = $values['role'] != $role || empty($values['dateEnrolled']) ? date('Y-m-d') : $values['dateEnrolled'];
                     try {
                         $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateEnrolled' => $dateEnrolled);
                         $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
@@ -55,8 +55,8 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID =
                 //If student not in course, add them
                 if ($result->rowCount() == 0) {
                     try {
-                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => date('Y-m-d'));
-                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateStart=:dateStart';
+                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateEnrolled' => date('Y-m-d'));
+                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateEnrolled=:dateEnrolled';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
@@ -64,10 +64,10 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID =
                     }
                 } else {
                     $values = $result->fetch();
-                    $dateStart = $values['role'] != $role ? date('Y-m-d') : $values['dateStart'];
+                    $dateEnrolled = $values['role'] != $role ? date('Y-m-d') : $values['dateEnrolled'];
                     try {
-                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => $dateStart);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
+                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateEnrolled' => $dateEnrolled);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
@@ -55,17 +55,19 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID =
                 //If student not in course, add them
                 if ($result->rowCount() == 0) {
                     try {
-                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role);
-                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role';
+                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => date('Y-m-d'));
+                        $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateStart=:dateStart';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
                         $update = false;
                     }
                 } else {
+                    $values = $result->fetch();
+                    $dateStart = $values['role'] != $role ? date('Y-m-d') : $values['dateStart'];
                     try {
-                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
+                        $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => $dateStart);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=NULL WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     } else {
         try {
             $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
-            $sql = "SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.reportable FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (gibbonPerson.status='Full' OR gibbonPerson.status='Expected')";
+            $sql = "SELECT role, gibbonCourseClassPerson.dateEnrolled, gibbonCourseClassPerson.dateUnenrolled, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.reportable FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (gibbonPerson.status='Full' OR gibbonPerson.status='Expected')";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
@@ -102,6 +102,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable'));
 				$row->addYesNo('reportable')->required()->selected($values['reportable']);
+
+            if (!empty($values['dateEnrolled'])) {
+                $row = $form->addRow();
+                    $row->addLabel('dateEnrolled', __('Date Enrolled'));
+                    $row->addTextField('dateEnrolled')->readonly()->setValue(Format::date($values['dateEnrolled']));
+            }
+                
+            if (!empty($values['dateUnenrolled']) && stripos($values['role'], 'Left') !== false) {
+                $row = $form->addRow();
+                    $row->addLabel('dateUnenrolled', __('Date Unenrolled'));
+                    $row->addTextField('dateUnenrolled')->readonly()->setValue(Format::date($values['dateUnenrolled']));
+            }
 
 			$row = $form->addRow();
 				$row->addFooter();

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
@@ -63,8 +63,8 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                     header("Location: {$URL}");
                 } else {
                     //Write to database
-                    $dateEnrolled = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
-                    $dateUnenrolled = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
+                    $dateEnrolled = $role != $values['role'] && stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateUnenrolled = $role != $values['role'] && stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
                         $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'dateEnrolled' => $dateEnrolled, 'dateUnenrolled' => $dateUnenrolled);
                         $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=:dateUnenrolled reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
@@ -40,7 +40,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
         } else {
             try {
                 $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
-                $sql = "SELECT gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateStart, gibbonCourseClassPerson.dateEnd,  gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (gibbonPerson.status='Full' OR gibbonPerson.status='Expected')";
+                $sql = "SELECT gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateEnrolled, gibbonCourseClassPerson.dateEnd,  gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (gibbonPerson.status='Full' OR gibbonPerson.status='Expected')";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -63,11 +63,11 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                     header("Location: {$URL}");
                 } else {
                     //Write to database
-                    $dateStart = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateStart'];
-                    $dateEnd = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
+                    $dateEnrolled = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateUnenrolled = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
-                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'dateStart' => $dateStart, 'dateEnd' => $dateEnd);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=:dateEnd reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
+                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'dateEnrolled' => $dateEnrolled, 'dateUnenrolled' => $dateUnenrolled);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=:dateUnenrolled reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
@@ -40,7 +40,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
         } else {
             try {
                 $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
-                $sql = "SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (gibbonPerson.status='Full' OR gibbonPerson.status='Expected')";
+                $sql = "SELECT gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateStart, gibbonCourseClassPerson.dateEnd,  gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (gibbonPerson.status='Full' OR gibbonPerson.status='Expected')";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -54,6 +54,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                 header("Location: {$URL}");
             } else {
                 //Validate Inputs
+                $values = $result->fetch();
                 $role = $_POST['role'];
                 $reportable = $_POST['reportable'];
 
@@ -62,9 +63,11 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                     header("Location: {$URL}");
                 } else {
                     //Write to database
+                    $dateStart = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateStart'];
+                    $dateEnd = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
-                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
+                        $data = array('role' => $role, 'reportable' => $reportable, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID, 'dateStart' => $dateStart, 'dateEnd' => $dateEnd);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=:dateEnd reportable=:reportable WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
@@ -48,11 +48,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                     'gibbonRollGroupID' => $gibbonRollGroupID,
                     'gibbonPersonID' => $gibbonPersonID,
                     'role' => $role,
-                    'dateStart' => date('Y-m-d'),
+                    'dateEnrolled' => date('Y-m-d'),
                 );
 
-                $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateStart`, `reportable`)
-                        SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, :role, :dateStart, 'Y'
+                $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateEnrolled`, `reportable`)
+                        SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, :role, :dateEnrolled, 'Y'
                         FROM gibbonCourseClassMap
                         LEFT JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClassMap.gibbonCourseClassID AND gibbonCourseClassPerson.role=:role)
                         WHERE gibbonCourseClassMap.gibbonRollGroupID=:gibbonRollGroupID

--- a/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
@@ -48,10 +48,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                     'gibbonRollGroupID' => $gibbonRollGroupID,
                     'gibbonPersonID' => $gibbonPersonID,
                     'role' => $role,
+                    'dateStart' => date('Y-m-d'),
                 );
 
-                $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `reportable`)
-                        SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, :role, 'Y'
+                $sql = "INSERT INTO gibbonCourseClassPerson (`gibbonCourseClassID`, `gibbonPersonID`, `role`, `dateStart`, `reportable`)
+                        SELECT gibbonCourseClassMap.gibbonCourseClassID, :gibbonPersonID, :role, :dateStart, 'Y'
                         FROM gibbonCourseClassMap
                         LEFT JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClassMap.gibbonCourseClassID AND gibbonCourseClassPerson.role=:role)
                         WHERE gibbonCourseClassMap.gibbonRollGroupID=:gibbonRollGroupID

--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -18,7 +18,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
-use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -220,8 +219,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                 $rollStudents = isset($_POST['rollStudents'])? $_POST['rollStudents'] : '';
                 $rollTeachers = isset($_POST['rollTeachers'])? $_POST['rollTeachers'] : '';
 
-                $courseEnrolmentGateway = $container->get(CourseEnrolmentGateway::class);
-
                 if ($rollStudents != 'on' and $rollTeachers != 'on') {
                     echo "<div class='error'>";
                     echo __('Your request failed because your inputs were invalid.');
@@ -257,9 +254,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                         }
                         if ($resultCurrent->rowCount() > 0) {
                             while ($rowCurrent = $resultCurrent->fetch()) {
-
-                                // Ensure any previous class enrolments have an end date
-                                $courseEnrolmentGateway->update($rowCurrent['gibbonCourseClassPersonID'], ['dateUnenrolled' => $rowCurrent['lastDay']]);
 
                                 try {
                                     $dataInsert = array('gibbonCourseClassID' => $gibbonCourseClassIDNext, 'gibbonPersonID' => $rowCurrent['gibbonPersonID'], 'role' => $rowCurrent['role'], 'reportable' => $rowCurrent['reportable'], 'dateEnrolled' => date('Y-m-d'));

--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -259,11 +259,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                             while ($rowCurrent = $resultCurrent->fetch()) {
 
                                 // Ensure any previous class enrolments have an end date
-                                $courseEnrolmentGateway->update($rowCurrent['gibbonCourseClassPersonID'], ['dateEnd' => $rowCurrent['lastDay']]);
+                                $courseEnrolmentGateway->update($rowCurrent['gibbonCourseClassPersonID'], ['dateUnenrolled' => $rowCurrent['lastDay']]);
 
                                 try {
-                                    $dataInsert = array('gibbonCourseClassID' => $gibbonCourseClassIDNext, 'gibbonPersonID' => $rowCurrent['gibbonPersonID'], 'role' => $rowCurrent['role'], 'reportable' => $rowCurrent['reportable'], 'dateStart' => date('Y-m-d'));
-                                    $sqlInsert = 'INSERT INTO gibbonCourseClassPerson SET gibbonCourseClassID=:gibbonCourseClassID, gibbonPersonID=:gibbonPersonID, role=:role, dateStart=:dateStart, reportable=:reportable';
+                                    $dataInsert = array('gibbonCourseClassID' => $gibbonCourseClassIDNext, 'gibbonPersonID' => $rowCurrent['gibbonPersonID'], 'role' => $rowCurrent['role'], 'reportable' => $rowCurrent['reportable'], 'dateEnrolled' => date('Y-m-d'));
+                                    $sqlInsert = 'INSERT INTO gibbonCourseClassPerson SET gibbonCourseClassID=:gibbonCourseClassID, gibbonPersonID=:gibbonPersonID, role=:role, dateEnrolled=:dateEnrolled, reportable=:reportable';
                                     $resultInsert = $connection2->prepare($sqlInsert);
                                     $resultInsert->execute($dataInsert);
                                 } catch (PDOException $e) {

--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -194,10 +194,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
             echo '</div>';
         } else {
             
-            $dataCurrent = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID']);
-            $sqlCurrent = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
-            $rowCurrent = $pdo->selectOne($sqlCurrent, $dataCurrent);
-            
             $dataNext = array('gibbonSchoolYearID' => $nextYear);
             $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
             $rowNext = $pdo->selectOne($sqlNext, $dataNext);

--- a/modules/Timetable Admin/tt_import.php
+++ b/modules/Timetable Admin/tt_import.php
@@ -666,8 +666,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
 
                                                     //Write ID to gibbonCourseClassPerson
                                                     try {
-                                                        $dataMake = array('gibbonPersonID' => $rowConvert['gibbonPersonID'], 'gibbonCourseClassID' => $rowCheck['gibbonCourseClassID'],'dateStart' => date('Y-m-d'));
-                                                        $sqlMake = "INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role='Teacher', dateStart=:dateStart";
+                                                        $dataMake = array('gibbonPersonID' => $rowConvert['gibbonPersonID'], 'gibbonCourseClassID' => $rowCheck['gibbonCourseClassID'],'dateEnrolled' => date('Y-m-d'));
+                                                        $sqlMake = "INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role='Teacher', dateEnrolled=:dateEnrolled";
                                                         $resultMake = $connection2->prepare($sqlMake);
                                                         $resultMake->execute($dataMake);
                                                     } catch (PDOException $e) {

--- a/modules/Timetable Admin/tt_import.php
+++ b/modules/Timetable Admin/tt_import.php
@@ -666,8 +666,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
 
                                                     //Write ID to gibbonCourseClassPerson
                                                     try {
-                                                        $dataMake = array('gibbonPersonID' => $rowConvert['gibbonPersonID'], 'gibbonCourseClassID' => $rowCheck['gibbonCourseClassID']);
-                                                        $sqlMake = "INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role='Teacher'";
+                                                        $dataMake = array('gibbonPersonID' => $rowConvert['gibbonPersonID'], 'gibbonCourseClassID' => $rowCheck['gibbonCourseClassID'],'dateStart' => date('Y-m-d'));
+                                                        $sqlMake = "INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role='Teacher', dateStart=:dateStart";
                                                         $resultMake = $connection2->prepare($sqlMake);
                                                         $resultMake->execute($dataMake);
                                                     } catch (PDOException $e) {

--- a/modules/Timetable/studentEnrolment_manage_edit.php
+++ b/modules/Timetable/studentEnrolment_manage_edit.php
@@ -167,8 +167,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
 
                     $row->addContent($student['email']);
                     $row->addContent($student['role']);
-                    $col = $row->addColumn()->addClass('inline');
+                    
                     if ($student['role'] == 'Student') {
+                        $col = $row->addColumn()->addClass('inline');
                         $col->addWebLink('<img title="' . __('Edit') . '" src="./themes/' . $_SESSION[$guid]['gibbonThemeName'] . '/img/config.png"/>')
                             ->setURL($_SESSION[$guid]['absoluteURL'] . '/index.php?q=/modules/' . $_SESSION[$guid]['module'] . '/studentEnrolment_manage_edit_edit.php')
                             ->addParam('gibbonCourseID', $gibbonCourseID)
@@ -177,7 +178,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
                         $row->addCheckbox('gibbonPersonID[]')->setValue($student['gibbonPersonID'])->setClass('textCenter');
                     }
                     else {
-                        $row->addContent();
+                        $row->addContent(__('N/A'));
+                        $row->addContent('');
                     }
 
                 }

--- a/modules/Timetable/studentEnrolment_manage_editProcessBulk.php
+++ b/modules/Timetable/studentEnrolment_manage_editProcessBulk.php
@@ -57,8 +57,8 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $action == '') { echo
                 if ($action == 'Mark as left') {
                     foreach ($people as $gibbonPersonID) {
                         try {
-                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
-                            $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left ') WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID  AND (role = 'Student' OR role = 'Teacher')";
+                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnd' => date('Y-m-d'));
+                            $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left'), dateEnd=:dateEnd  WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID  AND (role = 'Student' OR role = 'Teacher')";
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {

--- a/modules/Timetable/studentEnrolment_manage_editProcessBulk.php
+++ b/modules/Timetable/studentEnrolment_manage_editProcessBulk.php
@@ -57,8 +57,8 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $action == '') { echo
                 if ($action == 'Mark as left') {
                     foreach ($people as $gibbonPersonID) {
                         try {
-                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnd' => date('Y-m-d'));
-                            $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left'), dateEnd=:dateEnd  WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID  AND (role = 'Student' OR role = 'Teacher')";
+                            $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateUnenrolled' => date('Y-m-d'));
+                            $sql = "UPDATE gibbonCourseClassPerson SET role=CONCAT(role, ' - Left'), dateUnenrolled=:dateUnenrolled  WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID  AND (role = 'Student' OR role = 'Teacher')";
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {

--- a/modules/Timetable/studentEnrolment_manage_edit_addProcess.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_addProcess.php
@@ -75,7 +75,7 @@ if ($gibbonCourseID == '' or $gibbonCourseClassID == '') { echo 'Fatal error loa
                         }
                     } else {
                         $values = $result->fetch();
-                        $dateEnrolled = $values['role'] != $role ? date('Y-m-d') : $values['dateEnrolled'];
+                        $dateEnrolled = $values['role'] != $role || empty($values['dateEnrolled']) ? date('Y-m-d') : $values['dateEnrolled'];
                         try {
                             $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateEnrolled' => $dateEnrolled);
                             $sql = "UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateEnd=NULL, reportable='Y' WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID";

--- a/modules/Timetable/studentEnrolment_manage_edit_addProcess.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_addProcess.php
@@ -66,8 +66,8 @@ if ($gibbonCourseID == '' or $gibbonCourseClassID == '') { echo 'Fatal error loa
                     //If student not in course, add them
                     if ($result->rowCount() == 0) {
                         try {
-                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => date('Y-m-d'));
-                            $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateStart=:dateStart';
+                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateEnrolled' => date('Y-m-d'));
+                            $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateEnrolled=:dateEnrolled';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
@@ -75,10 +75,10 @@ if ($gibbonCourseID == '' or $gibbonCourseClassID == '') { echo 'Fatal error loa
                         }
                     } else {
                         $values = $result->fetch();
-                        $dateStart = $values['role'] != $role ? date('Y-m-d') : $values['dateStart'];
+                        $dateEnrolled = $values['role'] != $role ? date('Y-m-d') : $values['dateEnrolled'];
                         try {
-                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => $dateStart);
-                            $sql = "UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=NULL, reportable='Y' WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID";
+                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateEnrolled' => $dateEnrolled);
+                            $sql = "UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateEnd=NULL, reportable='Y' WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID";
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {

--- a/modules/Timetable/studentEnrolment_manage_edit_addProcess.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_addProcess.php
@@ -66,17 +66,19 @@ if ($gibbonCourseID == '' or $gibbonCourseClassID == '') { echo 'Fatal error loa
                     //If student not in course, add them
                     if ($result->rowCount() == 0) {
                         try {
-                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role);
-                            $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role';
+                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => date('Y-m-d'));
+                            $sql = 'INSERT INTO gibbonCourseClassPerson SET gibbonPersonID=:gibbonPersonID, gibbonCourseClassID=:gibbonCourseClassID, role=:role, dateStart=:dateStart';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
                             $update = false;
                         }
                     } else {
+                        $values = $result->fetch();
+                        $dateStart = $values['role'] != $role ? date('Y-m-d') : $values['dateStart'];
                         try {
-                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role);
-                            $sql = "UPDATE gibbonCourseClassPerson SET role=:role, reportable='Y' WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID";
+                            $data = array('gibbonPersonID' => $t, 'gibbonCourseClassID' => $gibbonCourseClassID, 'role' => $role, 'dateStart' => $dateStart);
+                            $sql = "UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=NULL, reportable='Y' WHERE gibbonPersonID=:gibbonPersonID AND gibbonCourseClassID=:gibbonCourseClassID";
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {

--- a/modules/Timetable/studentEnrolment_manage_edit_edit.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_edit.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
     } else {
         try {
             $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID2' => $gibbonPersonID);
-            $sql = "SELECT surname, preferredName, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClassPerson.role, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonYearGroupIDList FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonDepartment ON (gibbonCourse.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE (gibbonDepartmentStaff.role='Coordinator' OR gibbonDepartmentStaff.role='Assistant Coordinator') AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID2";
+            $sql = "SELECT surname, preferredName, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateEnrolled, gibbonCourseClassPerson.dateUnenrolled, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonYearGroupIDList FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonDepartment ON (gibbonCourse.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE (gibbonDepartmentStaff.role='Coordinator' OR gibbonDepartmentStaff.role='Assistant Coordinator') AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID2";
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
@@ -97,6 +97,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
                 $row->addLabel('role', __('Role'));
                 $row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
             
+            if (!empty($values['dateEnrolled'])) {
+                $row = $form->addRow();
+                    $row->addLabel('dateEnrolled', __('Date Enrolled'));
+                    $row->addTextField('dateEnrolled')->readonly()->setValue(Format::date($values['dateEnrolled']));
+            }
+                
+            if (!empty($values['dateUnenrolled']) && stripos($values['role'], 'Left') !== false) {
+                $row = $form->addRow();
+                    $row->addLabel('dateUnenrolled', __('Date Unenrolled'));
+                    $row->addTextField('dateUnenrolled')->readonly()->setValue(Format::date($values['dateUnenrolled']));
+            }
+
             $row = $form->addRow();
                 $row->addFooter();
                 $row->addSubmit();

--- a/modules/Timetable/studentEnrolment_manage_edit_editProcess.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_editProcess.php
@@ -39,7 +39,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonPersonID == ''
         } else {
             try {
                 $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID2' => $gibbonPersonID);
-                $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonYearGroupIDList, gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateStart, gibbonCourseClassPerson.dateEnd  FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonDepartment ON (gibbonCourse.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE (gibbonDepartmentStaff.role='Coordinator' OR gibbonDepartmentStaff.role='Assistant Coordinator') AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID2";
+                $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonYearGroupIDList, gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateEnrolled, gibbonCourseClassPerson.dateUnenrolled  FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonDepartment ON (gibbonCourse.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE (gibbonDepartmentStaff.role='Coordinator' OR gibbonDepartmentStaff.role='Assistant Coordinator') AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID2";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -61,11 +61,11 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonPersonID == ''
                     header("Location: {$URL}");
                 } else {
                     //Write to database
-                    $dateStart = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateStart'];
-                    $dateEnd = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
+                    $dateEnrolled = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateUnenrolled = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
-                        $data = array('role' => $role, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateStart' => $dateStart, 'dateEnd' => $dateEnd);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=:dateEnd WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
+                        $data = array('role' => $role, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnrolled' => $dateEnrolled, 'dateUnenrolled' => $dateUnenrolled);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=:dateUnenrolled WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable/studentEnrolment_manage_edit_editProcess.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_editProcess.php
@@ -61,8 +61,8 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonPersonID == ''
                     header("Location: {$URL}");
                 } else {
                     //Write to database
-                    $dateEnrolled = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
-                    $dateUnenrolled = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
+                    $dateEnrolled = $role != $values['role'] && stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
+                    $dateUnenrolled = $role != $values['role'] && stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
                         $data = array('role' => $role, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateEnrolled' => $dateEnrolled, 'dateUnenrolled' => $dateUnenrolled);
                         $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateEnrolled=:dateEnrolled, dateUnenrolled=:dateUnenrolled WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';

--- a/modules/Timetable/studentEnrolment_manage_edit_editProcess.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_editProcess.php
@@ -39,7 +39,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonPersonID == ''
         } else {
             try {
                 $data = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $_SESSION[$guid]['gibbonPersonID'], 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID2' => $gibbonPersonID);
-                $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonYearGroupIDList FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonDepartment ON (gibbonCourse.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE (gibbonDepartmentStaff.role='Coordinator' OR gibbonDepartmentStaff.role='Assistant Coordinator') AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID2";
+                $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonYearGroupIDList, gibbonCourseClassPerson.role, gibbonCourseClassPerson.dateStart, gibbonCourseClassPerson.dateEnd  FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonDepartment ON (gibbonCourse.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE (gibbonDepartmentStaff.role='Coordinator' OR gibbonDepartmentStaff.role='Assistant Coordinator') AND gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID2";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -53,6 +53,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonPersonID == ''
                 header("Location: {$URL}");
             } else {
                 //Validate Inputs
+                $values = $result->fetch();
                 $role = $_POST['role'];
 
                 if ($role == '') {
@@ -60,9 +61,11 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonPersonID == ''
                     header("Location: {$URL}");
                 } else {
                     //Write to database
+                    $dateStart = stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateStart'];
+                    $dateEnd = stripos($role, 'Left') !== false ? date('Y-m-d') : null;
                     try {
-                        $data = array('role' => $role, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
-                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
+                        $data = array('role' => $role, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID, 'dateStart' => $dateStart, 'dateEnd' => $dateEnd);
+                        $sql = 'UPDATE gibbonCourseClassPerson SET role=:role, dateStart=:dateStart, dateEnd=:dateEnd WHERE gibbonCourseClassID=:gibbonCourseClassID AND gibbonPersonID=:gibbonPersonID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -734,7 +734,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                                         // Ensure any class enrolments from the last year have an end date
                                         $data = ['gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $gibbonPersonID];
-                                        $sql = "UPDATE gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) JOIN gibbonSchoolYear ON (gibbonSchoolYear.gibbonSchoolYearID=gibbonCourse.gibbonSchoolYearID) SET gibbonCourseClassPerson.dateEnd=gibbonSchoolYear.lastDay WHERE gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID";
+                                        $sql = "UPDATE gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) JOIN gibbonSchoolYear ON (gibbonSchoolYear.gibbonSchoolYearID=gibbonCourse.gibbonSchoolYearID) SET gibbonCourseClassPerson.dateUnenrolled=gibbonSchoolYear.lastDay WHERE gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID";
                                         $pdo->update($sql, $data);
 
                                         try {

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -732,11 +732,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                     if ($enroled) {
                                         ++$success;
 
-                                        // Ensure any class enrolments from the last year have an end date
-                                        $data = ['gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $gibbonPersonID];
-                                        $sql = "UPDATE gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) JOIN gibbonSchoolYear ON (gibbonSchoolYear.gibbonSchoolYearID=gibbonCourse.gibbonSchoolYearID) SET gibbonCourseClassPerson.dateUnenrolled=gibbonSchoolYear.lastDay WHERE gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID";
-                                        $pdo->update($sql, $data);
-
                                         try {
                                             $dataFamily = array('gibbonPersonID' => $gibbonPersonID);
                                             $sqlFamily = 'SELECT gibbonFamilyID FROM gibbonFamilyChild WHERE gibbonPersonID=:gibbonPersonID';

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -732,6 +732,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                     if ($enroled) {
                                         ++$success;
 
+                                        // Ensure any class enrolments from the last year have an end date
+                                        $data = ['gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $gibbonPersonID];
+                                        $sql = "UPDATE gibbonCourseClassPerson JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) JOIN gibbonSchoolYear ON (gibbonSchoolYear.gibbonSchoolYearID=gibbonCourse.gibbonSchoolYearID) SET gibbonCourseClassPerson.dateEnd=gibbonSchoolYear.lastDay WHERE gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID";
+                                        $pdo->update($sql, $data);
+
                                         try {
                                             $dataFamily = array('gibbonPersonID' => $gibbonPersonID);
                                             $sqlFamily = 'SELECT gibbonFamilyID FROM gibbonFamilyChild WHERE gibbonPersonID=:gibbonPersonID';


### PR DESCRIPTION
This PR adds dateEnrolled and dateUnenrolled fields to the gibbonCourseClassEnrolment table. It updates these dates when enrolling as well as syncing or auto-enrolling. The dates 

**Motivation and Context**
We've discovered a few instances where it is helpful to know when a student joined or left a class, for the purpose of filtering relevant lessons and homework for that student.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="785" alt="Screenshot 2020-09-30 at 2 33 30 PM" src="https://user-images.githubusercontent.com/897700/94650791-f3936e00-0329-11eb-97c2-ac93af83a5fb.png">
