### PR TITLE
School Admin: add intro text setting to Medical Conditions section

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -705,4 +705,5 @@ ALTER TABLE `gibbonRubricColumn` ADD `backgroundColor` VARCHAR(7) NULL DEFAULT N
 ALTER TABLE `gibbonRubricRow` ADD `backgroundColor` VARCHAR(7) NULL DEFAULT NULL AFTER `title`;end
 INSERT INTO `gibboni18n` (`code`, `name`, `version`, `active`, `installed`, `systemDefault`, `dateFormat`, `dateFormatRegEx`, `dateFormatPHP`, `rtl`) VALUES ('af_ZN', 'Afrikaans - Suid-Afrika', '21.0.00', 'Y', 'Y', 'N', 'dd/mm/yyyy', '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i', 'd/m/Y', 'N');end
 UPDATE gibboni18n SET code='af_ZA' WHERE code='af_ZN';end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('Students', 'medicalConditionIntro', 'Medical Condition Introductory Text', 'HTML text that will appear above the medical conditions section.', '');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -69,6 +69,7 @@ v21.0.00
         Reports: added a bulk delete action in the Edit Reporting Scopes page
         Rubrics: added an option to colour rubric column and row headings
         School Admin: added Manage Medical Conditions action
+        School Admin: added optional introductory text setting for the Medical Conditions section
         Students: updated application acceptance message to reflect automatically created medical record
         Students: added uniqueness checks for Student ID field
         Students: send notifications for student notes to the Head of Year, if available

--- a/modules/Data Updater/data_medical.php
+++ b/modules/Data Updater/data_medical.php
@@ -312,6 +312,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 
 						$form->toggleVisibilityByClass('addConditionRow')->onCheckbox('addCondition')->when('Yes');
 
+                        if ($medicalConditionIntro = getSettingByScope($connection2, 'Students', 'medicalConditionIntro')) {
+                            $row = $form->addRow();
+                                $row->addContent($medicalConditionIntro);
+                        }
+
 						$row = $form->addRow();
 							$row->addCheckbox('addCondition')->setValue('Yes')->description(__('Check the box to add a new medical condition'));
 

--- a/modules/School Admin/medicalConditions_manage.php
+++ b/modules/School Admin/medicalConditions_manage.php
@@ -17,8 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Tables\DataTable;
+use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
 use Gibbon\Domain\Students\MedicalConditionGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalConditions_manage.php') == false) {
@@ -33,6 +34,21 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalCondit
     if (isset($_GET['return'])) {
         returnProcess($guid, $_GET['return'], null, null);
     }
+
+    $form = Form::create('medicalSettings', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/medicalConditions_manageProcess.php' );
+
+    $form->addHiddenValue('address', $_SESSION[$guid]['address']);
+
+    $setting = getSettingByScope($connection2, 'Students', 'medicalConditionIntro', true);
+    $col = $form->addRow()->addColumn();
+        $col->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $col->addEditor($setting['name'], $guid)->setRows(6)->setValue($setting['value']);
+
+    $row = $form->addRow();
+		$row->addFooter();
+		$row->addSubmit();
+
+	echo $form->getOutput();
 
     $medicalConditionGateway = $container->get(MedicalConditionGateway::class);
 

--- a/modules/School Admin/medicalConditions_manageProcess.php
+++ b/modules/School Admin/medicalConditions_manageProcess.php
@@ -1,0 +1,53 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\System\SettingGateway;
+
+include '../../gibbon.php';
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/medicalConditions_manage.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalConditions_manage.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    // Proceed!
+    $partialFail = false;
+
+    $settingGateway = $container->get(SettingGateway::class);
+    $settingsToUpdate = [
+        'Students' => [
+            'medicalConditionIntro',
+        ]
+    ];
+
+    foreach ($settingsToUpdate as $scope => $settings) {
+        foreach ($settings as $name) {
+            $value = $_POST[$name] ?? '';
+
+            $updated = $settingGateway->updateSettingByScope($scope, $name, $value);
+            $partialFail &= !$updated;
+        }
+    }
+
+    $URL .= $partialFail
+        ? '&return=error2'
+        : '&return=success0';
+    header("Location: {$URL}");
+}

--- a/modules/Students/medicalForm_manage_edit.php
+++ b/modules/Students/medicalForm_manage_edit.php
@@ -105,13 +105,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
             echo $form->getOutput();
 
-            echo '<h2>';
-            echo __('Medical Conditions');
-            echo '</h2>';
-
             $conditions = $medicalGateway->selectMedicalConditionsByID($gibbonPersonMedicalID);
 
             $table = DataTable::create('medicalConditions');
+            $table->setTitle(__('Medical Conditions'));
+            $table->setDescription(getSettingByScope($connection2, 'Students', 'medicalConditionIntro'));
 
             $table->addHeaderAction('add', __('Add'))
                 ->setURL('/modules/Students/medicalForm_manage_condition_add.php')


### PR DESCRIPTION
This PR adds the option to display text before the medical conditions section in the data updater and medical forms. This text can be used by schools to inform users about how to use this section, as well as display specific information that parents may need to know about medical conditions in general. Currently, with the Add Condition option being a single checkbox, it can be easy for parents to not notice it is there. This text can help draw attention to this section. 

**Description**
- Adds "Medical Condition Introductory Text" setting to the top of the Manage Medical Conditions page
- Displays intro text above the Add Condition option on the Data Updater > Update Medical Data page
- Displays intro text above the Medical Conditions section in Students > Edit Medical Form

**How Has This Been Tested?**
Locally.

**Screenshots**
School Admin:
<img width="793" alt="Screenshot 2020-10-15 at 10 08 21 AM" src="https://user-images.githubusercontent.com/897700/96068474-b6ed7800-0ece-11eb-9645-2741eb639a39.png">

Data Updater:
<img width="783" alt="Screenshot 2020-10-15 at 10 08 42 AM" src="https://user-images.githubusercontent.com/897700/96068484-bc4ac280-0ece-11eb-8a95-81c4c1502fd1.png">

