### PR TITLE
OOification: Return Process

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1777,100 +1777,11 @@ function isCommandLineInterface()
 }
 
 /**
- * Easy Return Display Processing. Print out message as appropriate.
- * See returnProcessGetAlert() for more details.
- *
- * @param string $guid
- *      The guid of your Gibbon Install.
- * @param string $return
- *      The return value of the process.
- * @param string $editLink
- *      (Optional) This should be a link. The link will appended to the end of a success0 return.
- * @param array $customReturns
- *      (Optional) This should be an array. The array allows you to set custom return checks and
- *      messages. Set the array key to the return name and the value to the return message.
- *
- * @return void
+ * @deprecated in v22. Use Page's ReturnMessage.
  */
 function returnProcess($guid, $return, $editLink = null, $customReturns = null)
 {
-    $alert = returnProcessGetAlert($return, $editLink, $customReturns);
-
-    echo !empty($alert)
-        ? "<div class='{$alert['context']}'>{$alert['text']}</div>"
-        : '';
-}
-
-/**
- * Render HTML for easy return display process.
- *
- * Default returns:
- *   success0: This is a default success message for adding a new record.
- *   error0:   This is a default error message for invalid permission for an action.
- *   error1:   This is a default error message for invalid inputs.
- *   error2:   This is a defualt error message for a database error.
- *   warning0: This is a default warning message for a extra data failing to save.
- *   warning1: This is a default warning message for a successful request, where certain data was not save properly.
- *
- * @param string $return
- *      The return value of the process.
- * @param string $editLink
- *      (Optional) This should be a link. The link will appended to the end of a success0 return.
- * @param array $customReturns
- *      (Optional) This should be an array. The array allows you to set custom return checks and
- *      messages. Set the array key to the return name and the value to the return message.
- * @return string
- *      The HTML ouput of the easy return display.
- */
-function returnProcessGetAlert($return, $editLink = null, $customReturns = null) {
-    if (isset($return)) {
-        $returns = [ 
-            //Successes
-            'success0' => __('Your request was completed successfully.'),
-            'successa' => __('Your account has been successfully updated. You can now continue to use the system as per normal.'),
-            'success5' => __('Your request has been successfully started as a background process. It will continue to run on the server until complete and you will be notified of any errors.'),
-            
-            //Errors
-            'error0' => __('Your request failed because you do not have access to this action.'),
-            'error1' => __('Your request failed because your inputs were invalid.'),
-            'error2' => __('Your request failed due to a database error.'),
-            'error3' => __('Your request failed because your inputs were invalid.'),
-            'error4' => __('Your request failed because your passwords did not match.'),
-            'error5' => __('Your request failed because there are no records to show.'),
-            'error6' => __('Your request was completed successfully, but there was a problem saving some uploaded files.'),
-            'error7' => __('Your request failed because some required values were not unique.'),
-            'error8' => __('Your request failed because the link is invalid or has expired.'),
-
-            //Warnings
-            'warning0' => __('Your optional extra data failed to save.'),
-            'warning1' => __('Your request was successful, but some data was not properly saved.'),
-            'warning2' => __('Your request was successful, but some data was not properly deleted.'),
-        ];
-
-        if (is_array($customReturns)) {
-            foreach ($customReturns as $key => $value) {
-                $customReturn = $value ?? __('Unknown Return');
-                $returns[$key] = $value;
-            }
-        }
-
-        $returnMessage = $returns[$return] ?? __('Unknown Return');
-        $returnClass = 'error';
-
-        $classes = ['warning', 'success', 'message'];
-        foreach ($classes as $class) {
-            //TODO: Replace this with str_starts_with when PHP8 is required
-            if (substr($return, 0, strlen($class)) == $class) {
-                $returnClass = $class;
-                break;
-            }
-        }
-
-        if ($class == 'success' && $editLink != null) {
-            $returnMessage .= ' '.sprintf(__('You can edit your newly created record %1$shere%2$s.'), "<a href='$editLink'>", '</a>');
-        }
-
-        return ['context' => $returnClass, 'text' => $returnMessage];
-    }
-    return null;
+    global $page;
+    $page->return->setEditLink($editLink ?? '');
+    $page->return->addCustomReturns($customReturns ?? []);
 }

