### PR TITLE
github-actions: Setup test server to show error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,15 @@ jobs:
           sudo locale-gen
 
       - name: Run PHP server for tests to run
-        run: php -S 127.0.0.1:8888 -t ${{ github.workspace }} >/dev/null 2>&1 &
+        run: |
+          # Start a PHP test server for codeception to run against
+          [ -d ./tests/log ] || mkdir ./tests/log
+          php --server 127.0.0.1:8888 \
+            --docroot ${{ github.workspace }} \
+            --define display_startup_errors=1 \
+            --define display_errors=1 \
+            --define error_reporting=E_ALL \
+            >/dev/null 2>./tests/log/server_log &
 
       - name: Cache Composer dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
**Description**

* Showing error messages normally in CI test environment. The
  failed test artifact will get the full xdebug message instead
  of nothing at all.

* Have the test server to save logs to tests/log/server_log so
  it will be included in the test artifact for download and
  debug.

**Motivation and Context**

GitHub Actions CI workflow would save test logs as artifact when failed. This is for easier debugging on test failure. But the CI's PHP environment would hide all error message (even fatal errors) by default. So it would be very hard to debug a test failure without reproducing the environment locally. And this defeats the purpose of multiple version test in CI environment.

**How Has This Been Tested?**

Tested in my fork of the repository.

You may download the test artifact of this deliberately failed test and see the result:
https://github.com/yookoala/GibbonEduCore/actions/runs/504274066

![2021-01-23 02-01-09 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105527638-ee19c380-5d1e-11eb-8296-c720daaf0763.png)


**Screenshots**

xdebug output of test log in recovered artifact:

![2021-01-23 01-58-00 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105527290-777cc600-5d1e-11eb-893c-772259c081cc.png)