### PR TITLE
User Admin: enable restricting Public Registration to a list of allowed domains

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -774,4 +774,5 @@ INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `val
 ALTER TABLE `gibbonDiscussion` ADD `gibbonPersonIDTarget` INT(10) UNSIGNED ZEROFILL NULL AFTER `gibbonPersonID`;end
 DELETE FROM `gibbonSetting` WHERE scope='Messenger' AND name IN ('messengerLastBubble','messageBubbleBGColor','messageBubbleWidthType','messageBubbleAutoHide');end
 INSERT INTO gibbonCountry VALUES ('South Sudan', '211');end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('User Admin', 'publicRegistrationAllowedDomains', 'Public Registration Allowed Domains', 'Comma-separated list of email address domains allowed when registering. Leave blank for no restriction.', '');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ v22.0.00
         System Admin: added a Reporting Values by Roll Group import option
         System Admin: updated user-related imports to enable importing by username or email address
         System Admin: added file uploader for choosing logo and background images in System Settings
+        User Admin: added an option to restrict Public Registration to a list of allowed domains
         Tests: migrated test suite to GitHub actions, updated testing libraries to recent versions
 
     Bug Fixes

--- a/modules/User Admin/publicRegistrationSettings.php
+++ b/modules/User Admin/publicRegistrationSettings.php
@@ -56,6 +56,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/publicRegistrat
             ->selected($setting['value'])
             ->required();
 
+    $setting = getSettingByScope($connection2, 'User Admin', 'publicRegistrationAllowedDomains', true);
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addTextField($setting['name'])->setValue($setting['value']);
+
     $row = $form->addRow()->addHeading(__('Interface Options'));
 
     $setting = getSettingByScope($connection2, 'User Admin', 'publicRegistrationIntro', true);
@@ -84,4 +89,3 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/publicRegistrat
 
     echo $form->getOutput();
 }
-?>

--- a/publicRegistrationProcess.php
+++ b/publicRegistrationProcess.php
@@ -40,18 +40,6 @@ if ($proceed == false) {
     $URL .= '&return=error0';
     header("Location: {$URL}");
 } else {
-    //Lock activities table
-    try {
-        $data = array();
-        $sql = 'LOCK TABLES gibbonPerson WRITE, gibbonSetting READ, gibbonNotification WRITE, gibbonModule WRITE, gibbonPersonField WRITE';
-        $result = $connection2->prepare($sql);
-        $result->execute($data);
-    } catch (PDOException $e) {
-        $URL .= '&return=error2';
-        header("Location: {$URL}");
-        exit();
-    }
-
     // Sanitize the whole $_POST array
     $validator = new \Gibbon\Data\Validator();
     $_POST = $validator->sanitize($_POST);
@@ -80,112 +68,117 @@ if ($proceed == false) {
     if ($surname == '' or $firstName == '' or $preferredName == '' or $officialName == '' or $gender == '' or $dob == '' or $email == '' or $username == '' or $password == '' or $gibbonRoleIDPrimary == '' or $gibbonRoleIDPrimary == '' or ($status != 'Pending Approval' and $status != 'Full')) {
         $URL .= '&return=error1';
         header("Location: {$URL}");
-    } else {
-        $customRequireFail = false;
-        $resultFields = getCustomFields($connection2, $guid, null, null, null, null, null, null, true);
-        $fields = array();
-        if ($resultFields->rowCount() > 0) {
-            while ($rowFields = $resultFields->fetch()) {
-                if (isset($_POST['custom'.$rowFields['gibbonPersonFieldID']])) {
-                    if ($rowFields['type'] == 'date') {
-                        $fields[$rowFields['gibbonPersonFieldID']] = dateConvert($guid, $_POST['custom'.$rowFields['gibbonPersonFieldID']]);
-                    } else {
-                        $fields[$rowFields['gibbonPersonFieldID']] = $_POST['custom'.$rowFields['gibbonPersonFieldID']];
-                    }
-                }
-                if ($rowFields['required'] == 'Y') {
-                    if (isset($_POST['custom'.$rowFields['gibbonPersonFieldID']]) == false) {
-                        $customRequireFail = true;
-                    } elseif ($_POST['custom'.$rowFields['gibbonPersonFieldID']] == '') {
-                        $customRequireFail = true;
-                    }
-                }
-            }
-        }
+        exit;
+    }
 
-        if ($customRequireFail) {
-            $URL .= '&return=error1';
+    // Check email address domain
+    $allowedDomains = getSettingByScope($connection2, 'User Admin', 'publicRegistrationAllowedDomains');
+    $allowedDomains = array_filter(array_map('trim', explode(',', $allowedDomains)));
+
+    if (!empty($allowedDomains)) {
+        $emailCheck = array_filter($allowedDomains, function ($domain) use ($email) {
+            return stripos($email, $domain) !== false;
+        });
+        if (empty($emailCheck)) {
+            $URL .= '&return=error8';
             header("Location: {$URL}");
-            exit();
-        } else {
-            $fields = json_encode($fields);
+            exit;
         }
+    }
 
-        //Check strength of password
-        $passwordMatch = doesPasswordMatchPolicy($connection2, $password);
-
-        if ($passwordMatch == false) {
-            $URL .= '&return=error7';
-            header("Location: {$URL}");
-        } else {
-            //Check uniqueness of username (and/or email, if required)
-            $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
-            if ($uniqueEmailAddress == 'Y') {
-                $data = array('username' => $username, 'email' => $email);
-                $sql = 'SELECT * FROM gibbonPerson WHERE username=:username OR email=:email';
-                $result = $pdo->selectOne($sql, $data);
-            } else {
-                $data = array('username' => $username);
-                $sql = 'SELECT * FROM gibbonPerson WHERE username=:username';
-                $result = $pdo->selectOne($sql, $data);
-            }
-
-            if (!empty($result)) {
-                $URL .= '&return=error3';
-                header("Location: {$URL}");
-            } else {
-                //Check publicRegistrationMinimumAge
-                $publicRegistrationMinimumAge = getSettingByScope($connection2, 'User Admin', 'publicRegistrationMinimumAge');
-
-                $ageFail = false;
-                if ($publicRegistrationMinimumAge == '') {
-                    $ageFail = true;
-                } elseif ($publicRegistrationMinimumAge > 0 and $publicRegistrationMinimumAge > (new DateTime('@'.Format::timestamp($dob)))->diff(new DateTime())->y) {
-                    $ageFail = true;
-                }
-
-                if ($ageFail == true) {
-                    $URL .= '&return=fail5';
-                    header("Location: {$URL}");
+    // Check required custom fields
+    $customRequireFail = false;
+    $resultFields = getCustomFields($connection2, $guid, null, null, null, null, null, null, true);
+    $fields = array();
+    if ($resultFields->rowCount() > 0) {
+        while ($rowFields = $resultFields->fetch()) {
+            if (isset($_POST['custom'.$rowFields['gibbonPersonFieldID']])) {
+                if ($rowFields['type'] == 'date') {
+                    $fields[$rowFields['gibbonPersonFieldID']] = dateConvert($guid, $_POST['custom'.$rowFields['gibbonPersonFieldID']]);
                 } else {
-                    //Write to database
-                    try {
-                        $data = array('surname' => $surname, 'firstName' => $firstName, 'preferredName' => $preferredName, 'officialName' => $officialName, 'gender' => $gender, 'dob' => $dob, 'email' => $email, 'username' => $username, 'passwordStrong' => $passwordStrong, 'passwordStrongSalt' => $salt, 'status' => $status, 'gibbonRoleIDPrimary' => $gibbonRoleIDPrimary, 'gibbonRoleIDAll' => $gibbonRoleIDAll, 'fields' => $fields);
-                        $sql = "INSERT INTO gibbonPerson SET surname=:surname, firstName=:firstName, preferredName=:preferredName, officialName=:officialName, gender=:gender, dob=:dob, email=:email, username=:username, password='', passwordStrong=:passwordStrong, passwordStrongSalt=:passwordStrongSalt, status=:status, gibbonRoleIDPrimary=:gibbonRoleIDPrimary, gibbonRoleIDAll=:gibbonRoleIDAll, fields=:fields";
-                        $result = $connection2->prepare($sql);
-                        $result->execute($data);
-                    } catch (PDOException $e) {
-                        echo $e->getMessage();
-                        exit();
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
-                        exit();
-                    }
-
-                    $gibbonPersonID = $connection2->lastInsertId();
-
-                    
-                        $sqlLock = 'UNLOCK TABLES';
-                        $result = $connection2->query($sqlLock);
-
-                    if ($status == 'Pending Approval') {
-                        // Raise a new notification event
-                        $event = new NotificationEvent('User Admin', 'New Public Registration');
-
-                        $event->addRecipient($gibbon->session->get('organisationAdmissions'));
-                        $event->setNotificationText(sprintf(__('An new public registration, for %1$s, is pending approval.'), Format::name('', $preferredName, $surname, 'Student')));
-                        $event->setActionLink("/index.php?q=/modules/User Admin/user_manage_edit.php&gibbonPersonID=$gibbonPersonID&search=");
-
-                        $event->sendNotifications($pdo, $gibbon->session);
-
-                        $URL .= '&return=success1';
-                        header("Location: {$URL}");
-                    } else {
-                        $URL .= '&return=success0';
-                        header("Location: {$URL}");
-                    }
+                    $fields[$rowFields['gibbonPersonFieldID']] = $_POST['custom'.$rowFields['gibbonPersonFieldID']];
+                }
+            }
+            if ($rowFields['required'] == 'Y') {
+                if (isset($_POST['custom'.$rowFields['gibbonPersonFieldID']]) == false) {
+                    $customRequireFail = true;
+                } elseif ($_POST['custom'.$rowFields['gibbonPersonFieldID']] == '') {
+                    $customRequireFail = true;
                 }
             }
         }
+    }
+
+    if ($customRequireFail) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    } else {
+        $fields = json_encode($fields);
+    }
+
+    // Check strength of password
+    $passwordMatch = doesPasswordMatchPolicy($connection2, $password);
+
+    if ($passwordMatch == false) {
+        $URL .= '&return=error6';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Check uniqueness of username (and/or email, if required)
+    $uniqueEmailAddress = getSettingByScope($connection2, 'User Admin', 'uniqueEmailAddress');
+    if ($uniqueEmailAddress == 'Y') {
+        $data = array('username' => $username, 'email' => $email);
+        $sql = 'SELECT * FROM gibbonPerson WHERE username=:username OR email=:email';
+        $result = $pdo->selectOne($sql, $data);
+    } else {
+        $data = array('username' => $username);
+        $sql = 'SELECT * FROM gibbonPerson WHERE username=:username';
+        $result = $pdo->selectOne($sql, $data);
+    }
+
+    if (!empty($result)) {
+        $URL .= '&return=error7';
+        header("Location: {$URL}");
+        exit;
+    } 
+
+    // Check publicRegistrationMinimumAge
+    $publicRegistrationMinimumAge = getSettingByScope($connection2, 'User Admin', 'publicRegistrationMinimumAge');
+
+    if (!empty($publicRegistrationMinimumAge) > 0 and $publicRegistrationMinimumAge > (new DateTime('@'.Format::timestamp($dob)))->diff(new DateTime())->y) {
+        $URL .= '&return=error5';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    //Write to database
+    $data = array('surname' => $surname, 'firstName' => $firstName, 'preferredName' => $preferredName, 'officialName' => $officialName, 'gender' => $gender, 'dob' => $dob, 'email' => $email, 'username' => $username, 'passwordStrong' => $passwordStrong, 'passwordStrongSalt' => $salt, 'status' => $status, 'gibbonRoleIDPrimary' => $gibbonRoleIDPrimary, 'gibbonRoleIDAll' => $gibbonRoleIDAll, 'fields' => $fields);
+    $sql = "INSERT INTO gibbonPerson SET surname=:surname, firstName=:firstName, preferredName=:preferredName, officialName=:officialName, gender=:gender, dob=:dob, email=:email, username=:username, password='', passwordStrong=:passwordStrong, passwordStrongSalt=:passwordStrongSalt, status=:status, gibbonRoleIDPrimary=:gibbonRoleIDPrimary, gibbonRoleIDAll=:gibbonRoleIDAll, fields=:fields";
+
+    $gibbonPersonID = $pdo->insert($sql, $data);
+
+    if (empty($gibbonPersonID)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    if ($status == 'Pending Approval') {
+        // Raise a new notification event
+        $event = new NotificationEvent('User Admin', 'New Public Registration');
+
+        $event->addRecipient($gibbon->session->get('organisationAdmissions'));
+        $event->setNotificationText(sprintf(__('An new public registration, for %1$s, is pending approval.'), Format::name('', $preferredName, $surname, 'Student')));
+        $event->setActionLink("/index.php?q=/modules/User Admin/user_manage_edit.php&gibbonPersonID=$gibbonPersonID&search=");
+
+        $event->sendNotifications($pdo, $gibbon->session);
+
+        $URL .= '&return=success1';
+        header("Location: {$URL}");
+    } else {
+        $URL .= '&return=success0';
+        header("Location: {$URL}");
     }
 }


### PR DESCRIPTION
This PR adds an optional Public Registration Setting to enable restricting public registration to users from a comma-separated list of allowed domains. The domains are checked with client-side and server-side validation. OOifies and tidies up some code along the way, as well as adds a password confirmation field, which was oddly missing.

**Motivation and Context**
Enables administrators to restrict who can register.

**How Has This Been Tested?**
Locally

**Setting**
<img width="896" alt="Screenshot 2021-02-16 at 10 35 24 AM" src="https://user-images.githubusercontent.com/897700/108011781-ccbca680-7042-11eb-86df-bcb62561cc23.png">

**Registration**
<img width="896" alt="Screenshot 2021-02-16 at 10 35 14 AM" src="https://user-images.githubusercontent.com/897700/108011786-cfb79700-7042-11eb-8cca-fde20f33020c.png">
