### PR TITLE
Format: nameLinked

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -72,6 +72,7 @@ v21.0.00
         System Admin: added a flag to import types to enable updating non-unique rows
         Timetable Admin: added a dateEnrolled and dateUnenrolled to class enrolments
         Testing: Changed install suite admin username and password to be compliant with the default password requirements
+	Format: added nameLinked formatter
 
     Bug Fixes
         System: fixed missing organization name on welcome page

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -784,7 +784,7 @@ class Format
                 return __('After End Date');
             }
             if (empty($person['yearGroup'])) {
-                return __('Not Enroled');
+                return __('Not Enrolled');
             }
         } else {
             if (!empty($person['staffType'])) {

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -596,14 +596,21 @@ class Format
      * @param bool $informal
      * @return string
      */
-    public static function nameLinked($gibbonPersonID, $title, $preferredName, $surname, $roleCategory = 'Other', $reverse = false, $informal = false)
+    public static function nameLinked($gibbonPersonID, $title, $preferredName, $surname, $roleCategory = 'Other', $params, $reverse = false, $informal = false)
     {
         $name = self::name($title, $preferredName, $surname, $roleCategory, $reverse, $informal);
         if ($roleCategory == 'Staff') {
             $url = static::$settings['absoluteURL'].'/index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$gibbonPersonID;
+            if (!empty($params)) {
+                $url .= '&'.http_build_query($params);
+            }
             $output = self::link($url, $name);
+            }
         } elseif ($roleCategory == 'Student') {
             $url = static::$settings['absoluteURL'].'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID;
+            if (!empty($params)) {
+                $url .= '&'.http_build_query($params);
+            }
             $output = self::link($url, $name);
         } else {
             $output = $name;

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -383,9 +383,9 @@ class Format
      * @param string $value
      * @return string
      */
-    public static function tag($value, $class, $title = '')
+    public static function tag($value, $class)
     {
-        return '<span class="tag '.$class.'" title="'.$title.'">'.$value.'</span>';
+        return '<span class="tag '.$class.'">'.$value.'</span>';
     }
 
     /**
@@ -584,7 +584,33 @@ class Format
 
         return trim($output, ' ');
     }
-
+    
+    /**
+     * Formats a linked name based on roleCategory
+     * @param string $gibbonPersonID
+     * @param string $title
+     * @param string $preferredName
+     * @param string $surname
+     * @param string $roleCategory
+     * @param bool $reverse
+     * @param bool $informal
+     * @return string
+     */
+    public static function nameLinked($gibbonPersonID, $title, $preferredName, $surname, $roleCategory = 'Other', $reverse = false, $informal = false)
+    {
+        $name = self::name($title, $preferredName, $surname, $roleCategory, $reverse, $informal);
+        if ($roleCategory == 'Staff') {
+            $url = '/index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$gibbonPersonID;
+            $output = self::link($url, $name);
+        } elseif ($roleCategory == 'Student') {
+            $url = '/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID;
+            $output = self::link($url, $name);
+        } else {
+            $output = $name;
+        }
+        return $output;
+    }
+    
     /**
      * Formats a list of names from an array containing standard title, preferredName & surname fields.
      *
@@ -752,7 +778,7 @@ class Format
                 return __('After End Date');
             }
             if (empty($person['yearGroup'])) {
-                return __('Not Enrolled');
+                return __('Not Enroled');
             }
         } else {
             if (!empty($person['staffType'])) {

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -596,7 +596,7 @@ class Format
      * @param bool $informal
      * @return string
      */
-    public static function nameLinked($gibbonPersonID, $title, $preferredName, $surname, $roleCategory = 'Other', $params, $reverse = false, $informal = false)
+    public static function nameLinked($gibbonPersonID, $title, $preferredName, $surname, $roleCategory = 'Other', $reverse = false, $informal = false, $params = [])
     {
         $name = self::name($title, $preferredName, $surname, $roleCategory, $reverse, $informal);
         if ($roleCategory == 'Staff') {

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -605,7 +605,6 @@ class Format
                 $url .= '&'.http_build_query($params);
             }
             $output = self::link($url, $name);
-            }
         } elseif ($roleCategory == 'Student') {
             $url = static::$settings['absoluteURL'].'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID;
             if (!empty($params)) {

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -383,9 +383,9 @@ class Format
      * @param string $value
      * @return string
      */
-    public static function tag($value, $class)
+    public static function tag($value, $class, $title = '')
     {
-        return '<span class="tag '.$class.'">'.$value.'</span>';
+        return '<span class="tag '.$class.'" title="'.$title.'">'.$value.'</span>';
     }
 
     /**

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -600,10 +600,10 @@ class Format
     {
         $name = self::name($title, $preferredName, $surname, $roleCategory, $reverse, $informal);
         if ($roleCategory == 'Staff') {
-            $url = '/index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$gibbonPersonID;
+            $url = static::$settings['absoluteURL'].'/index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$gibbonPersonID;
             $output = self::link($url, $name);
         } elseif ($roleCategory == 'Student') {
-            $url = '/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID;
+            $url = static::$settings['absoluteURL'].'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID;
             $output = self::link($url, $name);
         } else {
             $output = $name;


### PR DESCRIPTION
**Description**
This PR adds the formatter function for a linked profile

**Motivation and Context**
Discussed on slack with @SKuipers after encountering the need for a name to link to a profile. Current method of doing so involves nesting a format::name in a format::link with a few extra steps to define the URL etc, this automatically does it based off of the role type in one function.

**How Has This Been Tested?**
Locally, using the development helpdesk module as a playing ground

