### PR TITLE
System: add an Enrolment tab to the Staff Dashboard

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ v22.0.00
 
     Significant Changes
         System: improved support for custom themes
+        System: added an Enrolment tab to the Staff Dashboard
 
     Changes With Important Notices
 

--- a/resources/templates/ui/enrolmentOverview.twig.html
+++ b/resources/templates/ui/enrolmentOverview.twig.html
@@ -1,0 +1,49 @@
+{#<!--
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+<div class="flex w-full mt-4 mb-6 bg-white shadow rounded font-sans">
+
+    <div class="w-1/3 flex flex-wrap font-sans items-start content-end justify-between py-5 px-6 border-r border-gray-300">
+        <div class="w-full text-sm font-light text-gray-600">
+            {{ __('Current Enrolment') }}
+        </div>
+        <div class="text-xl font-semibold text-gray-800 leading-normal">
+            {{ currentEnrolment }}
+        </div>
+    </div>
+
+    <div class="w-1/3 flex flex-wrap font-sans items-start content-end justify-between py-5 px-6 border-r border-gray-300">
+        <div class="w-full text-sm font-light text-gray-600">
+            {{ __('Last 60 Days') }}
+        </div>
+        <div class="text-xl font-semibold text-gray-800 leading-normal">
+            {{ lastEnrolment }}
+        </div>
+        <div class="mt-1">
+            {% set change = currentEnrolment - lastEnrolment %}
+            <span class="tag rounded-full {{ change > 0 ? 'success' : ( change < 0 ? 'error' : 'dull' ) }}">
+                {{ change > 0 ? "+" ~ change : ( change < 0 ? change : __('No Change') ) }}
+            </span>
+        </div>
+    </div>
+
+    <div class="w-1/3 flex flex-wrap font-sans items-start content-end justify-between py-5 px-6 border-gray-300">
+        <div class="w-full text-sm font-light text-gray-600">
+            {{ __('Next 60 Days') }}
+        </div>
+        <div class="text-xl font-semibold text-gray-800 leading-normal">
+            {{ nextEnrolment }}
+        </div>
+        <div class="mt-1">
+            {% set change = nextEnrolment - currentEnrolment  %}
+            <span class="tag rounded-full {{ change > 0 ? 'success' : ( change < 0 ? 'error' : 'dull' ) }}">
+                {{ change > 0 ? "+" ~ change : ( change < 0 ? change : __('No Change') ) }}
+            </span>
+        </div>
+    </div>
+</div>

--- a/resources/templates/ui/enrolmentOverview.twig.html
+++ b/resources/templates/ui/enrolmentOverview.twig.html
@@ -19,7 +19,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
     <div class="w-1/3 flex flex-wrap font-sans items-start content-end justify-between py-5 px-6 border-r border-gray-300">
         <div class="w-full text-sm font-light text-gray-600">
-            {{ __('Last 60 Days') }}
+            {{ __('60 Days Ago') }}
         </div>
         <div class="text-xl font-semibold text-gray-800 leading-normal">
             {{ lastEnrolment }}
@@ -34,7 +34,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
     <div class="w-1/3 flex flex-wrap font-sans items-start content-end justify-between py-5 px-6 border-gray-300">
         <div class="w-full text-sm font-light text-gray-600">
-            {{ __('Next 60 Days') }}
+            {{ __('In 60 Days') }}
         </div>
         <div class="text-xl font-semibold text-gray-800 leading-normal">
             {{ nextEnrolment }}

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -256,15 +256,20 @@ class StudentGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
-    public function getStudentEnrolmentCount($gibbonSchoolYearID)
+    public function getStudentEnrolmentCount($gibbonSchoolYearID, $date = null)
     {
-        $data = ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'today' => date('Y-m-d')];
+        $data = ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'date' => $date ?? date('Y-m-d')];
         $sql = "SELECT COUNT(gibbonPerson.gibbonPersonID)
                 FROM gibbonPerson
                 JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
                 JOIN gibbonRollGroup ON (gibbonStudentEnrolment.gibbonRollGroupID=gibbonRollGroup.gibbonRollGroupID)
-                WHERE gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID
-                AND status='FULL' AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL  OR dateEnd>=:today)";
+                WHERE gibbonRollGroup.gibbonSchoolYearID=:gibbonSchoolYearID ";
+                
+        $sql .= !empty($date)
+            ? " AND (status='Full' OR status='Left') "
+            : " AND status='Full' ";
+
+        $sql .= "AND (dateStart IS NULL OR dateStart<=:date) AND (dateEnd IS NULL OR dateEnd>=:date)";
 
         return $this->db()->selectOne($sql, $data);
     }

