### PR TITLE
Installer: extract inline-javascript as much as possible

### DIFF
--- a/installer/assets/installer.js
+++ b/installer/assets/installer.js
@@ -1,0 +1,54 @@
+(function () {
+    $(document).ready(function() {
+
+        // If an element with id "status" is found, do the version check
+        // Supposed to only have one "#status" in the page, so this is only run once.
+        $("#status").first().each(function () {
+            var $status = $(this);
+            var $edgeIndicator = $('#cuttingEdgeCode');
+            var $edgeHiddenInput = $("input[name=cuttingEdgeCodeHidden]");
+
+            // environment check
+            var gibboninstallerError = false;
+            if (typeof gibboninstaller === 'undefined') {
+                console.error('Unable to find gibboninstaller in global variables');
+                gibboninstallerError = true;
+            } else if (typeof gibboninstaller.version === 'undefined') {
+                console.error('No gibbon version is specified in the environment');
+                gibboninstallerError = true;
+            } else if (typeof gibboninstaller.msg === 'undefined') {
+                console.error('Translation function gibboninstaller.msg() does not exits.');
+                gibboninstallerError = true;
+            }
+            if (gibboninstallerError) {
+                $status.attr("class", "error");
+                $status.html("Cutting Edge Code check: Unexpected javascript error.");
+                return;
+            }
+
+            // cutting edge code check
+            $.ajax({
+                crossDomain: true,
+                type:"GET",
+                url: "https://gibbonedu.org/services/version/devCheck.php?version=" + gibboninstaller.version + "&callback=?",
+                dataType: "jsonp",
+                jsonpCallback: 'fnsuccesscallback',
+                jsonpResult: 'jsonpResult',
+                success: function(data) {
+                    $status.attr("class", "success");
+                    if (data['status'] === 'false') {
+                        $status.html(gibboninstaller.msg('__edge_code_check_success__')) ;
+                    } else {
+                        $status.html(gibboninstaller.msg('__edge_code_check_success__')) ;
+                        $edgeIndicator.val('Yes');
+                        $edgeHiddenInput.val('Y');
+                    }
+                },
+                error: function(data, textStatus, errorThrown) {
+                    $status.attr("class", "error");
+                    $status.html(gibboninstaller.msg('__edge_code_check_failed__')) ;
+                }
+            });
+        });
+    });
+})();

--- a/installer/install.php
+++ b/installer/install.php
@@ -484,6 +484,25 @@ if ($canInstall == false) {
                         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
                         $row->addSelect($setting['name'])->fromArray($installTypes)->selected('Testing')->required();
 
+                    // Expose version information and translation strings to installer.js functions
+                    // for check and set cutting edge code based on gibbonedu.org services value
+                    $js_version = json_encode($version);
+                    $js_i18n = json_encode([
+                        '__edge_code_check_success__' => __('Cutting Edge Code check successful.'),
+                        '__edge_code_check_failed__' => __('Cutting Edge Code check failed'),
+                    ]);
+                    echo <<<HTML
+<script type="text/javascript">
+window.gibboninstaller = {
+    version: $js_version,
+    i18n: $js_i18n,
+    msg: function (msg) {
+        return this.i18n[msg] || msg;
+    },
+};
+</script>
+HTML;
+
                     $statusInitial = "<div id='status' class='warning'><div style='width: 100%; text-align: center'><img style='margin: 10px 0 5px 0' src='../themes/Default/img/loading.gif' alt='Loading'/><br/>".__('Checking for Cutting Edge Code.')."</div></div>";
                     $row = $form->addRow();
                         $row->addContent($statusInitial);
@@ -491,32 +510,6 @@ if ($canInstall == false) {
                     $row = $form->addRow();
                         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
                         $row->addTextField($setting['name'])->setValue('No')->readonly();
-
-                    //Check and set cutting edge code based on gibbonedu.org services value
-                    echo '<script type="text/javascript">';
-                    echo '$(document).ready(function(){';
-                    echo '$.ajax({';
-                    echo 'crossDomain: true, type:"GET", contentType: "application/json; charset=utf-8",async:false,';
-                    echo 'url: "https://gibbonedu.org/services/version/devCheck.php?version='.$version.'&callback=?",';
-                    echo "data: \"\",dataType: \"jsonp\", jsonpCallback: 'fnsuccesscallback',jsonpResult: 'jsonpResult',";
-                    echo 'success: function(data) {';
-                    echo '$("#status").attr("class","success");';
-                    echo "if (data['status']==='false') {";
-                    echo "$(\"#status\").html('".__('Cutting Edge Code check successful.')."') ;";
-                    echo '}';
-                    echo 'else {';
-                    echo "$(\"#status\").html('".__('Cutting Edge Code check successful.')."') ;";
-                    echo "$(\"#cuttingEdgeCode\").val('Yes');";
-                    echo "$(\"input[name=cuttingEdgeCodeHidden]\").val('Y');";
-                    echo '}';
-                    echo '},';
-                    echo 'error: function (data, textStatus, errorThrown) {';
-                    echo '$("#status").attr("class","error");';
-                    echo "$(\"#status\").html('".__('Cutting Edge Code check failed').".') ;";
-                    echo '}';
-                    echo '});';
-                    echo '});';
-                    echo '</script>';
 
                     $setting = getSettingByScope($connection2, 'System', 'statsCollection', true);
                     $row = $form->addRow();

--- a/resources/templates/installer/install.twig.html
+++ b/resources/templates/installer/install.twig.html
@@ -19,6 +19,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     <script type="text/javascript" src="../lib/jquery/jquery.js"></script>
     <script type="text/javascript" src="../lib/jquery/jquery-migrate.min.js"></script>
     <script type='text/javascript' src='../resources/assets/js/core.js'></script>
+    <script type="text/javascript" src="./assets/installer.js"></script>
 {% endblock head %}
 
 {% block sidebar %}


### PR DESCRIPTION
**Description**

* Separate the code that expose environment data to javascript for the javascript that uses the data.
* Extract majority of `install.php` javascript into `installer.js` for easier development and debug. Leave only the variable exposing part for inline.

**Motivation and Context**
* Make the installer easier to read and maintain.
* A step to gradually improve the installer.

**How Has This Been Tested?**
Tested locally as well as with Travis.