### PR TITLE
System Admin: add a composer.lock hash check to the Update page

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -792,4 +792,5 @@ ALTER TABLE `gibbonPersonMedicalUpdate` ADD `fields` TEXT NULL AFTER `timestamp`
 DELETE FROM `gibbonSetting` WHERE scope='Students' AND name='extendedBriefProfile';end
 ALTER TABLE `gibbonActivitySlot` CHANGE `gibbonSpaceID` `gibbonSpaceID` int(10) UNSIGNED ZEROFILL DEFAULT NULL;end
 ALTER TABLE `gibbonCustomField` ADD `hidden` ENUM('Y','N') NULL DEFAULT 'N' AFTER `required`;end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('System Admin', 'composerLockHash', 'Composer Update Required', '', '742368e59c40f1eb9b7d8f116f7af49d');end
 ";

--- a/modules/System Admin/update.php
+++ b/modules/System Admin/update.php
@@ -108,6 +108,14 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') 
         $form->addHiddenValue('address', $gibbon->session->get('address'));
         $form->addHiddenValue('type', 'cuttingEdge');
 
+        if ($updater->isComposerUpdateRequired()) {
+            echo Format::alert('<b>'.__('Composer Update Required').'</b>: '.__('The updater has detected a change in the composer.lock file. In the command line, navigate to your Gibbon base path and run the {composer} command. Visit the {docsLink} page in the docs for more information about using composer.<br/><br/>Once you have updated composer, click {updateLink} to dismiss this message. ', [
+                'composer' => '<code class="bg-gray-800 text-white rounded px-1 py-px">composer install</code>',
+                'docsLink' => Format::link('https://docs.gibbonedu.org/developers/getting-started/developer-workflow/', __('Developer Workflow')),
+                'updateLink' => Format::link('./modules/System Admin/updateComposerProcess.php', __('Update')),
+            ]), 'error');
+        }
+
         if ($return == 'success0') {
             $form->addRow()->addContent(__('You seem to be all up to date, good work buddy!'))->addClass('py-16 text-center text-gray-600 text-lg');
         } elseif (!$updateRequired) {

--- a/modules/System Admin/updateComposerProcess.php
+++ b/modules/System Admin/updateComposerProcess.php
@@ -1,0 +1,54 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Database\Updater;
+use Gibbon\Domain\System\SettingGateway;
+
+$_POST['address'] = '/index.php?q=/modules/System Admin/update.php';
+
+include '../../gibbon.php';
+
+//Module includes
+require_once __DIR__ . '/moduleFunctions.php';
+
+$URL = $_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/System Admin/update.php';
+$partialFail = false;
+
+if (isActionAccessible($guid, $connection2, '/modules/System Admin/update.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    // Proceed!
+    $updater = $container->get(Updater::class);
+    $settingGateway = $container->get(SettingGateway::class);
+    
+    if (!$updater->isComposerUpdateRequired()) {
+        $URL .= '&return=error3';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $newComposerHash = $updater->getComposerHash();
+    $updated = $settingGateway->updateSettingByScope('System Admin', 'composerLockHash', $newComposerHash);
+
+    $URL .= !$updated
+        ? '&return=error2'
+        : '&return=success0';
+    header("Location: {$URL}");
+}

--- a/src/Database/Updater.php
+++ b/src/Database/Updater.php
@@ -101,6 +101,14 @@ class Updater implements ContainerAwareInterface
         return false;
     }
 
+    public function isComposerUpdateRequired()
+    {
+        $currentHash = $this->settingGateway->getSettingByScope('System Admin', 'composerLockHash');
+        $autoloadFile = $this->absolutePath.'/vendor/autoload.php';
+
+        return $currentHash != $this->getComposerHash() || !is_file($autoloadFile);
+    }
+
     public function update() : array
     {
         if (!$this->isUpdateRequired()) {
@@ -252,6 +260,14 @@ class Updater implements ContainerAwareInterface
                 $this->db->insert($sql, $data);
             }
         }
+    }
+
+    public function getComposerHash()
+    {
+        $composerLock = file_get_contents($this->absolutePath.'/composer.lock');
+        $composerLock = json_decode($composerLock, true);
+
+        return $composerLock['content-hash'] ?? '';
     }
 
     protected function loadChangeDB()


### PR DESCRIPTION
In preparation for merging #1209, we're looking at how we can help inform developers of the change in workflow, as well as ensure their systems remain up to date with the cutting edge code. This PR adds a check to the Update process to see if the content-hash in the composer.lock file has changed, and prompts users if they need to run a composer install.

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="923" alt="Screenshot 2021-03-04 at 1 11 36 PM" src="https://user-images.githubusercontent.com/897700/109914944-eff67f80-7ceb-11eb-82b2-a3340fb83af1.png">
