### PR TITLE
System Admin: add new Custom Field types

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -784,4 +784,6 @@ UPDATE `gibbonAction` SET `category`='Customise' WHERE `name`='String Replacemen
 UPDATE `gibbonAction` SET `category`='Customise' WHERE `name`='Email Templates' AND `gibbonModuleID`=(SELECT gibbonModuleID FROM gibbonModule WHERE name='System Admin');end
 ALTER TABLE `gibbonCustomField` ADD `context` VARCHAR(60) NOT NULL DEFAULT 'Person' AFTER `gibbonCustomFieldID`;end
 ALTER TABLE `gibbonCustomField` ADD `sequenceNumber` INT(4) NOT NULL AFTER `required`;end
+ALTER TABLE `gibbonCustomField` ADD `heading` VARCHAR(90) NOT NULL AFTER `required`;end
+ALTER TABLE `gibbonCustomField` CHANGE `type` `type` ENUM('varchar','text','date','time','url','select','checkboxes','radio','yesno','editor','color','number','image','file') CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,8 @@ v22.0.00
 --------
     Headlines
         New 2021 core theme
-        Improved custom field system
+        Improved custom fields system
+        Added custom fields to Medical Forms
 
     Significant Changes
         System: improved support for custom themes

--- a/modules/System Admin/customFields_addProcess.php
+++ b/modules/System Admin/customFields_addProcess.php
@@ -30,6 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     //Proceed!
     $enablePublicRegistration = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration');
     $customFieldGateway = $container->get(CustomFieldGateway::class);
+
     
     $data = [
         'context'                  => $_POST['context'] ?? 'Person',
@@ -39,10 +40,15 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         'type'                     => $_POST['type'] ?? '',
         'options'                  => $_POST['options'] ?? '',
         'required'                 => $_POST['required'] ?? '',
+        'heading'                  => $_POST['heading'] ?? '',
         'activeDataUpdater'        => $_POST['activeDataUpdater'] ?? '0',
         'activeApplicationForm'    => $_POST['activeApplicationForm'] ?? '0',
         'activePublicRegistration' => $enablePublicRegistration == 'Y' ? ($_POST['activePublicRegistration'] ?? '0') : '0',
     ];
+
+    // Add this field to the bottom of the current sequenceNumber for this context
+    $sequenceCheck = $customFieldGateway->selectBy(['context' => $data['context']], ['sequenceNumber'])->fetch();
+    $data['sequenceNumber'] = $sequenceCheck['sequenceNumber'] + 1;
 
     if ($data['type'] == 'varchar') $data['options'] = min(max(0, intval($data['options'])), 255);
     if ($data['type'] == 'text') $data['options'] = max(0, intval($data['options']));

