### PR TITLE
Timetable Admin: implement custom fields for Courses and Classes

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -802,4 +802,5 @@ UPDATE `gibbonPlannerEntry` SET `gibbonUnitID`=NULL WHERE `gibbonUnitID`='000000
 ALTER TABLE `gibbonFirstAid` ADD `fields` TEXT NULL AFTER `timestamp`;end
 ALTER TABLE `gibbonStaff` ADD `fields` TEXT NULL AFTER `biographicalGroupingPriority`;end
 ALTER TABLE `gibbonCourse` ADD `fields` TEXT NULL AFTER `orderBy`;end
+ALTER TABLE `gibbonCourseClass` ADD `fields` TEXT NULL AFTER `gibbonScaleIDTarget`;end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -801,4 +801,5 @@ UPDATE `gibbonCustomField` SET `context`='User' WHERE `context`='Person';end
 UPDATE `gibbonPlannerEntry` SET `gibbonUnitID`=NULL WHERE `gibbonUnitID`='0000000000';end
 ALTER TABLE `gibbonFirstAid` ADD `fields` TEXT NULL AFTER `timestamp`;end
 ALTER TABLE `gibbonStaff` ADD `fields` TEXT NULL AFTER `biographicalGroupingPriority`;end
+ALTER TABLE `gibbonCourse` ADD `fields` TEXT NULL AFTER `orderBy`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,7 +21,7 @@ v22.0.00
     Headlines
         New 2021 core theme
         Improved custom fields system
-        Added custom fields to Medical Forms
+        Added custom fields to Medical Forms, Staff records, Courses and Classes
 
     Significant Changes
         System: improved support for custom themes

--- a/modules/Departments/department_course.php
+++ b/modules/Departments/department_course.php
@@ -17,6 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Tables\DataTable;
+use Gibbon\Forms\CustomFieldHandler;
+
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
 
@@ -32,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_cou
     } else {
         
             $data = array('gibbonDepartmentID' => $gibbonDepartmentID, 'gibbonCourseID' => $gibbonCourseID);
-            $sql = 'SELECT gibbonDepartment.name AS department, gibbonCourse.name, gibbonCourse.description, gibbonSchoolYear.name AS year, gibbonCourse.gibbonSchoolYearID FROM gibbonDepartment JOIN gibbonCourse ON (gibbonDepartment.gibbonDepartmentID=gibbonCourse.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE gibbonDepartment.gibbonDepartmentID=:gibbonDepartmentID AND gibbonCourseID=:gibbonCourseID';
+            $sql = 'SELECT gibbonDepartment.name AS department, gibbonCourse.name, gibbonCourse.description, gibbonSchoolYear.name AS year, gibbonCourse.gibbonSchoolYearID, gibbonCourse.fields FROM gibbonDepartment JOIN gibbonCourse ON (gibbonDepartment.gibbonDepartmentID=gibbonCourse.gibbonDepartmentID) JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) WHERE gibbonDepartment.gibbonDepartmentID=:gibbonDepartmentID AND gibbonCourseID=:gibbonCourseID';
             $result = $connection2->prepare($sql);
             $result->execute($data);
 
@@ -73,6 +76,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_cou
                 echo $row['description'];
                 echo '</p>';
             }
+
+            // Custom fields
+            $table = DataTable::createDetails('fields');
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Course', [], $row['fields']);
+            echo $table->render([$row]);
 
             //Print Units
             echo '<h2>';

--- a/modules/Departments/department_course_class.php
+++ b/modules/Departments/department_course_class.php
@@ -22,6 +22,7 @@ use Gibbon\Domain\DataSet;
 use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Tables\View\GridView;
+use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Tables\Prefab\ClassGroupTable;
 
 //Module includes