--- a/src/Domain/Students/StudentReportGateway.php
+++ b/src/Domain/Students/StudentReportGateway.php
@@ -192,4 +192,22 @@ class StudentReportGateway extends QueryableGateway
 
         return $this->runQuery($query, $criteria);
     }
+
+    public function selectStudentCountByYearGroup($gibbonSchoolYearID)
+    {
+        $data = ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'today' => date('Y-m-d')];
+        $sql = "SELECT gibbonYearGroup.nameShort as yearGroup, count(DISTINCT gibbonStudentEnrolmentID) as studentCount
+                FROM gibbonStudentEnrolment
+                JOIN gibbonPerson ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
+                JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
+                WHERE gibbonPerson.status='Full'
+                AND gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID
+                AND (dateStart IS NULL OR dateStart<=:today)
+                AND (dateEnd IS NULL OR dateEnd>=:today)
+                GROUP BY gibbonYearGroup.gibbonYearGroupID
+                ORDER BY gibbonYearGroup.sequenceNumber";
+
+        return $this->db()->select($sql, $data);
+    }
 }

--- a/src/Domain/Traits/SharedUserLogic.php
+++ b/src/Domain/Traits/SharedUserLogic.php
@@ -55,7 +55,7 @@ trait SharedUserLogic
             $highlight = '';
             if (!empty($person['status']) && $person['status'] != 'Full') $highlight = 'error';
             if (!empty($person['roleCategory']) && $person['roleCategory'] == 'Student') {
-                if (!(empty($person['dateStart']) || $person['dateStart'] <= date('Y-m-d'))) $highlight = 'error';
+                if (!(empty($person['dateStart']) || $person['dateStart'] <= date('Y-m-d'))) $highlight = 'dull';
                 if (!(empty($person['dateEnd'] ) || $person['dateEnd'] >= date('Y-m-d'))) $highlight = 'error';
                 if (empty($person['gibbonStudentEnrolmentID'])) $highlight = 'error';
             }

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -808,6 +808,9 @@ class Format
             if (!(empty($person['dateEnd']) || $person['dateEnd'] >= date('Y-m-d'))) {
                 return __('After End Date');
             }
+            if (!empty($person['dateEnd']) && $person['dateEnd'] <= date('Y-m-d', strtotime('today + 60 days'))) {
+                return __('Leaving');
+            }
             if (empty($person['yearGroup'])) {
                 return __('Not Enrolled');
             }

