### PR TITLE
Activities: fix count error with null in php 8

### DIFF
--- a/modules/Activities/activities_manage_addProcess.php
+++ b/modules/Activities/activities_manage_addProcess.php
@@ -116,9 +116,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             }
         }
 
-        //Scan through staff
-        $staff = isset($_POST['staff'])? $_POST['staff'] : null;
-        $role = isset($_POST['role']) ? $_POST['role'] : 'Other';
+        // Scan through staff
+        $staff = $_POST['staff'] ?? [];
+        $role = $_POST['role'] ?? 'Other';
+
+        // make sure that staff is an array
+        if (!is_array($staff)) {
+            $staff = [(string) $staff];
+        }
 
         if (count($staff) > 0) {
             foreach ($staff as $t) {

--- a/modules/Activities/activities_manage_editProcess.php
+++ b/modules/Activities/activities_manage_editProcess.php
@@ -113,15 +113,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
                     }
                 }
 
-                //Scan through staff
-                $staff = null;
-                if (isset($_POST['staff'])) {
-                    $staff = $_POST['staff'];
+                // Scan through staff
+                $staff = $_POST['staff'] ?? [];
+                $role = $_POST['role'] ?? 'Other';
+
+                // make sure that staff is an array
+                if (!is_array($staff)) {
+                    $staff = [(string) $staff];
                 }
-                $role = $_POST['role'];
-                if ($role == '') {
-                    $role = 'Other';
-                }
+
                 if (count($staff) > 0) {
                     foreach ($staff as $t) {
                         //Check to see if person is already registered in this activity


### PR DESCRIPTION
* The variable $staff (from $_POST['staff']) should be an array
  from the form input. The previous fallback was to null, which
  is not Countable nor array. In PHP 8, using count() on anything
  other than the 2 is a TypeError.

* Instead, changed the fallback to empty array would fix the issue.

* In addition, add extra sanitation step to make sure it is an
  array.

<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
<!-- Please describe your changes in detail. -->

**Motivation and Context**
<!-- Why is this change suggested? Is there a problem it helps to solve?
If this PR fixes an open issue, please link to the issue here. -->

**How Has This Been Tested?**
<!-- Please describe how you've tested your changes. Include details of 
your testing environment, and any tests you've run to see how your 
change affects other areas of the code. -->

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
