### PR TITLE
System: improve the error page when the database connection fails

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ v21.0.00
         System: added text labels to Print and Export options in ReportTable
         System: prevented theme names with spaces from breaking background image
         System: removed the unused gibbonPersonMedicalSymptoms table
+        System: improved the error page when the database connection fails
         Attendance: added an Offsite - Late option for attendance codes
         Departments: improved course/class naming in Class view
         Data Updater: data updates with no changes will be automatically accepted

--- a/gibbon.php
+++ b/gibbon.php
@@ -17,6 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\View\Page;
+use Gibbon\View\View;
+
 // Setup the composer autoloader
 $autoloader = require_once __DIR__.'/vendor/autoload.php';
 
@@ -76,7 +79,13 @@ if ($gibbon->isInstalled() == true) {
         // We need to handle failed database connections after install. Display an error if no connection 
         // can be established. Needs a specific error page once header/footer is split out of index.
         if (!$gibbon->isInstalling()) {
-            include(__DIR__ . '/error.php');
+            $page = $container->get(Page::class)->setDefaults(__DIR__);
+            $page->writeFromTemplate('error.twig.html', [
+                'error' => sprintf(__('A database connection could not be established. Please %1$stry again%2$s.'), '', ''),
+                'message' => ' ',
+            ]);
+            
+            echo $page->render('index.twig.html');
             exit;
         }
     }

--- a/resources/templates/error.twig.html
+++ b/resources/templates/error.twig.html
@@ -9,7 +9,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     {{ __('Oh no!') }}
 </h1>
 <p>
-    {{ __('Something has gone wrong: the Gibbons have escaped!') }}<br/>
+    {{ error ? error : __('Something has gone wrong: the Gibbons have escaped!') }}<br/>
     <br/>
-    {{ __('An error has occurred. This could mean a number of different things, but generally indicates that you have a misspelt address, or are trying to access a page that you are not permitted to access.') }} {{ __('If you cannot solve this problem by retyping the address, or through other means, please contact your system administrator.') }}<br/>
+    {{ message ? message : __('An error has occurred. This could mean a number of different things, but generally indicates that you have a misspelt address, or are trying to access a page that you are not permitted to access.') }} {{ __('If you cannot solve this problem by retyping the address, or through other means, please contact your system administrator.') }}<br/>
 </p>

--- a/src/Gibbon/Locale.php
+++ b/src/Gibbon/Locale.php
@@ -53,7 +53,7 @@ class Locale implements LocaleInterface
     {
         $this->absolutePath = $absolutePath;
         $this->session = $session;
-        $this->supportsGetText = function_exists('gettext');
+        $this->supportsGetText = function_exists('gettext') && function_exists('dgettext');
     }
 
     /**
@@ -245,6 +245,10 @@ class Locale implements LocaleInterface
     public function translate(string $text, array $params = [], array $options = [])
     {
         if ($text === '') {
+            return $text;
+        }
+
+        if (empty($this->i18ncode)) {
             return $text;
         }
 

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\View;
 
+use Twig\Environment;
 use Gibbon\View\View;
 use Gibbon\View\AssetBundle;
 use Gibbon\View\Components\Breadcrumbs;
@@ -56,7 +57,7 @@ class Page extends View
      *
      * @param array $params Essential parameters for building a page.
      */
-    public function __construct($templateEngine = null, array $params = [])
+    public function __construct(Environment $templateEngine = null, array $params = [])
     {
         parent::__construct($templateEngine);
         
@@ -326,6 +327,35 @@ class Page extends View
             'extraFoot'    => $this->getExtraCode('foot'),
             'extraSidebar' => $this->getExtraCode('sidebar'),
         ];
+    }
+
+    /**
+     * Initializes the page class with some usable defaults. Useful for error pages where the full index has not been initialized.
+     *
+     * @param string $absolutePath
+     * @return self
+     */
+    public function setDefaults($absolutePath)
+    {
+        $server = (!empty($_SERVER['HTTPS']) ? 'https' : 'http') . '://' . $_SERVER['HTTP_HOST'];
+        $absoluteURL = $server . dirname($_SERVER['PHP_SELF']);
+        $this->addData([
+            'title'           => __('Gibbon'),
+            'gibbonThemeName' => 'Default',
+            'absolutePath'    => $absolutePath,
+            'absoluteURL'     => $absoluteURL,
+        ]);
+
+        $this->stylesheets->add('main', 'themes/Default/css/main.css');
+        $this->stylesheets->add('theme', 'resources/assets/css/theme.min.css');
+        $this->stylesheets->add('core', 'resources/assets/css/core.min.css', ['weight' => 10]);
+        $this->stylesheets->add(
+            'personal-background',
+            'body { background: url("'.$absoluteURL.'/themes/Default/img/backgroundPage.jpg'.'") repeat fixed center top #626cd3!important; }',
+            ['type' => 'inline']
+        );
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Currently, if the database connection fails or temporarily cannot connect, a blank white page with the 'oh no' message is displayed. This PR improves the error page so that the index template is still displayed, aimed to make this error less jarring for any users that experience it.

Feel free to suggest some better error message text 🤔 

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="1200" alt="Screenshot 2020-11-13 at 10 25 04 AM" src="https://user-images.githubusercontent.com/897700/99020954-8ca8dc00-259a-11eb-896a-734a0ef3fec2.png">
