### PR TITLE
Hash deleted in code, because the alertColor attribute has hash in the value

### DIFF
--- a/modules/Students/report_students_byRollGroup.php
+++ b/modules/Students/report_students_byRollGroup.php
@@ -144,7 +144,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_b
 
                     foreach ($conditions as $index => $condition) {
                         $output .= '<b><i>'.__('Condition').' '.($index+1).'</i></b>: '.$condition['name'];
-                        $output .= ' <span style="color: #'.$condition['alertColor'].'; font-weight: bold">('.__($condition['risk']).' '.__('Risk').')</span>';
+                        $output .= ' <span style="color: '.$condition['alertColor'].'; font-weight: bold">('.__($condition['risk']).' '.__('Risk').')</span>';
                         $output .= '<br/>';
                     }
                 }

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1662,7 +1662,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                         foreach ($conditions as $condition) {
                             $table = DataTable::createDetails('medicalConditions');
-                            $table->setTitle(__($condition['name'])." <span style='color: #".$condition['alertColor']."'>(".__($condition['risk']).' '.__('Risk').')</span>');
+                            $table->setTitle(__($condition['name'])." <span style='color: ".$condition['alertColor']."'>(".__($condition['risk']).' '.__('Risk').')</span>');
                             $table->setDescription($condition['description']);
                             $table->addMetaData('gridClass', 'grid-cols-1 md:grid-cols-2');
 

--- a/resources/templates/formats/medicalConditions.twig.html
+++ b/resources/templates/formats/medicalConditions.twig.html
@@ -22,11 +22,11 @@ all stylesheets and scripts with a 'head' context.
 
 {% for condition in medicalConditions %}
 
-<div style="border-left: 4px solid #{{ condition.alertColor }}; padding-left: 14px;">
+<div style="border-left: 4px solid {{ condition.alertColor }}; padding-left: 14px;">
 
     <b><i>{{ __('Condition') }} {{ loop.index }}:</i></b> {{ __(condition.name) }}<br/>
 
-    <u><i>{{ __('Risk') }}:</i></u> <span style="color: #{{ condition.alertColor }};font-weight: bold;">{{ __(condition.risk) }}</span><br/>
+    <u><i>{{ __('Risk') }}:</i></u> <span style="color: {{ condition.alertColor }};font-weight: bold;">{{ __(condition.risk) }}</span><br/>
 
     {% if condition.triggers %}
         <u><i>{{ __('Triggers') }}:</i></u> {{ condition.triggers }}<br/>


### PR DESCRIPTION
**Motivation and Context **
The pages doesn't show the color correctly

**Description**
- Hash deleted from the code, because the alertColor attribute has the value with hash
- alertColor attribute fixed in template medicalConditions

**How Has This Been Tested?**
 Local and Travis