--- a/functions.php
+++ b/functions.php
@@ -1778,7 +1778,7 @@ function isCommandLineInterface()
 
 /**
  * Easy Return Display Processing. Print out message as appropriate.
- * See returnProcessMessage() for more details.
+ * See returnProcessGetAlert() for more details.
  *
  * @param string $guid
  *      The guid of your Gibbon Install.
@@ -1812,8 +1812,6 @@ function returnProcess($guid, $return, $editLink = null, $customReturns = null)
  *   warning0: This is a default warning message for a extra data failing to save.
  *   warning1: This is a default warning message for a successful request, where certain data was not save properly.
  *
- * @param string $guid
- *      The guid of your Gibbon Install.
  * @param string $return
  *      The return value of the process.
  * @param string $editLink
@@ -1826,58 +1824,53 @@ function returnProcess($guid, $return, $editLink = null, $customReturns = null)
  */
 function returnProcessGetAlert($return, $editLink = null, $customReturns = null) {
     if (isset($return)) {
-        $class = 'error';
-        $returnMessage = 'Unknown Return';
-        $returns = array();
-        $returns['success0'] = __('Your request was completed successfully.');
-        $returns['successa'] = __('Your account has been successfully updated. You can now continue to use the system as per normal.');
-        $returns['success5'] = __('Your request has been successfully started as a background process. It will continue to run on the server until complete and you will be notified of any errors.');
-        $returns['error0'] = __('Your request failed because you do not have access to this action.');
-        $returns['error1'] = __('Your request failed because your inputs were invalid.');
-        $returns['error2'] = __('Your request failed due to a database error.');
-        $returns['error3'] = __('Your request failed because your inputs were invalid.');
-        $returns['error4'] = __('Your request failed because your passwords did not match.');
-        $returns['error5'] = __('Your request failed because there are no records to show.');
-        $returns['error6'] = __('Your request was completed successfully, but there was a problem saving some uploaded files.');
-        $returns['error7'] = __('Your request failed because some required values were not unique.');
-        $returns['error8'] = _('Your request failed because the link is invalid or has expired.');
-        $returns['warning0'] = __('Your optional extra data failed to save.');
-        $returns['warning1'] = __('Your request was successful, but some data was not properly saved.');
-        $returns['warning2'] = __('Your request was successful, but some data was not properly deleted.');
+        $returns = [ 
+            //Successes
+            'success0' => __('Your request was completed successfully.'),
+            'successa' => __('Your account has been successfully updated. You can now continue to use the system as per normal.'),
+            'success5' => __('Your request has been successfully started as a background process. It will continue to run on the server until complete and you will be notified of any errors.'),
+            
+            //Errors
+            'error0' => __('Your request failed because you do not have access to this action.'),
+            'error1' => __('Your request failed because your inputs were invalid.'),
+            'error2' => __('Your request failed due to a database error.'),
+            'error3' => __('Your request failed because your inputs were invalid.'),
+            'error4' => __('Your request failed because your passwords did not match.'),
+            'error5' => __('Your request failed because there are no records to show.'),
+            'error6' => __('Your request was completed successfully, but there was a problem saving some uploaded files.'),
+            'error7' => __('Your request failed because some required values were not unique.'),
+            'error8' => __('Your request failed because the link is invalid or has expired.'),
 
-        if (isset($customReturns)) {
-            if (is_array($customReturns)) {
-                $customReturnKeys = array_keys($customReturns);
-                foreach ($customReturnKeys as $customReturnKey) {
-                    $customReturn = __('Unknown Return');
-                    if (isset($customReturns[$customReturnKey])) {
-                        $customReturn = $customReturns[$customReturnKey];
-                    }
-                    $returns[$customReturnKey] = $customReturn;
-                }
+            //Warnings
+            'warning0' => __('Your optional extra data failed to save.'),
+            'warning1' => __('Your request was successful, but some data was not properly saved.'),
+            'warning2' => __('Your request was successful, but some data was not properly deleted.'),
+        ];
+
+        if (is_array($customReturns)) {
+            foreach ($customReturns as $key => $value) {
+                $customReturn = $value ?? __('Unknown Return');
+                $returns[$key] = $value;
             }
         }
-        $returnKeys = array_keys($returns);
-        foreach ($returnKeys as $returnKey) {
-            if ($return == $returnKey) {
-                $returnMessage = $returns[$returnKey];
-                if (stripos($return, 'error') !== false) {
-                    $class = 'error';
-                } elseif (stripos($return, 'warning') !== false) {
-                    $class = 'warning';
-                } elseif (stripos($return, 'success') !== false) {
-                    $class = 'success';
-                } elseif (stripos($return, 'message') !== false) {
-                    $class = 'message';
-                }
+
+        $returnMessage = $returns[$return] ?? __('Unknown Return');
+        $returnClass = 'error';
+
+        $classes = ['warning', 'success', 'message'];
+        foreach ($classes as $class) {
+            //TODO: Replace this with str_starts_with when PHP8 is required
+            if (substr($return, 0, strlen($class)) == $class) {
+                $returnClass = $class;
                 break;
             }
         }
+
         if ($class == 'success' && $editLink != null) {
             $returnMessage .= ' '.sprintf(__('You can edit your newly created record %1$shere%2$s.'), "<a href='$editLink'>", '</a>');
         }
 
-        return ['context' => $class, 'text' => $returnMessage];
+        return ['context' => $returnClass, 'text' => $returnMessage];
     }
     return null;
 }

--- a/functions.php
+++ b/functions.php
@@ -1783,5 +1783,5 @@ function returnProcess($guid, $return, $editLink = null, $customReturns = null)
 {
     global $page;
     $page->return->setEditLink($editLink ?? '');
-    $page->return->addCustomReturns($customReturns ?? []);
+    $page->return->addReturns($customReturns ?? []);
 }

--- a/index.php
+++ b/index.php
@@ -686,7 +686,7 @@ if (!$session->has('address')) {
  *
  * TODO: Replace all returnProcess() from pages with respective $page->return calls.
  */
-if ($session->has('address') && !empty($_GET['return'])) {
+if (!empty($_GET['return'])) {
     if ($alert = $page->return->process($_GET['return'])){
         $page->addAlert($alert['context'], $alert['text']);
     }

--- a/index.php
+++ b/index.php
@@ -453,25 +453,6 @@ if ($isLoggedIn) {
 }
 
 /**
- * RETURN PROCESS
- *
- * Adds an alert to the index based on the URL 'return' parameter.
- *
- * TODO: Remove all returnProcess() from pages. We could add a method to the
- * Page class to allow them to register custom messages, or use Session flash
- * to add the message directly from the Process pages.
- */
-if (!$session->has('address') && !empty($_GET['return'])) {
-    $customReturns = [
-        'success1' => __('Password reset was successful: you may now log in.')
-    ];
-
-    if ($alert = returnProcessGetAlert($_GET['return'], '', $customReturns)) {
-        $page->addAlert($alert['context'], $alert['text']);
-    }
-}
-
-/**
  * MENU ITEMS & FAST FINDER
  *
  * TODO: Move this somewhere more sensible.
@@ -698,6 +679,18 @@ if (!$session->has('address')) {
     }
 }
 
+/**
+ * RETURN PROCESS
+ *
+ * Adds an alert to the index based on the URL 'return' parameter.
+ *
+ * TODO: Replace all returnProcess() from pages with respective $page->return calls.
+ */
+if ($session->has('address') && !empty($_GET['return'])) {
+    if ($alert = $page->return->process($_GET['return'])){
+        $page->addAlert($alert['context'], $alert['text']);
+    }
+}
 /**
  * GET SIDEBAR CONTENT
  *

--- a/src/View/Components/ReturnMessage.php
+++ b/src/View/Components/ReturnMessage.php
@@ -35,7 +35,7 @@ class ReturnMessage
      */
     public function __construct()
     {
-        $this->addCustomReturns([ 
+        $this->addReturns([ 
             //Successes
             'success0' => __('Your request was completed successfully.'),
             'success1' => __('Password reset was successful: you may now log in.'),
@@ -75,7 +75,7 @@ class ReturnMessage
      * @param string $return
      * @param string $message
      */
-    public function addCustomReturn(string $return, string $message)
+    public function addReturn(string $return, string $message)
     {
         $this->returns[$return] = $message;
     }
@@ -83,11 +83,11 @@ class ReturnMessage
     /**
      * Registers an array of new returns
      *
-     * @param array $customReturns
+     * @param array $returns
      */
-    public function addCustomReturns(array $customReturns)
+    public function addReturns(array $returns)
     {
-        $this->returns = array_replace($this->returns, $customReturns);
+        $this->returns = array_replace($this->returns, $returns);
     }
 
     /**

--- a/src/View/Components/ReturnMessage.php
+++ b/src/View/Components/ReturnMessage.php
@@ -1,0 +1,122 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\View\Components;
+
+/**
+ * Return Message.
+ *
+ * @version v22
+ * @since   v22
+ */
+class ReturnMessage
+{
+    protected $editLink = '';
+    protected $returns = []; 
+
+    /**
+     * Add default returns.
+     */
+    public function __construct()
+    {
+        $this->addCustomReturns([ 
+            //Successes
+            'success0' => __('Your request was completed successfully.'),
+            'success1' => __('Password reset was successful: you may now log in.'),
+            'success5' => __('Your request has been successfully started as a background process. It will continue to run on the server until complete and you will be notified of any errors.'),
+            'successa' => __('Your account has been successfully updated. You can now continue to use the system as per normal.'),
+            
+            //Errors
+            'error0' => __('Your request failed because you do not have access to this action.'),
+            'error1' => __('Your request failed because your inputs were invalid.'),
+            'error2' => __('Your request failed due to a database error.'),
+            'error3' => __('Your request failed because your inputs were invalid.'),
+            'error4' => __('Your request failed because your passwords did not match.'),
+            'error5' => __('Your request failed because there are no records to show.'),
+            'error6' => __('Your request was completed successfully, but there was a problem saving some uploaded files.'),
+            'error7' => __('Your request failed because some required values were not unique.'),
+            'error8' => __('Your request failed because the link is invalid or has expired.'),
+
+            //Warnings
+            'warning0' => __('Your optional extra data failed to save.'),
+            'warning1' => __('Your request was successful, but some data was not properly saved.'),
+            'warning2' => __('Your request was successful, but some data was not properly deleted.'),
+        ]);
+    }
+
+    /**
+     * Sets the Edit Link for the return message.
+     * @param string $editLink
+     */
+    public function setEditLink(string $editLink)
+    {
+        $this->editLink = $editLink;
+    }
+
+    /**
+     * Registers a new return with the given key and message. 
+     *
+     * @param string $return
+     * @param string $message
+     */
+    public function addCustomReturn(string $return, string $message)
+    {
+        $this->returns[$return] = $message;
+    }
+
+    /**
+     * Registers an array of new returns
+     *
+     * @param array $customReturns
+     */
+    public function addCustomReturns(array $customReturns)
+    {
+        $this->returns = array_replace($this->returns, $customReturns);
+    }
+
+    /**
+     * Process a return string and get back a context and text.
+     *
+     * @param string $return
+     * @return array
+     */
+    public function process(string $return): array
+    {
+        if (isset($return)) {
+            $returnMessage = $this->returns[$return] ?? __('Unknown Return');
+            $returnClass = 'error';
+
+            $classes = ['warning', 'success', 'message'];
+            foreach ($classes as $class) {
+                //TODO: Replace this with str_starts_with when PHP8 is required
+                if (substr($return, 0, strlen($class)) == $class) {
+                    $returnClass = $class;
+                    break;
+                }
+            }
+
+            if ($class == 'success' && !empty($this->editLink)) {
+                $returnMessage .= ' '.sprintf(__('You can edit your newly created record %1$shere%2$s.'), "<a href='$this->editLink'>", '</a>');
+            }
+
+            return ['context' => $returnClass, 'text' => $returnMessage];
+        }
+        return null;
+    }
+}

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -23,6 +23,7 @@ use Twig\Environment;
 use Gibbon\View\View;
 use Gibbon\View\AssetBundle;
 use Gibbon\View\Components\Breadcrumbs;
+use Gibbon\View\Components\ReturnMessage;
 
 /**
  * Holds the details for rendering the current page.
@@ -49,8 +50,11 @@ class Page extends View
     protected $stylesheets;
     protected $scripts;
     protected $breadcrumbs;
+    protected $return;
     protected $alerts = ['error' => [], 'warning' => [], 'success' => [], 'message' => []];
     protected $extra = ['head' => [], 'foot' => [], 'sidebar' => []];
+    protected $editLink;
+    protected $returns;
 
     /**
      * Create a new page from a variable set of constructor params.
@@ -64,6 +68,7 @@ class Page extends View
         $this->breadcrumbs = new Breadcrumbs();
         $this->stylesheets = new AssetBundle();
         $this->scripts = new AssetBundle();
+        $this->return = new ReturnMessage();
 
         // Merge constructor params into class properties
         foreach ($params as $key => $value) {

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -53,8 +53,6 @@ class Page extends View
     protected $return;
     protected $alerts = ['error' => [], 'warning' => [], 'success' => [], 'message' => []];
     protected $extra = ['head' => [], 'foot' => [], 'sidebar' => []];
-    protected $editLink;
-    protected $returns;
 
     /**
      * Create a new page from a variable set of constructor params.


### PR DESCRIPTION
**Description**
OOification of Return Processing. This PR deprecates the old returnProcess method and implements a new ReturnMessage class which is handled by Page to process and render return messages. ReturnMessage has methods to set the edit link for a page and add custom returns for processing. For backwards compatibility, the returnProcess method calls the new ReturnMessage methods to set the relevant details.

**How Has This Been Tested?**
Locally on several modules with untouched returnProcess methods and pages altered to use new system.
