### PR TITLE
Tests: revamp grouping

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -31,4 +31,17 @@ modules:
             cleanup: false
             reconnect: true
 groups:
-    users: [/Users]
+    users:
+      - acceptance/User Tests
+      - acceptance/User Admin
+    system:
+      - acceptance/System Admin
+    modules:
+      - acceptance/Activities
+      - acceptance/Data Updater
+      - acceptance/Finance
+      - acceptance/Markbook
+      - acceptance/Planner
+      - acceptance/School Admin
+      - acceptance/Students
+      - acceptance/Timetable Admin


### PR DESCRIPTION
**Description**
* Fix previously obsoleted grouping config.
* Regroup the tests by functionality.

**Motivation and Context**
* According to documentations, the [groups](https://codeception.com/docs/07-AdvancedUsage#group-files
) directive in configuration serves to specify files and folders so user can run tests selectively. But the directive has to specify files and folders that exists.
* The current configuration seems to be generated by `codecept init`. All previous iterations of this file don't seems to match with any specific subfolder in the `tests/` folder:

  https://github.com/GibbonEdu/core/blob/7272bd60218ac59dc5e259556f923ee8d2dc6eb4/tests/acceptance.suite.yml#L17-L18
  https://github.com/GibbonEdu/core/blob/adf8f0f5b5556219024413c790db0eb3d0c785ca/tests/acceptance.suite.yml#L33-L34

* In codecption 3, the directive is not checked so there is no issue with it. In codectpion 4, however, this will cause ConfigurationException:
  ![2021-01-26 13-38-36 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105804930-e63a7780-5fdb-11eb-8388-ed1f527a5b3a.png)

**How Has This Been Tested?**
Tested locally and in CI environment.