### PR TITLE
Fix nested ternary operator in custom field

### DIFF
--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -218,7 +218,7 @@ class CustomFieldHandler
         return $table;
     }
 
-    public function addCustomFieldsToDataUpdate(&$form, $context, $params = [], $oldValues, $newValues)
+    public function addCustomFieldsToDataUpdate(&$form, $context, array $params = [], $oldValues = '', $newValues = '')
     {
         $oldFields = !empty($oldValues['fields'])? json_decode($oldValues['fields'], true) : [];
         $newFields = !empty($newValues['fields'])? json_decode($newValues['fields'], true) : [];

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -229,8 +229,12 @@ class CustomFieldHandler
             $fieldName = $field['gibbonCustomFieldID'];
             $label = __($field['name']);
 
-            $oldValue = isset($oldFields[$fieldName])? $oldFields[$fieldName] : isset($oldFields[substr($fieldName, 1, 3)])? $oldFields[substr($fieldName, 1, 3)] : '';
-            $newValue = isset($newFields[$fieldName])? $newFields[$fieldName] : isset($newFields[substr($fieldName, 1, 3)])? $newFields[substr($fieldName, 1, 3)] : '';
+            $oldValue = isset($oldFields[$fieldName])
+                ? $oldFields[$fieldName]
+                : (isset($oldFields[substr($fieldName, 1, 3)])? $oldFields[substr($fieldName, 1, 3)] : '');
+            $newValue = isset($newFields[$fieldName])
+                ? $newFields[$fieldName]
+                : (isset($newFields[substr($fieldName, 1, 3)])? $newFields[substr($fieldName, 1, 3)] : '');
 
             if ($field['type'] == 'date') {
                 $oldValue = Format::date($oldValue);


### PR DESCRIPTION
**Description**

* Unparenthesized ternary is deprecated in php 7.4 and
  considered fatal error in php 8.0. Added explicit
  parentheses to fix the error.

* Optional parameters should be provided after required
  parameters. Provide default value '' to the later $oldValue
  and $newValue in CustomFieldHandler::addCustomFieldsToDataUpdate
  to make them also optional and fix the message.

* Also add typehint `array` to `$params` of
  CustomFieldHandler::addCustomFieldsToDataUpdate.
 

**Motivation and Context**
References:
* https://www.php.net/manual/en/migration74.deprecated.php
* https://www.php.net/manual/en/migration80.incompatible.php
* https://php.watch/versions/8.0/deprecate-required-param-after-optional

**How Has This Been Tested?**
CI environment

**Screenshots**
![2021-03-08 10-51-55 的螢幕擷圖](https://user-images.githubusercontent.com/91274/110268292-63560500-7ffc-11eb-8781-d4ef8465f6d5.png)