@@ -42,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_cou
     } else {
         if (!empty($gibbonDepartmentID)) {
             $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
-            $sql = "SELECT gibbonCourse.gibbonSchoolYearID,gibbonDepartment.name AS department, gibbonCourse.name AS courseLong, gibbonCourse.nameShort AS course, gibbonCourseClass.name AS classLong, gibbonCourseClass.nameShort AS class, gibbonCourse.gibbonCourseID, gibbonSchoolYear.name AS year, gibbonCourseClass.attendance
+            $sql = "SELECT gibbonCourse.gibbonSchoolYearID,gibbonDepartment.name AS department, gibbonCourse.name AS courseLong, gibbonCourse.nameShort AS course, gibbonCourseClass.name AS classLong, gibbonCourseClass.nameShort AS class, gibbonCourse.gibbonCourseID, gibbonSchoolYear.name AS year, gibbonCourseClass.attendance, gibbonCourseClass.fields
                     FROM gibbonCourse
                     JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
                     JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
@@ -50,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_cou
                     WHERE gibbonCourseClassID=:gibbonCourseClassID";
         } else {
             $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
-            $sql = "SELECT gibbonCourse.gibbonSchoolYearID, gibbonCourse.name AS courseLong, gibbonCourse.nameShort AS course, gibbonCourseClass.name AS classLong, gibbonCourseClass.nameShort AS class, gibbonCourse.gibbonCourseID, gibbonSchoolYear.name AS year, gibbonCourseClass.attendance
+            $sql = "SELECT gibbonCourse.gibbonSchoolYearID, gibbonCourse.name AS courseLong, gibbonCourse.nameShort AS course, gibbonCourseClass.name AS classLong, gibbonCourseClass.nameShort AS class, gibbonCourse.gibbonCourseID, gibbonSchoolYear.name AS year, gibbonCourseClass.attendance, gibbonCourseClass.fields
                     FROM gibbonCourse
                     JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
                     JOIN gibbonSchoolYear ON (gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
@@ -154,6 +155,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_cou
                 });
 
             echo $table->render(new DataSet($menuItems));
+
+            // Custom fields
+            $table = DataTable::createDetails('fields');
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Class', [], $row['fields']);
+            echo $table->render([$row]);
 
             // Participants
             if (!empty($menuItems)) {

--- a/modules/System Admin/customFields_add.php
+++ b/modules/System Admin/customFields_add.php
@@ -100,14 +100,14 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $form->toggleVisibilityByClass('optionsRows')->onSelect('type')->when(['text', 'editor']);
     $row = $form->addRow()->addClass('optionsRows');
         $row->addLabel('options', __('Rows'))->description(__('Number of rows for field.'));
-        $row->addNumber('options')->minimum(1)->maximum(20)->onlyInteger(true);
+        $row->addNumber('options')->minimum(1)->maximum(255)->onlyInteger(true);
 
     $form->toggleVisibilityByClass('optionsOptions')->onSelect('type')->when(['select', 'checkboxes', 'radio']);
     $row = $form->addRow()->addClass('optionsOptions');
         $row->addLabel('options', __('Options'))
             ->description(__('Comma separated list of options.'))
             ->description(__('Dropdown: use [] to create option groups.'));
-        $row->addTextArea('options')->setRows(3)->required();
+        $row->addTextArea('options')->setRows(3);
 
     $form->toggleVisibilityByClass('optionsFile')->onSelect('type')->when(['file']);
     $row = $form->addRow()->addClass('optionsFile');

--- a/modules/Timetable Admin/course_manage_add.php
+++ b/modules/Timetable Admin/course_manage_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
@@ -63,6 +64,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			$form->addHiddenValue('address', $_SESSION[$guid]['address']);
 			$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 			
+            $row = $form->addRow()->addHeading(__('Basic Details'));
+
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
 				$row->addTextField('schoolYearName')->required()->readonly()->setValue($schoolYear['name']);
@@ -84,6 +87,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addLabel('orderBy', __('Order'))->description(__('May be used to adjust arrangement of courses in reports.'));
 				$row->addNumber('orderBy')->maxLength(3);
 			
+            $row = $form->addRow()->addHeading(__('Display Information'));
+
 			$row = $form->addRow();
 				$column = $row->addColumn('blurb');
 				$column->addLabel('description', __('Blurb'));
@@ -93,10 +98,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addLabel('map', __('Include In Curriculum Map'));
 				$row->addYesNo('map')->required();
 			
+            $row = $form->addRow()->addHeading(__('Configure'));
+
 			$row = $form->addRow();
 				$row->addLabel('gibbonYearGroupIDList', __('Year Groups'))->description(__('Enrolable year groups.'));
 				$row->addCheckboxYearGroup('gibbonYearGroupIDList');
 			
+            // Custom Fields
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Course', []);
+
 			$row = $form->addRow();
 				$row->addFooter();
 				$row->addSubmit();

--- a/modules/Timetable Admin/course_manage_addProcess.php
+++ b/modules/Timetable Admin/course_manage_addProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Forms\CustomFieldHandler;
+
 include '../../gibbon.php';
 
 if ($_POST['gibbonDepartmentID'] != '') {
@@ -56,14 +58,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             exit();
         }
 
+        $customRequireFail = false;
+        $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Course', [], $customRequireFail);
+
+        if ($customRequireFail) {
+            $URL .= '&return=error1';
+            header("Location: {$URL}");
+            exit;
+        }
+
         if ($result->rowCount() > 0) {
             $URL .= '&return=error3';
             header("Location: {$URL}");
         } else {
             //Write to database
             try {
-                $data = array('gibbonDepartmentID' => $gibbonDepartmentID, 'gibbonSchoolYearID' => $gibbonSchoolYearID, 'name' => $name, 'nameShort' => $nameShort, 'orderBy' => $orderBy, 'description' => $description, 'map' => $map, 'gibbonYearGroupIDList' => $gibbonYearGroupIDList);
-                $sql = 'INSERT INTO gibbonCourse SET gibbonDepartmentID=:gibbonDepartmentID, gibbonSchoolYearID=:gibbonSchoolYearID, name=:name, nameShort=:nameShort, orderBy=:orderBy, description=:description, map=:map, gibbonYearGroupIDList=:gibbonYearGroupIDList';
+                $data = array('gibbonDepartmentID' => $gibbonDepartmentID, 'gibbonSchoolYearID' => $gibbonSchoolYearID, 'name' => $name, 'nameShort' => $nameShort, 'orderBy' => $orderBy, 'description' => $description, 'map' => $map, 'gibbonYearGroupIDList' => $gibbonYearGroupIDList, 'fields' => $fields);
+                $sql = 'INSERT INTO gibbonCourse SET gibbonDepartmentID=:gibbonDepartmentID, gibbonSchoolYearID=:gibbonSchoolYearID, name=:name, nameShort=:nameShort, orderBy=:orderBy, description=:description, map=:map, gibbonYearGroupIDList=:gibbonYearGroupIDList, fields=:fields';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/Timetable Admin/course_manage_class_add.php
+++ b/modules/Timetable Admin/course_manage_class_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\CustomFieldHandler;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_class_add.php') == false) {
     // Access denied
@@ -60,6 +61,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 			$form->addHiddenValue('gibbonCourseID', $gibbonCourseID);
 			
+            $row = $form->addRow()->addHeading(__('Basic Details'));
+
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
 				$row->addTextField('schoolYearName')->required()->readonly()->setValue($values['yearName']);
@@ -85,6 +88,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addLabel('attendance', __('Track Attendance?'))->description(__('Should this class allow attendance to be taken?'));
 				$row->addYesNo('attendance');
 			}
+
+            // Custom Fields
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Class', []);
 
 			$row = $form->addRow();
 				$row->addFooter();

--- a/modules/Timetable Admin/course_manage_class_addProcess.php
+++ b/modules/Timetable Admin/course_manage_class_addProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Forms\CustomFieldHandler;
+
 include '../../gibbon.php';
 
 $name = $_POST['name'];
@@ -50,14 +52,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             exit();
         }
 
+        $customRequireFail = false;
+        $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Class', [], $customRequireFail);
+
+        if ($customRequireFail) {
+            $URL .= '&return=error1';
+            header("Location: {$URL}");
+            exit;
+        }
+
         if ($result->rowCount() > 0) {
             $URL .= '&return=error3';
             header("Location: {$URL}");
         } else {
             //Write to database
             try {
-                $data = array('gibbonCourseID' => $gibbonCourseID, 'name' => $name, 'nameShort' => $nameShort, 'reportable' => $reportable, 'attendance' => $attendance);
-                $sql = 'INSERT INTO gibbonCourseClass SET gibbonCourseID=:gibbonCourseID, name=:name, nameShort=:nameShort, reportable=:reportable, attendance=:attendance';
+                $data = array('gibbonCourseID' => $gibbonCourseID, 'name' => $name, 'nameShort' => $nameShort, 'reportable' => $reportable, 'attendance' => $attendance, 'fields' => $fields);
+                $sql = 'INSERT INTO gibbonCourseClass SET gibbonCourseID=:gibbonCourseID, name=:name, nameShort=:nameShort, reportable=:reportable, attendance=:attendance, fields=:fields';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/Timetable Admin/course_manage_class_edit.php
+++ b/modules/Timetable Admin/course_manage_class_edit.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Forms\CustomFieldHandler;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_class_edit.php') == false) {
     // Access denied
@@ -38,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
     } else {
         
             $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID);
-            $sql = 'SELECT gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, reportable, attendance FROM gibbonCourseClass, gibbonCourse, gibbonSchoolYear WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClassID=:gibbonCourseClassID';
+            $sql = 'SELECT gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, reportable, attendance, gibbonCourseClass.fields FROM gibbonCourseClass, gibbonCourse, gibbonSchoolYear WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClassID=:gibbonCourseClassID';
             $result = $connection2->prepare($sql);
             $result->execute($data);
 
@@ -55,6 +56,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			$form->addHiddenValue('gibbonCourseClassID', $gibbonCourseClassID);
 			$form->addHiddenValue('gibbonCourseID', $gibbonCourseID);
 			
+            $row = $form->addRow()->addHeading(__('Basic Details'));
+
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
 				$row->addTextField('schoolYearName')->required()->readonly()->setValue($values['yearName']);
@@ -81,6 +84,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addYesNo('attendance');
 			}
 
+            // Custom Fields
+            $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Class', [], $values['fields']);
+            
 			$row = $form->addRow();
 				$row->addFooter();
 				$row->addSubmit();

--- a/modules/Timetable Admin/course_manage_class_editProcess.php
+++ b/modules/Timetable Admin/course_manage_class_editProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Forms\CustomFieldHandler;
+
 include '../../gibbon.php';
 
 $gibbonCourseClassID = $_POST['gibbonCourseClassID'];
@@ -58,6 +60,15 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                 $reportable = $_POST['reportable'];
                 $attendance = (isset($_POST['attendance']))? $_POST['attendance'] : 'N';
 
+                $customRequireFail = false;
+                $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Class', [], $customRequireFail);
+
+                if ($customRequireFail) {
+                    $URL .= '&return=error1';
+                    header("Location: {$URL}");
+                    exit;
+                }
+
                 if ($name == '' or $nameShort == '') {
                     $URL .= '&return=error3';
                     header("Location: {$URL}");
@@ -80,8 +91,8 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                     } else {
                         //Write to database
                         try {
-                            $data = array('name' => $name, 'nameShort' => $nameShort, 'reportable' => $reportable, 'attendance' => $attendance, 'gibbonCourseClassID' => $gibbonCourseClassID);
-                            $sql = 'UPDATE gibbonCourseClass SET name=:name, nameShort=:nameShort, reportable=:reportable, attendance=:attendance WHERE gibbonCourseClassID=:gibbonCourseClassID';
+                            $data = array('name' => $name, 'nameShort' => $nameShort, 'reportable' => $reportable, 'attendance' => $attendance, 'fields' => $fields, 'gibbonCourseClassID' => $gibbonCourseClassID);
+                            $sql = 'UPDATE gibbonCourseClass SET name=:name, nameShort=:nameShort, reportable=:reportable, attendance=:attendance, fields=:fields WHERE gibbonCourseClassID=:gibbonCourseClassID';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {

--- a/modules/Timetable Admin/course_manage_editProcess.php
+++ b/modules/Timetable Admin/course_manage_editProcess.php
@@ -1,6 +1,4 @@
 <?php
-
-use Gibbon\Forms\CustomFieldHandler;
 /*
 Gibbon, Flexible & Open School System
 Copyright (C) 2010, Ross Parker
@@ -18,6 +16,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
+
+use Gibbon\Forms\CustomFieldHandler;
 
 include '../../gibbon.php';
 

--- a/modules/Timetable Admin/course_manage_editProcess.php
+++ b/modules/Timetable Admin/course_manage_editProcess.php
@@ -1,4 +1,6 @@
 <?php
+
+use Gibbon\Forms\CustomFieldHandler;
 /*
 Gibbon, Flexible & Open School System
 Copyright (C) 2010, Ross Parker
@@ -77,14 +79,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
                     exit();
                 }
 
+                $customRequireFail = false;
+                $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Course', [], $customRequireFail);
+
+                if ($customRequireFail) {
+                    $URL .= '&return=error1';
+                    header("Location: {$URL}");
+                    exit;
+                }
+
                 if ($result->rowCount() > 0) {
                     $URL .= '&return=error3';
                     header("Location: {$URL}");
                 } else {
                     //Write to database
                     try {
-                        $data = array('gibbonDepartmentID' => $gibbonDepartmentID, 'name' => $name, 'nameShort' => $nameShort, 'orderBy' => $orderBy, 'description' => $description, 'map' => $map, 'gibbonYearGroupIDList' => $gibbonYearGroupIDList, 'gibbonCourseID' => $gibbonCourseID);
-                        $sql = 'UPDATE gibbonCourse SET gibbonDepartmentID=:gibbonDepartmentID, name=:name, nameShort=:nameShort, orderBy=:orderBy, description=:description, map=:map, gibbonYearGroupIDList=:gibbonYearGroupIDList WHERE gibbonCourseID=:gibbonCourseID';
+                        $data = array('gibbonDepartmentID' => $gibbonDepartmentID, 'name' => $name, 'nameShort' => $nameShort, 'orderBy' => $orderBy, 'description' => $description, 'map' => $map, 'gibbonYearGroupIDList' => $gibbonYearGroupIDList, 'fields' => $fields, 'gibbonCourseID' => $gibbonCourseID);
+                        $sql = 'UPDATE gibbonCourse SET gibbonDepartmentID=:gibbonDepartmentID, name=:name, nameShort=:nameShort, orderBy=:orderBy, description=:description, map=:map, gibbonYearGroupIDList=:gibbonYearGroupIDList, fields=:fields WHERE gibbonCourseID=:gibbonCourseID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/src/Forms/CustomFieldHandler.php
+++ b/src/Forms/CustomFieldHandler.php
@@ -48,6 +48,10 @@ class CustomFieldHandler
                 'First Aid'    => __('First Aid'),
                 'Medical Form' => __('Medical Form'),
             ],
+            __('Timetable Admin') => [
+                'Course' => __('Course'),
+                'Class' => __('Class'),
+            ]
         ];
 
         $this->types = [
@@ -99,6 +103,14 @@ class CustomFieldHandler
             ],
             'Medical Form' => [
                 'General Information' => __('General Information'),
+            ],
+            'Course' => [
+                'Basic Details' => __('Basic Details'),
+                'Display Information' => __('Display Information'),
+                'Configure' => __('Configure'),
+            ],
+            'Class' => [
+                'Basic Details' => __('Basic Details'),
             ],
         ];
     }


### PR DESCRIPTION
Next step in the process. This PR adds custom fields for courses and classes. They are editable in Manage Courses & Classes, and will show up on the department page unless hidden.

**Motivation and Context**
Continues extending the areas in the system which can be customized.

**How Has This Been Tested?**
Locally.

**Screenshots**
Example of custom fields on a course:
<img width="990" alt="Screenshot 2021-03-23 at 2 02 42 PM" src="https://user-images.githubusercontent.com/897700/112100682-77932800-8be0-11eb-801a-bc7e5fe16cf9.png">

Example on the Custom Fields page:
<img width="974" alt="Screenshot 2021-03-23 at 8 43 56 AM" src="https://user-images.githubusercontent.com/897700/112100275-d4421300-8bdf-11eb-9df6-89fa51dd54ca.png">
