### PR TITLE
Tests: php8 test in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,9 +34,8 @@
     - mkdir $HOME/bin
     - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
     - php -r "if (getenv('COMPOSER_CHECKSUM') === false) exit('No COMPOSER_CHECKSUM. Installer verification skipped.' . PHP_EOL); if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_CHECKSUM')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); exit(1); } echo PHP_EOL;"
-    - php composer-setup.php --install-dir=$HOME/bin --filename=composer
+    - php composer-setup.php --install-dir=/usr/local/bin --filename=composer
     - php -r "unlink('composer-setup.php');"
-    - export PATH=$HOME/bin:$PATH
     # run test server for codeception tests
     - php -S 127.0.0.1:8888 -t $CI_PROJECT_DIR >/dev/null 2>&1 &
     # install dependencies for test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,19 +36,19 @@
     - php -r "if (getenv('COMPOSER_CHECKSUM') === false) exit('No COMPOSER_CHECKSUM. Installer verification skipped.' . PHP_EOL); if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_CHECKSUM')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); exit(1); } echo PHP_EOL;"
     - php composer-setup.php --install-dir=$HOME/bin --filename=composer
     - php -r "unlink('composer-setup.php');"
-    - export PATH=$HOME/bin:$HOME/.composer/vendor/bin:$PATH
+    - export PATH=$HOME/bin:$PATH
     # run test server for codeception tests
     - php -S 127.0.0.1:8888 -t $CI_PROJECT_DIR >/dev/null 2>&1 &
     # install dependencies for test
     - composer install --prefer-dist --no-interaction --no-progress
     # setup system locale for test
-    - echo -e "es_ES.UTF-8 UTF-8\nfr_FR.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8" > /etc/locale.gen
-    - cat /etc/locale.gen
-    - locale-gen es_ES.utf8
-    - locale-gen fr_FR.utf8
-    - locale-gen zh_TW.utf8
-    - localedef --list-archive
-    - locale -a
+    - |
+      cat <<- EOF | tee -a /etc/locale.gen
+      es_ES.UTF-8 UTF-8
+      fr_FR.UTF-8 UTF-8
+      zh_TW.UTF-8 UTF-8
+      EOF
+    - locale-gen
   script:
     - composer test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@
         >/dev/null 2>./tests/log/server_log &
 
     # install dependencies for test
-    - composer install --prefer-dist --no-interaction --no-progress
+    - composer install --prefer-dist --ansi --no-interaction --no-progress
 
     # setup system locale for test
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,18 +52,14 @@
   script:
     - composer test
 
-php:7.0:
-  image: php:7.0
-  extends: .tests
-
-php:7.1:
-  image: php:7.1
-  extends: .tests
-
-php:7.2:
-  image: php:7.2
-  extends: .tests
-
 php:7.3:
   image: php:7.3
+  extends: .tests
+
+php:7.4:
+  image: php:7.4
+  extends: .tests
+
+php:8.0:
+  image: php:8.0
   extends: .tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@
 
     # install apt packages
     - apt-get update -qy
-    - apt-get install -qy gettext git libzip-dev libgd-dev libpng-dev locales unzip zip zlib1g-dev
+    - apt-get install -qy mariadb-client gettext git libzip-dev libgd-dev libpng-dev locales unzip zip zlib1g-dev
 
     # install php extensions
     - docker-php-ext-install gd gettext pdo_mysql zip > /dev/null
@@ -114,6 +114,7 @@
   artifacts:
     paths:
       - tests/log
+      - tests/configs
     when: on_failure
     expire_in: 1 week
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,15 @@
       EOF
       locale-gen
 
+    # configure php cli to only report severe errors
+    - |
+      # improve php cli error reporting manner
+      export PHP_D=$(php --ini | grep 'Scan for additional .ini files in' | tr -s ' ' '\n' | tail -n1)
+      cat <<- EOF | tee $PHP_D/custom-error-reporting.ini
+      [PHP]
+      error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+      EOF
+
   script:
     - composer test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,32 +22,52 @@
   tags:
     - git-annex
   before_script:
+
     # install apt packages
     - apt-get update -qy
     - apt-get install -qy gettext git libzip-dev libgd-dev libpng-dev locales unzip zip zlib1g-dev
+
     # install php extensions
     - docker-php-ext-install gd gettext pdo_mysql zip > /dev/null
