### PR TITLE
Fix Gibbon\Forms\DatabaseFormFactory database methods

### DIFF
--- a/modules/User Admin/user_manage_editProcess.php
+++ b/modules/User Admin/user_manage_editProcess.php
@@ -101,11 +101,10 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
             $currentUserRoles = (is_array($_SESSION[$guid]['gibbonRoleIDAll'])) ? array_column($_SESSION[$guid]['gibbonRoleIDAll'], 0) : array();
             $currentUserRoles[] = $_SESSION[$guid]['gibbonRoleIDPrimary'];
 
-            
-                $dataRoles = array('gibbonRoleIDAll' => $row['gibbonRoleIDAll']);
+
                 $sqlRoles = 'SELECT gibbonRoleID, restriction, name FROM gibbonRole';
                 $resultRoles = $connection2->prepare($sqlRoles);
-                $resultRoles->execute($dataRoles);
+                $resultRoles->execute();
 
             $gibbonRoleIDAll = array();
             $gibbonRoleIDPrimary = $row['gibbonRoleIDPrimary'];
@@ -531,7 +530,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
                             if ($privacy_old != $privacy) {
 
                                 //Notify tutor
-                                
+
                                     $dataDetail = array('gibbonSchoolYearID' => $_SESSION[$guid]['gibbonSchoolYearID'], 'gibbonPersonID' => $gibbonPersonID);
                                     $sqlDetail = 'SELECT gibbonPersonIDTutor, gibbonPersonIDTutor2, gibbonPersonIDTutor3, gibbonYearGroupID FROM gibbonRollGroup JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID) JOIN gibbonPerson ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonPersonID=:gibbonPersonID';
                                     $resultDetail = $connection2->prepare($sqlDetail);

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -489,6 +489,10 @@ class DatabaseFormFactory extends FormFactory
             }
         }
 
+        //Clearn all values
+        $values = [];
+        $data = [];
+
         //Add students by name
         if ($params["byName"]) {
             if ($params["allStudents"]) {

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -375,7 +375,7 @@ class DatabaseFormFactory extends FormFactory
                     JOIN gibbonStaff ON (gibbonPerson.gibbonPersonID=gibbonStaff.gibbonPersonID)
                     WHERE gibbonPerson.status='Full'
                     ORDER BY gibbonPerson.surname, gibbonPerson.preferredName";
-            $result = $this->pdo->executeQuery([], $sql);
+            $result = $this->pdo->select($sql);
             if ($result->rowCount() > 0) {
                 $users[__('Staff')] = array_reduce($result->fetchAll(), function ($group, $item) {
                     $group[$item['gibbonPersonID']] = Format::name('', htmlPrep($item['preferredName']), htmlPrep($item['surname']), 'Staff', true, true)." (".$item['username'].")";

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -370,12 +370,12 @@ class DatabaseFormFactory extends FormFactory
 
         if ($params['includeStaff'] == true) {
             $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'date' => date('Y-m-d'));
-            $sql = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, username 
+            $sql = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, username
                     FROM gibbonPerson
                     JOIN gibbonStaff ON (gibbonPerson.gibbonPersonID=gibbonStaff.gibbonPersonID)
                     WHERE gibbonPerson.status='Full'
                     ORDER BY gibbonPerson.surname, gibbonPerson.preferredName";
-            $result = $this->pdo->executeQuery($data, $sql);
+            $result = $this->pdo->executeQuery([], $sql);
             if ($result->rowCount() > 0) {
                 $users[__('Staff')] = array_reduce($result->fetchAll(), function ($group, $item) {
                     $group[$item['gibbonPersonID']] = Format::name('', htmlPrep($item['preferredName']), htmlPrep($item['surname']), 'Staff', true, true)." (".$item['username'].")";


### PR DESCRIPTION
**Description**
* Fix a mistake in reusing variable.

**Motivation and Context**
* In createSelectStudent
  * When the query is both byRoll and byName and is neither allStudents
    nor activeStudents, the $data defined in the first query will affect
    that of the second query.

    And in some MySQL / MariaDB / PDO configuration or version, this
    will cause error: "SQLSTATE[HY093]: Invalid parameter number: number
    of bound variables does not match number of tokens".

  * The solution is to re-initialize $data (and $value) before the
    second condition.

* In createSelectUsers
  * A query without placeholder is supplied with a non-empty data
    array, causing "SQLSTATE[HY093]: Invalid parameter number: number
    of bound variables does not match number of tokens". Simply change
    to query with empty array would fix it.

* In modules/User Admin/user_manage_editProcess.php
  *  A very similar issue of SQLSTATE[HY093].

**How Has This Been Tested?**
On GitLab CI.

**Screenshots**
Relevant error messages in CI:

![2021-01-28 02-55-42 的螢幕擷圖](https://user-images.githubusercontent.com/91274/106040773-dd4dc100-6115-11eb-8d71-4f4c9935ba3c.png)
![2021-01-28 02-55-54 的螢幕擷圖](https://user-images.githubusercontent.com/91274/106040769-dc1c9400-6115-11eb-97c4-67173abfdec2.png)
![2021-01-28 02-56-10 的螢幕擷圖](https://user-images.githubusercontent.com/91274/106040764-daeb6700-6115-11eb-866b-00e7b5642eda.png)
![2021-01-28 02-56-21 的螢幕擷圖](https://user-images.githubusercontent.com/91274/106040759-d9ba3a00-6115-11eb-8edb-b78fc5656c65.png)

