### PR TITLE
Students: add custom fields to Medical Forms, migrate some data into custom fields

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -787,4 +787,5 @@ ALTER TABLE `gibbonCustomField` ADD `sequenceNumber` INT(4) NOT NULL AFTER `requ
 ALTER TABLE `gibbonCustomField` ADD `heading` VARCHAR(90) NOT NULL AFTER `required`;end
 ALTER TABLE `gibbonCustomField` CHANGE `type` `type` ENUM('varchar','text','date','time','url','select','checkboxes','radio','yesno','editor','color','number','image','file') CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
 ALTER TABLE `gibbonPersonMedical` ADD `fields` TEXT NULL AFTER `comment`;end
+ALTER TABLE `gibbonPersonMedicalUpdate` ADD `fields` TEXT NULL AFTER `timestamp`;end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -789,4 +789,5 @@ ALTER TABLE `gibbonCustomField` CHANGE `type` `type` ENUM('varchar','text','date
 INSERT INTO gibbonLanguage (name) SELECT * FROM (SELECT 'Somali') AS tmp WHERE NOT EXISTS (SELECT name FROM gibbonLanguage WHERE (name='Somali')) LIMIT 1;end
 ALTER TABLE `gibbonPersonMedical` ADD `fields` TEXT NULL AFTER `comment`;end
 ALTER TABLE `gibbonPersonMedicalUpdate` ADD `fields` TEXT NULL AFTER `timestamp`;end
+DELETE FROM `gibbonSetting` WHERE scope='Students' AND name='extendedBriefProfile';end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -786,4 +786,5 @@ ALTER TABLE `gibbonCustomField` ADD `context` VARCHAR(60) NOT NULL DEFAULT 'Pers
 ALTER TABLE `gibbonCustomField` ADD `sequenceNumber` INT(4) NOT NULL AFTER `required`;end
 ALTER TABLE `gibbonCustomField` ADD `heading` VARCHAR(90) NOT NULL AFTER `required`;end
 ALTER TABLE `gibbonCustomField` CHANGE `type` `type` ENUM('varchar','text','date','time','url','select','checkboxes','radio','yesno','editor','color','number','image','file') CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;end
+ALTER TABLE `gibbonPersonMedical` ADD `fields` TEXT NULL AFTER `comment`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,7 +28,8 @@ v22.0.00
         System: added an Enrolment tab to the Staff Dashboard
 
     Changes With Important Notices
-        System: the gibbonPersonField table has been renamed to gibbonCustomField
+        System: renamed the gibbonPersonField table to gibbonCustomField
+        Students: migrated Blood Type and Tetanus fields from Medical Form into Custom Fields
 
     Tweaks & Additions
         System: added the Getting Started info to the post-install page
@@ -38,6 +39,8 @@ v22.0.00
         System: added Mozambique Metical as currency option
         Finance: removed student DOB and Gender from Export Invoices
         Reports: clear report cache when editing template assets in Production
+        Students: added Medical Form custom fields to student profile
+        Students: updated Medical Data Summary to include medical custom fields
         System Admin: added option to manually invalidate front end cache for Cutting Edge installs
         System Admin: added a Reporting Values by Roll Group import option
         System Admin: updated user-related imports to enable importing by username or email address

--- a/modules/Data Updater/data_medical.php
+++ b/modules/Data Updater/data_medical.php
@@ -207,10 +207,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 						$form->addHiddenValue('existing', $values['gibbonPersonMedicalUpdateID'] ?? 'N');
 
 						$row = $form->addRow();
-							$row->addLabel('bloodType', __('Blood Type'));
-							$row->addSelectBloodType('bloodType')->placeholder();
-
-						$row = $form->addRow();
 							$row->addLabel('longTermMedication', __('Long-Term Medication?'));
 							$row->addYesNo('longTermMedication')->placeholder();
 
@@ -219,10 +215,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 						$row = $form->addRow()->addClass('longTermMedicationDetails');
 							$row->addLabel('longTermMedicationDetails', __('Medication Details'));
 							$row->addTextArea('longTermMedicationDetails')->setRows(5);
-
-						$row = $form->addRow();
-							$row->addLabel('tetanusWithin10Years', __('Tetanus Within Last 10 Years?'));
-							$row->addYesNo('tetanusWithin10Years')->placeholder();
 
                         // CUSTOM FIELDS
                         $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Medical Form', ['dataUpdater' => 1], $values['fields']);

--- a/modules/Data Updater/data_medical.php
+++ b/modules/Data Updater/data_medical.php
@@ -18,10 +18,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Services\Format;
+use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\Students\MedicalGateway;
 use Gibbon\Domain\DataUpdater\MedicalUpdateGateway;
-use Gibbon\Services\Format;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -222,6 +223,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 						$row = $form->addRow();
 							$row->addLabel('tetanusWithin10Years', __('Tetanus Within Last 10 Years?'));
 							$row->addYesNo('tetanusWithin10Years')->placeholder();
+
+                        // CUSTOM FIELDS
+                        $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Medical Form', ['dataUpdater' => 1], $values['fields']);
 
                         $row = $form->addRow();
 							$row->addLabel('comment', __('Comment'));

--- a/modules/Data Updater/data_medicalProcess.php
+++ b/modules/Data Updater/data_medicalProcess.php
@@ -100,10 +100,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
                 $data = [
                     'gibbonPersonMedicalID'     => $gibbonPersonMedicalID,
                     'gibbonPersonID'            => $gibbonPersonID,
-                    'bloodType'                 => $_POST['bloodType'] ?? '',
                     'longTermMedication'        => $_POST['longTermMedication'] ?? 'N',
                     'longTermMedicationDetails' => $_POST['longTermMedicationDetails'] ?? '',
-                    'tetanusWithin10Years'      => $_POST['tetanusWithin10Years'] ?? '',
                     'comment'                   => $_POST['comment'] ?? '',
                 ];
 
@@ -144,10 +142,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
                 if ($existing != 'N') {
                     $gibbonPersonMedicalUpdateID = $existing;
                     $data['gibbonPersonMedicalUpdateID'] = $gibbonPersonMedicalUpdateID;
-                    $sql = 'UPDATE gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, fields=:fields, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp WHERE gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID';
+                    $sql = 'UPDATE gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, fields=:fields, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp WHERE gibbonPersonMedicalUpdateID=:gibbonPersonMedicalUpdateID';
                     $pdo->update($sql, $data);
                 } else {
-                    $sql = 'INSERT INTO gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, fields=:fields, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp';
+                    $sql = 'INSERT INTO gibbonPersonMedicalUpdate SET gibbonSchoolYearID=:gibbonSchoolYearID, gibbonPersonMedicalID=:gibbonPersonMedicalID, gibbonPersonID=:gibbonPersonID, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, fields=:fields, comment=:comment, gibbonPersonIDUpdater=:gibbonPersonIDUpdater, timestamp=:timestamp';
                     $gibbonPersonMedicalUpdateID = $pdo->insert($sql, $data);
                 }
 

--- a/modules/Data Updater/data_medical_manage_edit.php
+++ b/modules/Data Updater/data_medical_manage_edit.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
+use Gibbon\Forms\CustomFieldHandler;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -158,6 +159,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
             foreach ($compare as $fieldName => $label) {
                 $comparisonFields($form, $oldValues, $newValues, $fieldName, $label);
             }
+
+            // CUSTOM FIELDS
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToDataUpdate($form, 'Medical Form', ['dataUpdater' => 1], $oldValues, $newValues);
 
             // Existing Conditions
             $data = array('gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID);

--- a/modules/Data Updater/data_medical_manage_edit.php
+++ b/modules/Data Updater/data_medical_manage_edit.php
@@ -73,10 +73,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
             }
 
             $compare = array(
-                'bloodType'                 => __('Blood Type'),
                 'longTermMedication'        => __('Long-Term Medication?'),
                 'longTermMedicationDetails' => __('Medication Details'),
-                'tetanusWithin10Years'      => __('Tetanus Within Last 10 Years?'),
                 'comment'      => __('Comment'),
             );
 

--- a/modules/Data Updater/data_medical_manage_editProcess.php
+++ b/modules/Data Updater/data_medical_manage_editProcess.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Domain\Students\MedicalGateway;
 use Gibbon\Domain\Students\StudentGateway;
 
@@ -57,6 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
         } else {
             $row = $result->fetch();
             $gibbonPersonMedicalID = $row['gibbonPersonMedicalID'];
+            $row2 = $medicalGateway->getByID($gibbonPersonMedicalID);
             $conditions = [];
 
             //Set values
@@ -92,6 +94,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
                     $sqlSet .= 'comment=:comment, ';
                 }
             }
+
+            // CUSTOM FIELDS
+            $data['fields'] = $container->get(CustomFieldHandler::class)->getFieldDataFromDataUpdate('Medical Form', [], $row2['fields']);
+            $sqlSet .= 'fields=:fields, ';
 
             $partialFail = false;
 

--- a/modules/Data Updater/data_medical_manage_editProcess.php
+++ b/modules/Data Updater/data_medical_manage_editProcess.php
@@ -64,12 +64,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
             //Set values
             $data = array();
             $sqlSet = '';
-            if (isset($_POST['bloodTypeOn'])) {
-                if ($_POST['bloodTypeOn'] == 'on') {
-                    $data['bloodType'] = $_POST['bloodType'];
-                    $sqlSet .= 'bloodType=:bloodType, ';
-                }
-            }
             if (isset($_POST['longTermMedicationOn'])) {
                 if ($_POST['longTermMedicationOn'] == 'on') {
                     $data['longTermMedication'] = $_POST['longTermMedication'];
@@ -80,12 +74,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
                 if ($_POST['longTermMedicationDetailsOn'] == 'on') {
                     $data['longTermMedicationDetails'] = $_POST['longTermMedicationDetails'];
                     $sqlSet .= 'longTermMedicationDetails=:longTermMedicationDetails, ';
-                }
-            }
-            if (isset($_POST['tetanusWithin10YearsOn'])) {
-                if ($_POST['tetanusWithin10YearsOn'] == 'on') {
-                    $data['tetanusWithin10Years'] = $_POST['tetanusWithin10Years'];
-                    $sqlSet .= 'tetanusWithin10Years=:tetanusWithin10Years, ';
                 }
             }
             if (isset($_POST['commentOn'])) {

--- a/modules/Data Updater/data_personal_manage_edit.php
+++ b/modules/Data Updater/data_personal_manage_edit.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
-use Gibbon\Domain\System\CustomFieldGateway;
+use Gibbon\Forms\CustomFieldHandler;
 
 //Module includes
 include './modules/User Admin/moduleFunctions.php';
@@ -209,38 +209,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
             }
 
             // CUSTOM FIELDS
-			$oldFields = !empty($oldValues['fields'])? json_decode($oldValues['fields'], true) : [];
-            $newFields = !empty($newValues['fields'])? json_decode($newValues['fields'], true) : [];
-
             $params = compact('student', 'staff', 'parent', 'other');
-            $customFields = $container->get(CustomFieldGateway::class)->selectCustomFields('Person', $params + ['dataUpdater' => 1])->fetchAll();
-
-            foreach ($customFields as $field) {
-                $fieldName = $field['gibbonCustomFieldID'];
-                $label = __($field['name']);
-
-                $oldValue = isset($oldFields[$fieldName])? $oldFields[$fieldName] : '';
-                $newValue = isset($newFields[$fieldName])? $newFields[$fieldName] : '';
-
-                if ($field['type'] == 'date') {
-                    $oldValue = Format::date($oldValue);
-                    $newValue = Format::date($newValue);
-                }
-
-                $isMatching = ($oldValue != $newValue);
-
-                $row = $form->addRow();
-                $row->addLabel('new'.$fieldName.'On', $label);
-                $row->addContent($oldValue);
-                $row->addContent($newValue)->addClass($isMatching ? 'matchHighlightText' : '');
-
-                if ($isMatching) {
-                    $row->addCheckbox('newcustom'.$fieldName.'On')->checked(true)->setClass('textCenter');
-                    $form->addHiddenValue('newcustom'.$fieldName, $newValue);
-                } else {
-                    $row->addContent();
-                }
-            }
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToDataUpdate($form, 'Person', $params + ['dataUpdater' => 1], $oldValues, $newValues);
             
             $row = $form->addRow();
                 $row->addSubmit();

--- a/modules/Data Updater/data_personal_manage_editProcess.php
+++ b/modules/Data Updater/data_personal_manage_editProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
-use Gibbon\Domain\System\CustomFieldGateway;
+use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Domain\System\LogGateway;
 use Gibbon\Domain\System\NotificationGateway;
 
@@ -436,19 +436,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
                 // CUSTOM FIELDS
                 $params = compact('student', 'staff', 'parent', 'other');
-                $customFields = $container->get(CustomFieldGateway::class)->selectCustomFields('Person', $params + ['dataUpdater' => 1])->fetchAll();
-
-                $fields = !empty($row2['fields']) ? json_decode($row2['fields'], true) : [];
-                foreach ($customFields as $field) {
-                    if (!isset($_POST['newcustom'.$field['gibbonCustomFieldID'].'On'])) continue;
-                    if (!isset($_POST['newcustom'.$field['gibbonCustomFieldID']])) continue;
-
-                    $fields[$field['gibbonCustomFieldID']] = $field['type'] == 'date'
-                        ? Format::dateConvert($_POST['newcustom'.$field['gibbonCustomFieldID']])
-                        : $_POST['newcustom'.$field['gibbonCustomFieldID']];
-                }
-
-                $fields = json_encode($fields);
+                $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromDataUpdate('Person', $params, $row2['fields']);
 
                 if (strlen($set) > 1) {
                     //Write to database

--- a/modules/Students/medicalForm_manage.php
+++ b/modules/Students/medicalForm_manage.php
@@ -83,15 +83,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
     $table->addColumn('rollGroup', __('Roll Group'));
 
-    $table->addColumn('bloodType', __('Blood Type'));
-
     $table->addColumn('longTermMedication', __('Medication'))
         ->format(function($person) {
             return !empty($person['longTermMedicationDetails'])? $person['longTermMedicationDetails'] : Format::yesNo($person['longTermMedication']);
         });
-
-    $table->addColumn('tetanusWithin10Years', __('Tetanus'))
-        ->format(Format::using('yesNo', 'tetanusWithin10Years'));
 
     $table->addColumn('conditionCount', __('Conditions'));
 

--- a/modules/Students/medicalForm_manage_add.php
+++ b/modules/Students/medicalForm_manage_add.php
@@ -57,22 +57,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
         $row->addSelectStudent('gibbonPersonID', $_SESSION[$guid]['gibbonSchoolYearID'])->required()->placeholder()->selected($gibbonPersonID);
 
     $row = $form->addRow();
-        $row->addLabel('bloodType', __('Blood Type'));
-        $row->addSelectBloodType('bloodType')->placeholder();
-
-    $row = $form->addRow();
         $row->addLabel('longTermMedication', __('Long-Term Medication?'));
         $row->addYesNo('longTermMedication')->placeholder();
 
     $form->toggleVisibilityByClass('longTermMedicationDetails')->onSelect('longTermMedication')->when('Y');
 
-    $row = $form->addRow()->addClass('longTermMedicationDetails');;
+    $row = $form->addRow()->addClass('longTermMedicationDetails');
         $row->addLabel('longTermMedicationDetails', __('Medication Details'));
         $row->addTextArea('longTermMedicationDetails')->setRows(5);
-
-    $row = $form->addRow();
-        $row->addLabel('tetanusWithin10Years', __('Tetanus Within Last 10 Years?'));
-        $row->addYesNo('tetanusWithin10Years')->placeholder();
 
     // CUSTOM FIELDS
     $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Medical Form', []);

--- a/modules/Students/medicalForm_manage_add.php
+++ b/modules/Students/medicalForm_manage_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Forms\DatabaseFormFactory;
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage_add.php') == false) {
@@ -72,6 +73,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     $row = $form->addRow();
         $row->addLabel('tetanusWithin10Years', __('Tetanus Within Last 10 Years?'));
         $row->addYesNo('tetanusWithin10Years')->placeholder();
+
+    // CUSTOM FIELDS
+    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Medical Form', []);
 
     $row = $form->addRow();
         $row->addLabel('comment', __('Comment'));

--- a/modules/Students/medicalForm_manage_addProcess.php
+++ b/modules/Students/medicalForm_manage_addProcess.php
@@ -30,10 +30,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 } else {
     //Proceed!
     $gibbonPersonID = $_POST['gibbonPersonID'];
-    $bloodType = $_POST['bloodType'];
     $longTermMedication = $_POST['longTermMedication'];
     $longTermMedicationDetails = (isset($_POST['longTermMedicationDetails']) ? $_POST['longTermMedicationDetails'] : '');
-    $tetanusWithin10Years = $_POST['tetanusWithin10Years'];
     $comment = $_POST['comment'];
 
     //Validate Inputs
@@ -68,8 +66,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
         } else {
             //Write to database
             try {
-                $data = array('gibbonPersonID' => $gibbonPersonID, 'bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'fields' => $fields, 'comment' => $comment);
-                $sql = 'INSERT INTO gibbonPersonMedical SET gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, fields=:fields, comment=:comment';
+                $data = array('gibbonPersonID' => $gibbonPersonID, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'fields' => $fields, 'comment' => $comment);
+                $sql = 'INSERT INTO gibbonPersonMedical SET gibbonPersonID=:gibbonPersonID, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, fields=:fields, comment=:comment';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/Students/medicalForm_manage_addProcess.php
+++ b/modules/Students/medicalForm_manage_addProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Forms\CustomFieldHandler;
+
 include '../../gibbon.php';
 
 $search = $_GET['search'];
@@ -39,6 +41,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
         $URL .= '&return=error1';
         header("Location: {$URL}");
     } else {
+        $customRequireFail = false;
+        $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Medical Form', [], $customRequireFail);
+
+        if ($customRequireFail) {
+            $URL .= '&return=error1';
+            header("Location: {$URL}");
+            exit;
+        }
+
         //Check unique inputs for uniquness
         try {
             $data = array('gibbonPersonID' => $gibbonPersonID);
@@ -57,8 +68,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
         } else {
             //Write to database
             try {
-                $data = array('gibbonPersonID' => $gibbonPersonID, 'bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'comment' => $comment);
-                $sql = 'INSERT INTO gibbonPersonMedical SET gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, comment=:comment';
+                $data = array('gibbonPersonID' => $gibbonPersonID, 'bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'fields' => $fields, 'comment' => $comment);
+                $sql = 'INSERT INTO gibbonPersonMedical SET gibbonPersonID=:gibbonPersonID, bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, fields=:fields, comment=:comment';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/Students/medicalForm_manage_edit.php
+++ b/modules/Students/medicalForm_manage_edit.php
@@ -18,9 +18,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
-use Gibbon\Forms\DatabaseFormFactory;
-use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Forms\CustomFieldHandler;
+use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\Students\MedicalGateway;
 
 if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage_edit.php') == false) {
@@ -82,6 +83,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $row = $form->addRow();
                 $row->addLabel('tetanusWithin10Years', __('Tetanus Within Last 10 Years?'));
                 $row->addYesNo('tetanusWithin10Years')->placeholder();
+
+            // CUSTOM FIELDS
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Medical Form', [], $values['fields']);
 
             $row = $form->addRow();
                 $row->addLabel('comment', __('Comment'));

--- a/modules/Students/medicalForm_manage_edit.php
+++ b/modules/Students/medicalForm_manage_edit.php
@@ -67,10 +67,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
                 $row->addTextField('name')->setValue(Format::name('', $values['preferredName'], $values['surname'], 'Student'))->required()->readonly();
 
             $row = $form->addRow();
-                $row->addLabel('bloodType', __('Blood Type'));
-                $row->addSelectBloodType('bloodType')->placeholder();
-
-            $row = $form->addRow();
                 $row->addLabel('longTermMedication', __('Long-Term Medication?'));
                 $row->addYesNo('longTermMedication')->placeholder();
 
@@ -79,10 +75,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $row = $form->addRow()->addClass('longTermMedicationDetails');
                 $row->addLabel('longTermMedicationDetails', __('Medication Details'));
                 $row->addTextArea('longTermMedicationDetails')->setRows(5);
-
-            $row = $form->addRow();
-                $row->addLabel('tetanusWithin10Years', __('Tetanus Within Last 10 Years?'));
-                $row->addYesNo('tetanusWithin10Years')->placeholder();
 
             // CUSTOM FIELDS
             $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Medical Form', [], $values['fields']);

--- a/modules/Students/medicalForm_manage_editProcess.php
+++ b/modules/Students/medicalForm_manage_editProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Forms\CustomFieldHandler;
+
 include '../../gibbon.php';
 
 $gibbonPersonMedicalID = $_GET['gibbonPersonMedicalID'];
@@ -54,10 +56,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $tetanusWithin10Years = $_POST['tetanusWithin10Years'];
             $comment = $_POST['comment'];
 
+            $customRequireFail = false;
+            $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Medical Form', [], $customRequireFail);
+
+            if ($customRequireFail) {
+                $URL .= '&return=error1';
+                header("Location: {$URL}");
+                exit;
+            }
+
             //Write to database
             try {
-                $data = array('bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'comment' => $comment, 'gibbonPersonMedicalID' => $gibbonPersonMedicalID);
-                $sql = 'UPDATE gibbonPersonMedical SET bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, comment=:comment WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID';
+                $data = array('bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'fields' => $fields, 'comment' => $comment, 'gibbonPersonMedicalID' => $gibbonPersonMedicalID);
+                $sql = 'UPDATE gibbonPersonMedical SET bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, fields=:fields, comment=:comment WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/Students/medicalForm_manage_editProcess.php
+++ b/modules/Students/medicalForm_manage_editProcess.php
@@ -50,10 +50,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $URL .= '&return=error2';
             header("Location: {$URL}");
         } else {
-            $bloodType = $_POST['bloodType'];
             $longTermMedication = $_POST['longTermMedication'];
             $longTermMedicationDetails = (isset($_POST['longTermMedicationDetails']) ? $_POST['longTermMedicationDetails'] : '');
-            $tetanusWithin10Years = $_POST['tetanusWithin10Years'];
             $comment = $_POST['comment'];
 
             $customRequireFail = false;
@@ -67,8 +65,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
             //Write to database
             try {
-                $data = array('bloodType' => $bloodType, 'longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'tetanusWithin10Years' => $tetanusWithin10Years, 'fields' => $fields, 'comment' => $comment, 'gibbonPersonMedicalID' => $gibbonPersonMedicalID);
-                $sql = 'UPDATE gibbonPersonMedical SET bloodType=:bloodType, longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, tetanusWithin10Years=:tetanusWithin10Years, fields=:fields, comment=:comment WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID';
+                $data = array('longTermMedication' => $longTermMedication, 'longTermMedicationDetails' => $longTermMedicationDetails, 'fields' => $fields, 'comment' => $comment, 'gibbonPersonMedicalID' => $gibbonPersonMedicalID);
+                $sql = 'UPDATE gibbonPersonMedical SET longTermMedication=:longTermMedication, longTermMedicationDetails=:longTermMedicationDetails, fields=:fields, comment=:comment WHERE gibbonPersonMedicalID=:gibbonPersonMedicalID';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/Students/report_student_medicalSummary.php
+++ b/modules/Students/report_student_medicalSummary.php
@@ -24,6 +24,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Tables\Prefab\ReportTable;
 use Gibbon\Domain\Students\MedicalGateway;
 use Gibbon\Domain\Students\StudentReportGateway;
+use Gibbon\Domain\System\CustomFieldGateway;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -119,16 +120,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_student_me
         });
 
     $view = new View($container->get('twig'));
+    $customFieldGateway = $container->get(CustomFieldGateway::class);
 
     $table->addColumn('medicalForm', __('Medical Form?'))
-        ->width('16%')
+        ->width('26%')
         ->sortable('gibbonPersonMedicalID')
-        ->format(function ($student) use ($view) {
+        ->format(function ($student) use ($view, $customFieldGateway) {
+            $student['customFields'] = $customFieldGateway->selectCustomFields('Medical Form')->fetchAll();
+            $student['fields'] = !empty($student['fields']) ? json_decode($student['fields'], true) : [];
             return $view->fetchFromTemplate('formats/medicalForm.twig.html', $student);
         });
 
     $table->addColumn('conditions', __('Medical Conditions'))
-        ->width('60%')
+        ->width('50%')
         ->notSortable()
         ->format(function ($student) use ($view) {
             return $view->fetchFromTemplate('formats/medicalConditions.twig.html', $student);

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1604,7 +1604,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     : Format::small(__('Unknown'));
                             });
 
+                        $table = $container->get(CustomFieldHandler::class)->createCustomFieldsTable('Medical Form', [], $medical['fields'], $table);
+
                         $table->addColumn('medicalConditions', __('Medical Conditions?'))
+                            ->addClass('col-span-3')
                             ->format(function ($medical) use ($conditions) {
                                 return count($conditions) > 0
                                     ? __('Yes').'. '.__('Details below.')

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1618,7 +1618,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             $table->addColumn('comment', __('Comment'))->addClass('col-span-3');
                         }
 
-                        echo $table->render(!empty($medical) ? [$medical] : []);
+                        $fields = is_string($medical['fields']) ? json_decode($medical['fields'], true) : [];
+                        echo $table->render(!empty($medical) ? [$medical + $fields] : []);
 
                         // MEDICAL CONDITIONS
                         $canManageMedical = isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manage.php');

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1604,10 +1604,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     : Format::small(__('Unknown'));
                             });
 
-                        $table->addColumn('tetanusWithin10Years', __('Tetanus Last 10 Years?'))
-                            ->format(Format::using('yesno', 'longTermMedication'));
-
-                        $table->addColumn('bloodType', __('Blood Type'));
                         $table->addColumn('medicalConditions', __('Medical Conditions?'))
                             ->format(function ($medical) use ($conditions) {
                                 return count($conditions) > 0

--- a/modules/System Admin/customFields_add.php
+++ b/modules/System Admin/customFields_add.php
@@ -35,21 +35,16 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     }
     $page->return->setEditLink($editLink);
 
-    $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/customFields_addProcess.php');
+    $customFieldHandler = $container->get(CustomFieldHandler::class);
 
+    $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/customFields_addProcess.php');
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
 
     $form->addRow()->addHeading(__('Basic Details'));
 
-    $contexts = [
-        __('User Admin') => [
-            'Person' => __('Person'),
-        ],
-    ];
-
     $row = $form->addRow();
         $row->addLabel('context', __('Context'));
-        $row->addSelect('context')->fromArray($contexts)->required()->placeholder();
+        $row->addSelect('context')->fromArray($customFieldHandler->getContexts())->required()->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique for this context.'));
@@ -65,10 +60,9 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     $form->addRow()->addHeading(__('Configure'));
 
-    $types = $container->get(CustomFieldHandler::class)->getTypes();
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
-        $row->addSelect('type')->fromArray($types)->required()->placeholder();
+        $row->addSelect('type')->fromArray($customFieldHandler->getTypes())->required()->placeholder();
 
     $form->toggleVisibilityByClass('optionsLength')->onSelect('type')->when(['varchar', 'number']);
     $row = $form->addRow()->addClass('optionsLength');
@@ -103,29 +97,31 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $form->addRow()->addClass('contextPerson')->addHeading(__('Visibility'));
 
     $form->toggleVisibilityByClass('contextPerson')->onSelect('context')->when('Person');
-    $activePersonOptions = array(
+    $form->toggleVisibilityByClass('contextDataUpdate')->onSelect('context')->when(['Person', 'Medical Form']);
+
+    $activePersonOptions = [
         'activePersonStudent' => __('Student'),
         'activePersonStaff'   => __('Staff'),
         'activePersonParent'  => __('Parent'),
         'activePersonOther'   => __('Other'),
-    );
+    ];
     $row = $form->addRow()->addClass('contextPerson');
         $row->addLabel('roleCategories', __('Role Categories'));
         $row->addCheckbox('roleCategories')->fromArray($activePersonOptions)->checked('activePersonStudent');
 
-    $row = $form->addRow()->addClass('contextPerson');
+    $row = $form->addRow()->addClass('contextDataUpdate');
         $row->addLabel('activeDataUpdater', __('Include In Data Updater?'));
-        $row->addSelect('activeDataUpdater')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('1')->required();
+        $row->addSelect('activeDataUpdater')->fromArray(['1' => __('Yes'), '0' => __('No')])->selected('1')->required();
 
     $row = $form->addRow()->addClass('contextPerson');
         $row->addLabel('activeApplicationForm', __('Include In Application Form?'));
-        $row->addSelect('activeApplicationForm')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->required();
+        $row->addSelect('activeApplicationForm')->fromArray(['1' => __('Yes'), '0' => __('No')])->selected('0')->required();
     
     $enablePublicRegistration = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration');
     if ($enablePublicRegistration == 'Y') {
         $row = $form->addRow()->addClass('contextPerson');
             $row->addLabel('activePublicRegistration', __('Include In Public Registration Form?'));
-            $row->addSelect('activePublicRegistration')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->required();
+            $row->addSelect('activePublicRegistration')->fromArray(['1' => __('Yes'), '0' => __('No')])->selected('0')->required();
     }
 
     $row = $form->addRow();

--- a/modules/System Admin/customFields_edit.php
+++ b/modules/System Admin/customFields_edit.php
@@ -137,6 +137,12 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
                 $row->addLabel('activePublicRegistration', __('Include In Public Registration Form?'));
                 $row->addSelect('activePublicRegistration')->fromArray(array('1' => __('Yes'), '0' => __('No')))->selected('0')->required();
         }
+    } elseif ($values['context'] == 'Medical Form') {
+        $form->addRow()->addHeading(__('Visibility'));
+
+        $row = $form->addRow();
+            $row->addLabel('activeDataUpdater', __('Include In Data Updater?'));
+            $row->addSelect('activeDataUpdater')->fromArray(array('1' => __('Yes'), '0' => __('No')))->required();
     }
 
     $row = $form->addRow();

--- a/resources/imports/medicalForms.yml
+++ b/resources/imports/medicalForms.yml
@@ -16,10 +16,6 @@ table:
         desc: "Username or Email (if unique)"
         args: { filter: nospaces, required: true }
         relationship: { table: gibbonPerson, key: gibbonPersonID, field: username|email  }
-    bloodType:
-        name: "Blood Type"
-        desc: ""
-        args: {filter: string}
     longTermMedication:
         name: "Long Term Medication"
         desc: ""
@@ -28,10 +24,6 @@ table:
         name: "Medication Details"
         desc: ""
         args: {filter: string}
-    tetanusWithin10Years:
-        name: "Tetanus Within Last 10 Years?"
-        desc: ""
-        args: {filter: yesno, custom: true}
     comment:
         name: "Comment"
         desc: ""

--- a/resources/templates/formats/medicalForm.twig.html
+++ b/resources/templates/formats/medicalForm.twig.html
@@ -11,10 +11,6 @@ all stylesheets and scripts with a 'head' context.
 
 {% if gibbonPersonMedicalID %}
 
-    <i>{{ __('Blood Type') }}:</i> {{ bloodType }}<br/>
-
-    <i>{{ __('Tetanus') }}:</i> {{ formatUsing('yesNo', tetanusWithin10Years) }}<br/>
-
     <i>{{ __('Medication') }}:</i> {{ formatUsing('yesNo', longTermMedication) }}<br/>
 
 {% else %}

--- a/resources/templates/formats/medicalForm.twig.html
+++ b/resources/templates/formats/medicalForm.twig.html
@@ -13,6 +13,13 @@ all stylesheets and scripts with a 'head' context.
 
     <i>{{ __('Medication') }}:</i> {{ formatUsing('yesNo', longTermMedication) }}<br/>
 
+    {% for field in customFields %}
+        {% if fields[field.gibbonCustomFieldID] %}
+        <i>{{ __(field.name) }}:</i> {{ fields[field.gibbonCustomFieldID] ?? '' }}<br/>
+        {% endif %}
+    {% endfor %}
+
+
 {% else %}
 
     <span style="color: #ff0000; font-weight: bold">{{ __('No') }}</span>

--- a/src/Database/Migrations/2021-03-03-MedicalFields.php
+++ b/src/Database/Migrations/2021-03-03-MedicalFields.php
@@ -1,0 +1,110 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Contracts\Database\Connection;
+use Gibbon\Database\Migrations\Migration;
+use Gibbon\Domain\Students\MedicalGateway;
+use Gibbon\Domain\System\CustomFieldGateway;
+use Gibbon\Domain\DataUpdater\MedicalUpdateGateway;
+
+/**
+ * Medical Fields migration - removes Blood Type and Tetanus fields and migrates them into custom fields.
+ */
+class MedicalFields extends Migration
+{
+    protected $db;
+    protected $customFieldGateway;
+    protected $medicalGateway;
+    protected $medicalUpdateGateway;
+
+    public function __construct(Connection $db, CustomFieldGateway $customFieldGateway, MedicalGateway $medicalGateway, MedicalUpdateGateway $medicalUpdateGateway)
+    {
+        $this->db = $db;
+        $this->customFieldGateway = $customFieldGateway;
+        $this->medicalGateway = $medicalGateway;
+        $this->medicalUpdateGateway = $medicalUpdateGateway;
+    }   
+
+    public function migrate()
+    {
+        $partialFail = false;
+
+        // Create the Blood Type and Tetanus custom fields
+        $data = [
+            'context'                  => 'Medical Form',
+            'name'                     => 'Blood Type',
+            'active'                   => 'Y',
+            'description'              => '',
+            'type'                     => 'select',
+            'options'                  => 'O+,A+,B+,AB+,O-,A-,B-,AB-',
+            'required'                 => 'N',
+            'heading'                  => '',
+            'activeDataUpdater'        => '1',
+        ];
+        $bloodTypeFieldID = $this->customFieldGateway->insertAndUpdate($data, $data);
+        $bloodTypeFieldID = str_pad($bloodTypeFieldID, 4, '0', STR_PAD_LEFT);
+
+        $data = [
+            'context'                  => 'Medical Form',
+            'name'                     => 'Tetanus Within Last 10 Years?',
+            'active'                   => 'Y',
+            'description'              => '',
+            'type'                     => 'yesno',
+            'options'                  => '',
+            'required'                 => 'N',
+            'heading'                  => '',
+            'activeDataUpdater'        => '1',
+        ];
+        $tetanusFieldID = $this->customFieldGateway->insert($data, $data);
+        $tetanusFieldID = str_pad($tetanusFieldID, 4, '0', STR_PAD_LEFT);
+
+        // Loop all medical forms and move fields into custom field data, merge existing
+        $medicalForms = $this->medicalGateway->selectBy([])->fetchAll();
+        foreach ($medicalForms as $form) {
+            $fields = !empty($form['fields']) ? json_decode($form['fields'], true) : [];
+
+            $fields[$bloodTypeFieldID] = $form['bloodType'];
+            $fields[$tetanusFieldID] = $form['tetanusWithin10Years'];
+            
+            $updated = $this->medicalGateway->update($form['gibbonPersonMedicalID'], ['fields' => json_encode($fields)]);
+            $partialFail &= !$updated;
+        }
+
+        // Loop all medical updates and move fields into custom field data, merge existing
+        $medicalFormUpdates = $this->medicalUpdateGateway->selectBy([])->fetchAll();
+        foreach ($medicalFormUpdates as $form) {
+            $fields = !empty($form['fields']) ? json_decode($form['fields'], true) : [];
+
+            $fields[$bloodTypeFieldID] = $form['bloodType'];
+            $fields[$tetanusFieldID] = $form['tetanusWithin10Years'];
+            
+            $updated = $this->medicalUpdateGateway->update($form['gibbonPersonMedicalUpdateID'], ['fields' => json_encode($fields)]);
+            $partialFail &= !$updated;
+        }
+
+        // Remove fields from gibbonPersonMedical, gibbonPersonMedicalUpdate tables
+        $sql = "ALTER TABLE `gibbonPersonMedical` DROP `bloodType`, DROP `tetanusWithin10Years`;";
+        $this->db->statement($sql);
+
+        $sql = "ALTER TABLE `gibbonPersonMedicalUpdate` DROP `bloodType`, DROP `tetanusWithin10Years`;";
+        $this->db->statement($sql);
+
+        return !$partialFail;
+    }
+}

--- a/src/Domain/DataUpdater/MedicalUpdateGateway.php
+++ b/src/Domain/DataUpdater/MedicalUpdateGateway.php
@@ -42,7 +42,7 @@ class MedicalUpdateGateway extends QueryableGateway implements ScrubbableGateway
     private static $searchableColumns = [''];
 
     private static $scrubbableKey = 'gibbonPersonID';
-    private static $scrubbableColumns = ['longTermMedication' => '','longTermMedicationDetails' => '','comment' => ''];
+    private static $scrubbableColumns = ['longTermMedication' => '','longTermMedicationDetails' => '','comment' => '', 'fields' => ''];
     
     /**
      * @param QueryCriteria $criteria

--- a/src/Domain/DataUpdater/MedicalUpdateGateway.php
+++ b/src/Domain/DataUpdater/MedicalUpdateGateway.php
@@ -42,7 +42,7 @@ class MedicalUpdateGateway extends QueryableGateway implements ScrubbableGateway
     private static $searchableColumns = [''];
 
     private static $scrubbableKey = 'gibbonPersonID';
-    private static $scrubbableColumns = ['bloodType' => '','longTermMedication' => '','longTermMedicationDetails' => '','tetanusWithin10Years' => '','comment' => ''];
+    private static $scrubbableColumns = ['longTermMedication' => '','longTermMedicationDetails' => '','comment' => ''];
     
     /**
      * @param QueryCriteria $criteria

--- a/src/Domain/Students/MedicalGateway.php
+++ b/src/Domain/Students/MedicalGateway.php
@@ -42,7 +42,7 @@ class MedicalGateway extends QueryableGateway implements ScrubbableGateway
     private static $searchableColumns = ['preferredName', 'surname', 'username'];
 
     private static $scrubbableKey = 'gibbonPersonID';
-    private static $scrubbableColumns = ['bloodType' => '','longTermMedication' => '','longTermMedicationDetails' => '','tetanusWithin10Years' => '','comment' => ''];
+    private static $scrubbableColumns = ['longTermMedication' => '','longTermMedicationDetails' => '','comment' => ''];
     
     /**
      * @param QueryCriteria $criteria
@@ -54,7 +54,7 @@ class MedicalGateway extends QueryableGateway implements ScrubbableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonPersonMedicalID', 'bloodType', 'longTermMedication', 'longTermMedicationDetails', 'tetanusWithin10Years', 'comment', 'gibbonPerson.gibbonPersonID', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'gibbonRollGroup.name as rollGroup', '(SELECT COUNT(*) FROM gibbonPersonMedicalCondition WHERE gibbonPersonMedicalCondition.gibbonPersonMedicalID=gibbonPersonMedical.gibbonPersonMedicalID) as conditionCount'
+                'gibbonPersonMedicalID', 'longTermMedication', 'longTermMedicationDetails', 'comment', 'gibbonPerson.gibbonPersonID', 'gibbonPerson.preferredName', 'gibbonPerson.surname', 'gibbonRollGroup.name as rollGroup', '(SELECT COUNT(*) FROM gibbonPersonMedicalCondition WHERE gibbonPersonMedicalCondition.gibbonPersonMedicalID=gibbonPersonMedical.gibbonPersonMedicalID) as conditionCount'
             ])
             ->innerJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonPersonMedical.gibbonPersonID')
             ->innerJoin('gibbonStudentEnrolment', 'gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID')

--- a/src/Domain/Students/MedicalGateway.php
+++ b/src/Domain/Students/MedicalGateway.php
@@ -42,7 +42,7 @@ class MedicalGateway extends QueryableGateway implements ScrubbableGateway
     private static $searchableColumns = ['preferredName', 'surname', 'username'];
 
     private static $scrubbableKey = 'gibbonPersonID';
-    private static $scrubbableColumns = ['longTermMedication' => '','longTermMedicationDetails' => '','comment' => ''];
+    private static $scrubbableColumns = ['longTermMedication' => '','longTermMedicationDetails' => '','comment' => '', 'fields' => ''];
     
     /**
      * @param QueryCriteria $criteria

--- a/src/Domain/System/CustomFieldGateway.php
+++ b/src/Domain/System/CustomFieldGateway.php
@@ -101,17 +101,17 @@ class CustomFieldGateway extends QueryableGateway
                     $query->orWhere('activePersonOther=:other', ['other' => $params['other']]);
                 }
             });
+        }
 
-            // Handle additional flags as ANDs
-            if ($params['applicationForm'] ?? false) {
-                $query->where('activeApplicationForm=:applicationForm', ['applicationForm' => $params['applicationForm']]);
-            }
-            if ($params['dataUpdater'] ?? false) {
-                $query->where('activeDataUpdater=:dataUpdater', ['dataUpdater' => $params['dataUpdater']]);
-            }
-            if ($params['publicRegistration'] ?? false) {
-                $query->where('activePublicRegistration=:publicRegistration', ['publicRegistration' => $params['publicRegistration']]);
-            }
+        // Handle additional flags as ANDs
+        if ($params['applicationForm'] ?? false) {
+            $query->where('activeApplicationForm=:applicationForm', ['applicationForm' => $params['applicationForm']]);
+        }
+        if ($params['dataUpdater'] ?? false) {
+            $query->where('activeDataUpdater=:dataUpdater', ['dataUpdater' => $params['dataUpdater']]);
+        }
+        if ($params['publicRegistration'] ?? false) {
+            $query->where('activePublicRegistration=:publicRegistration', ['publicRegistration' => $params['publicRegistration']]);
         }
 
         $query->orderBy(['sequenceNumber', 'name']);

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -160,12 +160,14 @@ class CustomFieldHandler
         }
     }
 
-    public function createCustomFieldsTable($context, $params = [], $fields = [])
+    public function createCustomFieldsTable($context, $params = [], $fields = [], $table = null)
     {
         $existingFields = isset($fields) && is_string($fields)? json_decode($fields, true) : $fields;
         $customFields = $this->customFieldGateway->selectCustomFields($context, $params)->fetchAll();
 
-        $table = DataTable::createDetails('customFields')->withData([$existingFields]);
+        if (empty($table)) {
+            $table = DataTable::createDetails('customFields')->withData([$existingFields]);
+        }
 
         foreach ($customFields as $field) {
             $col = $table->addColumn($field['gibbonCustomFieldID'], __($field['name']));

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -165,7 +165,9 @@ class CustomFieldHandler
         $existingFields = isset($fields) && is_string($fields)? json_decode($fields, true) : $fields;
         $customFields = $this->customFieldGateway->selectCustomFields($context, $params)->fetchAll();
 
-        if (empty($table)) {
+        if (!empty($table)) {
+            $table->withData([$existingFields]);
+        } else {
             $table = DataTable::createDetails('customFields')->withData([$existingFields]);
         }
 

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -369,19 +369,6 @@ class FormFactory implements FormFactoryInterface
             'Other'          => __('Other')
         ))->placeholder();
     }
-    public function createSelectBloodType($name)
-    {
-        return $this->createSelect($name)->fromArray(array(
-            'O+' => 'O+',
-            'A+' => 'A+',
-            'B+' => 'B+',
-            'AB+' => 'AB+',
-            'O-' => 'O-',
-            'A-' => 'A-',
-            'B-' => 'B-',
-            'AB-' => 'AB-'
-        ))->placeholder();
-    }
 
     public function createSelectSystemLanguage($name)
     {

--- a/tests/acceptance/Data Updater/UpdateMedicalDataCept.php
+++ b/tests/acceptance/Data Updater/UpdateMedicalDataCept.php
@@ -34,10 +34,8 @@ $gibbonPersonMedicalUpdateID = $I->grabValueFrom("input[type='hidden'][name='exi
 $I->amOnModulePage('Data Updater', 'data_medical_manage_edit.php', array('gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID));
 $I->seeBreadcrumb('Edit Request');
 
-$I->see('AB+', 'td');
 $I->see('Y', 'td');
 $I->see('Test', 'td');
-$I->see('Y', 'td');
 
 $I->click('Submit');
 $I->seeSuccessMessage();
@@ -82,10 +80,8 @@ $gibbonPersonMedicalUpdateID = $I->grabValueFrom("input[type='hidden'][name='exi
 $I->amOnModulePage('Data Updater', 'data_medical_manage_edit.php', array('gibbonPersonMedicalUpdateID' => $gibbonPersonMedicalUpdateID));
 $I->seeBreadcrumb('Edit Request');
 
-$I->see('O+', 'td');
 $I->see('N', 'td');
 $I->see('Test2', 'td');
-$I->see('N', 'td');
 
 $I->click('Submit');
 $I->seeSuccessMessage();

--- a/tests/acceptance/Data Updater/UpdateMedicalDataCept.php
+++ b/tests/acceptance/Data Updater/UpdateMedicalDataCept.php
@@ -14,10 +14,8 @@ $I->click('Submit');
 $I->see('Update Data');
 
 $editFormValues = array(
-    'bloodType'                 => 'AB+',
     'longTermMedication'        => 'Y',
     'longTermMedicationDetails' => 'Test',
-    'tetanusWithin10Years'      => 'Y',
 );
 
 $I->submitForm('#content form[method="post"]', $editFormValues, 'Submit');
@@ -64,10 +62,8 @@ $I->click('Submit');
 $I->see('Update Data');
 
 $editFormValues = array(
-    'bloodType'                 => 'O+',
     'longTermMedication'        => 'N',
     'longTermMedicationDetails' => 'Test2',
-    'tetanusWithin10Years'      => 'N',
 );
 
 $I->submitForm('#content form[method="post"]', $editFormValues, 'Submit');


### PR DESCRIPTION
This PR is a proof of concept of the extended custom fields system, but is also more complex than most applications of custom fields because medical data is included in the Data Updater as well as the Student Profile and student reports.

Includes a  number of changes:
- Enables the Medical Form context in System Admin > Custom Fields
- Implements custom fields in Students > Manage Medical Forms
- Implements custom fields in Data Updater > Medical Updates
- Migrates the Blood Type and Tetanus fields into Custom Fields (using a migration script)
- Removes the built-in  Blood Type and Tetanus fields from various areas of the system
- Updates the Student Profile > Medical section to include custom medical fields
- Updates the Student Medical Data Summary report to include custom medical fields
- Adds reusable addCustomFieldsToDataUpdate/getFieldDataFromDataUpdate methods to CustomFieldHandler

**Motivation and Context**
Schools have such a variety of medical data they ask for that the current medical form was likely insufficient. Additionally, migrating existing fields over to custom fields enables schools to remove the fields they do not need.

**How Has This Been Tested?**
Locally.

**Screenshots**
New custom field context:
<img width="917" alt="Screenshot 2021-03-03 at 11 11 35 AM" src="https://user-images.githubusercontent.com/897700/109749600-ee5a8800-7c15-11eb-9b54-c16d7ccaa495.png">

Medical form fields in the Custom Fields list:
<img width="931" alt="Screenshot 2021-03-03 at 11 11 19 AM" src="https://user-images.githubusercontent.com/897700/109749608-f1ee0f00-7c15-11eb-95ca-49d25cf03c5b.png">

Medical form fields on the student profile:
<img width="921" alt="Screenshot 2021-03-03 at 11 11 56 AM" src="https://user-images.githubusercontent.com/897700/109749611-f3b7d280-7c15-11eb-934c-adeb51e23861.png">