+
     # properly setup php
     - cp -pdf /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
-    - php --ini
+
     # install composer
-    - mkdir $HOME/bin
-    - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    - php -r "if (getenv('COMPOSER_CHECKSUM') === false) exit('No COMPOSER_CHECKSUM. Installer verification skipped.' . PHP_EOL); if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_CHECKSUM')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); exit(1); } echo PHP_EOL;"
-    - php composer-setup.php --install-dir=/usr/local/bin --filename=composer
-    - php -r "unlink('composer-setup.php');"
+    - |
+      # install composer
+      php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+      php -r "if (getenv('COMPOSER_CHECKSUM') === false) exit('No COMPOSER_CHECKSUM. Installer verification skipped.' . PHP_EOL); if (hash_file('SHA384', 'composer-setup.php') === getenv('COMPOSER_CHECKSUM')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); exit(1); } echo PHP_EOL;"
+      php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+      php -r "unlink('composer-setup.php');"
+
+    # create test log folder
+    - |
+      [ -d ./tests/log ] || mkdir ./tests/log
+
     # run test server for codeception tests
-    - php -S 127.0.0.1:8888 -t $CI_PROJECT_DIR >/dev/null 2>&1 &
+    - |
+      # run test server for codeception tests
+      php --server 127.0.0.1:8888 \
+        --docroot $CI_PROJECT_DIR \
+        --define display_startup_errors=1 \
+        --define display_errors=1 \
+        --define error_reporting=E_ALL \
+        >/dev/null 2>./tests/log/server_log &
+
     # install dependencies for test
     - composer install --prefer-dist --no-interaction --no-progress
+
     # setup system locale for test
     - |
-      cat <<- EOF | tee -a /etc/locale.gen
+      # setup system locale for test
+      cat <<- EOF | tee -a /etc/locale.gen >/dev/null
       es_ES.UTF-8 UTF-8
       fr_FR.UTF-8 UTF-8
       zh_TW.UTF-8 UTF-8
       EOF
-    - locale-gen
+      locale-gen
+
   script:
     - composer test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,52 @@
   script:
     - composer test
 
+  after_script:
+    - |
+      # dump database, if test failed
+      if [ "$CI_JOB_STATUS" = "failed" ]; then
+        [ -d ./tests/log ] || mkdir ./tests/log
+        mysqldump \
+          --protocol=tcp \
+          --host=$DB_HOST \
+          --user=$DB_USERNAME \
+          --password=$DB_PASSWORD \
+          $DB_NAME > ./tests/log/$DB_NAME.sql
+      else
+        echo "skipped"
+      fi
+    - |
+      # extract php.ini information if test failed
+      if [ "$CI_JOB_STATUS" = "failed" ]; then
+
+        # create folder to store configs
+        echo "Create ./tests/configs"
+        [ -d ./tests/configs ] || mkdir ./tests/configs
+
+        # get php --ini output
+        echo "Gather php --ini to php--ini.txt"
+        php --ini | tee ./tests/configs/php--ini.txt
+
+        # get the main php ini config
+        export PHP_INI=$(php --ini | grep 'Loaded Configuration File' | tr -s ' ' '\n' | tail -n1)
+        echo "Backup $PHP_INI"
+        cp -pdf $PHP_INI ./tests/configs/.
+
+        # get all files in the php.d folder
+        export PHP_D=$(php --ini | grep 'Scan for additional .ini files in' | tr -s ' ' '\n' | tail -n1)
+        echo "Backup $PHP_D"
+        cp -Rpdf $PHP_D ./tests/configs/.
+      else
+        echo "skipped"
+      fi
+
+  # store test logs when fail.
+  artifacts:
+    paths:
+      - tests/log
+    when: on_failure
+    expire_in: 1 week
+
 php:7.3:
   image: php:7.3
   extends: .tests


### PR DESCRIPTION
**Description**
* Update GitLab CI to test PHP 7.3 to 8.0.
* Clean up the syntax of the GitLab CI config.
* Improve test review by uploading artifact of failed tests.

**Motivation and Context**
* Move the GitLab CI config along side the latest repository changes

**How Has This Been Tested?**
On [my fork at GitLab.com](https://gitlab.com/yookoala/gibboneducore/-/pipelines?page=1&scope=branches&ref=feature%2Fphp8-test-in-gitlab-ci)