### PR TITLE
Fixed null reference when row modifier returned null

### DIFF
--- a/src/Tables/View/DataTableView.php
+++ b/src/Tables/View/DataTableView.php
@@ -180,6 +180,7 @@ class DataTableView extends View implements RendererInterface
 
         foreach ($table->getRowModifiers() as $callable) {
             $row = $callable($data, $row, $table->getColumnCount());
+            if (!$row) break;
         }
 
         return $row;


### PR DESCRIPTION
**Description**
Fix for a bug that occurs when two (or more) row modifiers are added to a table. If any (except the last) row modifier returns null, an error will be thrown as all subsequent modifiers will be given the null variable.

**Motivation and Context**
Expandable columns use rowModifiers, however, if a custom row modifier that can (and does) return null is used, an error will be thrown and the table will not render.

**How Has This Been Tested?**
Locally on the Trip Planner (where the bug existed) and on the Help Desk (where an existing table with a row modifier exists)

**Screenshots**
![image](https://user-images.githubusercontent.com/8520854/104869907-4c4f4b00-599b-11eb-9978-aba998cde66b.png)