### PR TITLE
V21 breadcrumb fix

### DIFF
--- a/src/Domain/System/Module.php
+++ b/src/Domain/System/Module.php
@@ -32,6 +32,7 @@ class Module
     protected $gibbonModuleID;
     protected $name;
     protected $version;
+    protected $type;
     protected $entryURL;
 
     protected $stylesheets;


### PR DESCRIPTION
**Description**
missing "type" attribute in Module class

**Motivation and Context**
In addition to the commit (https://github.com/GibbonEdu/core/commit/82aa1e9870e54e31d5ad8fdf935ee15be08c6cf4)

**How Has This Been Tested?**
Local and Travis