--- a/modules/System Admin/customFields_delete.php
+++ b/modules/System Admin/customFields_delete.php
@@ -18,29 +18,27 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Domain\System\CustomFieldGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_delete.php') == false) {
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
-    $gibbonCustomFieldID = $_GET['gibbonCustomFieldID'];
-    if ($gibbonCustomFieldID == '') {
-        $page->addError(__('You have not specified one or more required parameters.'));
-    } else {
-        
-            $data = array('gibbonCustomFieldID' => $gibbonCustomFieldID);
-            $sql = 'SELECT gibbonCustomField.* FROM gibbonCustomField WHERE gibbonCustomFieldID=:gibbonCustomFieldID';
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
+    $customFieldGateway = $container->get(CustomFieldGateway::class);
 
-        if ($result->rowCount() != 1) {
-            $page->addError(__('The specified record cannot be found.'));
-        } else {
-            $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/customFields_deleteProcess.php?gibbonCustomFieldID=$gibbonCustomFieldID");
-            echo $form->getOutput();
-        }
+    $gibbonCustomFieldID = $_GET['gibbonCustomFieldID'] ?? '';
+    if (empty($gibbonCustomFieldID)) {
+        $page->addError(__('You have not specified one or more required parameters.'));
+        return;
     }
+
+    $values = $customFieldGateway->getByID($gibbonCustomFieldID);
+    if (empty($values)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+    $form = DeleteForm::createForm($_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module']."/customFields_deleteProcess.php?gibbonCustomFieldID=$gibbonCustomFieldID");
+    echo $form->getOutput();
 }
-?>

--- a/modules/System Admin/customFields_deleteProcess.php
+++ b/modules/System Admin/customFields_deleteProcess.php
@@ -17,52 +17,41 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\System\CustomFieldGateway;
+
 include '../../gibbon.php';
 
-$gibbonCustomFieldID = $_GET['gibbonCustomFieldID'];
+$gibbonCustomFieldID = $_GET['gibbonCustomFieldID'] ?? '';
 
-$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address'])."/customFields_delete.php&gibbonCustomFieldID=$gibbonCustomFieldID";
-$URLDelete = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/customFields.php';
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/'.getModuleName($_POST['address']).'/customFields.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_delete.php') == false) {
     $URL .= '&return=error0';
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
-    if ($gibbonCustomFieldID == '') {
+    $customFieldGateway = $container->get(CustomFieldGateway::class);
+    
+    // Validate the required values are present
+    if (empty($gibbonCustomFieldID)) {
         $URL .= '&return=error1';
         header("Location: {$URL}");
-    } else {
-        try {
-            $data = array('gibbonCustomFieldID' => $gibbonCustomFieldID);
-            $sql = 'SELECT * FROM gibbonCustomField WHERE gibbonCustomFieldID=:gibbonCustomFieldID';
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
-            exit();
-        }
-
-        if ($result->rowCount() != 1) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
-        } else {
-            //Write to database
-            try {
-                $data = array('gibbonCustomFieldID' => $gibbonCustomFieldID);
-                $sql = 'DELETE FROM gibbonCustomField WHERE gibbonCustomFieldID=:gibbonCustomFieldID';
-                $result = $connection2->prepare($sql);
-                $result->execute($data);
-            } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
-                exit();
-            }
-
-            $URLDelete = $URLDelete.'&return=success0';
-            header("Location: {$URLDelete}");
-        }
+        exit;
     }
+
+    // Validate the database relationships exist
+    if (!$customFieldGateway->exists($gibbonCustomFieldID)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Delete the record
+    $deleted = $customFieldGateway->delete($gibbonCustomFieldID);
+
+    $URL .= !$deleted
+        ? "&return=error2"
+        : "&return=success0";
+
+    header("Location: {$URL}");
 }

--- a/modules/System Admin/customFields_editOrderAjax.php
+++ b/modules/System Admin/customFields_editOrderAjax.php
@@ -1,0 +1,44 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\System\CustomFieldGateway;
+
+$_POST['address'] = '/modules/System Admin/customFields.php';
+
+require_once '../../gibbon.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.php') == false) {
+    exit;
+} else {
+    // Proceed!
+    $data = $_POST['data'] ?? [];
+    $order = json_decode($_POST['order']);
+
+    if (empty($order)) {
+        exit;
+    } else {
+        $customFieldGateway = $container->get(CustomFieldGateway::class);
+
+        $count = 1;
+        foreach ($order as $gibbonCustomFieldID) {
+            $updated = $customFieldGateway->update($gibbonCustomFieldID, ['sequenceNumber' => $count]);
+            $count++;
+        }
+    }
+}

--- a/modules/System Admin/customFields_editProcess.php
+++ b/modules/System Admin/customFields_editProcess.php
@@ -40,6 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         'type'                     => $_POST['type'] ?? '',
         'options'                  => $_POST['options'] ?? '',
         'required'                 => $_POST['required'] ?? '',
+        'heading'                  => $_POST['heading'] ?? '',
         'activeDataUpdater'        => $_POST['activeDataUpdater'] ?? '0',
         'activeApplicationForm'    => $_POST['activeApplicationForm'] ?? '0',
         'activePublicRegistration' => $enablePublicRegistration == 'Y' ? ($_POST['activePublicRegistration'] ?? '0') : '0',


### PR DESCRIPTION
Requires #1260.

Third piece of the Custom Fields refactoring.

- Adds new field types: Rich Text, Checkboxes, Radio, Time, File, Image, Yes/No, Number, Colour
  <img width="880" alt="Screenshot 2021-03-01 at 2 53 23 PM" src="https://user-images.githubusercontent.com/897700/109476184-9276ee80-7ab1-11eb-830b-a0a6e462c0c5.png">

- Improves the layout and usability of the Add/Edit Custom Fields pages
- Enables optgroups in Dropdown fields using [] around an option name
  <img width="847" alt="Screenshot 2021-03-01 at 5 08 25 PM" src="https://user-images.githubusercontent.com/897700/109476144-87bc5980-7ab1-11eb-9add-5eb78d879a18.png">

- Adds drag-drop ordering to the Custom Fields page
  <img width="883" alt="Screenshot 2021-03-01 at 2 53 10 PM" src="https://user-images.githubusercontent.com/897700/109476176-8ee36780-7ab1-11eb-9a0a-1808a6d25de3.png">

**How Has This Been Tested?**
Locally.

**Screenshots**
Example of a variety of custom fields displayed through a Details table:
<img width="884" alt="Screenshot 2021-03-01 at 5 06 03 PM" src="https://user-images.githubusercontent.com/897700/109476304-b89c8e80-7ab1-11eb-99a6-d52d8b6a816b.png">
