### PR TITLE
System: add a migration to update all custom field IDs

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -795,4 +795,5 @@ ALTER TABLE `gibbonCustomField` ADD `hidden` ENUM('Y','N') NULL DEFAULT 'N' AFTE
 INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('System Admin', 'composerLockHash', 'Composer Update Required', '', '742368e59c40f1eb9b7d8f116f7af49d');end
 UPDATE `gibbonAction` SET categoryPermissionParent='N' WHERE `name`='View Markbook_myMarks' AND `gibbonModuleID`=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Markbook');end
 DELETE `gibbonPermission` FROM `gibbonPermission` JOIN `gibbonAction` ON (gibbonAction.gibbonActionID=gibbonPermission.gibbonActionID) JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPermission.gibbonRoleID) WHERE gibbonAction.name='View Markbook_myMarks' AND gibbonRole.category='Parent';end
+SELECT NULL;end
 ";

--- a/modules/Data Updater/data_personalProcess.php
+++ b/modules/Data Updater/data_personalProcess.php
@@ -225,10 +225,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
                     // Check for data changed
                     $existingFields = json_decode($values['fields'], true);
-                    foreach ($existingFields as $key => $value) {
-                        $existingFields[str_pad($key, 4, "0", STR_PAD_LEFT)] = $value;
-                    }
-
                     $newFields = json_decode($fields, true);
                     foreach ($newFields as $key => $fieldValue) {
                         if ($existingFields[$key] != $fieldValue) {

--- a/src/Database/Migrations/2021-03-18-CustomFieldIDs.php
+++ b/src/Database/Migrations/2021-03-18-CustomFieldIDs.php
@@ -1,0 +1,104 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\User\UserGateway;
+use Gibbon\Database\Migrations\Migration;
+use Gibbon\Domain\DataUpdater\PersonUpdateGateway;
+use Gibbon\Domain\Students\ApplicationFormGateway;
+
+/**
+ * Custom Field ID migration - update all custom fields to use 4 digit ID numbers.
+ */
+class CustomFieldIDs extends Migration
+{
+    protected $userGateway;
+    protected $personUpdateGateway;
+    protected $applicationGateway;
+
+    public function __construct(UserGateway $userGateway, PersonUpdateGateway $personUpdateGateway, ApplicationFormGateway $applicationGateway)
+    {
+        $this->userGateway = $userGateway;
+        $this->personUpdateGateway = $personUpdateGateway;
+        $this->applicationGateway = $applicationGateway;
+    }   
+
+    public function migrate()
+    {
+        $partialFail = false;
+
+        $updateIDs = function ($fieldData) {
+            return array_reduce(array_keys($fieldData), function ($group, $key) use (&$fieldData) {
+                $group[str_pad($key, 4, '0', STR_PAD_LEFT)] = $fieldData[$key];
+                return $group;
+            }, []);
+        };
+
+        // Update user custom fields
+        $users = $this->userGateway->selectBy([], ['gibbonPersonID', 'fields']); 
+
+        foreach ($users as $user) {
+            if (empty($user['fields'])) continue;
+
+            $fieldData = json_decode($user['fields'], true);
+            $fieldData = $updateIDs($fieldData);
+            
+            $partialFail &= !$this->userGateway->update($user['gibbonPersonID'], [
+                'fields' => !empty($fieldData) ? json_encode($fieldData) : '',
+            ]);
+        }
+
+        // Update data updater custom fields
+        $updates = $this->personUpdateGateway->selectBy([], ['gibbonPersonUpdateID', 'fields']); 
+
+        foreach ($updates as $update) {
+            if (empty($update['fields'])) continue;
+
+            $fieldData = json_decode($update['fields'], true);
+            $fieldData = $updateIDs($fieldData);
+
+            $partialFail &= !$this->personUpdateGateway->update($update['gibbonPersonUpdateID'], [
+                'fields' => !empty($fieldData) ? json_encode($fieldData) : '',
+            ]);
+        }
+
+        // Update application form custom fields
+        $applications = $this->applicationGateway->selectBy([], ['gibbonApplicationFormID', 'fields', 'parent1fields', 'parent2fields']); 
+
+        foreach ($applications as $application) {
+            if (empty($application['fields']) && empty($application['parent1fields']) && empty($application['parent2fields'])) continue;
+
+            $fieldData = json_decode($application['fields'], true);
+            $fieldData = $updateIDs($fieldData);
+
+            $parent1fieldData = json_decode($application['parent1fields'], true);
+            $parent1fieldData = $updateIDs($parent1fieldData);
+
+            $parent2fieldData = json_decode($application['parent2fields'], true);
+            $parent2fieldData = $updateIDs($parent2fieldData);
+
+            $partialFail &= !$this->applicationGateway->update($application['gibbonApplicationFormID'], [
+                'fields' => !empty($fieldData) ? json_encode($fieldData) : '',
+                'parent1fields' => !empty($parent1fieldData) ? json_encode($parent1fieldData) : '',
+                'parent2fields' => !empty($parent2fieldData) ? json_encode($parent2fieldData) : '',
+            ]);
+        }
+
+        return !$partialFail;
+    }
+}

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -126,18 +126,12 @@ class CustomFieldHandler
 
     public function addCustomFieldsToForm(&$form, $context, $params = [], $fields = [])
     {
-        $fields = !empty($fields) && is_string($fields)? json_decode($fields, true) : (is_array($fields) ? $fields : []);
+        $existingFields = !empty($fields) && is_string($fields)? json_decode($fields, true) : (is_array($fields) ? $fields : []);
         $customFieldsGrouped = $this->customFieldGateway->selectCustomFields($context, $params)->fetchGrouped();
         $prefix = $params['prefix'] ?? 'custom';
 
         if (empty($customFieldsGrouped)) {
             return;
-        }
-
-        $existingFields = [];
-        foreach ($fields as $key => $value) {
-            $key = str_pad($key, 4, "0", STR_PAD_LEFT);
-            $existingFields[$key] = $value;
         }
 
         if (!empty($params['heading'])) {
@@ -170,14 +164,8 @@ class CustomFieldHandler
 
     public function createCustomFieldsTable($context, $params = [], $fields = [], $table = null)
     {
-        $fields = !empty($fields) && is_string($fields)? json_decode($fields, true) : (is_array($fields) ? $fields : []);
+        $existingFields = !empty($fields) && is_string($fields)? json_decode($fields, true) : (is_array($fields) ? $fields : []);
         $customFields = $this->customFieldGateway->selectCustomFields($context, $params + ['hideHidden' => '1'])->fetchAll();
-
-        $existingFields = [];
-        foreach ($fields as $key => $value) {
-            $key = str_pad($key, 4, "0", STR_PAD_LEFT);
-            $existingFields[$key] = $value;
-        }
 
         if (!empty($table)) {
             $table->withData([$existingFields]);
@@ -223,17 +211,10 @@ class CustomFieldHandler
         $oldFields = !empty($oldValues['fields'])? json_decode($oldValues['fields'], true) : [];
         $newFields = !empty($newValues['fields'])? json_decode($newValues['fields'], true) : [];
 
-        foreach ($oldFields as $key => $value) {
-            $oldFields[str_pad($key, 4, "0", STR_PAD_LEFT)] = $value;
-        }
-        foreach ($newFields as $key => $value) {
-            $newFields[str_pad($key, 4, "0", STR_PAD_LEFT)] = $value;
-        }
-
         $customFields = $this->customFieldGateway->selectCustomFields($context, $params)->fetchAll();
 
         foreach ($customFields as $field) {
-            $fieldID = str_pad($field['gibbonCustomFieldID'], 4, "0", STR_PAD_LEFT);
+            $fieldID = $field['gibbonCustomFieldID'];
             $label = __($field['name']);
 
             $oldValue = $oldFields[$fieldID] ?? '';


### PR DESCRIPTION
As part of our custom field improvements, the gibbonCustomFieldID length was increased from 3 to 4. This change ended up requiring various checks in the code to ensure old and new custom fields were compared correctly. This PR addresses the issue by adding a migration to update all custom field ID lengths, which enables removing the added complexity from the code.

The `SELECT NULL;` in the changedb is there to trigger an update. Ideally, this generally wont be needed because the migration almost always entails a database change. However, this migration happens to be a follow-up change to the previous migration.