### PR TITLE
Tests: promote PHP 8.0 to formal test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ["7.3", "7.4"]
+        php-version: ["7.3", "7.4", "8.0"]
         experimental: [false]
         name: ["CI Test"]
-        include:
-          - php-version: "8.0"
-            experimental: true
-            name: "CI Test, Experimental"
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
**Description**
* PHP 8.0 test failure will no longer be ignored.
* Test Artifact of PHP 8.0 will only be uploaded any of the tests failed.

**Motivation and Context**
* To ensure #1210 is delivered in v22.0.00, we should do this at some point of time.
* Since all tests are green in PHP 8.0 now, it seems to be a good time to do so.

**How Has This Been Tested?**
* CI Environment