--- a/src/Tables/Prefab/EnrolmentTable.php
+++ b/src/Tables/Prefab/EnrolmentTable.php
@@ -1,0 +1,184 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Tables\Prefab;
+
+use Gibbon\View\View;
+use Gibbon\UI\Chart\Chart;
+use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Forms\OutputableInterface;
+use Gibbon\Contracts\Services\Session;
+use Gibbon\Domain\Students\StudentGateway;
+use Gibbon\Domain\Students\StudentReportGateway;
+
+/**
+ * EnrolmentTable
+ *
+ * @version v22
+ * @since   v22
+ */
+class EnrolmentTable implements OutputableInterface
+{
+    protected $session;
+    protected $studentGateway;
+
+    public function __construct(Session $session, View $view, StudentGateway $studentGateway, StudentReportGateway $studentReportGateway)
+    {
+        $this->session = $session;
+        $this->view = $view;
+        $this->studentGateway = $studentGateway;
+        $this->studentReportGateway = $studentReportGateway;
+    }
+
+    public function getOutput()
+    {
+        global $page;
+        $page->scripts->add('chart');
+
+        $gibbonSchoolYearID = $this->session->get('gibbonSchoolYearID');
+
+        $output = '';
+
+        // TEMPLATE
+        $output .= $this->view->fetchFromTemplate('ui/enrolmentOverview.twig.html', [
+            'currentEnrolment' => $this->studentGateway->getStudentEnrolmentCount($gibbonSchoolYearID),
+            'lastEnrolment' => $this->studentGateway->getStudentEnrolmentCount($gibbonSchoolYearID, date('Y-m-d', strtotime('today - 60 days'))),
+            'nextEnrolment' => $this->studentGateway->getStudentEnrolmentCount($gibbonSchoolYearID, date('Y-m-d', strtotime('today + 60 days'))),
+        ]);
+
+        
+        // CHART
+        $chartData = $this->studentReportGateway->selectStudentCountByYearGroup($gibbonSchoolYearID)->fetchAll();
+
+        $chart = Chart::create('overview', 'bar');
+        $chart->setTitle(__('Student Enrolment by Year Group'));
+        $chart->setLabels(array_column($chartData, 'yearGroup'));
+        $chart->setLegend(false);
+        $chart->setColors(['rgba(54, 162, 235, 1.0)']);
+        $chart->setOptions([
+            'height' => '50',
+            'tooltips' => [
+                'mode' => 'x-axis',
+            ],
+            'scales' => [
+                'yAxes' => [[
+                    'display' => false,
+                ]],
+                'xAxes' => [[
+                    'display'   => true,
+                    'gridLines' => ['display' => false],
+                ]],
+            ],
+        ]);
+        
+        $chart->addDataset('total', __('Total Students'))
+            ->setData(array_column($chartData, 'studentCount'));
+
+        // RENDER CHART
+        $output .= '<div style="overflow: visible;">'.$chart->render().'</div>';
+
+        // CRITERIA
+        $criteria = $this->studentReportGateway->newQueryCriteria()
+            ->sortBy(['dateStart', 'rollGroup', 'gibbonPerson.surname', 'gibbonPerson.preferredName'])
+            ->fromPOST();
+
+        $students = $this->studentReportGateway->queryStudentStatusBySchoolYear($criteria, $gibbonSchoolYearID, 'Full', date('Y-m-d', strtotime('today - 60 days')), date('Y-m-d', strtotime('today + 60 days')), false);
+
+        // NEW TABLE
+        $table = DataTable::create('studentsNew');
+        $table->setTitle(__('New Students'));
+        $table->setDescription(__('In the past 60 days or upcoming 60 days'));
+
+        $table->addHeaderAction('view', __('View All'))
+            ->setURL('/modules/Students/report_students_new.php')
+            ->addParam('type', 'Current School Year')
+            ->displayLabel();
+
+        $table->modifyRows($this->studentReportGateway->getSharedUserRowHighlighter());
+
+        $table->addColumn('student', __('Student'))
+            ->context('primary')
+            ->sortable(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
+            ->format(function ($student) {
+                return Format::nameLinked($student['gibbonPersonID'], '', $student['preferredName'], $student['surname'], 'Student', true, true, ['allStudents' => 'on'])
+                    . '<br/><small><i>'.Format::userStatusInfo($student).'</i></small>';
+            });
+        $table->addColumn('rollGroup', __('Roll Group'))->context('primary');
+        $table->addColumn('username', __('Username'));
+        $table->addColumn('officialName', __('Official Name'));
+        $table->addColumn('dateStart', __('Start Date'))->context('secondary')->format(Format::using('date', 'dateStart'));
+        $table->addColumn('lastSchool', __('Last School'));
+
+        $table->addActionColumn()
+            ->addParam('gibbonPersonID')
+            ->addParam('allStudents', 'on')
+            ->format(function ($row, $actions) {
+                $actions->addAction('view', __('View Details'))
+                    ->setURL('/modules/Students/student_view_details.php');
+            });
+
+        $output .= $table->render($students);
+
+        // CRITERIA
+        $criteria = $this->studentReportGateway->newQueryCriteria()
+            ->sortBy(['dateEnd', 'rollGroup', 'gibbonPerson.surname', 'gibbonPerson.preferredName'])
+            ->fromPOST();
+
+        $students = $this->studentReportGateway->queryStudentStatusBySchoolYear($criteria, $gibbonSchoolYearID, 'Left', date('Y-m-d', strtotime('today - 60 days')), date('Y-m-d', strtotime('today + 60 days')), true);
+
+        // LEFT TABLE
+        $table = DataTable::createPaginated('studentsLeft', $criteria);
+        $table->setTitle(__('Left Students'));
+        $table->setDescription(__('In the past 60 days or upcoming 60 days'));
+
+        $table->addHeaderAction('view', __('View All'))
+            ->setURL('/modules/Students/report_students_left.php')
+            ->addParam('type', 'Current School Year')
+            ->displayLabel();
+
+        $table->modifyRows($this->studentReportGateway->getSharedUserRowHighlighter());
+        $table->addMetaData('hidePagination', true);
+
+        $table->addColumn('student', __('Student'))
+            ->context('primary')
+            ->sortable(['gibbonPerson.surname', 'gibbonPerson.preferredName'])
+            ->format(function ($student) {
+                return Format::nameLinked($student['gibbonPersonID'], '', $student['preferredName'], $student['surname'], 'Student', true, true, ['allStudents' => 'on'])
+                    . '<br/><small><i>'.Format::userStatusInfo($student).'</i></small>';
+            });
+        $table->addColumn('rollGroup', __('Roll Group'))->context('primary');
+        $table->addColumn('username', __('Username'));
+        $table->addColumn('officialName', __('Official Name'));
+        $table->addColumn('dateStart', __('End Date'))->context('secondary')->format(Format::using('date', 'dateEnd'));
+        $table->addColumn('nextSchool', __('Next School'));
+
+        $table->addActionColumn()
+            ->addParam('gibbonPersonID')
+            ->addParam('allStudents', 'on')
+            ->format(function ($row, $actions) {
+                $actions->addAction('view', __('View Details'))
+                    ->setURL('/modules/Students/student_view_details.php');
+            });
+
+        $output .= $table->render($students);
+
+        return $output;
+    }
+}

--- a/src/UI/Dashboard/StaffDashboard.php
+++ b/src/UI/Dashboard/StaffDashboard.php
@@ -19,11 +19,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\UI\Dashboard;
 
+use Gibbon\Services\Format;
 use Gibbon\Forms\OutputableInterface;
 use Gibbon\Contracts\Services\Session;
+use Gibbon\Tables\Prefab\EnrolmentTable;
 use Gibbon\Tables\Prefab\RollGroupTable;
 use Gibbon\Contracts\Database\Connection;
-use Gibbon\Services\Format;
 
 /**
  * Staff Dashboard View Composer
@@ -37,11 +38,12 @@ class StaffDashboard implements OutputableInterface
     protected $session;
     protected $rollGroupTable;
 
-    public function __construct(Connection $db, Session $session, RollGroupTable $rollGroupTable)
+    public function __construct(Connection $db, Session $session, RollGroupTable $rollGroupTable, EnrolmentTable $enrolmentTable)
     {
         $this->db = $db;
         $this->session = $session;
         $this->rollGroupTable = $rollGroupTable;
+        $this->enrolmentTable = $enrolmentTable;
     }
 
     public function getOutput()
@@ -445,6 +447,14 @@ class StaffDashboard implements OutputableInterface
                 }
             }
 
+            if (isActionAccessible($guid, $connection2, '/modules/Students/student_view.php')) {
+                $return .= "<li><a href='#tabs".$tabCount."'>".__('Enrolment').'</a></li>';
+                if ($staffDashboardDefaultTab == 'Enrolment') {
+                    $staffDashboardDefaultTabCount = $tabCount;
+                }
+                ++$tabCount;
+            }
+
             foreach ($hooks as $hook) {
                 $return .= "<li><a href='#tabs".$tabCount."'>".__($hook['name']).'</a></li>';
                 if ($staffDashboardDefaultTab == $hook['name'])
@@ -461,6 +471,7 @@ class StaffDashboard implements OutputableInterface
                 $return .= '</div>';
                 ++$tabCount;
             }
+
             if (count($rollGroups) > 0) {
                 foreach ($rollGroups as $rollGroup) {
                     $return .= "<div id='tabs".$tabCount."'>";
@@ -476,6 +487,15 @@ class StaffDashboard implements OutputableInterface
                     }
                 }
             }
+
+            // Enrolment tab
+            if (isActionAccessible($guid, $connection2, '/modules/Students/student_view.php')) {
+                $return .= "<div id='tabs".$tabCount."'>";
+                $return .= $this->enrolmentTable->getOutput();
+                $return .= '</div>';
+                ++$tabCount;
+            }
+
             foreach ($hooks as $hook) {
                 $return .= "<div style='min-height: 100px' id='tabs".$tabCount."'>";
                 $include = $_SESSION[$guid]['absolutePath'].'/modules/'.$hook['sourceModuleName'].'/'.$hook['sourceModuleInclude'];


### PR DESCRIPTION
This PR adds an Enrolment tab to the staff dashboard, which displays the current enrolment count, the breakdown by year group, as well as any new or left students in a +/- 60 day range.

**Motivation and Context**
This gives staff a quick glace at the enrolment numbers, and a quick way to see who is joining or leaving the school. Also useful for themes that don't have an enrolment count in the Fast Finder box.

**How Has This Been Tested?**
Locally.

**Screenshots**
![Screenshot_2021-02-22 DEMO - Gibbon(2)](https://user-images.githubusercontent.com/897700/108661720-80bca680-7507-11eb-95ba-25a4edbd1b76.png)
