### PR TITLE
Timetable Admin: add an option to overwrite existing TT dates in Tie Days to Dates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@ v22.0.00
         System Admin: added file uploader for choosing logo and background images in System Settings
         User Admin: added an option to restrict Public Registration to a list of allowed domains
         Tests: migrated test suite to GitHub actions, updated testing libraries to recent versions
+        Timetable Admin: added an option to overwrite existing TT dates in Tie Days to Dates
         Timetable: added green cell background, and day colour highlight, to dates with days tied in Tie Days to Dates
 
     Bug Fixes

--- a/modules/Timetable Admin/ttDates.php
+++ b/modules/Timetable Admin/ttDates.php
@@ -87,7 +87,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
             echo '</div>';
         } else {
 
-            $form = Form::create('ttDates', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/ttDates_addMultiProcess.php?gibbonSchoolYearID='.$gibbonSchoolYearID);
+            $page->addData('preventOverflow', true);
+
+            $form = Form::createTable('ttDates', $_SESSION[$guid]['absoluteURL'].'/modules/'.$_SESSION[$guid]['module'].'/ttDates_addMultiProcess.php?gibbonSchoolYearID='.$gibbonSchoolYearID);
             $form->setClass('w-full blank');
 
             $form->addHiddenValue('q', $_SESSION[$guid]['address']);
@@ -113,29 +115,26 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
                 }
 
                 //Get the special days
-
-                    $dataSpecial = array('gibbonSchoolYearTermID' => $values['gibbonSchoolYearTermID']);
-                    $sqlSpecial = 'SELECT date, type, name FROM gibbonSchoolYearSpecialDay WHERE gibbonSchoolYearTermID=:gibbonSchoolYearTermID ORDER BY date';
-                    $resultSpecial = $connection2->prepare($sqlSpecial);
-                    $resultSpecial->execute($dataSpecial);
+                $dataSpecial = array('gibbonSchoolYearTermID' => $values['gibbonSchoolYearTermID']);
+                $sqlSpecial = 'SELECT date, type, name FROM gibbonSchoolYearSpecialDay WHERE gibbonSchoolYearTermID=:gibbonSchoolYearTermID ORDER BY date';
+                $resultSpecial = $connection2->prepare($sqlSpecial);
+                $resultSpecial->execute($dataSpecial);
 
                 $specialDays = $resultSpecial->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE);
 
                 // Get the TT day names
-
-                    $dataDay = array();
-                    $sqlDay = 'SELECT date, gibbonTTDay.nameShort AS dayName, gibbonTT.nameShort AS ttName, color, fontColor FROM gibbonTTDayDate JOIN gibbonTTDay ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) JOIN gibbonTT ON (gibbonTTDay.gibbonTTID=gibbonTT.gibbonTTID)';
-                    $resultDay = $connection2->prepare($sqlDay);
-                    $resultDay->execute($dataDay);
+                $dataDay = array();
+                $sqlDay = 'SELECT date, gibbonTTDay.nameShort AS dayName, gibbonTT.nameShort AS ttName, color, fontColor FROM gibbonTTDayDate JOIN gibbonTTDay ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) JOIN gibbonTT ON (gibbonTTDay.gibbonTTID=gibbonTT.gibbonTTID)';
+                $resultDay = $connection2->prepare($sqlDay);
+                $resultDay->execute($dataDay);
 
                 $ttDays = $resultDay->fetchAll(\PDO::FETCH_GROUP);
 
 				//Check which days are school days
-
-                    $dataDays = array();
-                    $sqlDays = "SELECT nameShort, schoolDay FROM gibbonDaysOfWeek";
-                    $resultDays = $connection2->prepare($sqlDays);
-                    $resultDays->execute($dataDays);
+                $dataDays = array();
+                $sqlDays = "SELECT nameShort, schoolDay FROM gibbonDaysOfWeek";
+                $resultDays = $connection2->prepare($sqlDays);
+                $resultDays->execute($dataDays);
 
                 $days = $resultDays->fetchAll(\PDO::FETCH_KEY_PAIR);
 
@@ -158,7 +157,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
 
                     // $column = $row->addColumn();
                     // $column->addContent()->addClass('textCenter');
-                    $row->addCheckbox('checkall'.$dowShort.$values['nameShort'])->prepend(__($dowLong).'<br/>')->append($script)->alignCenter();
+                    $row->addCheckbox('checkall'.$dowShort.$values['nameShort'])->prepend(__($dowLong).'<br/>')->append($script)->alignCenter()->addClass('sticky top-0 z-10');
                 }
 
                 for ($i = $startDayStamp; $i <= $endDayStamp;$i = strtotime('+1 day', $i)) {
@@ -221,6 +220,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
             $row = $table->addRow();
                 $row->addLabel('gibbonTTDayID', __('Day'));
                 $row->addSelect('gibbonTTDayID')->fromQuery($pdo, $sql, $data)->addClass('mediumWidth');
+
+            $row = $table->addRow();
+                $row->addLabel('overwrite', __('Overwrite'))->description(__('Should existing timetable days be replaced by the new ones?'));
+                $row->addCheckbox('overwrite')->setValue('Y')->checked('N');
 
             $row = $table->addRow()->addClass('right');
                 $row->addContent();

--- a/src/Domain/Timetable/TimetableDayDateGateway.php
+++ b/src/Domain/Timetable/TimetableDayDateGateway.php
@@ -1,0 +1,36 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Timetable;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * @version v22
+ * @since   v22
+ */
+class TimetableDayDateGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonTTDayDate';
+    private static $primaryKey = 'gibbonTTDayDateID';
+}


### PR DESCRIPTION
- This PR adds a checkbox to the bottom of the Tie Days to Dates page, which enables overwriting existing TT day dates when adding new ones. 
- It also makes the weekday header sticky, to make it easier to see and select columns when scrolling through the whole year.
- Also tidies up the ttDates_addMultiProcess.php script.

**Motivation and Context**
When making a timetable change, currently one would need to manually delete existing entries, or use an SQL command to do so.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="963" alt="Screenshot 2021-03-25 at 10 26 45 AM" src="https://user-images.githubusercontent.com/897700/112409691-eb564180-8d54-11eb-91f8-ed455ac49979.png">
