### PR TITLE
WIP: GitHub Actions for CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: test
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-version: ["7.4"]
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: gibbon_test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    env:
+      CI_PLATFORM: travis_ci
+
+    steps:
+
+      - name: Setup PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: gettext, gd, zip
+          tools: composer:v2
+          ini-values: date.timezone="Etc/UTC"
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+
+      - name: Setup System Locale
+        run: |
+          cat <<- EOF |
+          en_US.UTF-8 UTF-8
+          es_ES.UTF-8 UTF-8
+          fr_FR.UTF-8 UTF-8
+          zh_TW.UTF-8 UTF-8
+          EOF
+          sudo tee -a /etc/locale.gen >/dev/null
+          sudo locale-gen
+
+      - name: Run PHP server for tests to run
+        run: php -S 127.0.0.1:8888 -t ${{ github.workspace }} >/dev/null 2>&1 &
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+
+      - name: Install PHP vendor libraries
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Run composer test
+        run: composer test
+        env:
+          TEST_ENV: codeception
+          ABSOLUTE_URL: http://127.0.0.1:8888
+          DB_HOST: 127.0.0.1
+          DB_NAME: gibbon_test
+          DB_USERNAME: root
+          DB_PASSWORD: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,11 @@ on:
 
 jobs:
   test:
+    name: CI Test (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ["7.4"]
+        php-version: ["7.0", "7.3", "7.4"]
     services:
       mysql:
         image: mysql:5.7
@@ -28,9 +29,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: gettext, gd, zip
+          extensions: gettext, gd, zip, pdo-mysql
           tools: composer:v2
-          ini-values: date.timezone="Etc/UTC"
+          ini-values: date.timezone="Etc/UTC", xdebug.max_nesting_level = -1
 
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -56,7 +57,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php${{ matrix.php-version }}-
 
       - name: Install PHP vendor libraries
         run: composer install --prefer-dist --no-interaction
@@ -70,3 +73,11 @@ jobs:
           DB_NAME: gibbon_test
           DB_USERNAME: root
           DB_PASSWORD: ""
+
+      - name: Save Test Artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Test Artifacts (PHP ${{ matrix.php-version }})
+          path: tests/log
+          retention-days: 5


### PR DESCRIPTION
**Description**
A proof-of-concept setup to run the CI tests with [GitHub Actions](https://github.com/features/actions). Basically a drop-in-replacement of the current Travis CI tests.



**Motivation and Context**
Travis CI has seen [some issue](https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works). And its fun to learn about GitHub Actions in the process.

The speed seems a little bit faster. And the output in Pull Requests look a bit nicer. Also it paves road to implement #1123 with [GitHub Action - Releases API](https://github.com/actions/upload-release-asset), which should enjoy some level of native support.

The obvious downside is making the source release process more reliant on GitHub.

**How Has This Been Tested?**
Tested in my fork of the repository. See [here](https://github.com/yookoala/GibbonEduCore/actions/runs/498018718).

**Screenshots**
![2021-01-20 16-12-48 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105146143-97539480-5b3a-11eb-8568-d724eff20964.png)

![2021-01-20 16-13-03 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105146064-80ad3d80-5b3a-11eb-9385-1121a6d96c1f.png)

![2021-01-20 16-13-30 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105146088-860a8800-5b3a-11eb-9e5d-4626adc15304.png)

