### PR TITLE
Automate Lesson plan naming

### DIFF
--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -187,7 +187,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Lesson Name'));
-                $row->addTextField('name')->setValue()->maxLength(50)->required();
+                $row->addTextField('name')->setValue()->maxLength(50);
 
             $row = $form->addRow();
                 $row->addLabel('summary', __('Summary'));

--- a/modules/Planner/planner_addProcess.php
+++ b/modules/Planner/planner_addProcess.php
@@ -54,7 +54,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
             $timeStart = $_POST['timeStart'];
             $timeEnd = $_POST['timeEnd'];
             $gibbonUnitID = !empty($_POST['gibbonUnitID']) ? $_POST['gibbonUnitID'] : null;
-            $name = $_POST['name'] ?? 'Lesson';
+            $name = $_POST['name'] ?? '';
+            if (empty($name)) {
+               $name = 'Lesson for ' . $gibbonCourseClassID;
+            }
             $summary = $_POST['summary'] ?? '';
             if (empty($summary)) {
                 $summary = trim(strip_tags($_POST['description'] ?? '')) ;

--- a/modules/Planner/planner_addProcess.php
+++ b/modules/Planner/planner_addProcess.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
             $timeStart = $_POST['timeStart'];
             $timeEnd = $_POST['timeEnd'];
             $gibbonUnitID = !empty($_POST['gibbonUnitID']) ? $_POST['gibbonUnitID'] : null;
-            $name = $_POST['name'];
+            $name = $_POST['name'] ?? 'Lesson';
             $summary = $_POST['summary'] ?? '';
             if (empty($summary)) {
                 $summary = trim(strip_tags($_POST['description'] ?? '')) ;


### PR DESCRIPTION
A simple change to creating Lesson plans that does not require that the Lesson be named. This makes it a bit quicker for teachers to add lessons. If the Lesson name is blank it is set to "Lesson".
