### PR TITLE
Tests: fix test Domain/QueryCriteriaTest

### DIFF
--- a/tests/unit/Domain/QueryCriteriaTest.php
+++ b/tests/unit/Domain/QueryCriteriaTest.php
@@ -142,7 +142,13 @@ class QueryCriteriaTest extends TestCase
         $this->criteria->searchBy('columnName', 'foo bar active:Y');
 
         $this->assertTrue($this->criteria->hasFilter('active', 'Y'));
-        $this->assertNotContains('active:Y', $this->criteria->getSearchText());
+        if (method_exists($this, 'assertStringNotContainsString')) {
+            // for newer phpunit versions
+            $this->assertStringNotContainsString('active:Y', $this->criteria->getSearchText());
+        } else {
+            // for older phpunit versions
+            $this->assertNotContains('active:Y', $this->criteria->getSearchText());
+        }
     }
 
     public function testCanFilterByString()


### PR DESCRIPTION
**Description**
* assertContains should be only used on iterables (e.g. array) in newer phpunit. To check if a string contains another string, use assertStringContainsString or assertStringNotContainsString instead (if available).

**Motivation and Context**
* Make the test forward compatible with phpunit 9
* This fixed an error that block #1214.

**How Has This Been Tested?**
CI platform.