### PR TITLE
GitHub Actions: fix curl time issue

### DIFF
--- a/tests/config/envs/travis_ci.yml
+++ b/tests/config/envs/travis_ci.yml
@@ -3,6 +3,8 @@ modules:
     enabled:
         - PhpBrowser:
             url: "http://127.0.0.1:8888"
+            curl:
+                CURLOPT_TIMEOUT: 180
     config:
         Db:
             dsn: "mysql:host=127.0.0.1;dbname=gibbon_test"


### PR DESCRIPTION
**Description**
* Extend timeout from 30s (default) to 180s to tolerate the long installer operation.

**Motivation and Context**
* GitHub Actions CI process easily run into timeout in the installer because wait time for the data base import is too much.

**How Has This Been Tested?**
CI Environment

**Screenshots**
![2021-02-25 12-44-26 的螢幕擷圖](https://user-images.githubusercontent.com/91274/109287896-27ce7480-785f-11eb-9292-acd28fd03ec0.png)

