### PR TITLE
Fixed errors when DataSet is empty

### DIFF
--- a/src/Forms/Traits/MultipleOptionsTrait.php
+++ b/src/Forms/Traits/MultipleOptionsTrait.php
@@ -126,15 +126,15 @@ trait MultipleOptionsTrait
             $options = array_filter($dataset->toArray(), function ($item) use ($valCol,$nameCol) {
                 return isset($item[$valCol]) && isset($item[$nameCol]);
             });
-        }
 
-        foreach ($options as $option) {
-            $option = array_map('trim', $option);
+            foreach ($options as $option) {
+                $option = array_map('trim', $option);
 
-            if ($groupBy !== false) {
-                $this->options[$option[$groupBy]][$option[$valCol]] = __($option[$nameCol]);
-            } else {
-                $this->options[$option[$valCol]]= __($option[$nameCol]);
+                if ($groupBy !== false) {
+                    $this->options[$option[$groupBy]][$option[$valCol]] = __($option[$nameCol]);
+                } else {
+                    $this->options[$option[$valCol]]= __($option[$nameCol]);
+                }
             }
         }
 


### PR DESCRIPTION
**Description**
When an empty DataSet is given to a select with the function from DataSet, a warning and a notice will pop up.

**How Has This Been Tested?**
Locally.

**Screenshots**
![image](https://user-images.githubusercontent.com/8520854/106838245-0363fa00-66f0-11eb-81a0-eae035ba5211.png)

