### PR TITLE
Fix installer config rendering

### DIFF
--- a/installer/install.php
+++ b/installer/install.php
@@ -123,7 +123,7 @@ if ($step >= 1) {
 // Check config values for ' " \ / chars which will cause errors in config.php
 $pattern = '/[\'"\/\\\\]/';
 if (preg_match($pattern, $databaseServer) == true || preg_match($pattern, $databaseName) == true ||
-    preg_match($pattern, $databaseUsername) == true || preg_match($pattern, $databasePassword) == true) {
+    preg_match($pattern, $databaseUsername) == true) {
     $isConfigValid = false;
 }
 

--- a/installer/install.php
+++ b/installer/install.php
@@ -291,8 +291,9 @@ if ($canInstall == false) {
         echo '</div>';
     } else {
         //Set up config.php
+        include './installerFunctions.php';
         $configData = compact('databaseServer', 'databaseUsername', 'databasePassword', 'databaseName', 'guid');
-        $config = $page->fetchFromTemplate('installer/config.twig.html', $configData);
+        $config = $page->fetchFromTemplate('installer/config.twig.html', process_config_vars($configData));
 
         //Write config
         $fp = fopen('../config.php', 'wb');
@@ -310,8 +311,6 @@ if ($canInstall == false) {
                 echo __('../gibbon.sql does not exist, and so the installer cannot proceed.');
                 echo '</div>';
             } else {
-                include './installerFunctions.php';
-
                 $query = @fread(@fopen('../gibbon.sql', 'r'), @filesize('../gibbon.sql')) or die('Encountered a problem.');
                 $query = remove_remarks($query);
                 $query = split_sql_file($query, ';');

--- a/installer/installerFunctions.php
+++ b/installer/installerFunctions.php
@@ -172,3 +172,27 @@ function split_sql_file($sql, $delimiter)
 
     return $output;
 }
+
+
+/**
+ * Process config variables into string literals stored in string.
+ *
+ * @param array variables
+ *      An array of config variables to be passed into config
+ *      file template.
+ *
+ * @return array
+ *      The variables forced to be string type and properly quoted.
+ */
+function process_config_vars(array $variables): array {
+    $variables += [
+        'databaseServer' => '',
+        'databaseUsername' => '',
+        'databasePassword' => '',
+        'databaseName' => '',
+        'guid' => '',
+    ];
+    return array_map(function ($value) {
+        return var_export((string) $value, true); // force render into string literals
+    }, $variables);
+}

--- a/resources/templates/installer/config.twig.html
+++ b/resources/templates/installer/config.twig.html
@@ -28,15 +28,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * Sets the database connection information.
  * You can supply an optional $databasePort if your server requires one.
  */
-$databaseServer = '{{ databaseServer|raw }}';
-$databaseUsername = '{{ databaseUsername|raw }}';
-$databasePassword = '{{ databasePassword|raw }}';
-$databaseName = '{{ databaseName|raw }}';
+$databaseServer = {{ databaseServer|raw }};
+$databaseUsername = {{ databaseUsername|raw }};
+$databasePassword = {{ databasePassword|raw }};
+$databaseName = {{ databaseName|raw }};
 
 /**
  * Sets a globally unique id, to allow multiple installs on a single server.
  */
-$guid = '{{ guid|raw }}';
+$guid = {{ guid|raw }};
 
 /**
  * Sets system-wide caching factor, used to balance performance and freshness.

--- a/tests/unit/Installer/ProcessConfigVarsTest.php
+++ b/tests/unit/Installer/ProcessConfigVarsTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Gibbon\Tests\UnitTest\Installer;
+
+use PHPUnit\Framework\TestCase;
+use Gibbon\Services\CoreServiceProvider;
+
+require_once __DIR__ . '/../../../installer/installerFunctions.php';
+
+/**
+ * @covers process_config_vars function and config file template
+ */
+class ProcessConfigVarsTest extends TestCase {
+
+    private $PatternNoSyntaxError = '/^No syntax errors detected in /';
+
+    /**
+     * @inherit
+     */
+    public function setUp() {
+        $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/../../../resources/templates');
+        $this->templateEngine = new \Twig\Environment($loader);
+    }
+
+    /**
+     * Mocking render a very raw PHP with all the variables in
+     * a given array with key as variable name.
+     *
+     * @return string
+     *     Full path to the temporary mock php file rendered.
+     */
+    private function mockPhpRender(array $variables): string {
+        $filename = @tempnam(sys_get_temp_dir(), 'ProcessConfigVarsTestMockPhp') . '.config.php';
+        $fh = fopen($filename, 'w');
+        fwrite($fh, "<?php\n");
+        foreach ($variables as $key => $value) {
+            fwrite($fh, "\${$key} = {$value};\n");
+        }
+        fclose($fh);
+        return $filename;
+    }
+
+    /**
+     * Mocking render given variables with the production config template.
+     *
+     * @return string
+     *     Full path to the temporary mock config file rendered.
+     */
+    private function mockTemplateRender(array $variables): string {
+        $filename = @tempnam(sys_get_temp_dir(), 'ProcessConfigVarsTestMockTemplate') . '.config.php';
+        $fh = fopen($filename, 'w');
+        fwrite($fh, $this->templateEngine->render('installer/config.twig.html', $variables));
+        fclose($fh);
+        return $filename;
+    }
+
+    /**
+     * Include a given PHP file in a function scope and return the variables
+     * value of the supplied keys.
+     *
+     * @return array
+     *     An array of variables of the supplied keys as variable names.
+     */
+    private function extractVariablesFrom(string $filename, array $keys) {
+        return (function ($filename, $keys) {
+            include $filename;
+            return compact(...$keys);
+        })($filename, $keys);
+    }
+
+    /**
+     * @covers config_file_template($configData)
+     */
+    public function testBasicCall()
+    {
+        $inputConfig = [
+            'databaseServer' => 'myDatabaseServer',
+            'databaseUsername' => 'myDatabaseUsername',
+            'databasePassword' => 'myDatabasePassword',
+            'databaseName' => 'myDatabaseName',
+            'guid' => 'myGuid',
+        ];
+
+        // check the syntax with mock config rendering function
+        // to see if all variables are valid to print raw
+        $filename = $this->mockPhpRender(process_config_vars($inputConfig));
+        $this->assertFileExists($filename, 'The temporary generated test target not found.');
+        $result = exec('php -l ' . $filename);
+        $this->assertTrue(
+            preg_match($this->PatternNoSyntaxError, $result) !== false,
+            'The generated config contains syntax error(s)'
+        );
+        unlink($filename);
+
+        // check the syntax of the render result of the would-be config file
+        // with the template file and given config data ($inputConfig)
+        $filename = $this->mockTemplateRender(process_config_vars($inputConfig));
+        $this->assertFileExists($filename, 'The temporary generated test target not found.');
+        $result = exec('php -l ' . $filename);
+        $this->assertTrue(
+            preg_match($this->PatternNoSyntaxError, $result) !== false,
+            'The generated config contains syntax error(s)'
+        );
+        $resultConfig = $this->extractVariablesFrom($filename,
+            ['databaseServer', 'databaseUsername', 'databasePassword', 'databaseName', 'guid']);
+        $this->assertEquals($inputConfig, $resultConfig, 'Unexpected set of result config variables');
+        unlink($filename);
+    }
+
+    /**
+     * @covers config_file_template($configData)
+     */
+    public function testEmptyArrayCall()
+    {
+        $inputConfig = [];
+
+        // check the syntax with mock config rendering function
+        // to see if all variables are valid to print raw
+        $filename = $this->mockPhpRender(process_config_vars($inputConfig));
+        $this->assertFileExists($filename, 'The temporary generated test target not found.');
+        $result = exec('php -l ' . $filename);
+        $this->assertTrue(
+            preg_match($this->PatternNoSyntaxError, $result) !== false,
+            'The generated config contains syntax error(s)'
+        );
+        unlink($filename);
+
+        // check the syntax of the render result of the would-be config file
+        // with the template file and given config data ($inputConfig)
+        $filename = $this->mockTemplateRender(process_config_vars($inputConfig));
+        $this->assertFileExists($filename, 'The temporary generated test target not found.');
+        $result = exec('php -l ' . $filename);
+        $this->assertTrue(
+            preg_match($this->PatternNoSyntaxError, $result) !== false,
+            'The generated config contains syntax error(s)'
+        );
+        $resultConfig = $this->extractVariablesFrom($filename,
+            ['databaseServer', 'databaseUsername', 'databasePassword', 'databaseName', 'guid']);
+        $this->assertEquals(
+            [
+                'databaseServer' => '',
+                'databaseUsername' => '',
+                'databasePassword' => '',
+                'databaseName' => '',
+                'guid' => '',
+            ],
+            $resultConfig,
+            'Unexpected set of result config variables'
+        );
+        unlink($filename);
+    }
+
+    /**
+     * @covers config_file_template($configData)
+     */
+    public function testDangerousDataCall()
+    {
+        $dangerousStr = 'everything dangerous: \\/"\'';
+        $inputConfig = [
+            'databasePassword' => $dangerousStr,
+            'databaseServer' => $dangerousStr,
+            'databaseUsername' => $dangerousStr,
+            'databasePassword' => $dangerousStr,
+            'databaseName' => $dangerousStr,
+            'guid' => $dangerousStr,
+        ];
+
+        // check the syntax with mock config rendering function
+        // to see if all variables are valid to print raw
+        $filename = $this->mockPhpRender(process_config_vars($inputConfig));
+        $this->assertFileExists($filename, 'The temporary generated test target not found.');
+        $result = exec('php -l ' . $filename);
+        $this->assertTrue(
+            preg_match($this->PatternNoSyntaxError, $result) !== false,
+            'The generated config contains syntax error(s)'
+        );
+        unlink($filename);
+
+        // check the syntax of the render result of the would-be config file
+        // with the template file and given config data ($inputConfig)
+        $filename = $this->mockTemplateRender(process_config_vars($inputConfig));
+        $this->assertFileExists($filename, 'The temporary generated test target not found.');
+        $result = exec('php -l ' . $filename);
+        $this->assertTrue(
+            preg_match($this->PatternNoSyntaxError, $result) !== false,
+            'The generated config contains syntax error(s)'
+        );
+        $resultConfig = $this->extractVariablesFrom($filename,
+            ['databaseServer', 'databaseUsername', 'databasePassword', 'databaseName', 'guid']);
+        $this->assertEquals($inputConfig, $resultConfig, 'Unexpected set of result config variables');
+        unlink($filename);
+    }
+}
+


### PR DESCRIPTION
**Description**
1. Properly sanatize the config variables before printing them in config file.
2. Remove the "bad character" check for the database password (for it is no longer needed).
3. Resolve #1040.

**Motivation and Context**
The config file is rendered from [config.twig.html](https://github.com/GibbonEdu/core/blob/3f27cf3e5ee857a2d4936a3210671b2d7b860c9f/resources/templates/installer/config.twig.html), which would manually wrap the variable with single quote `'` to make them string literals. This is approach is susceptible to injection attack. So the installer has some [bad-character check inplace](https://github.com/GibbonEdu/core/blob/3f27cf3e5ee857a2d4936a3210671b2d7b860c9f/installer/install.php#L123-L128) to mitigate the issue.

While this would work in many cases, this also create some strange limitation to the installation. For example, those "bad character" are actually valid character for a database password (hence #1040).

**How Has This Been Tested?**
It has been tested both locally and in Travis CI. Unit tests are also written for function `config_file_template()` to test:
1. Basic normal configuration.
2. If any of the variables are missing from the array by mistake.
3. Bad characters in all the config values.