### PR TITLE
github-actions: add experimental php8 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,17 @@ on:
 
 jobs:
   test:
-    name: CI Test (PHP ${{ matrix.php-version }})
+    name: ${{ matrix.name }} (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-version: ["7.3", "7.4"]
         experimental: [false]
+        name: ["CI Test"]
         include:
           - php-version: "8.0"
             experimental: true
+            name: "CI Test, Experimental"
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
     strategy:
       matrix:
         php-version: ["7.3", "7.4"]
+        experimental: [false]
+        include:
+          - php-version: "8.0"
+            experimental: true
     services:
       mysql:
         image: mysql:5.7
@@ -66,6 +70,7 @@ jobs:
 
       - name: Run composer test
         run: composer test
+        continue-on-error: ${{ matrix.experimental }}
         env:
           TEST_ENV: codeception
           ABSOLUTE_URL: http://127.0.0.1:8888
@@ -76,7 +81,7 @@ jobs:
 
       - name: Save Test Artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ failure() }}
+        if: ${{ failure() || matrix.experimental }}
         with:
           name: Test Artifacts (PHP ${{ matrix.php-version }})
           path: tests/log


### PR DESCRIPTION
**Description**
* Add PHP 8.0 test to CI.
* Mark it as "experimental" and do not treat failure as an error.
* Failure will still have message in the CI result. And test artifacts will still be available for study.

**Motivation and Context**
As as step to gradually resolve issue #1210 without disturbing other PR and updates.

**How Has This Been Tested?**
On this PR, with GitHub Actions.

**Screenshot**
![2021-01-23 16-05-02 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105572903-e39a1100-5d94-11eb-9920-92610cc7889a.png)
