### PR TITLE
Display dashboard tab (Enrolment) for high resolution screens fixed

### DIFF
--- a/resources/templates/index.twig.html
+++ b/resources/templates/index.twig.html
@@ -69,7 +69,7 @@ TODO: add template variable details.
                         <br style="clear: both">
                     {% endif %}
 
-                    <div id="content" class="w-full max-w-full {{ not sidebar ?'pt-0 sm:pt-6' }} lg:flex-1  p-6 lg:pt-0 {{ not preventOverflow ? 'overflow-x-scroll lg:overflow-x-auto' : 'overflow-x-auto xl:overflow-x-scroll' }} ">
+                    <div id="content" class="w-full max-w-full {{ not sidebar ?'pt-0 sm:pt-6' }} lg:flex-1  p-6 lg:pt-0 {{ not menuModule or not preventOverflow ? 'overflow-x-scroll lg:overflow-x-auto' : 'overflow-x-auto xl:overflow-x-unset' }} ">
 
                         {% block page %}
 

--- a/resources/templates/index.twig.html
+++ b/resources/templates/index.twig.html
@@ -69,7 +69,7 @@ TODO: add template variable details.
                         <br style="clear: both">
                     {% endif %}
 
-                    <div id="content" class="w-full max-w-full {{ not sidebar ?'pt-0 sm:pt-6' }} lg:flex-1  p-6 lg:pt-0 {{ not preventOverflow ? 'overflow-x-scroll lg:overflow-x-auto' : 'overflow-x-auto xl:overflow-x-unset' }} ">
+                    <div id="content" class="w-full max-w-full {{ not sidebar ?'pt-0 sm:pt-6' }} lg:flex-1  p-6 lg:pt-0 {{ not preventOverflow ? 'overflow-x-scroll lg:overflow-x-auto' : 'overflow-x-auto xl:overflow-x-scroll' }} ">
 
                         {% block page %}
 


### PR DESCRIPTION
**Description**
The value of  property xl:overflow-x-unset changed to xl:overflow-x-scroll


**Motivation and Context**
When the button "sidebarToggle" is clicked, the display tab (Enrolment) on high-resolution screens not working correctly.

**How Has This Been Tested?**
Local in high resolution 1920 x 1080

**Screenshots**
![v22_dashboard_error](https://user-images.githubusercontent.com/1969911/110708310-3f9be600-81d9-11eb-81e3-a4583bf70675.png)

