### PR TITLE
Feature: connector debug in installer

### DIFF
--- a/installer/install.php
+++ b/installer/install.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\View\Page;
 use Gibbon\Forms\Form;
 use Gibbon\Data\Validator;
+use Gibbon\Database\Connection;
 use Gibbon\Database\MySqlConnector;
 use Gibbon\Forms\DatabaseFormFactory;
 
@@ -55,10 +56,10 @@ if (empty($step)) {
     $guid = $_POST['guid'] ?? '';
     $guid = preg_replace('/[^a-z0-9-]/', '', substr($guid, 0, 36));
 }
-// Use the POSTed GUID in place of "undefined". 
-// Later steps have the guid in the config file but without 
+// Use the POSTed GUID in place of "undefined".
+// Later steps have the guid in the config file but without
 // a way to store variables relibly prior to that, installation can fail
-$gibbon->session->setGuid($guid); 
+$gibbon->session->setGuid($guid);
 $gibbon->session->set('absolutePath', realpath('../'));
 
 // Generate and save a nonce for forms on this page to use
@@ -92,8 +93,8 @@ $code = $_POST['code'] ?? 'en_GB';
 
 // Attempt to download & install the required language files
 if ($step >= 1) {
-    $languageInstalled = !i18nFileExists($gibbon->session->get('absolutePath'), $code) 
-        ? i18nFileInstall($gibbon->session->get('absolutePath'), $code) 
+    $languageInstalled = !i18nFileExists($gibbon->session->get('absolutePath'), $code)
+        ? i18nFileInstall($gibbon->session->get('absolutePath'), $code)
         : true;
 }
 
@@ -190,7 +191,7 @@ if ($canInstall == false) {
 
     if ($apacheVersion !== false) {
         $apacheModules = @apache_get_modules();
-        
+
         foreach ($apacheRequirement as $moduleName) {
             $active = @in_array($moduleName, $apacheModules);
             $row = $form->addRow();
@@ -278,18 +279,20 @@ if ($canInstall == false) {
         $config = compact('databaseServer', 'databaseUsername', 'databasePassword');
         $mysqlConnector = new MySqlConnector();
 
-        if ($pdo = $mysqlConnector->connect($config)) {
+        try {
+            $pdo = $mysqlConnector->connect($config, true);
             $mysqlConnector->useDatabase($pdo, $databaseName);
             $connection2 = $pdo->getConnection();
             $container->share(Gibbon\Contracts\Database\Connection::class, $pdo);
+        } catch (\Exception $e) {
+            echo "<div class='error'>";
+            echo '<div>' . sprintf(__('A database connection could not be established. Please %1$stry again%2$s.'), "<a href='./install.php'>", '</a>') . '</div>';
+            echo '<div>' . sprintf(__('Error details: {error_message}', $e->getMessage())) . '</div>';
+            echo '</div>';
         }
     }
 
-    if (empty($pdo)) {
-        echo "<div class='error'>";
-        echo sprintf(__('A database connection could not be established. Please %1$stry again%2$s.'), "<a href='./install.php'>", '</a>');
-        echo '</div>';
-    } else {
+    if ($pdo instanceof Connection) {
         //Set up config.php
         include './installerFunctions.php';
         $configData = compact('databaseServer', 'databaseUsername', 'databasePassword', 'databaseName', 'guid');
@@ -574,15 +577,18 @@ if ($canInstall == false) {
     //New PDO DB connection
     $mysqlConnector = new MySqlConnector();
 
-    if ($pdo = $mysqlConnector->connect($gibbon->getConfig())) {
+    try {
+        $pdo = $mysqlConnector->connect($gibbon->getConfig(), true);
         $connection2 = $pdo->getConnection();
+    } catch (Exception $e) {
+        echo "<div class='error'>";
+        echo '<div>' . sprintf(__('A database connection could not be established. Please %1$stry again%2$s.'), "<a href='./install.php'>", '</a>') . '</div>';
+        echo '<div>' . sprintf(__('Error details: {error_message}', $e->getMessage())) . '</div>';
+        echo '</div>';
     }
 
-    if (empty($pdo)) {
-        echo "<div class='error'>";
-        echo sprintf(__('A database connection could not be established. Please %1$stry again%2$s.'), "<a href='./install.php'>", '</a>');
-        echo '</div>';
-    } else {
+    // check if correctly created the PDO object.
+    if ($pdo instanceof Connection) {
         //Get user account details
         $title = $_POST['title'];
         $surname = $_POST['surname'];
@@ -891,8 +897,8 @@ if ($canInstall == false) {
             }
         }
     }
-}                 
-         
+}
+
 $page->write(ob_get_clean());
 
 $page->addData([

--- a/src/Database/MySqlConnector.php
+++ b/src/Database/MySqlConnector.php
@@ -34,10 +34,14 @@ class MySqlConnector
     /**
      * Establish a database connection.
      *
-     * @param  array  $config
-     * @return PDO
+     * @param  array  $config          The database configuration
+     * @param  bool   $throw_on_error  To throw error on connection issue or not. Default: false
+     *
+     * @return \Gibbon\Database\Connection|bool
+     *     The Connection instances, or false if failed to connect and
+     *     $throw_on_error is false.
      */
-    public function connect(array $config)
+    public function connect(array $config, bool $throw_on_error = false)
     {
         $dsn = $this->getDsn($config);
 
@@ -49,6 +53,9 @@ class MySqlConnector
 
             return new Connection($connection, $config);
         } catch (\PDOException $e) {
+            if ($throw_on_error) {
+                throw $e;
+            }
             return false;
         }
     }
@@ -56,7 +63,7 @@ class MySqlConnector
     public function useDatabase(Connection $connection, $databaseName)
     {
         $databaseName = "`" . str_replace("`", "``", $databaseName) . "`";
-        
+
         $querySuccess = $connection->statement("CREATE DATABASE IF NOT EXISTS {$databaseName} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci");
 
         if ($querySuccess) {


### PR DESCRIPTION
**Description**

* Add a backward-compatible change to connector to allow it to rethrow PDO connection error.
* Improves the installer error message with database connection issue(s).
* Probably fixed an installer bug. Instead of checking `empty($pdo)`, which is `false` instead of `null` when error, the installer should either check something like `$pdo instanceof \PDO` or `$pdo !== false`.

**Motivation and Context**

It's really hard to tell what went wrong if the installer failed to connect to database. Especially if you're debugging CI build errors. It would be really helpful to show some internal error message on the page. Then the test artifact would be more helpful to debug with.

**How Has This Been Tested?**

Tested locally.