### PR TITLE
Tests: Fix deprecation message

### DIFF
--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -5,8 +5,6 @@
 # If you need both WebDriver and PHPBrowser tests - create a separate suite.
 
 class_name: AcceptanceTester
-settings:
-    bootstrap: acceptance/bootstrap.php
 params:
     - env
     - config/environment.php
@@ -30,5 +28,6 @@ modules:
             populate: true
             cleanup: false
             reconnect: true
+bootstrap: bootstrap.php
 groups:
     users: [/Users]

--- a/tests/codeception.yml
+++ b/tests/codeception.yml
@@ -15,9 +15,6 @@ paths:
     # directory for environment configuration
     envs: config/envs
 settings:
-    # name of bootstrap that will be used
-    bootstrap: bootstrap.php
-
     # randomize test order
     shuffle: false
 
@@ -32,6 +29,7 @@ settings:
 
     # This value controls whether PHPUnit attempts to backup global variables
     backup_globals: false
+bootstrap: bootstrap.php
 params:
     - env
     - config/environment.php


### PR DESCRIPTION
**Description**
* Change according to warning message: "DEPRECATION: 'settings: bootstrap:
  bootstrap.php' option is deprecated! Replace it with: 'bootstrap:
  bootstrap.php' (not under settings section). See https://bit.ly/2"

**Motivation and Context**
* Simply to remove a deprecation message and make it more potent to future codeception upgrades.

**How Has This Been Tested?**
Locally and in CI environment.

**Screenshot**

Before:
![2021-01-26 15-02-45 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105811441-9bbef800-5fe7-11eb-90d9-094b97c3fb4c.png)

After:
![2021-01-26 15-02-34 的螢幕擷圖](https://user-images.githubusercontent.com/91274/105811450-9f527f00-5fe7-11eb-926f-c87ac13f4344.png)