### PR TITLE
System: migrate all custom fields from serialized data into json data

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -722,4 +722,5 @@ INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `typ
 ALTER TABLE `gibbonPersonMedicalConditionUpdate` ADD `attachment` VARCHAR(255) NULL DEFAULT NULL AFTER `comment`;end
 ALTER TABLE `gibbonStaff` ADD `firstAidQualification` VARCHAR(100) NULL DEFAULT NULL AFTER `firstAidQualified`;end
 CREATE TABLE `gibbonMigration` ( `gibbonMigrationID` INT(8) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT , `name` VARCHAR(60) NOT NULL , `version` VARCHAR(8) NOT NULL , `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP , PRIMARY KEY (`gibbonMigrationID`)) ENGINE = InnoDB;end
+ALTER TABLE `gibbonPerson` CHANGE `fields` `fields` TEXT CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT 'JSON object of custom field values';end
 ";

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -623,7 +623,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     }
 
                     // CUSTOM FIELDS
-                    $existingFields = (isset($values['fields']))? unserialize($values['fields']) : null;
+                    $existingFields = (isset($values['fields']))? json_decode($values['fields'], true) : null;
                     $resultFields = getCustomFields($connection2, $guid, $student, $staff, $parent, $other, false, true);
                     if ($resultFields->rowCount() > 0) {
                         $heading = $form->addRow()->addHeading(__('Custom Fields'));

--- a/modules/Data Updater/data_personalProcess.php
+++ b/modules/Data Updater/data_personalProcess.php
@@ -249,7 +249,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                         $URL .= '&return=error1';
                         header("Location: {$URL}");
                     } else {
-                        $data['fields'] = serialize($fields);
+                        $data['fields'] = json_encode($fields);
 
                         //Write to database
                         $existing = $_POST['existing'] ?? 'N';

--- a/modules/Data Updater/data_personal_manage_editProcess.php
+++ b/modules/Data Updater/data_personal_manage_editProcess.php
@@ -434,7 +434,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                 //DEAL WITH CUSTOM FIELDS
                 //Prepare field values
                 $resultFields = getCustomFields($connection2, $guid, $student, $staff, $parent, $other, null, true);
-                $fields = isset($row2['fields']) ? unserialize($row2['fields']) : [];
+                $fields = isset($row2['fields']) ? json_decode($row2['fields'], true) : [];
                 if ($resultFields->rowCount() > 0) {
                     while ($rowFields = $resultFields->fetch()) {
                         if (isset($_POST['newcustom'.$rowFields['gibbonPersonFieldID'].'On'])) {
@@ -449,7 +449,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     }
                 }
 
-                $fields = serialize($fields);
+                $fields = json_encode($fields);
 
                 if (strlen($set) > 1) {
                     //Write to database

--- a/modules/Staff/applicationFormProcess.php
+++ b/modules/Staff/applicationFormProcess.php
@@ -212,7 +212,7 @@ if ($proceed == false) {
             $URL .= '&return=error1';
             header("Location: {$URL}");
         } else {
-            $fields = serialize($fields);
+            $fields = json_encode($fields);
             $partialFail = false;
             $ids = '';
 

--- a/modules/Staff/applicationForm_manage_editProcess.php
+++ b/modules/Staff/applicationForm_manage_editProcess.php
@@ -216,7 +216,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                     $URL .= '&return=error3';
                     header("Location: {$URL}");
                 } else {
-                    $fields = serialize($fields);
+                    $fields = json_encode($fields);
 
                     //Write to database
                     try {

--- a/modules/Staff/staff_view_details.php
+++ b/modules/Staff/staff_view_details.php
@@ -293,7 +293,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view_details.p
                         echo $table->render([$row]);
 
                         //Custom Fields
-                        $fields = unserialize($row['fields']);
+                        $fields = json_decode($row['fields'], true);
                         $resultFields = getCustomFields($connection2, $guid, false, true);
                         if ($resultFields->rowCount() > 0) {
                             echo '<h4>';

--- a/modules/Students/applicationFormProcess.php
+++ b/modules/Students/applicationFormProcess.php
@@ -615,14 +615,14 @@ if ($proceed == false) {
                 header("Location: {$URL}");
                 exit();
             } else {
-                $fields = serialize($fields);
+                $fields = json_encode($fields);
                 if (isset($parent1fields)) {
-                    $parent1fields = serialize($parent1fields);
+                    $parent1fields = json_encode($parent1fields);
                 } else {
                     $parent1fields = '';
                 }
                 if (isset($parent2fields)) {
-                    $parent2fields = serialize($parent2fields);
+                    $parent2fields = json_encode($parent2fields);
                 } else {
                     $parent2fields = '';
                 }

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -489,7 +489,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     }
 
     // CUSTOM FIELDS FOR STUDENT
-    $existingFields = (isset($application["fields"]))? unserialize($application["fields"]) : null;
+    $existingFields = (isset($application["fields"]))? json_decode($application["fields"], true) : null;
     $resultFields = getCustomFields($connection2, $guid, true, false, false, false, true, null);
     if ($resultFields->rowCount() > 0) {
         $heading = $form->addRow()->addSubheading(__('Other Information'));
@@ -546,7 +546,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                 $row->addSelectRelationship('parent1relationship')->required();
 
             // CUSTOM FIELDS FOR PARENT 1 WITH FAMILY
-            $existingFields = (isset($application["parent1fields"]))? unserialize($application["parent1fields"]) : null;
+            $existingFields = (isset($application["parent1fields"]))? json_decode($application["parent1fields"], true) : null;
             $resultFields = getCustomFields($connection2, $guid, false, false, true, false, true, null);
             if ($resultFields->rowCount() > 0) {
                 $row = $form->addRow();
@@ -687,7 +687,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                 $row->addTextField("parent{$i}employer")->maxLength(90);
 
             // CUSTOM FIELDS FOR PARENTS
-            $existingFields = (isset($application["parent{$i}fields"]))? unserialize($application["parent{$i}fields"]) : null;
+            $existingFields = (isset($application["parent{$i}fields"]))? json_decode($application["parent{$i}fields"], true) : null;
             $resultFields = getCustomFields($connection2, $guid, false, false, true, false, true, null);
             if ($resultFields->rowCount() > 0) {
                 $row = $form->addRow()->setClass("parentSection{$i}");

--- a/modules/Students/applicationForm_manage_editProcess.php
+++ b/modules/Students/applicationForm_manage_editProcess.php
@@ -614,14 +614,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                     $URL .= '&return=error3';
                     header("Location: {$URL}");
                 } else {
-                    $fields = serialize($fields);
+                    $fields = json_encode($fields);
                     if (isset($parent1fields)) {
-                        $parent1fields = serialize($parent1fields);
+                        $parent1fields = json_encode($parent1fields);
                     } else {
                         $parent1fields = '';
                     }
                     if (isset($parent2fields)) {
-                        $parent2fields = serialize($parent2fields);
+                        $parent2fields = json_encode($parent2fields);
                     } else {
                         $parent2fields = '';
                     }

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1159,7 +1159,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         echo '</table>';
 
                         //Custom Fields
-                        $fields = unserialize($row['fields']);
+                        $fields = json_decode($row['fields'], true);
                         $resultFields = getCustomFields($connection2, $guid, true);
                         if ($resultFields->rowCount() > 0) {
                             echo '<h4>';

--- a/modules/User Admin/user_manage_editProcess.php
+++ b/modules/User Admin/user_manage_editProcess.php
@@ -512,7 +512,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
                         $URL .= '&return=error3';
                         header("Location: {$URL}");
                     } else {
-                        $fields = serialize($fields);
+                        $fields = json_encode($fields);
 
                         //Write to database
                         try {

--- a/publicRegistrationProcess.php
+++ b/publicRegistrationProcess.php
@@ -108,7 +108,7 @@ if ($proceed == false) {
             header("Location: {$URL}");
             exit();
         } else {
-            $fields = serialize($fields);
+            $fields = json_encode($fields);
         }
 
         //Check strength of password

--- a/src/Database/Migrations/2020-11-20-CustomFields.php
+++ b/src/Database/Migrations/2020-11-20-CustomFields.php
@@ -1,0 +1,88 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\User\UserGateway;
+use Gibbon\Database\Migrations\Migration;
+use Gibbon\Domain\DataUpdater\PersonUpdateGateway;
+use Gibbon\Domain\Students\ApplicationFormGateway;
+
+/**
+ * Custom Fields migration - moves all serialized user data into json user data stored in a customFields column.
+ */
+class CustomFields extends Migration
+{
+    protected $userGateway;
+    protected $personUpdateGateway;
+    protected $applicationGateway;
+
+    public function __construct(UserGateway $userGateway, PersonUpdateGateway $personUpdateGateway, ApplicationFormGateway $applicationGateway)
+    {
+        $this->userGateway = $userGateway;
+        $this->personUpdateGateway = $personUpdateGateway;
+        $this->applicationGateway = $applicationGateway;
+    }   
+
+    public function migrate()
+    {
+        $partialFail = false;
+
+        // Migrate user custom fields
+        $users = $this->userGateway->selectBy([], ['gibbonPersonID', 'fields']); 
+
+        foreach ($users as $user) {
+            if (empty($user['fields'])) continue;
+
+            $fieldData = unserialize($user['fields']);
+            $partialFail &= !$this->userGateway->update($user['gibbonPersonID'], [
+                'fields' => !empty($fieldData) ? json_encode($fieldData) : '',
+            ]);
+        }
+
+        // Migrate data updater custom fields
+        $updates = $this->personUpdateGateway->selectBy([], ['gibbonPersonUpdateID', 'fields']); 
+
+        foreach ($updates as $update) {
+            if (empty($update['fields'])) continue;
+
+            $fieldData = unserialize($update['fields']);
+            $partialFail &= !$this->personUpdateGateway->update($update['gibbonPersonUpdateID'], [
+                'fields' => !empty($fieldData) ? json_encode($fieldData) : '',
+            ]);
+        }
+
+        // Migrate application form custom fields
+        $applications = $this->applicationGateway->selectBy([], ['gibbonApplicationFormID', 'fields', 'parent1fields', 'parent2fields']); 
+
+        foreach ($applications as $application) {
+            if (empty($application['fields']) && empty($application['parent1fields']) && empty($application['parent2fields'])) continue;
+
+            $fieldData = unserialize($application['fields']);
+            $parent1fieldData = unserialize($application['parent1fields']);
+            $parent2fieldData = unserialize($application['parent2fields']);
+
+            $partialFail &= !$this->applicationGateway->update($application['gibbonApplicationFormID'], [
+                'fields' => !empty($fieldData) ? json_encode($fieldData) : '',
+                'parent1fields' => !empty($parent1fieldData) ? json_encode($parent1fieldData) : '',
+                'parent2fields' => !empty($parent2fieldData) ? json_encode($parent2fieldData) : '',
+            ]);
+        }
+
+        return !$partialFail;
+    }
+}

--- a/src/Domain/Traits/TableAware.php
+++ b/src/Domain/Traits/TableAware.php
@@ -108,10 +108,6 @@ trait TableAware
      */
     public function selectBy(array $keysAndValues, $cols = [])
     {
-        if (empty($keysAndValues)) {
-            throw new \InvalidArgumentException("Gateway selectBy method for {$this->getTableName()} must provide an array of keys and values.");
-        }
-
         $query = $this
             ->newSelect()
             ->cols(!empty($cols) ? $cols : ['*'])


### PR DESCRIPTION
This PR is a follow-up to #1176 which adds a migration for changing serialized custom fields into JSON custom fields. JSON in a database is more stable and has better functionality in more recent versions of MySQL. 

- Adds a migration file in src/Database/Migrations.
- Changes instances of unserialize/serialize to json_decode/json_encode.
- Allows the selectBy to be used with no constraints, returning all rows.

**How Has This Been Tested?**
Locally