### PR TITLE
School Admin: add optional descriptions for medical conditions

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -710,4 +710,5 @@ INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, 
 INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Students' AND gibbonAction.name='My Student History'));end
 INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('002', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Students' AND gibbonAction.name='My Student History'));end
 DROP TABLE `gibbonPersonMedicalSymptoms`;end
+ALTER TABLE `gibbonMedicalCondition` ADD `description` TEXT NULL DEFAULT NULL AFTER `name`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -83,6 +83,7 @@ v21.0.00
         Students: send notifications for student notes to the Head of Year, if available
         Students: adjusted the font size to scale down for names on Student ID cards
         Students: removed Student ID from View Student Profile_brief
+        School Admin: added optional descriptions for medical conditions
         System Admin: adjusted View Log to show only current year's log entries
         System Admin: added a flag to import types to enable updating non-unique rows
         Timetable Admin: added a dateEnrolled and dateUnenrolled to class enrolments

--- a/modules/School Admin/medicalConditions_manage.php
+++ b/modules/School Admin/medicalConditions_manage.php
@@ -67,6 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalCondit
         ->displayLabel();
 
     $table->addColumn('name', __('Name'));
+    $table->addColumn('description', __('Description'))->format(Format::using('truncate', 'description'));
 
     // ACTIONS
     $table->addActionColumn()

--- a/modules/School Admin/medicalConditions_manage_add.php
+++ b/modules/School Admin/medicalConditions_manage_add.php
@@ -46,6 +46,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalCondit
         $row->addTextField('name')->maxlength(80)->required();
 
     $row = $form->addRow();
+        $row->addLabel('description', __('Description'))->description(__('Medical condition descriptions are displayed next to the condition and can offer additional background information.'));
+        $row->addTextArea('description');
+
+    $row = $form->addRow();
         $row->addFooter();
         $row->addSubmit();
 

--- a/modules/School Admin/medicalConditions_manage_addProcess.php
+++ b/modules/School Admin/medicalConditions_manage_addProcess.php
@@ -32,7 +32,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalCondit
     $medicalConditionGateway = $container->get(MedicalConditionGateway::class);
 
     $data = [
-        'name'       => $_POST['name'] ?? '',
+        'name'        => $_POST['name'] ?? '',
+        'description' => $_POST['description'] ?? '',
     ];
 
     // Validate the required values are present

--- a/modules/School Admin/medicalConditions_manage_edit.php
+++ b/modules/School Admin/medicalConditions_manage_edit.php
@@ -58,6 +58,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalCondit
         $row->addTextField('name')->required()->maxlength(80);
 
     $row = $form->addRow();
+        $row->addLabel('description', __('Description'))->description(__('Medical condition descriptions are displayed next to the condition and can offer additional background information.'));
+        $row->addTextArea('description');
+
+    $row = $form->addRow();
         $row->addFooter();
         $row->addSubmit();
 

--- a/modules/School Admin/medicalConditions_manage_editProcess.php
+++ b/modules/School Admin/medicalConditions_manage_editProcess.php
@@ -34,7 +34,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/medicalCondit
     $medicalConditionGateway = $container->get(MedicalConditionGateway::class);
 
     $data = [
-        'name'         => $_POST['name'] ?? ''
+        'name'        => $_POST['name'] ?? '',
+        'description' => $_POST['description'] ?? '',
     ];
 
     // Validate the required values are present

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1714,7 +1714,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             //Get medical conditions
                             try {
                                 $dataCondition = array('gibbonPersonMedicalID' => $rowMedical['gibbonPersonMedicalID']);
-                                $sqlCondition = 'SELECT * FROM gibbonPersonMedicalCondition WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID ORDER BY name';
+                                $sqlCondition = 'SELECT gibbonPersonMedicalCondition.*, gibbonMedicalCondition.description FROM gibbonPersonMedicalCondition LEFT JOIN gibbonMedicalCondition ON (gibbonMedicalCondition.name=gibbonPersonMedicalCondition.name) WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID ORDER BY name';
                                 $resultCondition = $connection2->prepare($sqlCondition);
                                 $resultCondition->execute($dataCondition);
                             } catch (PDOException $e) {
@@ -1775,6 +1775,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     echo __($rowCondition['name'])." <span style='color: #".$alert['color']."'>(".__($alert['name']).' '.__('Risk').')</span>';
                                 }
                                 echo '</h4>';
+                                if (!empty($rowCondition['description'])) {
+                                    echo '<p class="text-xs text-gray-700">';
+                                    echo $rowCondition['description'];
+                                    echo '</p>';
+                                }
 
                                 echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
                                 echo '<tr>';

--- a/src/Domain/Students/MedicalConditionGateway.php
+++ b/src/Domain/Students/MedicalConditionGateway.php
@@ -46,7 +46,7 @@ class MedicalConditionGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonMedicalConditionID', 'name'
+                'gibbonMedicalConditionID', 'name', 'description'
             ]);
 
         return $this->runQuery($query, $criteria);


### PR DESCRIPTION
v21 adds the option to edit the list of Medical Conditions available in the medical section. This adds an optional description field for these conditions, which helps schools define any additional information for specific conditions.

**Motivation and Context**
Some medical conditions aren't self-explanatory, such as G6PD deficiency, so additional information can be useful. On a school-by-school basis, this could be used for specific information, for example allergies could list the location of epipens in the school in the description.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
<img width="808" alt="Screenshot 2020-11-13 at 9 09 01 AM" src="https://user-images.githubusercontent.com/897700/99015580-4cdcf700-2590-11eb-9f6f-69b54b26bd1f.png">
