### PR TITLE
Installer: fix gibbon.php include path

### DIFF
--- a/gibbon.php
+++ b/gibbon.php
@@ -76,7 +76,7 @@ if ($gibbon->isInstalled() == true) {
         // We need to handle failed database connections after install. Display an error if no connection 
         // can be established. Needs a specific error page once header/footer is split out of index.
         if (!$gibbon->isInstalling()) {
-            include('./error.php');
+            include(__DIR__ . '/error.php');
             exit;
         }
     }


### PR DESCRIPTION
**Description**
In gibbon.php, use `__DIR__` to resolve the absolute path to the `error.php` instead of relative path.

**Motivation and Context**
When gibbon.php is included from installer.php, the statement "include './error.php'" would be resolved incorrectly and hence unable to include and display the error message.

**How Has This Been Tested?**
Locally