### PR TITLE
Tests: fix TestCase for phpunit 9

### DIFF
--- a/tests/unit/Data/UsernameGeneratorTest.php
+++ b/tests/unit/Data/UsernameGeneratorTest.php
@@ -29,7 +29,7 @@ class UsernameGeneratorTest extends TestCase
 {
     private $usernameGenerator;
 
-    public function setUp()
+    public function setUp(): void
     {
         // Create a stub for the Gibbon\Contracts\Database\Connection class
         $mockPDO = $this->createMock(Connection::class);

--- a/tests/unit/Domain/QueryCriteriaTest.php
+++ b/tests/unit/Domain/QueryCriteriaTest.php
@@ -23,7 +23,7 @@ class QueryCriteriaTest extends TestCase
      */
     private $criteria;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->criteria = new QueryCriteria();
     }

--- a/tests/unit/Domain/QueryableGatewayTest.php
+++ b/tests/unit/Domain/QueryableGatewayTest.php
@@ -19,7 +19,7 @@ class QueryableGatewayTest extends TestCase
 {
     private $gateway;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->gateway = $this
             ->getMockBuilder(QueryableGateway::class)

--- a/tests/unit/Domain/System/ModuleTest.php
+++ b/tests/unit/Domain/System/ModuleTest.php
@@ -19,7 +19,7 @@ class ModuleTest extends TestCase
 {
     protected $module;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->module = $this->getMockBuilder(Module::class)
             ->setConstructorArgs([])

--- a/tests/unit/Domain/System/ThemeTest.php
+++ b/tests/unit/Domain/System/ThemeTest.php
@@ -19,7 +19,7 @@ class ThemeTest extends TestCase
 {
     protected $theme;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->theme = $this->getMockBuilder(Theme::class)
             ->setConstructorArgs([])

--- a/tests/unit/Forms/Layout/RowTest.php
+++ b/tests/unit/Forms/Layout/RowTest.php
@@ -21,7 +21,7 @@ class RowTest extends TestCase
     private $mockFactory;
     private $mockElement;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->mockFactory = $this->createMock('Gibbon\Forms\FormFactoryInterface');
         $this->mockElement = $this->createMock('Gibbon\Forms\OutputableInterface');

--- a/tests/unit/Gibbon/FileUploaderTest.php
+++ b/tests/unit/Gibbon/FileUploaderTest.php
@@ -22,7 +22,7 @@ class FileUploaderTest extends TestCase
 
     private $fileUploader;
 
-    public function setUp()
+    public function setUp(): void
     {
         // Mock the database results for a gibbonFileExtensions query
         $mockResults = $this->createMock(\PDOStatement::class);

--- a/tests/unit/Gibbon/Locale/TranslateNTest.php
+++ b/tests/unit/Gibbon/Locale/TranslateNTest.php
@@ -28,7 +28,7 @@ class TranslateNTest extends TestCase
     private $locale;
     private $gibbonToRestore;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Setup the composer autoloader
@@ -57,7 +57,7 @@ class TranslateNTest extends TestCase
         ];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         global $gibbon;
         unset($gibbon);

--- a/tests/unit/Gibbon/Locale/TranslateTest.php
+++ b/tests/unit/Gibbon/Locale/TranslateTest.php
@@ -28,7 +28,7 @@ class TranslateTest extends TestCase
     private $locale;
     private $gibbonToRestore;
 
-    public function setUp()
+    public function setUp(): void
     {
 
         // Setup the composer autoloader
@@ -57,7 +57,7 @@ class TranslateTest extends TestCase
         ];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         global $gibbon;
         unset($gibbon);

--- a/tests/unit/Gibbon/TranslationTest.php
+++ b/tests/unit/Gibbon/TranslationTest.php
@@ -18,7 +18,7 @@ class TranslationTest extends TestCase
 {
     protected $guid;
 
-    public function setUp()
+    public function setUp(): void
     {
         global $guid, $gibbon;
 
@@ -28,7 +28,7 @@ class TranslationTest extends TestCase
         $this->guid = $guid;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         global $gibbon;
 

--- a/tests/unit/Installer/ProcessConfigVarsTest.php
+++ b/tests/unit/Installer/ProcessConfigVarsTest.php
@@ -17,7 +17,7 @@ class ProcessConfigVarsTest extends TestCase {
     /**
      * @inherit
      */
-    public function setUp() {
+    public function setUp(): void {
         $loader = new \Twig\Loader\FilesystemLoader(__DIR__ . '/../../../resources/templates');
         $this->templateEngine = new \Twig\Environment($loader);
     }

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FormatTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $settings = [
             'code'                           => 'en_GB',

--- a/tests/unit/View/PageTest.php
+++ b/tests/unit/View/PageTest.php
@@ -21,7 +21,7 @@ class PageTest extends TestCase
     protected $mockModule;
     protected $mockTheme;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->prebuiltPage = new Page(null, [
             'module' => new Module(),


### PR DESCRIPTION
**Description**
* Fix forward all unit test compatibiliy with phpunit 9 by updating setUp and tearDown function signatures.

**Motivation and Context**
* Newer PHPUnit TestCase setUp and tearDown method needs to specifically hint to return "void".
* The change is backward compatible. Loose parent methods are compatible with strict children implementations.
* This fixed a few errors that block #1214.

**How Has This Been Tested?**
On CI platform.