### PR TITLE
Fix Gibbon\Forms\Layout\Row::__call magic method issue hanlding error output of actually called function

### DIFF
--- a/src/Forms/Layout/Row.php
+++ b/src/Forms/Layout/Row.php
@@ -70,21 +70,21 @@ class Row
                 $element->setRow($this);
             }
         } catch (\ReflectionException $e) {
-            $element = $this->factory->createContent(__('Cannot {function}. This form element does not exist in the current FormFactory: ', [
-                'function' => $function,
-                'message' => $e->getMessage(),
+            $element = $this->factory->createContent(strtr('Cannot {function}. This form element does not exist in the current FormFactory: {message}', [
+                '{function}' => $function,
+                '{message}' => $e->getMessage(),
             ]));
         } catch (\Exception $e) {
-            $element = $this->factory->createContent(__('Cannot {function}. Error creating form element: {message}', [
-                'function' => $function,
-                'message' => $e->getMessage(),
+            $element = $this->factory->createContent(strtr('Cannot {function}. Error creating form element: {message}', [
+                '{function}' => $function,
+                '{message}' => $e->getMessage(),
             ]));
         } finally {
             if (!($element instanceof OutputableInterface)) {
                 if (($element_type = gettype($element)) === 'object') $element_type = get_class($element);
-                $element = $this->factory->createContent(__('{function} returned {type} instead of an outputable form element.', [
-                    'type' => $element_type,
-                    'function' => $function,
+                $element = $this->factory->createContent(strtr('{function} returned {type} instead of an outputable form element.', [
+                    '{type}' => $element_type,
+                    '{function}' => $function,
                 ]));
             }
             $this->addElement($element);

--- a/src/Forms/Layout/Row.php
+++ b/src/Forms/Layout/Row.php
@@ -70,9 +70,15 @@ class Row
                 $element->setRow($this);
             }
         } catch (\ReflectionException $e) {
-            $element = $this->factory->createContent(sprintf('Cannot %1$s. This form element does not exist in the current FormFactory', $function).': '.$e->getMessage());
+            $element = $this->factory->createContent(__('Cannot {function}. This form element does not exist in the current FormFactory: ', [
+                'function' => $function,
+                'message' => $e->getMessage(),
+            ]));
         } catch (\Exception $e) {
-            $element = $this->factory->createContent(sprintf('Cannot %1$s. Error creating form element.', $function).': '.$e->getMessage());
+            $element = $this->factory->createContent(__('Cannot {function}. Error creating form element: {message}', [
+                'function' => $function,
+                'message' => $e->getMessage(),
+            ]));
         } finally {
             if (!($element instanceof OutputableInterface)) {
                 if (($element_type = gettype($element)) === 'object') $element_type = get_class($element);

--- a/src/Forms/Layout/Row.php
+++ b/src/Forms/Layout/Row.php
@@ -74,6 +74,13 @@ class Row
         } catch (\Exception $e) {
             $element = $this->factory->createContent(sprintf('Cannot %1$s. Error creating form element.', $function).': '.$e->getMessage());
         } finally {
+            if (!($element instanceof OutputableInterface)) {
+                if (($element_type = gettype($element)) === 'object') $element_type = get_class($element);
+                $element = $this->factory->createContent(__('{function} returned {type} instead of an outputable form element.', [
+                    'type' => $element_type,
+                    'function' => $function,
+                ]));
+            }
             $this->addElement($element);
         }
 
@@ -83,7 +90,7 @@ class Row
     /**
      * Allows a conditional to be chained into the form row elements, rather than wrapping the whole section in an if statement.
      * @param bool $conditional
-     * @return object OutputableInterface   
+     * @return object OutputableInterface
      */
     public function onlyIf($conditional)
     {
@@ -188,11 +195,11 @@ class Row
         if (method_exists($element, 'getID') && !empty($element->getID())) {
             return $element->getID();
         }
-        
+
         if (method_exists($element, 'getName') && !empty($element->getName())) {
             return $element->getName();
         }
-        
+
         return 'element-'.$this->getElementCount();
     }
 }


### PR DESCRIPTION
**Description**
* Properly handle the case when function returned anything other than `Gibbon\Forms\OutputableInterface`.
* Properly rewrite the error messages from sprintf to __().

**Motivation and Context**
* Fix #1227.

**How Has This Been Tested?**
CI Environment

**Screenshots**
![2021-01-27 23-06-07 的螢幕擷圖](https://user-images.githubusercontent.com/91274/106021842-2dba2400-6100-11eb-84ff-e2911ccaebf9.png)
