### PR TITLE
Core: fix getHighestGroupedAction ordering

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -770,8 +770,22 @@ function getHighestGroupedAction($guid, $address, $connection2)
     $moduleID = checkModuleReady($address, $connection2);
 
     try {
-        $data = array('actionName' => '%'.getActionName($address).'%', 'gibbonRoleID' => $_SESSION[$guid]['gibbonRoleIDCurrent'], 'moduleID' => $moduleID);
-        $sql = 'SELECT gibbonAction.name FROM gibbonAction, gibbonPermission, gibbonRole WHERE (gibbonAction.URLList LIKE :actionName) AND (gibbonAction.gibbonActionID=gibbonPermission.gibbonActionID) AND (gibbonPermission.gibbonRoleID=gibbonRole.gibbonRoleID) AND (gibbonPermission.gibbonRoleID=:gibbonRoleID) AND (gibbonAction.gibbonModuleID=:moduleID) ORDER BY precedence DESC, gibbonAction.gibbonActionID';
+        $data = [
+            'actionName' => '%'.getActionName($address).'%',
+            'gibbonRoleID' => $_SESSION[$guid]['gibbonRoleIDCurrent'],
+            'moduleID' => $moduleID,
+        ];
+        $sql = 'SELECT
+        gibbonAction.name
+        FROM
+        gibbonAction
+        INNER JOIN gibbonPermission ON (gibbonAction.gibbonActionID=gibbonPermission.gibbonActionID)
+        INNER JOIN gibbonRole ON (gibbonPermission.gibbonRoleID=gibbonRole.gibbonRoleID)
+        WHERE
+        (gibbonAction.URLList LIKE :actionName) AND
+        (gibbonPermission.gibbonRoleID=:gibbonRoleID) AND
+        (gibbonAction.gibbonModuleID=:moduleID)
+        ORDER BY gibbonAction.precedence DESC, gibbonAction.gibbonActionID';
 
         $result = $connection2->prepare($sql);
         $result->execute($data);

--- a/functions.php
+++ b/functions.php
@@ -771,7 +771,8 @@ function getHighestGroupedAction($guid, $address, $connection2)
 
     try {
         $data = array('actionName' => '%'.getActionName($address).'%', 'gibbonRoleID' => $_SESSION[$guid]['gibbonRoleIDCurrent'], 'moduleID' => $moduleID);
-        $sql = 'SELECT gibbonAction.name FROM gibbonAction, gibbonPermission, gibbonRole WHERE (gibbonAction.URLList LIKE :actionName) AND (gibbonAction.gibbonActionID=gibbonPermission.gibbonActionID) AND (gibbonPermission.gibbonRoleID=gibbonRole.gibbonRoleID) AND (gibbonPermission.gibbonRoleID=:gibbonRoleID) AND (gibbonAction.gibbonModuleID=:moduleID) ORDER BY precedence DESC';
+        $sql = 'SELECT gibbonAction.name FROM gibbonAction, gibbonPermission, gibbonRole WHERE (gibbonAction.URLList LIKE :actionName) AND (gibbonAction.gibbonActionID=gibbonPermission.gibbonActionID) AND (gibbonPermission.gibbonRoleID=gibbonRole.gibbonRoleID) AND (gibbonPermission.gibbonRoleID=:gibbonRoleID) AND (gibbonAction.gibbonModuleID=:moduleID) ORDER BY precedence DESC, gibbonAction.gibbonActionID';
+
         $result = $connection2->prepare($sql);
         $result->execute($data);
         if ($result->rowCount() > 0) {


### PR DESCRIPTION
**Description**
* Add a secondary ordering column "gibbonActionID" to fix the order
  to make sure the ordering consist in different storage engine.

**Motivation and Context**
* Fix #1237

**How Has This Been Tested?**
Locally and in CI platform. All tests are pass.