### PR TITLE
Timetable Admin: hide non-reportable teachers from teacher lists

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -79,6 +79,7 @@ v21.0.00
         System Admin: adjusted View Log to show only current year's log entries
         System Admin: added a flag to import types to enable updating non-unique rows
         Timetable Admin: added a dateEnrolled and dateUnenrolled to class enrolments
+        Timetable Admin: hide teachers listed as non-reportable from teacher lists
         Testing: Changed install suite admin username and password to be compliant with the default password requirements
         User Admin: added Guardian and Grandmother/Grandfather to emergency relationships
 

--- a/modules/Formal Assessment/internalAssessment_manage.php
+++ b/modules/Formal Assessment/internalAssessment_manage.php
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
             $teaching = false;
             try {
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
-                $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName FROM gibbonCourseClassPerson JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
+                $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, gibbonCourseClassPerson.reportable FROM gibbonCourseClassPerson JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -101,6 +101,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 echo '</h3>';
                 echo '<ul>';
                 while ($row = $result->fetch()) {
+                    if ($row['reportable'] != 'Y') continue;
+
                     echo '<li>'.Format::name($row['title'], $row['preferredName'], $row['surname'], 'Staff').'</li>';
                     if ($row['gibbonPersonID'] == $gibbon->session->get('gibbonPersonID')) {
                         $teaching = true;

--- a/modules/Formal Assessment/internalAssessment_write.php
+++ b/modules/Formal Assessment/internalAssessment_write.php
@@ -103,7 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $teaching = false;
                 try {
                     $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
-                    $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName FROM gibbonCourseClassPerson JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
+                    $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, gibbonCourseClassPerson.reportable FROM gibbonCourseClassPerson JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
@@ -116,6 +116,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     echo '</h3>';
                     echo '<ul>';
                     while ($row = $result->fetch()) {
+                        if ($row['reportable'] != 'Y') continue;
+
                         echo '<li>'.Format::name($row['title'], $row['preferredName'], $row['surname'], 'Staff').'</li>';
                         if ($row['gibbonPersonID'] == $_SESSION[$guid]['gibbonPersonID']) {
                             $teaching = true;

--- a/modules/Markbook/moduleFunctions.php
+++ b/modules/Markbook/moduleFunctions.php
@@ -211,7 +211,7 @@ function getClass( $pdo, $gibbonPersonID, $gibbonCourseClassID, $highestAction )
 function getTeacherList( $pdo, $gibbonCourseClassID ) {
     try {
         $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
-        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName FROM gibbonCourseClassPerson JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, gibbonCourseClassPerson.reportable FROM gibbonCourseClassPerson JOIN gibbonPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
         $result = $pdo->executeQuery($data, $sql);
 
     } catch (PDOException $e) {
@@ -221,6 +221,8 @@ function getTeacherList( $pdo, $gibbonCourseClassID ) {
     $teacherList = array();
     if ($result->rowCount() > 0) {
         foreach ($result->fetchAll() as $teacher) {
+            if ($teacher['reportable'] != 'Y') continue;
+
             $teacherList[ $teacher['gibbonPersonID'] ] = Format::name($teacher['title'], $teacher['preferredName'], $teacher['surname'], 'Staff', false, false);
         }
     }

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -2171,7 +2171,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                                             try {
                                                 $dataTeachers = array('gibbonCourseClassID' => $rowList['gibbonCourseClassID']);
-                                                $sqlTeachers = "SELECT title, surname, preferredName FROM gibbonPerson JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
+                                                $sqlTeachers = "SELECT title, surname, preferredName, gibbonCourseClassPerson.reportable FROM gibbonPerson JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
                                                 $resultTeachers = $connection2->prepare($sqlTeachers);
                                                 $resultTeachers->execute($dataTeachers);
                                             } catch (PDOException $e) {
@@ -2180,6 +2180,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                                             $teachers = '<p><b>'.__('Taught by:').'</b> ';
                                             while ($rowTeachers = $resultTeachers->fetch()) {
+                                                if ($rowTeachers['reportable'] != 'Y') continue;
                                                 $teachers = $teachers.Format::name($rowTeachers['title'], $rowTeachers['preferredName'], $rowTeachers['surname'], 'Staff', false, false).', ';
                                             }
                                             $teachers = substr($teachers, 0, -2);

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 				$row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
 			
 			$row = $form->addRow();
-				$row->addLabel('reportable', __('Reportable'));
+				$row->addLabel('reportable', __('Reportable'))->description(__("Student set to non-reportable won't display in reports. Teachers set to non-reportable won't display in lists of class teachers."));
                 $row->addYesNo('reportable')->required()->selected($values['reportable']);
                 
             if (!empty($values['dateEnrolled'])) {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 				$row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
 			
 			$row = $form->addRow();
-				$row->addLabel('reportable', __('Reportable'))->description(__("Student set to non-reportable won't display in reports. Teachers set to non-reportable won't display in lists of class teachers."));
+				$row->addLabel('reportable', __('Reportable'))->description(__("Students set to non-reportable won't display in reports. Teachers set to non-reportable won't display in lists of class teachers."));
                 $row->addYesNo('reportable')->required()->selected($values['reportable']);
                 
             if (!empty($values['dateEnrolled'])) {

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 				$row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
 			
 			$row = $form->addRow();
-				$row->addLabel('reportable', __('Reportable'))->description(__("Student set to non-reportable won't display in reports. Teachers set to non-reportable won't display in lists of class teachers."));
+				$row->addLabel('reportable', __('Reportable'))->description(__("Students set to non-reportable won't display in reports. Teachers set to non-reportable won't display in lists of class teachers."));
 				$row->addYesNo('reportable')->required()->selected($values['reportable']);
 
             if (!empty($values['dateEnrolled'])) {

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 				$row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
 			
 			$row = $form->addRow();
-				$row->addLabel('reportable', __('Reportable'));
+				$row->addLabel('reportable', __('Reportable'))->description(__("Student set to non-reportable won't display in reports. Teachers set to non-reportable won't display in lists of class teachers."));
 				$row->addYesNo('reportable')->required()->selected($values['reportable']);
 
             if (!empty($values['dateEnrolled'])) {


### PR DESCRIPTION
Updates the gibbonCourseClassPerson reportable flag to optionally apply to teachers, to be able to hide them from places where class teachers are listed.

**Motivation and Context**
There are cases where teachers need to be added to a course, so they can help manage it or take attendance, but do not need to show up in the list of teachers for that course.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="779" alt="Screenshot 2020-11-04 at 9 10 53 AM" src="https://user-images.githubusercontent.com/897700/98057649-b9b00d00-1e7d-11eb-8c3a-fa0987cdd949.png">
