### PR TITLE
System Admin: enable custom fields to be listed under specific headings

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -797,4 +797,5 @@ UPDATE `gibbonAction` SET categoryPermissionParent='N' WHERE `name`='View Markbo
 DELETE `gibbonPermission` FROM `gibbonPermission` JOIN `gibbonAction` ON (gibbonAction.gibbonActionID=gibbonPermission.gibbonActionID) JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPermission.gibbonRoleID) WHERE gibbonAction.name='View Markbook_myMarks' AND gibbonRole.category='Parent';end
 SELECT NULL;end
 UPDATE `gibbonCustomField` SET `heading`='General Information' WHERE `context`='Medical Form' AND (`name`='Blood Type' OR `name`='Tetanus Within Last 10 Years?');end
+UPDATE `gibbonCustomField` SET `context`='User' WHERE `context`='Person';end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -796,4 +796,5 @@ INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `val
 UPDATE `gibbonAction` SET categoryPermissionParent='N' WHERE `name`='View Markbook_myMarks' AND `gibbonModuleID`=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Markbook');end
 DELETE `gibbonPermission` FROM `gibbonPermission` JOIN `gibbonAction` ON (gibbonAction.gibbonActionID=gibbonPermission.gibbonActionID) JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPermission.gibbonRoleID) WHERE gibbonAction.name='View Markbook_myMarks' AND gibbonRole.category='Parent';end
 SELECT NULL;end
+UPDATE `gibbonCustomField` SET `heading`='General Information' WHERE `context`='Medical Form' AND (`name`='Blood Type' OR `name`='Tetanus Within Last 10 Years?');end
 ";

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -622,8 +622,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     }
 
                     // CUSTOM FIELDS
-                    $heading = $form->addRow()->addHeading(__('Custom Fields'));
-
                     $params = compact('student', 'staff', 'parent', 'other');
                     $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params + ['dataUpdater' => 1], $values['fields']);
 

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -623,7 +623,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
                     // CUSTOM FIELDS
                     $params = compact('student', 'staff', 'parent', 'other');
-                    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params + ['dataUpdater' => 1], $values['fields']);
+                    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params + ['dataUpdater' => 1], $values['fields']);
 
                     $row = $form->addRow();
                         $row->addFooter();

--- a/modules/Data Updater/data_personalProcess.php
+++ b/modules/Data Updater/data_personalProcess.php
@@ -221,7 +221,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     // CUSTOM FIELDS
                     $customRequireFail = false;
                     $params = compact('student', 'staff', 'parent', 'other');
-                    $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Person', $params + ['dataUpdater' => 1], $customRequireFail);
+                    $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('User', $params + ['dataUpdater' => 1], $customRequireFail);
 
                     // Check for data changed
                     $existingFields = json_decode($values['fields'], true);

--- a/modules/Data Updater/data_personal_manage_edit.php
+++ b/modules/Data Updater/data_personal_manage_edit.php
@@ -210,7 +210,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
             // CUSTOM FIELDS
             $params = compact('student', 'staff', 'parent', 'other');
-            $container->get(CustomFieldHandler::class)->addCustomFieldsToDataUpdate($form, 'Person', $params + ['dataUpdater' => 1], $oldValues, $newValues);
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToDataUpdate($form, 'User', $params + ['dataUpdater' => 1], $oldValues, $newValues);
             
             $row = $form->addRow();
                 $row->addSubmit();

--- a/modules/Data Updater/data_personal_manage_editProcess.php
+++ b/modules/Data Updater/data_personal_manage_editProcess.php
@@ -436,7 +436,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
 
                 // CUSTOM FIELDS
                 $params = compact('student', 'staff', 'parent', 'other');
-                $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromDataUpdate('Person', $params, $row2['fields']);
+                $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromDataUpdate('User', $params, $row2['fields']);
 
                 if (strlen($set) > 1) {
                     //Write to database

--- a/modules/Reports/src/Sources/CustomFields.php
+++ b/modules/Reports/src/Sources/CustomFields.php
@@ -41,7 +41,7 @@ class CustomFields extends DataSource
         $fieldData = $this->db()->selectOne($sql, $data);
         $personFields = unserialize($fieldData ?? '');
 
-        $sql = "SELECT name, gibbonCustomFieldID FROM gibbonCustomField WHERE active='Y' AND context='Person' AND activePersonStudent=1";
+        $sql = "SELECT name, gibbonCustomFieldID FROM gibbonCustomField WHERE active='Y' AND context='User' AND activePersonStudent=1";
         $fields = $this->db()->select($sql)->fetchKeyPair();
         
         $personFields = array_map(function ($id) use ($personFields) {

--- a/modules/Staff/applicationForm.php
+++ b/modules/Staff/applicationForm.php
@@ -240,7 +240,7 @@ if ($proceed == false) {
 
         // CUSTOM FIELDS FOR STAFF
         $params = ['staff' => 1, 'applicationForm' => 1, 'heading' => __('Other Information')];
-        $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params);
+        $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params);
 
         // REQURIED DOCUMENTS
         $staffApplicationFormRequiredDocuments = getSettingByScope($connection2, 'Staff', 'staffApplicationFormRequiredDocuments');

--- a/modules/Staff/applicationFormProcess.php
+++ b/modules/Staff/applicationFormProcess.php
@@ -187,7 +187,7 @@ if ($proceed == false) {
     } else {
         //DEAL WITH CUSTOM FIELDS
         $customRequireFail = false;
-        $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Person', ['staff' => 1, 'applicationForm' => 1], $customRequireFail);
+        $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('User', ['staff' => 1, 'applicationForm' => 1], $customRequireFail);
 
         if ($customRequireFail) {
             $URL .= '&return=error1';

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -263,7 +263,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
             // CUSTOM FIELDS FOR STAFF
             $params = ['staff' => 1, 'applicationForm' => 1, 'heading' => __('Other Information')];
-            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $values['fields']);
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params, $values['fields']);
 
             // REQURIED DOCUMENTS
             $staffApplicationFormRequiredDocuments = getSettingByScope($connection2, 'Staff', 'staffApplicationFormRequiredDocuments');

--- a/modules/Staff/applicationForm_manage_editProcess.php
+++ b/modules/Staff/applicationForm_manage_editProcess.php
@@ -192,7 +192,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
             } else {
                 // CUSTOM FIELDS
                 $customRequireFail = false;
-                $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Person', ['staff' => 1, 'applicationForm' => 1], $customRequireFail);
+                $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('User', ['staff' => 1, 'applicationForm' => 1], $customRequireFail);
 
                 if ($customRequireFail) {
                     $URL .= '&return=error3';

--- a/modules/Staff/staff_view_details.php
+++ b/modules/Staff/staff_view_details.php
@@ -294,7 +294,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view_details.p
                         echo $table->render([$row]);
 
                         // Custom Fields
-                        $table = $container->get(CustomFieldHandler::class)->createCustomFieldsTable('Person', ['staff' => 1], $row['fields']);
+                        $table = DataTable::createDetails('custom');
+                        $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'User', ['staff' => 1], $row['fields']);
                         $table->setTitle(__('Custom Fields'));
                         echo $table->getOutput();
                     } elseif ($subpage == 'Family') {

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -415,7 +415,7 @@ if ($proceed == false) {
     }
 
     // CUSTOM FIELDS FOR STUDENT
-    $params = ['student' => 1, 'applicationForm' => 1, 'subheading' => __('Other Information')];
+    $params = ['student' => 1, 'applicationForm' => 1];
     $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params);
 
     // FAMILY

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -416,7 +416,7 @@ if ($proceed == false) {
 
     // CUSTOM FIELDS FOR STUDENT
     $params = ['student' => 1, 'applicationForm' => 1];
-    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params);
+    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params);
 
     // FAMILY
     if (!empty($gibbonFamilyID)) {
@@ -500,7 +500,7 @@ if ($proceed == false) {
 
             // CUSTOM FIELDS FOR PARENT 1 WITH FAMILY
             $params = ['parent' => 1, 'applicationForm' => 1, 'prefix' => 'parent1custom', 'subheading' => __('Parent/Guardian').' 1 '.__('Other Information')];
-            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $parent1fields);
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params, $parent1fields);
 
             $start = 2;
         } else {
@@ -627,7 +627,7 @@ if ($proceed == false) {
 
             // CUSTOM FIELDS FOR PARENTS
             $params = ['parent' => 1, 'applicationForm' => 1, 'prefix' => "parent{$i}custom", 'subheading' => __('Parent/Guardian')." $i ".__('Other Information')];
-            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $application["parent{$i}fields"] ?? '');
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params, $application["parent{$i}fields"] ?? '');
         }
     } else {
         // LOGGED IN PARENT WITH FAMILY

--- a/modules/Students/applicationFormProcess.php
+++ b/modules/Students/applicationFormProcess.php
@@ -545,16 +545,16 @@ if ($proceed == false) {
             $customFieldHandler = $container->get(CustomFieldHandler::class);
 
             $params = ['student' => 1, 'applicationForm' => 1];
-            $fields = $customFieldHandler->getFieldDataFromPOST('Person', $params, $customRequireFail);
+            $fields = $customFieldHandler->getFieldDataFromPOST('User', $params, $customRequireFail);
 
             $parent1fields = $parent2fields = '';
             if ($gibbonFamily == 'FALSE') { //Only if there is no family
                 $params = ['parent' => 1, 'applicationForm' => 1, 'prefix' => 'parent1custom'];
-                $parent1fields = $customFieldHandler->getFieldDataFromPOST('Person', $params, $customRequireFail);
+                $parent1fields = $customFieldHandler->getFieldDataFromPOST('User', $params, $customRequireFail);
                 
                 if (empty($_POST['secondParent'])) {
                     $params = ['parent' => 1, 'applicationForm' => 1, 'prefix' => 'parent2custom'];
-                    $parent2fields = $customFieldHandler->getFieldDataFromPOST('Person', $params, $customRequireFail);
+                    $parent2fields = $customFieldHandler->getFieldDataFromPOST('User', $params, $customRequireFail);
                 }
             }
 

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -485,7 +485,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     // CUSTOM FIELDS FOR STUDENT
     $params = ['student' => 1, 'applicationForm' => 1];
-    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $application['fields']);
+    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params, $application['fields']);
 
     // FAMILY
     if (empty($application['gibbonFamilyID'])) {
@@ -530,7 +530,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             // CUSTOM FIELDS FOR PARENT 1 WITH FAMILY
             $params = ['parent' => 1, 'applicationForm' => 1, 'prefix' => 'parent1custom', 'subheading' => __('Parent/Guardian').' 1 '.__('Other Information')];
-            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $application['parent1fields']);
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params, $application['parent1fields']);
 
             $start = 2;
         } else {
@@ -658,7 +658,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
             // CUSTOM FIELDS FOR PARENTS
             $params = ['parent' => 1, 'applicationForm' => 1, 'prefix' => "parent{$i}custom", 'subheading' => __('Parent/Guardian')." $i ".__('Other Information')];
-            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $application["parent{$i}fields"]);
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params, $application["parent{$i}fields"]);
         }
     } else {
         // EXISTING FAMILY

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -484,7 +484,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     }
 
     // CUSTOM FIELDS FOR STUDENT
-    $params = ['student' => 1, 'applicationForm' => 1, 'subheading' => __('Other Information')];
+    $params = ['student' => 1, 'applicationForm' => 1];
     $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $application['fields']);
 
     // FAMILY

--- a/modules/Students/applicationForm_manage_editProcess.php
+++ b/modules/Students/applicationForm_manage_editProcess.php
@@ -554,13 +554,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                 $customFieldHandler = $container->get(CustomFieldHandler::class);
 
                 $params = ['student' => 1, 'applicationForm' => 1];
-                $fields = $customFieldHandler->getFieldDataFromPOST('Person', $params, $customRequireFail);
+                $fields = $customFieldHandler->getFieldDataFromPOST('User', $params, $customRequireFail);
 
                 $parent1fields = $parent2fields = '';
                 if ($gibbonFamily != 'TRUE') { //Only if there is no family
                     $params = ['parent' => 1, 'applicationForm' => 1];
-                    $parent1fields = $customFieldHandler->getFieldDataFromPOST('Person', $params, $customRequireFail, 'parent1custom');
-                    $parent2fields = $customFieldHandler->getFieldDataFromPOST('Person', $params, $customRequireFail, 'parent2custom'); 
+                    $parent1fields = $customFieldHandler->getFieldDataFromPOST('User', $params, $customRequireFail, 'parent1custom');
+                    $parent2fields = $customFieldHandler->getFieldDataFromPOST('User', $params, $customRequireFail, 'parent2custom'); 
                 }
 
                 if ($customRequireFail) {

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -777,7 +777,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             });
                         }
 
-                        $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Person', ['student' => 1], $row['fields']);
+                        $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'User', ['student' => 1], $row['fields']);
 
                         echo $table->render([$row]);
 

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1077,10 +1077,60 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         }
                         echo '</table>';
 
-                        // Custom Fields
-                        $table = $container->get(CustomFieldHandler::class)->createCustomFieldsTable('Person', ['student' => 1], $row['fields']);
-                        $table->setTitle(__('Custom Fields'));
-                        echo $table->getOutput();
+                        $table = DataTable::createDetails('overview');
+
+                        if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php')) {
+                            $table->addHeaderAction('edit', __m('Edit User'))
+                                ->setURL('/modules/User Admin/user_manage.php')
+                                ->addParam('gibbonPersonID', $gibbonPersonID)
+                                ->displayLabel();
+                        }
+
+                        $col = $table->addColumn('Basic Information', __('Basic Information'));
+
+                        $col->addColumn('surname', __('Surname'));
+                        $col->addColumn('firstName', __('First Name'))->addClass('col-span-2');
+                        $col->addColumn('preferredName', __('Preferred Name'));
+                        $col->addColumn('officialName', __('Official Name'));
+                        $col->addColumn('nameInCharacters', __('Name in Characters'));
+                        $col->addColumn('gender', __('Gender'));
+                        $col->addColumn('dob', __('Date of Birth'))->format(Format::using('date', 'dob'));
+                        $col->addColumn('age', __('Age'))->format(Format::using('age', 'dob'));
+
+                        $col = $table->addColumn('contacts', __('Contacts'));
+
+                        $col->addColumn('email', __('Email'))->format(Format::using('link', 'email'));
+                        $col->addColumn('emailAlternate', __('Alternate Email'))->format(Format::using('link', 'emailAlternate'));
+                        $col->addColumn('website', __('Website'))->format(Format::using('link', 'website'));
+
+                        $col = $table->addColumn('School Information', __('School Information'));
+
+                        $col->addColumn('lastSchool', __('Last School'));
+                        $col->addColumn('dateStart', __('Start Date'))->format(Format::using('date', 'dateStart'));
+                        $col->addColumn('classOf', __('Class Of'));
+                        $col->addColumn('nextSchool', __('Next School'));
+                        $col->addColumn('dateEnd', __('End Date'))->format(Format::using('date', 'dateEnd'));
+                        $col->addColumn('departureReason', __('Departure Reason'));
+
+                        $col = $table->addColumn('Background', __('Background'));
+
+                        $col->addColumn('email', __('Email'));
+
+                        $col = $table->addColumn('School Data', __('School Data'));
+
+                        $col->addColumn('email', __('Email'));
+
+                        $col = $table->addColumn('System Data', __('System Data'));
+
+                        $col->addColumn('email', __('Email'));
+
+                        $col = $table->addColumn('Miscellaneous', __('Miscellaneous'));
+
+                        $col->addColumn('email', __('Email'));
+
+                        $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Person', ['student' => 1, 'heading' => 'Other Information'], $row['fields']);
+
+                        echo $table->render([$row]);
 
                     } elseif ($subpage == 'Family') {
 
@@ -1523,7 +1573,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     : Format::small(__('Unknown'));
                             });
 
-                        $table = $container->get(CustomFieldHandler::class)->createCustomFieldsTable('Medical Form', [], $medical['fields'], $table);
+                        $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Medical Form', [], $medical['fields'], $table);
 
                         $table->addColumn('medicalConditions', __('Medical Conditions?'))
                             ->addClass('col-span-3')

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -23,13 +23,17 @@ use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Tables\View\GridView;
 use Gibbon\Domain\User\UserGateway;
+use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Domain\School\YearGroupGateway;
 use Gibbon\Domain\Students\MedicalGateway;
 use Gibbon\Domain\Students\StudentGateway;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
+use Gibbon\Domain\RollGroups\RollGroupGateway;
 use Gibbon\Domain\Students\StudentNoteGateway;
 use Gibbon\Domain\Library\LibraryReportGateway;
-use Gibbon\Forms\CustomFieldHandler;
+use Gibbon\Domain\School\HouseGateway;
 use Gibbon\Module\Planner\Tables\HomeworkTable;
 use Gibbon\Module\Attendance\StudentHistoryData;
 use Gibbon\Module\Attendance\StudentHistoryView;
@@ -618,475 +622,27 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             }
                         }
                     } elseif ($subpage == 'Personal') {
-                        if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php') == true) {
-                            echo "<div class='linkTop'>";
-                            echo "<a href='".$_SESSION[$guid]['absoluteURL']."/index.php?q=/modules/User Admin/user_manage_edit.php&gibbonPersonID=$gibbonPersonID'>".__('Edit')."<img style='margin: 0 0 -4px 5px' title='".__('Edit')."' src='./themes/".$_SESSION[$guid]['gibbonThemeName']."/img/config.png'/></a> ";
-                            echo '</div>';
-                        }
+                        $schoolYearGateway = $container->get(SchoolYearGateway::class);
+                        $yearGroupGateway = $container->get(YearGroupGateway::class);
+                        $rollGroupGateway = $container->get(RollGroupGateway::class);
+                        $studentGateway = $container->get(StudentGateway::class);
 
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        echo '<tr>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Surname').'</span><br/>';
-                        echo $row['surname'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('First Name').'</span><br/>';
-                        echo $row['firstName'];
-                        echo '</td>';
-                        echo "<td style='width: 34%; vertical-align: top'>";
-
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Preferred Name').'</span><br/>';
-                        echo Format::name('', $row['preferredName'], $row['surname'], 'Student');
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Official Name').'</span><br/>';
-                        echo $row['officialName'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Name In Characters').'</span><br/>';
-                        echo $row['nameInCharacters'];
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Gender').'</span><br/>';
-                        echo $row['gender'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Date of Birth').'</span><br/>';
-                        if (is_null($row['dob']) == false and $row['dob'] != '0000-00-00') {
-                            echo dateConvertBack($guid, $row['dob']);
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Age').'</span><br/>';
-                        if (is_null($row['dob']) == false and $row['dob'] != '0000-00-00') {
-                            echo Format::age($row['dob']);
-                        }
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '</table>';
-
-                        echo '<h4>';
-                        echo __('Contacts');
-                        echo '</h4>';
-
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        $numberCount = 0;
-                        if ($row['phone1'] != '' or $row['phone2'] != '' or $row['phone3'] != '' or $row['phone4'] != '') {
-                            echo '<tr>';
-                            for ($i = 1; $i < 5; ++$i) {
-                                if ($row['phone'.$i] != '') {
-                                    ++$numberCount;
-                                    echo "<td width: 33%; style='vertical-align: top'>";
-                                    echo "<span style='font-size: 115%; font-weight: bold'>".__('Phone')." $numberCount</span><br/>";
-                                    if ($row['phone'.$i.'Type'] != '') {
-                                        echo $row['phone'.$i.'Type'].':</i> ';
-                                    }
-                                    if ($row['phone'.$i.'CountryCode'] != '') {
-                                        echo '+'.$row['phone'.$i.'CountryCode'].' ';
-                                    }
-                                    echo formatPhone($row['phone'.$i]).'<br/>';
-                                    echo '</td>';
-                                } else {
-                                    echo "<td width: 33%; style='vertical-align: top'>";
-
-                                    echo '</td>';
-                                }
-                            }
-                            echo '</tr>';
-                        }
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Email').'</span><br/>';
-                        if ($row['email'] != '') {
-                            echo "<i><a href='mailto:".$row['email']."'>".$row['email'].'</a></i>';
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Alternate Email').'</span><br/>';
-                        if ($row['emailAlternate'] != '') {
-                            echo "<i><a href='mailto:".$row['emailAlternate']."'>".$row['emailAlternate'].'</a></i>';
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top' colspan=2>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Website').'</span><br/>';
-                        if ($row['website'] != '') {
-                            echo "<i><a href='".$row['website']."'>".$row['website'].'</a></i>';
-                        }
-                        echo '</td>';
-                        echo '</tr>';
-                        if ($row['address1'] != '') {
-                            echo '<tr>';
-                            echo "<td style='width: 33%; padding-top: 15px; vertical-align: top' colspan=4>";
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('Address 1').'</span><br/>';
-                            $address1 = addressFormat($row['address1'], $row['address1District'], $row['address1Country']);
-                            if ($address1 != false) {
-                                echo $address1;
-                            }
-                            echo '</td>';
-                            echo '</tr>';
-                        }
-                        if ($row['address2'] != '') {
-                            echo '<tr>';
-                            echo "<td style='width: 33%; padding-top: 15px; vertical-align: top' colspan=3>";
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('Address 2').'</span><br/>';
-                            $address2 = addressFormat($row['address2'], $row['address2District'], $row['address2Country']);
-                            if ($address2 != false) {
-                                echo $address2;
-                            }
-                            echo '</td>';
-                            echo '</tr>';
-                        }
-                        echo '</table>';
-
-                        echo '<h4>';
-                        echo __('School Information');
-                        echo '</h4>';
-
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Last School').'</span><br/>';
-                        echo $row['lastSchool'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Start Date').'</span><br/>';
-                        echo dateConvertBack($guid, $row['dateStart']);
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Class Of').'</span><br/>';
-                        if ($row['gibbonSchoolYearIDClassOf'] == '') {
-                            echo '<i>'.__('NA').'</i>';
-                        } else {
-
-                                $dataDetail = array('gibbonSchoolYearIDClassOf' => $row['gibbonSchoolYearIDClassOf']);
-                                $sqlDetail = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearIDClassOf';
-                                $resultDetail = $connection2->prepare($sqlDetail);
-                                $resultDetail->execute($dataDetail);
-                            if ($resultDetail->rowCount() == 1) {
-                                $rowDetail = $resultDetail->fetch();
-                                echo $rowDetail['name'];
-                            }
-                        }
-
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Next School').'</span><br/>';
-                        echo $row['nextSchool'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('End Date').'</span><br/>';
-                        echo dateConvertBack($guid, $row['dateEnd']);
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Departure Reason').'</span><br/>';
-                        echo $row['departureReason'];
-                        echo '</td>';
-                        echo '</tr>';
-                        $dayTypeOptions = getSettingByScope($connection2, 'User Admin', 'dayTypeOptions');
-                        if ($dayTypeOptions != '') {
-                            echo '<tr>';
-                            echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('Day Type').'</span><br/>';
-                            echo $row['dayType'];
-                            echo '</td>';
-                            echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-
-                            echo '</td>';
-                            echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-
-                            echo '</td>';
-                            echo '</tr>';
-                        }
-                        echo '</table>';
-
-                        echo '<h4>';
-                        echo __('Background');
-                        echo '</h4>';
-
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        echo '<tr>';
-                        echo "<td width: 33%; style='vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Country of Birth').'</span><br/>';
-                        if ($row['countryOfBirth'] != '') {
-                            echo $row['countryOfBirth']."<br/>";
-                        }
-                        if ($row['birthCertificateScan'] != '') {
-                            echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$row['birthCertificateScan']."'>View Birth Certificate</a>";
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Ethnicity').'</span><br/>';
-                        echo $row['ethnicity'];
-                        echo '</td>';
-                        echo "<td style='width: 34%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Religion').'</span><br/>';
-                        echo $row['religion'];
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Citizenship 1').'</span><br/>';
-                        if ($row['citizenship1'] != '') {
-                            echo $row['citizenship1']."<br/>";
-                        }
-                        if ($row['citizenship1Passport'] != '') {
-                            echo $row['citizenship1Passport']."<br/>";
-                        }
-                        if ($row['citizenship1PassportScan'] != '') {
-                            echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$row['citizenship1PassportScan']."'>View Passport</a>";
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Citizenship 2').'</span><br/>';
-                        echo $row['citizenship2'];
-                        if ($row['citizenship2Passport'] != '') {
-                            echo '<br/>';
-                            echo $row['citizenship2Passport'];
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        if ($_SESSION[$guid]['country'] == '') {
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('National ID Card').'</span><br/>';
-                        } else {
-                            echo "<span style='font-size: 115%; font-weight: bold'>".$_SESSION[$guid]['country'].' '.__('ID Card').'</span><br/>';
-                        }
-                        if ($row['nationalIDCardNumber'] != '') {
-                            echo $row['nationalIDCardNumber']."<br/>";
-                        }
-                        if ($row['nationalIDCardScan'] != '') {
-                            echo "<a target='_blank' href='".$_SESSION[$guid]['absoluteURL'].'/'.$row['nationalIDCardScan']."'>View ID Card</a>";
-                        }
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('First Language').'</span><br/>';
-                        echo $row['languageFirst'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Second Language').'</span><br/>';
-                        echo $row['languageSecond'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Third Language').'</span><br/>';
-                        echo $row['languageThird'];
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '<tr>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        if ($_SESSION[$guid]['country'] == '') {
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('Residency/Visa Type').'</span><br/>';
-                        } else {
-                            echo "<span style='font-size: 115%; font-weight: bold'>".$_SESSION[$guid]['country'].' '.__('Residency/Visa Type').'</span><br/>';
-                        }
-                        echo $row['residencyStatus'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        if ($_SESSION[$guid]['country'] == '') {
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('Visa Expiry Date').'</span><br/>';
-                        } else {
-                            echo "<span style='font-size: 115%; font-weight: bold'>".$_SESSION[$guid]['country'].' '.__('Visa Expiry Date').'</span><br/>';
-                        }
-                        if ($row['visaExpiryDate'] != '') {
-                            echo dateConvertBack($guid, $row['visaExpiryDate']);
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '</table>';
-
-                        echo '<h4>';
-                        echo 'School Data';
-                        echo '</h4>';
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        echo '<tr>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Year Group').'</span><br/>';
-                        if (isset($row['gibbonYearGroupID'])) {
-
-                                $dataDetail = array('gibbonYearGroupID' => $row['gibbonYearGroupID']);
-                                $sqlDetail = 'SELECT * FROM gibbonYearGroup WHERE gibbonYearGroupID=:gibbonYearGroupID';
-                                $resultDetail = $connection2->prepare($sqlDetail);
-                                $resultDetail->execute($dataDetail);
-                            if ($resultDetail->rowCount() == 1) {
-                                $rowDetail = $resultDetail->fetch();
-                                echo __($rowDetail['name']);
-                            }
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Roll Group').'</span><br/>';
-                        if (isset($row['gibbonRollGroupID'])) {
-                            $sqlDetail = "SELECT * FROM gibbonRollGroup WHERE gibbonRollGroupID='".$row['gibbonRollGroupID']."'";
-
-                                $dataDetail = array('gibbonRollGroupID' => $row['gibbonRollGroupID']);
-                                $sqlDetail = 'SELECT * FROM gibbonRollGroup WHERE gibbonRollGroupID=:gibbonRollGroupID';
-                                $resultDetail = $connection2->prepare($sqlDetail);
-                                $resultDetail->execute($dataDetail);
-                            if ($resultDetail->rowCount() == 1) {
-                                $rowDetail = $resultDetail->fetch();
-                                if (isActionAccessible($guid, $connection2, '/modules/Roll Groups/rollGroups_details.php')) {
-                                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Roll Groups/rollGroups_details.php&gibbonRollGroupID='.$rowDetail['gibbonRollGroupID']."'>".$rowDetail['name'].'</a>';
-                                } else {
-                                    echo $rowDetail['name'];
-                                }
-                                $primaryTutor = $rowDetail['gibbonPersonIDTutor'];
-                            }
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 34%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Tutors').'</span><br/>';
-                        if (isset($rowDetail['gibbonPersonIDTutor'])) {
-
-                                $dataDetail = array('gibbonPersonIDTutor' => $rowDetail['gibbonPersonIDTutor'], 'gibbonPersonIDTutor2' => $rowDetail['gibbonPersonIDTutor2'], 'gibbonPersonIDTutor3' => $rowDetail['gibbonPersonIDTutor3']);
-                                $sqlDetail = 'SELECT gibbonPersonID, title, surname, preferredName FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonIDTutor OR gibbonPersonID=:gibbonPersonIDTutor2 OR gibbonPersonID=:gibbonPersonIDTutor3';
-                                $resultDetail = $connection2->prepare($sqlDetail);
-                                $resultDetail->execute($dataDetail);
-                            while ($rowDetail = $resultDetail->fetch()) {
-                                if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view_details.php')) {
-                                    echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$rowDetail['gibbonPersonID']."'>".Format::name('', $rowDetail['preferredName'], $rowDetail['surname'], 'Staff', false, true).'</a>';
-                                } else {
-                                    echo Format::name($rowDetail['title'], $rowDetail['preferredName'], $rowDetail['surname'], 'Staff');
-                                }
-                                if ($rowDetail['gibbonPersonID'] == $primaryTutor and $resultDetail->rowCount() > 1) {
-                                    echo ' ('.__('Main Tutor').')';
-                                }
-                                echo '<br/>';
-                            }
-                        }
-                        echo '</td>';
-                        echo '<tr>';
-                        echo "<td style='padding-top: 15px ; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('House').'</span><br/>';
-
-                            $dataDetail = array('gibbonHouseID' => $row['gibbonHouseID']);
-                            $sqlDetail = 'SELECT * FROM gibbonHouse WHERE gibbonHouseID=:gibbonHouseID';
-                            $resultDetail = $connection2->prepare($sqlDetail);
-                            $resultDetail->execute($dataDetail);
-                        if ($resultDetail->rowCount() == 1) {
-                            $rowDetail = $resultDetail->fetch();
-                            echo $rowDetail['name'];
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; padding-top: 15px; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Student ID').'</span><br/>';
-                        echo $row['studentID'];
-                        echo '</td>';
-                        echo "<td style='width: 34%; vertical-align: top'>";
-
-                            $dataDetail = array('gibbonYearGroupID' => $row['gibbonYearGroupID']);
-                            $sqlDetail = "SELECT DISTINCT gibbonPersonID, title, surname, preferredName FROM gibbonPerson JOIN gibbonYearGroup ON (gibbonYearGroup.gibbonPersonIDHOY=gibbonPersonID) WHERE status='Full' AND gibbonYearGroupID=:gibbonYearGroupID";
-                            $resultDetail = $connection2->prepare($sqlDetail);
-                            $resultDetail->execute($dataDetail);
-                        if ($resultDetail->rowCount() == 1) {
-                            echo "<span style='font-size: 115%; font-weight: bold;'>".__('Head of Year').'</span><br/>';
-                            $rowDetail = $resultDetail->fetch();
-                            if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view_details.php')) {
-                                echo "<a href='".$_SESSION[$guid]['absoluteURL'].'/index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$rowDetail['gibbonPersonID']."'>".Format::name('', $rowDetail['preferredName'], $rowDetail['surname'], 'Staff', false, true).'</a>';
-                            } else {
-                                echo Format::name($rowDetail['title'], $rowDetail['preferredName'], $rowDetail['surname'], 'Staff');
-                            }
-                            echo '<br/>';
-                        }
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '</table>';
-
-                        echo '<h4>';
-                        echo __('System Data');
-                        echo '</h4>';
-
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        echo '<tr>';
-                        echo "<td width: 33%; style='vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Username').'</span><br/>';
-                        echo $row['username'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Can Login?').'</span><br/>';
-                        echo ynExpander($guid, $row['canLogin']);
-                        echo '</td>';
-                        echo "<td style='width: 34%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Last IP Address').'</span><br/>';
-                        echo $row['lastIPAddress'];
-                        echo '</td>';
-                        echo '</tr>';
-                        echo '</table>';
-
-                        echo '<h4>';
-                        echo __('Miscellaneous');
-                        echo '</h4>';
-
-                        echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%'>";
-                        echo '<tr>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Transport').'</span><br/>';
-                        echo $row['transport'];
-                        if ($row['transportNotes'] != '') {
-                            echo '<br/>';
-                            echo $row['transportNotes'];
-                        }
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Vehicle Registration').'</span><br/>';
-                        echo $row['vehicleRegistration'];
-                        echo '</td>';
-                        echo "<td style='width: 33%; vertical-align: top'>";
-                        echo "<span style='font-size: 115%; font-weight: bold'>".__('Locker Number').'</span><br/>';
-                        echo $row['lockerNumber'];
-                        echo '</td>';
-                        echo '</tr>';
-
-                        $privacySetting = getSettingByScope($connection2, 'User Admin', 'privacy');
-                        if ($privacySetting == 'Y') {
-                            echo '<tr>';
-                            echo "<td style='width: 33%; padding-top: 15px; vertical-align: top' colspan=3>";
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('Image Privacy').'</span><br/>';
-                            if ($row['privacy'] != '') {
-                                echo "<span style='color: #cc0000; background-color: #F6CECB'>";
-                                echo __('Privacy required:').' '.$row['privacy'];
-                                echo '</span>';
-                            } else {
-                                echo "<span style='color: #390; background-color: #D4F6DC;'>";
-                                echo __('Privacy not required or not set.');
-                                echo '</span>';
-                            }
-
-                            echo '</td>';
-                            echo '</tr>';
-                        }
-                        $studentAgreementOptions = getSettingByScope($connection2, 'School Admin', 'studentAgreementOptions');
-                        if ($studentAgreementOptions != '') {
-                            echo '<tr>';
-                            echo "<td style='width: 33%; padding-top: 15px; vertical-align: top' colspan=3>";
-                            echo "<span style='font-size: 115%; font-weight: bold'>".__('Student Agreements').'</span><br/>';
-                            echo __('Agreements Signed:').' '.$row['studentAgreements'];
-                            echo '</td>';
-                            echo '</tr>';
-                        }
-                        echo '</table>';
+                        $student = $studentGateway->selectActiveStudentByPerson($gibbon->session->get('gibbonSchoolYearID'), $gibbonPersonID, false)->fetch();
+                        $tutors = $rollGroupGateway->selectTutorsByRollGroup($student['gibbonRollGroupID'] ?? '')->fetchAll();
+                        $yearGroup = $yearGroupGateway->getByID($student['gibbonYearGroupID'] ?? '', ['name', 'gibbonPersonIDHOY']);
+                        $headOfYear = $container->get(UserGateway::class)->getByID($yearGroup['gibbonPersonIDHOY'] ?? '', ['title', 'surname', 'preferredName', 'gibbonPersonID']);
+                        $house = $container->get(HouseGateway::class)->getByID($row['gibbonHouseID'] ?? '', ['name']);
 
                         $table = DataTable::createDetails('overview');
 
                         if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage.php')) {
                             $table->addHeaderAction('edit', __m('Edit User'))
-                                ->setURL('/modules/User Admin/user_manage.php')
+                                ->setURL('/modules/User Admin/user_manage_edit.php')
                                 ->addParam('gibbonPersonID', $gibbonPersonID)
                                 ->displayLabel();
                         }
 
-                        $col = $table->addColumn('Basic Information', __('Basic Information'));
+                        $col = $table->addColumn('Basic Information');
 
                         $col->addColumn('surname', __('Surname'));
                         $col->addColumn('firstName', __('First Name'))->addClass('col-span-2');
@@ -1097,38 +653,131 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         $col->addColumn('dob', __('Date of Birth'))->format(Format::using('date', 'dob'));
                         $col->addColumn('age', __('Age'))->format(Format::using('age', 'dob'));
 
-                        $col = $table->addColumn('contacts', __('Contacts'));
+                        $col = $table->addColumn('Contact Information', __('Contact Information'));
 
+                        for ($i = 1; $i <= 4; $i++) {
+                            if (empty($row["phone$i"])) continue;
+                            $col->addColumn("phone$i", __('Phone '.$i))->format(Format::using('phone', ["phone{$i}", "phone{$i}CountryCode", "phone{$i}Type"]));
+                        }
                         $col->addColumn('email', __('Email'))->format(Format::using('link', 'email'));
                         $col->addColumn('emailAlternate', __('Alternate Email'))->format(Format::using('link', 'emailAlternate'));
                         $col->addColumn('website', __('Website'))->format(Format::using('link', 'website'));
 
                         $col = $table->addColumn('School Information', __('School Information'));
 
+                        $col->addColumn('yearGroup', __('Year Group'))->format(function ($values) use ($student) {
+                            return $student['yearGroupName'];
+                        });
+                        $col->addColumn('gibbonRollGroupID', __('Roll Group'))->format(function ($values) use ($student) {
+                            return Format::link('./index.php?q=/modules/Roll Groups/rollGroups_details.php&gibbonRollGroupID='.$student['gibbonRollGroupID'], $student['rollGroupName']);
+                        });
+                        $col->addColumn('email', __('Tutors'))->format(function ($values) use ($tutors) {
+                            if (count($tutors) > 1) $tutors[0]['surname'] .= ' ('.__('Main Tutor').')';
+                            return Format::nameList($tutors, 'Staff', false, true);
+                        });
+                        $col->addColumn('gibbonHouseID', __('House'))->format(function ($values) use ($house) {
+                            return !empty($house['name']) ? $house['name'] : '';
+                        });
+                        $col->addColumn('studentID', __('Student ID'));
+                        $col->addColumn('headOfYear', __('Head of Year'))->format(function ($values) use ($headOfYear) {
+                            return !empty($headOfYear)
+                                ? Format::nameLinked($headOfYear['gibbonPersonID'], '', $headOfYear['preferredName'], $headOfYear['surname'], 'Staff')
+                                : '';
+                        });
+
                         $col->addColumn('lastSchool', __('Last School'));
                         $col->addColumn('dateStart', __('Start Date'))->format(Format::using('date', 'dateStart'));
-                        $col->addColumn('classOf', __('Class Of'));
+                        $col->addColumn('classOf', __('Class Of'))->format(function ($values) use ($schoolYearGateway) {
+                            if (empty($values['gibbonSchoolYearIDClassOf'])) return Format::small(__('N/A'));
+                            $schoolYear = $schoolYearGateway->getByID($values['gibbonSchoolYearIDClassOf'], ['name']);
+                            return $schoolYear['name'];
+                        });
                         $col->addColumn('nextSchool', __('Next School'));
                         $col->addColumn('dateEnd', __('End Date'))->format(Format::using('date', 'dateEnd'));
                         $col->addColumn('departureReason', __('Departure Reason'));
 
-                        $col = $table->addColumn('Background', __('Background'));
+                        $col = $table->addColumn('Background Information', __('Background Information'));
+                        $country = $gibbon->session->get('country');
 
-                        $col->addColumn('email', __('Email'));
+                        $col->addColumn('countryOfBirth', __('Country of Birth'))->format(function ($values) {
+                            $output = $values['countryOfBirth'];
+                            if (!empty($values['birthCertificateScan'])) {
+                                $output .= '<br/>'.Format::link('./'.$values['birthCertificateScan'], __('View Birth Certificate'), ['target' => '_blank']);
+                            }
+                            return $output;
+                        });
+                        $col->addColumn('ethnicity', __('Ethnicity'));
+                        $col->addColumn('religion', __('Religion'));
+                        $col->addColumn('citizenship1', __('Citizenship 1'))->format(function ($values) {
+                            $output = $values['citizenship1'];
+                            if (!empty($values['citizenship1Passport'])) {
+                                $output .= '<br/>'.$values['citizenship1Passport'];
+                            }
+                            if (!empty($values['citizenship1PassportScan'])) {
+                                $output .= '<br/>'.Format::link('./'.$values['citizenship1PassportScan'], __('View Passport'), ['target' => '_blank']);
+                            }
+                            return $output;
+                        });
+                        $col->addColumn('citizenship2', __('Citizenship 2'))->format(function ($values) {
+                            $output = $values['citizenship2'];
+                            if (!empty($values['citizenship2Passport'])) {
+                                $output .= '<br/>'.$values['citizenship2Passport'];
+                            }
+                            if (!empty($values['citizenship2PassportScan'])) {
+                                $output .= '<br/>'.Format::link('./'.$values['citizenship2PassportScan'], __('View Passport'), ['target' => '_blank']);
+                            }
+                            return $output;
+                        });
+                        $col->addColumn('nationalIDCardNumber', $country ? $country.' '.__('ID Card') : __('National ID Card'))->format(function ($values) {
+                            $output = $values['nationalIDCardNumber'];
+                            if (!empty($values['nationalIDCardScan'])) {
+                                $output .= '<br/>'.Format::link('./'.$values['nationalIDCardScan'], __('View ID Card'), ['target' => '_blank']);
+                            }
+                            return $output;
+                        });
+                        $col->addColumn('languageFirst', __('First Language'));
+                        $col->addColumn('languageSecond', __('Second Language'));
+                        $col->addColumn('languageThird', __('Third Language'));
+                        $col->addColumn('residencyStatus', $country ? $country.' '.__('Residency/Visa Type') : __('Residency/Visa Type'));
+                        $col->addColumn('visaExpiryDate', $country ? $country.' '.__('Visa Expiry Date') :__('Visa Expiry Date'))
+                            ->format(Format::using('date', 'visaExpiryDate'));
 
-                        $col = $table->addColumn('School Data', __('School Data'));
+                        $col = $table->addColumn('System Access', __('System Access'));
 
-                        $col->addColumn('email', __('Email'));
-
-                        $col = $table->addColumn('System Data', __('System Data'));
-
-                        $col->addColumn('email', __('Email'));
+                        $col->addColumn('username', __('Username'));
+                        $col->addColumn('canLogin', __('Can Login?'))->format(Format::using('yesNo', 'canLogin'));
+                        $col->addColumn('lastIPAddress', __('Last IP Address'));
 
                         $col = $table->addColumn('Miscellaneous', __('Miscellaneous'));
 
-                        $col->addColumn('email', __('Email'));
+                        $col->addColumn('transport', __('Transport'))->format(function ($values) {
+                            $output = $values['transport'];
+                            if (!empty($values['transportNotes'])) {
+                                $output .= '<br/>'.$values['transportNotes'];
+                            }
+                            return $output;
+                        });
+                        $col->addColumn('vehicleRegistration', __('Vehicle Registration'));
+                        $col->addColumn('lockerNumber', __('Locker Number'));
 
-                        $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Person', ['student' => 1, 'heading' => 'Other Information'], $row['fields']);
+                        $privacySetting = getSettingByScope($connection2, 'User Admin', 'privacy');
+                        if ($privacySetting == 'Y') {
+                            $col->addColumn('privacy', __('Privacy'))->format(function ($values) {
+                                if (!empty($values['privacy'])) {
+                                    return Format::tag(__('Privacy required:').' '.$values['privacy'], 'error');
+                                } else {
+                                    return Format::tag(__('Privacy not required or not set.'), 'success');
+                                }
+                            });
+                        }
+                        $studentAgreementOptions = getSettingByScope($connection2, 'School Admin', 'studentAgreementOptions');
+                        if (!empty($studentAgreementOptions)) {
+                            $col->addColumn('studentAgreements', __('Student Agreements:'))->format(function ($values) {
+                                return __('Agreements Signed:') .' '.$values['studentAgreements'];
+                            });
+                        }
+
+                        $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Person', ['student' => 1], $row['fields']);
 
                         echo $table->render([$row]);
 
@@ -1562,10 +1211,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             }
                         }
 
-                        $table->addColumn('longTermMedication', __('Long Term Medication'))
+                        $col = $table->addColumn('General Information');
+
+                        $col->addColumn('longTermMedication', __('Long Term Medication'))
                             ->format(Format::using('yesno', 'longTermMedication'));
 
-                        $table->addColumn('longTermMedicationDetails', __('Details'))
+                        $col->addColumn('longTermMedicationDetails', __('Details'))
                             ->addClass('col-span-2')
                             ->format(function ($medical) {
                                 return !empty($medical['longTermMedication'])
@@ -1575,7 +1226,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                         $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Medical Form', [], $medical['fields'], $table);
 
-                        $table->addColumn('medicalConditions', __('Medical Conditions?'))
+                        $col->addColumn('medicalConditions', __('Medical Conditions?'))
                             ->addClass('col-span-3')
                             ->format(function ($medical) use ($conditions) {
                                 return count($conditions) > 0
@@ -1584,8 +1235,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             });
 
                         if (!empty($medical['comment'])) {
-                            $table->addColumn('comment', __('Comment'))->addClass('col-span-3');
+                            $col->addColumn('comment', __('Comment'))->addClass('col-span-3');
                         }
+
+                        
 
                         $fields = is_string($medical['fields']) ? json_decode($medical['fields'], true) : [];
                         echo $table->render(!empty($medical) ? [$medical + $fields] : []);

--- a/modules/System Admin/customFields.php
+++ b/modules/System Admin/customFields.php
@@ -38,8 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
     array_walk_recursive($types, function($item, $key) use (&$customFieldTypes) { $customFieldTypes[$key] = $item; });
 
     $contexts = [];
-    $contextGroups = $customFieldHandler->getContexts();
-    foreach ($contextGroups as $group => $groupContexts) {
+    foreach ($customFieldHandler->getContexts() as $group => $groupContexts) {
         $contexts += $groupContexts;
     }
 
@@ -47,13 +46,13 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
         // QUERY
         $criteria = $customFieldGateway->newQueryCriteria()
             ->sortBy(['sequenceNumber', 'name'])
-            ->filterBy('context', $context)
+            ->filterBy('context', $context != 'User' ? $context : '')
             ->pageSize(0)
             ->fromPOST();
 
         $customFields = $customFieldGateway->queryCustomFields($criteria);
 
-        if (count($customFields) == 0 && $context != 'Person') continue;
+        if (count($customFields) == 0 && $context != 'User') continue;
 
         // DATA TABLE
         $table = DataTable::create('customFields'.$context);
@@ -68,14 +67,6 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
             ->setURL('/modules/System Admin/customFields_add.php')
             ->addParam('context', $context)
             ->displayLabel();
-
-        $customFieldTypes = array(
-            'varchar' => __('Short Text'),
-            'text'    => __('Long Text'),
-            'date'    => __('Date'),
-            'url'     => __('Link'),
-            'select'  => __('Dropdown')
-        );
 
         $table->addDraggableColumn('gibbonCustomFieldID', $gibbon->session->get('absoluteURL').'/modules/System Admin/customFields_editOrderAjax.php');
 
@@ -94,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
 
         $table->addColumn('required', __('Required'))->width('10%')->format(Format::using('yesNo', 'required'));
 
-        if ($context == 'Person') {
+        if ($context == 'User') {
             $table->addColumn('roles', __('Role Categories'))
                 ->format(function ($values) {
                     $output = '';

--- a/modules/System Admin/customFields.php
+++ b/modules/System Admin/customFields.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
         // QUERY
         $criteria = $customFieldGateway->newQueryCriteria()
             ->sortBy(['sequenceNumber', 'name'])
-            ->filterBy('context', $context != 'User' ? $context : '')
+            ->filterBy('context', $context)
             ->pageSize(0)
             ->fromPOST();
 
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
 
         $table->addHeaderAction('add', __('Add'))
             ->setURL('/modules/System Admin/customFields_add.php')
-            ->addParam('context', $context)
+            ->addParam('context', $context != 'User' ? $context : '')
             ->displayLabel();
 
         $table->addDraggableColumn('gibbonCustomFieldID', $gibbon->session->get('absoluteURL').'/modules/System Admin/customFields_editOrderAjax.php');

--- a/modules/System Admin/customFields.php
+++ b/modules/System Admin/customFields.php
@@ -30,91 +30,92 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
     $page->breadcrumbs->add(__('Custom Fields'));
 
     $customFieldGateway = $container->get(CustomFieldGateway::class);
+    $customFieldHandler = $container->get(CustomFieldHandler::class);
     
-    // QUERY
-    $criteria = $customFieldGateway->newQueryCriteria()
-        ->sortBy(['context', 'sequenceNumber', 'name'])
-        ->pageSize(0)
-        ->fromPOST();
-
-    $customFields = $customFieldGateway->queryCustomFields($criteria);
-
-    // DATA TABLE
-    $table = DataTable::createPaginated('customFieldManage', $criteria);
-
-    $table->modifyRows(function ($customField, $row) {
-        if ($customField['active'] == 'N') $row->addClass('error');
-        return $row;
-    });
-
-    $table->addHeaderAction('add', __('Add'))
-        ->setURL('/modules/System Admin/customFields_add.php')
-        ->displayLabel();
-
-    $table->addMetaData('filterOptions', [
-        'active:Y'     => __('Active').': '.__('Yes'),
-        'active:N'     => __('Active').': '.__('No'),
-        'role:student' => __('Role').': '.__('Student'),
-        'role:parent'  => __('Role').': '.__('Parent'),
-        'role:staff'   => __('Role').': '.__('Staff'),
-        'role:other'   => __('Role').': '.__('Other'),
-    ]);
-
-    $customFieldTypes = array(
-        'varchar' => __('Short Text'),
-        'text'    => __('Long Text'),
-        'date'    => __('Date'),
-        'url'     => __('Link'),
-        'select'  => __('Dropdown')
-    );
-
     // Get a flattened array of the custom field types for listing in the table
     $customFieldTypes = [];
     $types = $container->get(CustomFieldHandler::class)->getTypes();
     array_walk_recursive($types, function($item, $key) use (&$customFieldTypes) { $customFieldTypes[$key] = $item; });
 
-    $table->addDraggableColumn('gibbonCustomFieldID', $gibbon->session->get('absoluteURL').'/modules/System Admin/customFields_editOrderAjax.php');
+    $contexts = [];
+    $contextGroups = $customFieldHandler->getContexts();
+    foreach ($contextGroups as $group => $groupContexts) {
+        $contexts += $groupContexts;
+    }
 
-    $table->addColumn('context', __('Context'))
-        ->notSortable()
-        ->translatable();
+    foreach ($contexts as $context => $contextName) {
+        // QUERY
+        $criteria = $customFieldGateway->newQueryCriteria()
+            ->sortBy(['sequenceNumber', 'name'])
+            ->filterBy('context', $context)
+            ->pageSize(0)
+            ->fromPOST();
 
-    $table->addColumn('name', __('Name'))
-        ->description(__('Heading'))
-        ->notSortable()
-        ->format(function($values) {
-            return $values['name'].'<br/>'.Format::small($values['heading']);
+        $customFields = $customFieldGateway->queryCustomFields($criteria);
+
+        if (count($customFields) == 0 && $context != 'Person') continue;
+
+        // DATA TABLE
+        $table = DataTable::create('customFields'.$context);
+        $table->setTitle(__('{context} Fields', ['context' => $contextName]));
+
+        $table->modifyRows(function ($customField, $row) {
+            if ($customField['active'] == 'N') $row->addClass('error');
+            return $row;
         });
 
-    $table->addColumn('type', __('Type'))->notSortable()
-        ->format(function ($row) use ($customFieldTypes) {
-            return isset($customFieldTypes[$row['type']])? $customFieldTypes[$row['type']] : '';
-        });
+        $table->addHeaderAction('add', __('Add'))
+            ->setURL('/modules/System Admin/customFields_add.php')
+            ->addParam('context', $context)
+            ->displayLabel();
 
-    $table->addColumn('active', __('Active'))
-        ->notSortable()
-        ->format(Format::using('yesNo', 'active'));
+        $customFieldTypes = array(
+            'varchar' => __('Short Text'),
+            'text'    => __('Long Text'),
+            'date'    => __('Date'),
+            'url'     => __('Link'),
+            'select'  => __('Dropdown')
+        );
 
-    $table->addColumn('roles', __('Role Categories'))
-        ->notSortable()
-        ->format(function ($row) {
-            $output = '';
-            if ($row['activePersonStudent']) $output .= __('Student').'<br/>';
-            if ($row['activePersonParent']) $output .= __('Parent').'<br/>';
-            if ($row['activePersonStaff']) $output .= __('Staff').'<br/>';
-            if ($row['activePersonOther']) $output .= __('Other').'<br/>';
-            return $output;
-        });
+        $table->addDraggableColumn('gibbonCustomFieldID', $gibbon->session->get('absoluteURL').'/modules/System Admin/customFields_editOrderAjax.php');
 
-    $table->addActionColumn()
-        ->addParam('gibbonCustomFieldID')
-        ->format(function ($row, $actions) {
-            $actions->addAction('edit', __('Edit'))
-                ->setURL('/modules/System Admin/customFields_edit.php');
-            $actions->addAction('delete', __('Delete'))
-                ->setURL('/modules/System Admin/customFields_delete.php');
+        $table->addColumn('name', __('Name'))
+            ->description(__('Heading'))
+            ->format(function($values) {
+                return $values['name'].'<br/>'.Format::small($values['heading']);
+            });
+
+        $table->addColumn('type', __('Type'))
+            ->format(function ($values) use ($customFieldTypes) {
+                return isset($customFieldTypes[$values['type']])? $customFieldTypes[$values['type']] : '';
+            });
+
+        $table->addColumn('active', __('Active'))->width('10%')->format(Format::using('yesNo', 'active'));
+
+        $table->addColumn('required', __('Required'))->width('10%')->format(Format::using('yesNo', 'required'));
+
+        if ($context == 'Person') {
+            $table->addColumn('roles', __('Role Categories'))
+                ->format(function ($values) {
+                    $output = '';
+                    if ($values['activePersonStudent']) $output .= __('Student').'<br/>';
+                    if ($values['activePersonParent']) $output .= __('Parent').'<br/>';
+                    if ($values['activePersonStaff']) $output .= __('Staff').'<br/>';
+                    if ($values['activePersonOther']) $output .= __('Other').'<br/>';
+                    return $output;
+                });
+        }
+
+        $table->addActionColumn()
+            ->addParam('gibbonCustomFieldID')
+            ->format(function ($values, $actions) {
+                $actions->addAction('edit', __('Edit'))
+                    ->setURL('/modules/System Admin/customFields_edit.php');
+                $actions->addAction('delete', __('Delete'))
+                    ->setURL('/modules/System Admin/customFields_delete.php');
+                
+            });
             
-        });
-        
-    echo $table->render($customFields);
+        echo $table->render($customFields);
+    }
 }

--- a/modules/System Admin/customFields_add.php
+++ b/modules/System Admin/customFields_add.php
@@ -124,8 +124,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     $form->addRow()->addClass('contextPerson')->addHeading(__('Visibility'));
 
-    $form->toggleVisibilityByClass('contextPerson')->onSelect('context')->when('Person');
-    $form->toggleVisibilityByClass('contextDataUpdate')->onSelect('context')->when(['Person', 'Medical Form']);
+    $form->toggleVisibilityByClass('contextPerson')->onSelect('context')->when('User');
+    $form->toggleVisibilityByClass('contextDataUpdate')->onSelect('context')->when(['User', 'Medical Form']);
 
     $activePersonOptions = [
         'activePersonStudent' => __('Student'),

--- a/modules/System Admin/customFields_add.php
+++ b/modules/System Admin/customFields_add.php
@@ -36,6 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $page->return->setEditLink($editLink);
 
     $customFieldHandler = $container->get(CustomFieldHandler::class);
+    $context = $_GET['context'] ?? '';
 
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/customFields_addProcess.php');
     $form->addHiddenValue('address', $_SESSION[$guid]['address']);
@@ -44,15 +45,42 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     $row = $form->addRow();
         $row->addLabel('context', __('Context'));
-        $row->addSelect('context')->fromArray($customFieldHandler->getContexts())->required()->placeholder();
+        $row->addSelect('context')->fromArray($customFieldHandler->getContexts())->required()->placeholder()->selected($context);
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique for this context.'));
         $row->addTextField('name')->maxLength(50)->required();
 
     $row = $form->addRow();
-        $row->addLabel('description', __('Description'));
+        $row->addLabel('description', __('Description'))->description(__('Displayed as smaller text next to the field name.'));
         $row->addTextField('description')->maxLength(255);
+
+    $headings = $customFieldHandler->getHeadings();
+    $contextHeadings = $contextCustom = [];
+    $contextChained = array_reduce(array_keys($headings), function($group, $context) use (&$headings, &$contextHeadings, &$contextCustom) {
+        foreach ($headings[$context] as $key => $value) {
+            $contextHeadings[$key.'_'.$context] = $value;
+            $group[$value.'_'.$context] = $context;
+        }
+        $contextHeadings['Custom_'.$context] = '['.__('Custom').']';
+        $contextCustom[] = 'Custom_'.$context;
+        $group['Custom_'.$context] = $context;
+        return $group;
+    }, []);
+    
+    $row = $form->addRow();
+        $row->addLabel('heading', __('Heading'))->description(__('Optionally list this field under a heading.'));
+        $row->addSelect('heading')
+            ->fromArray($contextHeadings)
+            ->chainedTo('context', $contextChained)
+            ->placeholder();
+
+    $form->toggleVisibilityByClass('headingCustom')->onSelect('heading')->when($contextCustom);
+    
+    $row = $form->addRow()->addClass('headingCustom');
+        $row->addLabel('headingCustom', __('Custom Heading'));
+        $row->addTextField('headingCustom')->maxLength(90);
+
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
@@ -93,30 +121,6 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $row = $form->addRow();
         $row->addLabel('hidden', __('Hidden'))->description(__('Is this field hidden from profiles and user-facing pages?'));
         $row->addYesNo('hidden')->required()->selected('N');
-
-    $headings = $customFieldHandler->getHeadings();
-    $contextHeadings = [];
-    $contextChained = array_reduce(array_keys($headings), function($group, $context) use (&$headings, &$contextHeadings) {
-        foreach ($headings[$context] as $key => $value) {
-            $contextHeadings['Existing Heading'][$key] = $value;
-            $group[$value] = $context;
-        }
-        $contextHeadings['New Heading'][$context] = __('Custom');
-        $group[$context] = $context;
-        return $group;
-    }, []);
-    
-    $row = $form->addRow();
-        $row->addLabel('heading', __('Heading'))->description(__('Optionally list this field under a heading.'));
-        $row->addSelect('heading')
-            ->fromArray($contextHeadings)
-            ->chainedTo('context', $contextChained);
-
-    $form->toggleVisibilityByClass('headingCustom')->onSelect('heading')->when('Custom');
-    
-    $row = $form->addRow()->addClass('headingCustom');
-        $row->addLabel('headingCustom', __('Heading'))->description(__('Optionally list this field under a heading.'));
-        $row->addTextField('headingCustom')->maxLength(90);
 
     $form->addRow()->addClass('contextPerson')->addHeading(__('Visibility'));
 

--- a/modules/System Admin/customFields_add.php
+++ b/modules/System Admin/customFields_add.php
@@ -94,9 +94,29 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $row->addLabel('hidden', __('Hidden'))->description(__('Is this field hidden from profiles and user-facing pages?'));
         $row->addYesNo('hidden')->required()->selected('N');
 
+    $headings = $customFieldHandler->getHeadings();
+    $contextHeadings = [];
+    $contextChained = array_reduce(array_keys($headings), function($group, $context) use (&$headings, &$contextHeadings) {
+        foreach ($headings[$context] as $key => $value) {
+            $contextHeadings['Existing Heading'][$key] = $value;
+            $group[$value] = $context;
+        }
+        $contextHeadings['New Heading'][$context] = __('Custom');
+        $group[$context] = $context;
+        return $group;
+    }, []);
+    
     $row = $form->addRow();
         $row->addLabel('heading', __('Heading'))->description(__('Optionally list this field under a heading.'));
-        $row->addTextField('heading')->maxLength(90);
+        $row->addSelect('heading')
+            ->fromArray($contextHeadings)
+            ->chainedTo('context', $contextChained);
+
+    $form->toggleVisibilityByClass('headingCustom')->onSelect('heading')->when('Custom');
+    
+    $row = $form->addRow()->addClass('headingCustom');
+        $row->addLabel('headingCustom', __('Heading'))->description(__('Optionally list this field under a heading.'));
+        $row->addTextField('headingCustom')->maxLength(90);
 
     $form->addRow()->addClass('contextPerson')->addHeading(__('Visibility'));
 

--- a/modules/System Admin/customFields_addProcess.php
+++ b/modules/System Admin/customFields_addProcess.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $customFieldGateway = $container->get(CustomFieldGateway::class);
     
     $data = [
-        'context'                  => $_POST['context'] ?? 'Person',
+        'context'                  => $_POST['context'] ?? '',
         'name'                     => $_POST['name'] ?? '',
         'active'                   => $_POST['active'] ?? '',
         'description'              => $_POST['description'] ?? '',

--- a/modules/System Admin/customFields_addProcess.php
+++ b/modules/System Admin/customFields_addProcess.php
@@ -30,7 +30,6 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     //Proceed!
     $enablePublicRegistration = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration');
     $customFieldGateway = $container->get(CustomFieldGateway::class);
-
     
     $data = [
         'context'                  => $_POST['context'] ?? 'Person',
@@ -46,6 +45,11 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         'activeApplicationForm'    => $_POST['activeApplicationForm'] ?? '0',
         'activePublicRegistration' => $enablePublicRegistration == 'Y' ? ($_POST['activePublicRegistration'] ?? '0') : '0',
     ];
+
+    if (!empty($data['heading'])) {
+        $data['heading'] = strchr($data['heading'], '_', true);
+        $data['heading'] = $data['heading'] == 'Custom' ? $data['headingCustom'] : $data['heading'];
+    }
 
     // Add this field to the bottom of the current sequenceNumber for this context
     $sequenceCheck = $customFieldGateway->selectBy(['context' => $data['context']], ['sequenceNumber'])->fetch();

--- a/modules/System Admin/customFields_addProcess.php
+++ b/modules/System Admin/customFields_addProcess.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     if (!empty($data['heading'])) {
         $data['heading'] = strchr($data['heading'], '_', true);
-        $data['heading'] = $data['heading'] == 'Custom' ? $data['headingCustom'] : $data['heading'];
+        $data['heading'] = $data['heading'] == 'Custom' ? ($_POST['headingCustom'] ?? '') : $data['heading'];
     }
 
     // Add this field to the bottom of the current sequenceNumber for this context

--- a/modules/System Admin/customFields_edit.php
+++ b/modules/System Admin/customFields_edit.php
@@ -43,6 +43,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $page->addError(__('The specified record cannot be found.'));
         return;
     }
+
+    $customFieldHandler = $container->get(CustomFieldHandler::class);
         
     $form = Form::create('action', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/customFields_editProcess.php?gibbonCustomFieldID='.$gibbonCustomFieldID);
 
@@ -59,8 +61,26 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $row->addTextField('name')->maxLength(50)->required();
 
     $row = $form->addRow();
-        $row->addLabel('description', __('Description'));
+        $row->addLabel('description', __('Description'))->description(__('Displayed as smaller text next to the field name.'));
         $row->addTextField('description')->maxLength(255);
+
+    $headings = $customFieldHandler->getHeadings();
+    $headings = $headings[$values['context']] ?? [];
+    $isHeadingCustom = !empty($values['heading']) && !in_array($values['heading'], $headings);
+    $row = $form->addRow();
+        $row->addLabel('heading', __('Heading'))->description(__('Optionally list this field under a heading.'));
+        $row->addSelect('heading')
+            ->fromArray($headings)
+            ->fromArray(['Custom' => '['.__('Custom').']'])
+            ->placeholder()
+            ->selected($isHeadingCustom ? 'Custom' : $values['heading']);
+    
+    $form->toggleVisibilityByClass('headingCustom')->onSelect('heading')->when('Custom');
+    
+    $row = $form->addRow()->addClass('headingCustom');
+        $row->addLabel('headingCustom', __('Custom Heading'));
+        $row->addTextField('headingCustom')->maxLength(90)->setValue($isHeadingCustom ? $values['heading'] : '');
+        unset($values['heading']);
 
     $row = $form->addRow();
         $row->addLabel('active', __('Active'));
@@ -68,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     $form->addRow()->addHeading(__('Configure'));
 
-    $types = $container->get(CustomFieldHandler::class)->getTypes();
+    $types = $customFieldHandler->getTypes();
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
         $row->addSelect('type')->fromArray($types)->readOnly()->required()->placeholder();
@@ -106,10 +126,6 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $row = $form->addRow();
         $row->addLabel('hidden', __('Hidden'))->description(__('Is this field hidden from profiles and user-facing pages?'));
         $row->addYesNo('hidden')->required();
-
-    $row = $form->addRow();
-        $row->addLabel('heading', __('Heading'))->description(__('Optionally list this field under a heading.'));
-        $row->addTextField('heading')->maxLength(90);
 
     if ($values['context'] == 'Person') {
         $form->addRow()->addHeading(__('Visibility'));

--- a/modules/System Admin/customFields_edit.php
+++ b/modules/System Admin/customFields_edit.php
@@ -127,7 +127,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $row->addLabel('hidden', __('Hidden'))->description(__('Is this field hidden from profiles and user-facing pages?'));
         $row->addYesNo('hidden')->required();
 
-    if ($values['context'] == 'Person') {
+    if ($values['context'] == 'User') {
         $form->addRow()->addHeading(__('Visibility'));
 
         $activePersonOptions = array(

--- a/modules/System Admin/customFields_editProcess.php
+++ b/modules/System Admin/customFields_editProcess.php
@@ -41,12 +41,12 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         'options'                  => $_POST['options'] ?? '',
         'required'                 => $_POST['required'] ?? '',
         'hidden'                   => $_POST['hidden'] ?? 'N',
-        'heading'                  => $_POST['heading'] ?? '',
+        'heading'                  => $_POST['headingCustom'] ?? $_POST['heading'] ?? '',
         'activeDataUpdater'        => $_POST['activeDataUpdater'] ?? '0',
         'activeApplicationForm'    => $_POST['activeApplicationForm'] ?? '0',
         'activePublicRegistration' => $enablePublicRegistration == 'Y' ? ($_POST['activePublicRegistration'] ?? '0') : '0',
     ];
-
+    
     if ($data['type'] == 'varchar') $data['options'] = min(max(0, intval($data['options'])), 255);
     if ($data['type'] == 'text') $data['options'] = max(0, intval($data['options']));
 

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -619,7 +619,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 			// CUSTOM FIELDS
             $params = compact('student', 'staff', 'parent', 'other');
-            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', $params, $values['fields']);
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', $params, $values['fields']);
 
 			$row = $form->addRow();
 				$row->addFooter()->append('<small>'.getMaxUpload($guid, true).'</small>');

--- a/modules/User Admin/user_manage_editProcess.php
+++ b/modules/User Admin/user_manage_editProcess.php
@@ -490,7 +490,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
                     // CUSTOM FIELDS
                     $customRequireFail = false;
                     $params = compact('student', 'staff', 'parent', 'other');
-                    $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Person', $params, $customRequireFail);
+                    $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('User', $params, $customRequireFail);
                 
                     if ($customRequireFail) {
                         $URL .= '&return=error3';

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -129,7 +129,7 @@ if ($proceed == false) {
             ->maxLength(30);
 
     // CUSTOM FIELDS
-    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Person', ['publicRegistration' => 1]);
+    $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'User', ['publicRegistration' => 1]);
 
     $privacyStatement = getSettingByScope($connection2, 'User Admin', 'publicRegistrationPrivacyStatement');
     if ($privacyStatement != '') {

--- a/publicRegistrationProcess.php
+++ b/publicRegistrationProcess.php
@@ -88,7 +88,7 @@ if ($proceed == false) {
     }
 
     $customRequireFail = false;
-    $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Person', ['publicRegistration' => 1], $customRequireFail);
+    $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('User', ['publicRegistration' => 1], $customRequireFail);
 
     if ($customRequireFail) {
         $URL .= '&return=error1';

--- a/resources/templates/components/detailsTable.twig.html
+++ b/resources/templates/components/detailsTable.twig.html
@@ -39,17 +39,27 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     {% else %}
     
         {% for rowIndex, rowData in rows %}
-            <div class="grid {{ gridClass|default('grid-cols-1 md:grid-cols-3') }} rounded border bg-gray-100 text-xs text-gray-700">
+        
+            {% for heading, headingColumns in groups %}
+                {% if heading %}
+                    <h4>{{ __(heading) }}</h4>
+                {% endif %}
 
-            {% for columnIndex, column in columns %}
-                <div class="p-2 border-b -mb-px {{ column.getClass }}" 
-                    style="{{ column.getWidth != 'auto' ? 'width: ' ~ column.getWidth }}" >
-                    <span class="block text-sm font-bold mb-1">{{ column.getLabel | raw }}</span>
-                    <span class="block text-gray-700 ">{{ column.getOutput(rowData) | raw }}</span>
+                <div class="grid {{ gridClass|default('grid-cols-1 md:grid-cols-3') }} rounded border bg-gray-100 text-xs text-gray-700">
+            
+                {% for columnIndex, column in headingColumns %}
+
+                    <div class="p-2 border-b -mb-px {{ column.getClass }}" 
+                        style="{{ column.getWidth != 'auto' ? 'width: ' ~ column.getWidth }}" >
+                        <span class="block text-sm font-bold mb-1">{{ column.getLabel | raw }}</span>
+                        <span class="block text-gray-700 ">{{ column.getOutput(rowData) | raw }}</span>
+                    </div>
+
+                {% endfor %}
                 </div>
             {% endfor %}
 
-            </div>
+
         {% endfor %}
 
     {% endif %}

--- a/resources/templates/components/form.twig.html
+++ b/resources/templates/components/form.twig.html
@@ -37,57 +37,62 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
     {% if form.getRows|length > 0 %}
         <div class="{{ form.getClass }} font-sans text-xs text-gray-700 relative overflow-hidden {{ "blank" not in form.getClass ? 'bg-gray-100 rounded border mt-3' }}" style="{{ "noIntBorder" in form.getClass ? 'background:#edf7ff' }}" cellspacing="0">
-        {% for num, row in form.getRows %}
-        
-            {% set rowLoop = loop %}
-            {% if true or renderStyle == 'flex' %}
-                {% set rowClass = 'flex flex-col sm:flex-row justify-between sm:items-center content-center p-0' %}
-            {% endif %}
 
-            {% if (row.getElements|first).isInstanceOf('Gibbon\\Forms\\Layout\\Heading') %}
-                {% set rowClass = "blank" not in form.getClass ? rowClass ~ ' bg-gray-300' : rowClass ~ ' my-2' %}
-            {% endif %}
+        {% for section, rows in form.getRowsByHeading %}
+            {% set sectionLoop = loop %}
 
-            <div id="{{ row.getID }}" class="{{ row.getClass|replace({'standardWidth': ''}) }} {{ rowClass }} {{ "noIntBorder" not in form.getClass and "blank" not in form.getClass and not loop.last ? 'border-b' }} ">
-
-            {% for element in row.getElements %}
-                {% set colspan = loop.last and loop.length < totalColumns ? (totalColumns + 1 - loop.length) : 0  %}
-                
-                {% if element.isInstanceOf('Gibbon\\Forms\\Layout\\Heading') %}
-                    {% set class = 'flex-grow justify-center' %}
-                {% elseif element.isInstanceOf('Gibbon\\Forms\\Layout\\Label') %}
-                    {% set class = 'flex flex-col flex-grow justify-center -mb-1 sm:mb-0' %}
-                {% elseif element.isInstanceOf('Gibbon\\Forms\\Layout\\Column')  %}
-                    {% set class = loop.last and loop.length == 2 ? 'w-full max-w-full sm:max-w-sm flex justify-end' : 'w-full ' %}
-                {% elseif loop.last and loop.length == 2 and renderStyle == 'flex' %}
-                    {% set class = 'w-full max-w-full sm:max-w-sm flex justify-end items-center' %}
-                {% else %}
-                    {% set class = loop.last and loop.length > 2 ? '' : 'flex-1' %}
+            {% for num, row in rows %}
+            
+                {% set rowLoop = loop %}
+                {% if true or renderStyle == 'flex' %}
+                    {% set rowClass = 'flex flex-col sm:flex-row justify-between sm:items-center content-center p-0' %}
                 {% endif %}
 
-                {% if renderStyle == 'table' and element.isInstanceOf('Gibbon\\Forms\\Layout\\Label') %}
-                    {% set class = class ~ " lg:w-2/5" %}
+                {% if (row.getElements|first).isInstanceOf('Gibbon\\Forms\\Layout\\Heading') %}
+                    {% set rowClass = "blank" not in form.getClass ? rowClass ~ ' bg-gray-300' : rowClass ~ ' my-2' %}
                 {% endif %}
 
-                {% if "standardForm" in form.getClass %}
-                    {% set class = class ~ " px-4 py-4" %}
-                {% elseif "blank" not in form.getClass %}
-                {% set class = class ~ " px-3 py-2" %}
-                {% endif %}
+                <div id="{{ row.getID }}" class="{{ row.getClass|replace({'standardWidth': ''}) }} {{ rowClass }} {{ "noIntBorder" not in form.getClass and "blank" not in form.getClass and not (sectionLoop.last and loop.last) ? 'border-b' }} ">
 
-
-                <div class="{{ class }} {{ element.getClass|replace({'standardWidth': ''}) }}" {{ colspan ? 'colspan="%s"'|format(colspan)|raw }}>
-                    {{ element.getOutput|replace({'standardWidth': renderStyle == 'flex' ? 'w-full' : '' })|raw }}
-
-                    {% if element.instanceOf('Gibbon\\Forms\\ValidatableInterface') %}
-                    <script type="text/javascript">
-                        {{ element.getValidationOutput|raw }}
-                    </script>
+                {% for element in row.getElements %}
+                    {% set colspan = loop.last and loop.length < totalColumns ? (totalColumns + 1 - loop.length) : 0  %}
+                    
+                    {% if element.isInstanceOf('Gibbon\\Forms\\Layout\\Heading') %}
+                        {% set class = 'flex-grow justify-center' %}
+                    {% elseif element.isInstanceOf('Gibbon\\Forms\\Layout\\Label') %}
+                        {% set class = 'flex flex-col flex-grow justify-center -mb-1 sm:mb-0' %}
+                    {% elseif element.isInstanceOf('Gibbon\\Forms\\Layout\\Column')  %}
+                        {% set class = loop.last and loop.length == 2 ? 'w-full max-w-full sm:max-w-sm flex justify-end' : 'w-full ' %}
+                    {% elseif loop.last and loop.length == 2 and renderStyle == 'flex' %}
+                        {% set class = 'w-full max-w-full sm:max-w-sm flex justify-end items-center' %}
+                    {% else %}
+                        {% set class = loop.last and loop.length > 2 ? '' : 'flex-1' %}
                     {% endif %}
+
+                    {% if renderStyle == 'table' and element.isInstanceOf('Gibbon\\Forms\\Layout\\Label') %}
+                        {% set class = class ~ " lg:w-2/5" %}
+                    {% endif %}
+
+                    {% if "standardForm" in form.getClass %}
+                        {% set class = class ~ " px-4 py-4" %}
+                    {% elseif "blank" not in form.getClass %}
+                    {% set class = class ~ " px-3 py-2" %}
+                    {% endif %}
+
+
+                    <div class="{{ class }} {{ element.getClass|replace({'standardWidth': ''}) }}" {{ colspan ? 'colspan="%s"'|format(colspan)|raw }}>
+                        {{ element.getOutput|replace({'standardWidth': renderStyle == 'flex' ? 'w-full' : '' })|raw }}
+
+                        {% if element.instanceOf('Gibbon\\Forms\\ValidatableInterface') %}
+                        <script type="text/javascript">
+                            {{ element.getValidationOutput|raw }}
+                        </script>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+
                 </div>
             {% endfor %}
-
-            </div>
         {% endfor %}
     </div>
     {% endif %}

--- a/src/Domain/DataSet.php
+++ b/src/Domain/DataSet.php
@@ -302,4 +302,17 @@ class DataSet implements \Countable, \IteratorAggregate
     {
         array_walk($this->data, $callable);
     }
+
+    /**
+     * Merge another data set into this data set by row index.
+     *
+     * @param DataSet $data
+     */
+    public function merge(DataSet $newData)
+    {
+        foreach ($this->data as $index => $row) {
+            $rowData = $newData->getRow($index);
+            $this->data[$index] = array_merge($row, $rowData);
+        }
+    }
 }

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -232,7 +232,7 @@ class StudentGateway extends QueryableGateway
     public function selectActiveStudentByPerson($gibbonSchoolYearID, $gibbonPersonID, $onlyFull = true)
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonID' => $gibbonPersonID);
-        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, image_240, gender, dateStart, dateEnd, gibbonStudentEnrolment.gibbonStudentEnrolmentID, gibbonStudentEnrolment.gibbonSchoolYearID, gibbonYearGroup.gibbonYearGroupID, gibbonYearGroup.nameShort AS yearGroup, gibbonRollGroup.gibbonRollGroupID, gibbonRollGroup.nameShort AS rollGroup, 'Student' as roleCategory, gibbonPerson.privacy
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, image_240, gender, dateStart, dateEnd, gibbonStudentEnrolment.gibbonStudentEnrolmentID, gibbonStudentEnrolment.gibbonSchoolYearID, gibbonYearGroup.gibbonYearGroupID, gibbonYearGroup.nameShort AS yearGroup, gibbonYearGroup.name AS yearGroupName, gibbonRollGroup.gibbonRollGroupID, gibbonRollGroup.nameShort AS rollGroup, gibbonRollGroup.name AS rollGroupName, 'Student' as roleCategory, gibbonPerson.privacy
                 FROM gibbonPerson
                 JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
                 JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)

--- a/src/Domain/System/CustomFieldGateway.php
+++ b/src/Domain/System/CustomFieldGateway.php
@@ -85,7 +85,7 @@ class CustomFieldGateway extends QueryableGateway
             ->where('context=:context')
             ->bindValue('context', $context);
 
-        if ($context == 'Person') {
+        if ($context == 'User') {
             // Handle role category flags as ORs
             $query->where(function ($query) use (&$params) {
                 if ($params['student'] ?? false) {

--- a/src/Domain/System/CustomFieldGateway.php
+++ b/src/Domain/System/CustomFieldGateway.php
@@ -79,7 +79,7 @@ class CustomFieldGateway extends QueryableGateway
     {
         $query = $this
             ->newSelect()
-            ->cols(['heading as groupBy', 'gibbonCustomField.*'])
+            ->cols(["(CASE WHEN heading <> '' THEN heading ELSE 'Other Information' END) as groupBy", 'gibbonCustomField.*'])
             ->from('gibbonCustomField')
             ->where("active='Y'")
             ->where('context=:context')
@@ -115,6 +115,16 @@ class CustomFieldGateway extends QueryableGateway
         }
         if ($params['hideHidden'] ?? false) {
             $query->where('hidden=:hidden', ['hidden' => 'N']);
+        }
+
+        // Handle getting fields that match or do not match specific headings
+        if ($params['withHeading'] ?? false) {
+            $headings = is_array($params['withHeading']) ? implode(',', $params['withHeading']) : $params['withHeading'];
+            $query->where('FIND_IN_SET(heading, :headings)', ['headings' => $headings]);
+        }
+        if ($params['withoutHeading'] ?? false) {
+            $headings = is_array($params['withoutHeading']) ? implode(',', $params['withoutHeading']) : $params['withoutHeading'];
+            $query->where('NOT FIND_IN_SET(heading, :headings)', ['headings' => $headings]);
         }
 
         $query->orderBy(['sequenceNumber', 'name']);

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -39,7 +39,7 @@ class CustomFieldHandler
 
         $this->contexts = [
             __('User Admin') => [
-                'Person' => __('User'),
+                'User' => __('User'),
             ],
             __('Students') => [
                 'Medical Form' => __('Medical Form'),
@@ -74,7 +74,7 @@ class CustomFieldHandler
         ];
 
         $this->headings = [
-            'Person' => [
+            'User' => [
                 'Basic Information'      => __('Basic Information'),
                 'System Access'          => __('System Access'),
                 'Contact Information'    => __('Contact Information'),

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -30,6 +30,7 @@ class CustomFieldHandler
 
     protected $contexts;
     protected $types;
+    protected $headings;
 
     public function __construct(CustomFieldGateway $customFieldGateway, FileUploader $fileUploader)
     {
@@ -71,6 +72,32 @@ class CustomFieldHandler
                 'color'      => __('Colour'),
             ]
         ];
+
+        $this->headings = [
+            'Person' => [
+                'Basic Information'      => __('Basic Information'),
+                'System Access'          => __('System Access'),
+                'Contact Information'    => __('Contact Information'),
+                'School Information'     => __('School Information'),
+                'Background Information' => __('Background Information'),
+                'Employment'             => __('Employment'),
+                'Emergency Contacts'     => __('Emergency Contacts'),
+                'Miscellaneous'          => __('Miscellaneous'),
+            ],
+            'Staff' => [
+                'Basic Information' => __('Basic Information'),
+                'First Aid'         => __('First Aid'),
+                'Biography'         => __('Biography'),
+            ],
+            'First Aid' => [
+                'Basic Information' => __('Basic Information'),
+                'Follow Up'         => __('Follow Up'),
+                'Biography'         => __('Biography'),
+            ],
+            'Medical Form' => [
+                'General Information' => __('General Information'),
+            ],
+        ];
     }
 
     public function getContexts()
@@ -81,6 +108,11 @@ class CustomFieldHandler
     public function getTypes()
     {
         return $this->types;
+    }
+
+    public function getHeadings()
+    {
+        return $this->headings;
     }
 
     public function getFieldDataFromPOST($context, $params = [], &$customRequireFail = false)
@@ -135,15 +167,21 @@ class CustomFieldHandler
         }
 
         if (!empty($params['heading'])) {
-            $form->addRow()->addHeading($params['heading']);
-        }
-        if (!empty($params['subheading'])) {
-            $form->addRow()->addSubheading($params['subheading']);
+            $form->addRow()->addHeading(__($params['heading']));
+        } else if (!empty($params['subheading'])) {
+            $form->addRow()->addSubheading(__($params['subheading']));
         }
 
         foreach ($customFieldsGrouped as $heading => $customFields) {
-            if (!empty($heading)) {
-                $form->addRow()->addSubheading($heading);
+            if (!empty($heading) && !$form->hasHeading($heading)) {
+                $form->addRow()->addHeading(__($heading));
+            }
+            
+            if (empty($heading) && !empty($params['heading'])) {
+                if (!$form->hasHeading($params['heading'])) {
+                    $form->addRow()->addHeading(__($params['heading']));
+                }
+                $heading = $params['heading'];
             }
 
             foreach ($customFields as $field) {
@@ -155,51 +193,71 @@ class CustomFieldHandler
                 }
 
                 $name = $prefix.$field['gibbonCustomFieldID'];
-                $row = $field['type'] == 'editor' ? $form->addRow()->addColumn() : $form->addRow();
+                $row = $field['type'] == 'editor' ? $form->addRow()->setHeading($heading)->addColumn() : $form->addRow()->setHeading($heading);
                     $row->addLabel($name, $field['name'])->description($field['description']);
                     $row->addCustomField($name, $field)->setValue($fieldValue);
+
             }
         }
     }
 
-    public function createCustomFieldsTable($context, $params = [], $fields = [], $table = null)
+    public function addCustomFieldsToTable(&$table, $context, $params = [], $fields = [])
     {
         $existingFields = !empty($fields) && is_string($fields)? json_decode($fields, true) : (is_array($fields) ? $fields : []);
-        $customFields = $this->customFieldGateway->selectCustomFields($context, $params + ['hideHidden' => '1'])->fetchAll();
+        $customFieldsGrouped = $this->customFieldGateway->selectCustomFields($context, $params + ['hideHidden' => '1'])->fetchGrouped();
 
-        if (!empty($table)) {
-            $table->withData([$existingFields]);
-        } else {
-            $table = DataTable::createDetails('customFields')->withData([$existingFields]);
+        if (empty($table)) {
+            $table = DataTable::createDetails('customFields');
         }
 
-        foreach ($customFields as $field) {
-            $col = $table->addColumn($field['gibbonCustomFieldID'], __($field['name']));
+        if (!empty($existingFields)) {
+            $table->withData([$existingFields]);
+        }
 
-            switch ($field['type']) {
-                case 'date':
-                    $col->format(Format::using('date', $field['gibbonCustomFieldID']));
-                    break;
-                case 'url':
-                    $col->format(Format::using('link', [$field['gibbonCustomFieldID'], $field['gibbonCustomFieldID']]));
-                    break;
-                case 'file':
-                case 'image':
-                    $col->format(function ($values) use ($field) {
-                        return !empty($values[$field['gibbonCustomFieldID']])
-                            ? Format::link($values[$field['gibbonCustomFieldID']], __('Attachment'), '', ['target' => '_blank'])
-                            : '';
-                    });
-                    break;
-                case 'yesno':
-                    $col->format(Format::using('yesno', $field['gibbonCustomFieldID']));
-                    break;
-                case 'color':
-                    $col->format(function ($values) use ($field) {
-                        $value = $values[$field['gibbonCustomFieldID']] ?? '';
-                        return "<span class='tag text-xxs w-12' title='$value' style='background-color: $value'>&nbsp;</span>";
-                    });
-                    break;
+        foreach ($customFieldsGrouped as $heading => $customFields) {
+            // Try to get existing columns by custom field heading or parameter heading.
+            $headingCol = $table->getColumn($heading);
+            if (empty($headingCol) && empty($heading) && !empty($params['heading'])) {
+                $headingCol = $table->getColumn($params['heading']);
+            }
+
+            // If no heading column exists, add one
+            if (empty($headingCol) && !empty($heading)) {
+                $headingCol = $table->addColumn($heading, $heading);
+            } elseif (empty($headingCol) && !empty($params['heading'])) {
+                $headingCol = $table->addColumn($params['heading'], $params['heading']);
+            }
+
+            foreach ($customFields as $field) {
+                $col = !empty($headingCol)
+                    ? $headingCol->addColumn($field['gibbonCustomFieldID'], __($field['name']))
+                    : $table->addColumn($field['gibbonCustomFieldID'], __($field['name']));
+
+                switch ($field['type']) {
+                    case 'date':
+                        $col->format(Format::using('date', $field['gibbonCustomFieldID']));
+                        break;
+                    case 'url':
+                        $col->format(Format::using('link', [$field['gibbonCustomFieldID'], $field['gibbonCustomFieldID']]));
+                        break;
+                    case 'file':
+                    case 'image':
+                        $col->format(function ($values) use ($field) {
+                            return !empty($values[$field['gibbonCustomFieldID']])
+                                ? Format::link($values[$field['gibbonCustomFieldID']], __('Attachment'), '', ['target' => '_blank'])
+                                : '';
+                        });
+                        break;
+                    case 'yesno':
+                        $col->format(Format::using('yesno', $field['gibbonCustomFieldID']));
+                        break;
+                    case 'color':
+                        $col->format(function ($values) use ($field) {
+                            $value = $values[$field['gibbonCustomFieldID']] ?? '';
+                            return "<span class='tag text-xxs w-12' title='$value' style='background-color: $value'>&nbsp;</span>";
+                        });
+                        break;
+                }
             }
         }
 

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -39,7 +39,7 @@ class CustomFieldHandler
 
         $this->contexts = [
             __('User Admin') => [
-                'Person' => __('Person'),
+                'Person' => __('User'),
             ],
             __('Students') => [
                 'Medical Form' => __('Medical Form'),
@@ -223,9 +223,9 @@ class CustomFieldHandler
 
             // If no heading column exists, add one
             if (empty($headingCol) && !empty($heading)) {
-                $headingCol = $table->addColumn($heading, $heading);
+                $headingCol = $table->addColumn($heading, __($heading));
             } elseif (empty($headingCol) && !empty($params['heading'])) {
-                $headingCol = $table->addColumn($params['heading'], $params['heading']);
+                $headingCol = $table->addColumn($params['heading'], __($params['heading']));
             }
 
             foreach ($customFields as $field) {
@@ -234,6 +234,9 @@ class CustomFieldHandler
                     : $table->addColumn($field['gibbonCustomFieldID'], __($field['name']));
 
                 switch ($field['type']) {
+                    case 'editor':
+                        $col->addClass('col-span-3');
+                        break;
                     case 'date':
                         $col->format(Format::using('date', $field['gibbonCustomFieldID']));
                         break;

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -212,7 +212,9 @@ class Form implements OutputableInterface
      */
     public function addRow($id = '')
     {
-        $row = $this->factory->createRow($id);
+        $section = !empty($this->rows) ? end($this->rows)->getHeading() : '';
+        $row = $this->factory->createRow($id)->setHeading($section);
+        
         $this->rows[] = $row;
 
         return $row;
@@ -236,6 +238,21 @@ class Form implements OutputableInterface
         return array_filter($this->rows, function ($item) {
             return !empty($item->getElements());
         });
+    }
+
+    public function getRowsByHeading()
+    {
+        return array_reduce($this->rows, function ($group, $row) {
+            $group[$row->getHeading()][] = $row;
+            return $group;
+        }, []);
+    }
+
+    public function hasHeading($heading)
+    {
+        return count(array_filter($this->rows, function ($row) use ($heading) {
+            return $row->getHeading() == $heading;
+        }));
     }
 
     /**

--- a/src/Forms/Layout/Heading.php
+++ b/src/Forms/Layout/Heading.php
@@ -53,6 +53,8 @@ class Heading extends Element implements OutputableInterface, RowDependancyInter
 
         $headingID = preg_replace('/[^a-zA-Z0-9]/', '', substr(strip_tags($this->content), 0, 60)); 
         $this->row->setID($headingID);
+
+        $this->row->setHeading(preg_replace('/[^a-zA-Z0-9 -_]/', '', strip_tags($this->content)));
     }
 
     /**

--- a/src/Forms/Layout/Row.php
+++ b/src/Forms/Layout/Row.php
@@ -35,7 +35,8 @@ class Row
     use BasicAttributesTrait;
 
     protected $factory;
-    protected $formElements = array();
+    protected $heading = '';
+    protected $formElements = [];
 
     /**
      * Construct a row with access to a specific factory.
@@ -91,6 +92,17 @@ class Row
         }
 
         return $element;
+    }
+
+    public function getHeading()
+    {
+        return $this->heading;
+    }
+
+    public function setHeading($heading)
+    {
+        $this->heading = $heading;
+        return $this;
     }
 
     /**

--- a/src/Forms/Layout/Row.php
+++ b/src/Forms/Layout/Row.php
@@ -70,6 +70,10 @@ class Row
             if ($element instanceof RowDependancyInterface) {
                 $element->setRow($this);
             }
+
+            if ($function == 'createSubmit') {
+                $this->setHeading('');
+            }
         } catch (\ReflectionException $e) {
             $element = $this->factory->createContent(strtr('Cannot {function}. This form element does not exist in the current FormFactory: {message}', [
                 '{function}' => $function,

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -419,7 +419,7 @@ class Format
      *
      * @param string $url
      * @param string $text
-     * @param string $title
+     * @param array $attr
      * @return string
      */
     public static function link($url, $text = '', $attr = [])
@@ -434,6 +434,9 @@ class Format
             $attr = ['title' => $attr];
         }
 
+        if (stripos($url, '@') !== false) {
+            $url = 'mailto:'.$url;
+        }
         if (substr($url, 0, 2) == './') {
             $url = static::$settings['absoluteURL'].substr($url, 1);
         }

--- a/src/Tables/DataTable.php
+++ b/src/Tables/DataTable.php
@@ -196,7 +196,11 @@ class DataTable implements OutputableInterface
     {
         $dataSet = is_array($dataSet) ? new DataSet($dataSet) : $dataSet;
 
-        $this->data = $dataSet;
+        if (!empty($this->data)) {
+            $this->data->merge($dataSet);
+        } else {
+            $this->data = $dataSet;
+        }
 
         return $this;
     }
@@ -323,6 +327,11 @@ class DataTable implements OutputableInterface
         };
 
         return $getNestedColumns($this->columns);
+    }
+
+    public function getColumn($key)
+    {
+        return $this->columns[$key] ?? null;
     }
 
     public function getColumnByIndex($index)
@@ -461,10 +470,10 @@ class DataTable implements OutputableInterface
      */
     public function render($dataSet, RendererInterface $renderer = null)
     {
-        $dataSet = is_array($dataSet) ? new DataSet($dataSet) : $dataSet;
         $renderer = isset($renderer)? $renderer : $this->renderer;
+        $this->withData($dataSet);
 
-        return $renderer->renderTable($this, $dataSet);
+        return $renderer->renderTable($this, $this->data);
     }
 
     /**

--- a/src/Tables/View/DetailsView.php
+++ b/src/Tables/View/DetailsView.php
@@ -45,13 +45,38 @@ class DetailsView extends View implements RendererInterface
 
         if ($dataSet->count() > 0) {
             $this->addData([
+                'groups'     => $this->getColumnGroups($table),
                 'columns'    => $table->getColumns(),
                 'rows'       => $dataSet,
                 'blankSlate' => $table->getMetaData('blankSlate'),
-                'gridClass' => $table->getMetaData('gridClass'),
+                'gridClass'  => $table->getMetaData('gridClass'),
             ]);
         }
 
         return $this->render('components/detailsTable.twig.html');
+    }
+
+    /**
+     * 
+     *
+     * @param DataTable $table
+     * @return array
+     */
+    protected function getColumnGroups(DataTable $table)
+    {
+        $groups = [];
+
+        foreach ($table->getColumns(0) as $columnIndex => $column) {
+            if ($column->hasNestedColumns()) {
+                foreach ($column->getColumns() as $subColumnIndex => $subColumn) {
+                    $groups[$column->getLabel()][$subColumnIndex] = $subColumn;
+                }
+            } else {
+                $groups[''][$columnIndex] = $column;
+            }
+            
+        }
+        
+        return $groups;
     }
 }

--- a/tests/acceptance/System Admin/CustomFieldsManageCept.php
+++ b/tests/acceptance/System Admin/CustomFieldsManageCept.php
@@ -9,7 +9,7 @@ $I->clickNavigation('Add');
 $I->seeBreadcrumb('Add Custom Field');
 
 $addFormValues = array(
-    'context'               => 'Person',
+    'context'               => 'User',
     'name'                  => 'Test Field',
     'active'                => 'Y',
     'description'           => 'For Testing',
@@ -37,7 +37,7 @@ $I->seeCheckboxIsChecked('input[type=checkbox][value=activePersonStudent]');
 $I->seeCheckboxIsChecked('input[type=checkbox][value=activePersonOther]');
 
 $editFormValues = array(
-    'context'               => 'Person',
+    'context'               => 'User',
     'name'                  => 'Test Field!',
     'active'                => 'N',
     'description'           => 'For Testing?',


### PR DESCRIPTION
This PR contains a number of general fixes and changes that make implementing and managing custom fields easier. The overall aim is for custom fields to more seamlessly be added to areas of the system, rather than tacked on at the end under the heading 'Custom Fields'.

- Improves form rendering so rows are grouped by heading and rendered in order. This enables a form field to be added to a specific heading after the rest of the form is declared. It's backwards compatible and doesn't affect existing forms and headings.
- Enables detail tables to make use of nested columns, which are already supported by the base DataTable objects. This allows a page of details with headings to be rendered as a single table rather than as separate tables. It also enables adding a field under a specific heading.
- Enables selecting a heading for a custom field from a drop-down or entering a new custom heading. Existing headings are listed based on the selected context.
- Splits the list of fields on the Custom Field page to group the fields by context. This makes the drag-drop ordering more intuitive.
- Refactors the Personal page of the Student Profile and enables it to support the display of custom fields.
- Renames the existing 'Person' context to 'User' for better clarity and naming (eg: User Fields vs Person Fields)

**How Has This Been Tested?**
Locally.

**Screenshots**
An example of custom fields added to an existing heading, a new heading, and no heading (defaults to Other Information)
<img width="944" alt="Screenshot 2021-03-19 at 2 02 06 PM" src="https://user-images.githubusercontent.com/897700/111740490-d0e91780-88bf-11eb-9a6c-876f993d72ce.png">
