### PR TITLE
Twig: fix template forward compatibility

### DIFF
--- a/resources/templates/menu.twig.html
+++ b/resources/templates/menu.twig.html
@@ -13,19 +13,21 @@ Main Menu: Displays the top-level categories and active modules.
         <a class="block uppercase font-bold text-sm text-gray-800 hover:text-purple-500 no-underline px-2 py-3" href="{{ absoluteURL }}/index.php">{{ __('Home') }}</a>
     </li>
 
-    {% for categoryName, items in menuMain if isLoggedIn %}
-    <li class="sm:relative group mt-1">
-        <a class="block uppercase font-bold text-sm text-gray-800 hover:text-purple-500 no-underline px-2 py-3" href="#">{{ __(categoryName) }}</a>
+    {% if isLoggedIn %}
+        {% for categoryName, items in menuMain  %}
+        <li class="sm:relative group mt-1">
+            <a class="block uppercase font-bold text-sm text-gray-800 hover:text-purple-500 no-underline px-2 py-3" href="#">{{ __(categoryName) }}</a>
 
-        <ul class="list-none bg-transparent-900 absolute hidden group-hover:block w-full sm:w-48 left-0 m-0 -mt-1 py-1 sm:p-1 z-50">
-            {% for item in items %}
-            <li class="hover:bg-purple-700">
-                <a class="block text-sm text-white focus:text-purple-200 text-left no-underline px-1 py-2 md:py-1 leading-normal" href="{{ item.url }}">{{ __(item.name, item.textDomain) }}</a>
-            </li>
-            {% endfor %}
-        </ul>
-    </li>
-    {% endfor %}
+            <ul class="list-none bg-transparent-900 absolute hidden group-hover:block w-full sm:w-48 left-0 m-0 -mt-1 py-1 sm:p-1 z-50">
+                {% for item in items %}
+                <li class="hover:bg-purple-700">
+                    <a class="block text-sm text-white focus:text-purple-200 text-left no-underline px-1 py-2 md:py-1 leading-normal" href="{{ item.url }}">{{ __(item.name, item.textDomain) }}</a>
+                </li>
+                {% endfor %}
+            </ul>
+        </li>
+        {% endfor %}
+    {% endif %}
 
     <li class="notificationTray self-end flex-grow">
         {{ notificationTray|raw }}

--- a/resources/templates/navigation.twig.html
+++ b/resources/templates/navigation.twig.html
@@ -5,8 +5,8 @@ Copyright (C) 2010, Ross Parker
 This is a Gibbon template file, written in HTML and Twig syntax.
 For info about editing, see: https://twig.symfony.com/doc/2.x/
 
-Module Menu: Displays a list of module actions available for the 
-current user. Outputs the sidebar in 'full' view-mode and as a 
+Module Menu: Displays a list of module actions available for the
+current user. Outputs the sidebar in 'full' view-mode and as a
 collapsed drop-down list in 'mini' view-mode.
 -->#}
 
@@ -20,26 +20,28 @@ collapsed drop-down list in 'mini' view-mode.
     </button>
     {% endif %}
 
-    {% for code in page.extraSidebar if sidebar and sidebarPosition != 'bottom' %}
-        {% if code is not empty %}
-        <div class="md:column-2 lg:column-1 pt-6 sm:pt-16 lg:pt-6">
-            {{ code|raw }}
-        </div>
-        {% endif %}
-    {% endfor %}
-    
+    {% if sidebar and sidebarPosition != 'bottom' %}
+        {% for code in page.extraSidebar %}
+            {% if code is not empty %}
+                <div class="md:column-2 lg:column-1 pt-6 sm:pt-16 lg:pt-6">
+                    {{ code|raw }}
+                </div>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
 
     {% if sidebar and sidebarContents %}
     <div class="md:column-2 lg:column-1 {{ page.breadcrumbs ? 'pt-10 lg:pt-0' }} ">
         {{ sidebarContents|raw }}
     </div>
     {% endif %}
-    
+
     {% if menuModule %}
-    <nav id="navigation" class="w-full font-sans hidden absolute top-0 z-40 mt-24 sm:mt-12 -ml-6 px-6  
+    <nav id="navigation" class="w-full font-sans hidden absolute top-0 z-40 mt-24 sm:mt-12 -ml-6 px-6
         {{ sidebar ? 'lg:block lg:static lg:p-0 lg:my-6 lg:mx-0' }}">
 
-        <ul class="w-full bg-white border list-none column-1 sm:column-2 md:column-3 m-0 pt-4 px-6 shadow-lg 
+        <ul class="w-full bg-white border list-none column-1 sm:column-2 md:column-3 m-0 pt-4 px-6 shadow-lg
             {{ sidebar ? 'lg:bg-transparent lg:border-0 lg:column-1 lg:shadow-none lg:p-0' : 'lg:px-8' }}">
 
             {% for categoryName, items in menuModule %}
@@ -62,11 +64,13 @@ collapsed drop-down list in 'mini' view-mode.
         </ul>
     </nav>
     {% endif %}
-    
-    {% for code in page.extraSidebar if sidebar and sidebarPosition == 'bottom' %}
-    <div class="md:column-2 lg:column-1 pt-6 sm:pt-16 lg:pt-0">
-        {{ code|raw }}
-    </div>
-    {% endfor %}
+
+    {% if sidebar and sidebarPosition == 'bottom' %}
+        {% for code in page.extraSidebar  %}
+            <div class="md:column-2 lg:column-1 pt-6 sm:pt-16 lg:pt-0">
+                {{ code|raw }}
+            </div>
+        {% endfor %}
+    {% endif %}
 </div>
 


### PR DESCRIPTION
**Description**
* Twig 2.x used to support using condition as a part of the for
  statement. But 3.x no longer support this syntax. Using it will
  result in "syntax error" exception from Twig.

  Reference:
  https://twig.symfony.com/doc/2.x/tags/for.html#adding-a-condition
  https://twig.symfony.com/doc/3.x/tags/for.html

* To future-proof the templates, simply extract the if statement
  from the for loop and wrap it on outside.

**Motivation and Context**
* Stumbled upon this error when trying to upgrade Twig from 2 and 3.
* We might not upgrade to Twig 3, we can still future proof our templates.

**How Has This Been Tested?**
Locally and In CI testing platform.