### PR TITLE
travis: phpunit always use color

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
             "cd tests && codecept run acceptance --debug --env $CI_PLATFORM"
         ],
         "test:phpunit": [
-            "cd tests && ../vendor/bin/phpunit --verbose --configuration phpunit.xml"
+            "cd tests && ../vendor/bin/phpunit --verbose --colors=always --configuration phpunit.xml"
         ],
         "test:codesniffer": [
           "vendor/bin/phpcs --standard=PSR2 modules/Library/" 


### PR DESCRIPTION
**Description**
Add `--colors=always` flag to phpunit call in Travis. See [Documentations](https://phpunit.readthedocs.io/en/9.3/textui.html).

**Motivation and Context**
This is purely for better development experience.

**How Has This Been Tested?**
On Travis.