### PR TITLE
System Admin: prevent installing or updating a module that requires a newer core version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,7 @@ v22.0.00
         System Admin: added a Reporting Values by Roll Group import option
         System Admin: updated user-related imports to enable importing by username or email address
         System Admin: added file uploader for choosing logo and background images in System Settings
+        System Admin: prevent installing or updating a module that requires a newer core version
         User Admin: added an option to restrict Public Registration to a list of allowed domains
         Tests: migrated test suite to GitHub actions, updated testing libraries to recent versions
         Timetable: added green cell background, and day colour highlight, to dates with days tied in Tie Days to Dates

--- a/modules/System Admin/moduleFunctions.php
+++ b/modules/System Admin/moduleFunctions.php
@@ -140,7 +140,7 @@ function getModuleVersion($moduleName, $guid)
     $versionFile = $_SESSION[$guid]['absolutePath'].'/modules/'.$moduleName.'/version.php';
     if (is_file($versionFile)) {
         include $versionFile;
-       return $moduleVersion;
+       return ['moduleVersion' => $moduleVersion, 'coreVersion' => ($coreVersion ?? '')];
     } else {
         return false;
     }

--- a/modules/System Admin/module_manage.php
+++ b/modules/System Admin/module_manage.php
@@ -70,10 +70,15 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
         $module['status'] = __('Installed');
         $module['name'] = $module['type'] == 'Core' ? __($module['name']) : $module['name'];
         $module['versionDisplay'] = $module['type'] == 'Core' ? 'v'.$version : 'v'.$module['version'];
+        $module['update'] = false;
 
         if ($module['type'] == 'Additional') {
             $versionFromFile = getModuleVersion($module['name'], $guid);
-            if (version_compare($versionFromFile, $module['version'], '>')) {
+            
+            if (!empty($versionFromFile['coreVersion']) && version_compare($versionFromFile['coreVersion'], $version, '>')) {
+                $module['status'] = Format::bold(__('Requires {version}', ['version' => 'v'.$versionFromFile['coreVersion']])).'<br/>';
+                $module['warning'] = true;
+            } else if (version_compare($versionFromFile['moduleVersion'], $module['version'], '>')) {
                 $module['status'] = Format::bold(__('Update Available')).'<br/>';
                 $module['update'] = true;
             }
@@ -82,10 +87,12 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
 
     // Build a set of uninstalled modules by checking the $modules DataSet.
     // Validates the manifest file and grabs the module details from there.
-    $uninstalledModules = array_reduce($moduleFolders, function($group, $modulePath) use ($guid, &$moduleNames, $gibbon) {
+    $uninstalledModules = array_reduce($moduleFolders, function($group, $modulePath) use ($guid, &$moduleNames, $gibbon, $version) {
         $moduleName = substr($modulePath, strlen($gibbon->session->get('absolutePath').'/modules/'));
         if (!in_array($moduleName, $moduleNames)) {
             $module = getModuleManifest($moduleName, $guid);
+            $versionFromFile = getModuleVersion($module['name'], $guid);
+
             $module['status'] = __('Not Installed');
             $module['versionDisplay'] = !empty($module['version']) ? 'v'.$module['version'] : '';
 
@@ -94,6 +101,12 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
                 $module['status'] = __('Error');
                 $module['description'] = __('Module error due to incorrect manifest file or folder name.');
             }
+
+            if (!empty($versionFromFile['coreVersion']) && version_compare($versionFromFile['coreVersion'], $version, '>')) {
+                $module['status'] = Format::bold(__('Requires {version}', ['version' => 'v'.$versionFromFile['coreVersion']])).'<br/>';
+                $module['manifestOK'] = false;
+            }
+
             $group[] = $module;
         }
 
@@ -140,6 +153,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
     $table->modifyRows(function ($module, $row) {
         if (!empty($module['orphaned'])) return '';
         if (!empty($module['update'])) $row->addClass('current');
+        if (!empty($module['warning'])) $row->addClass('warning');
         if ($module['active'] == 'N') $row->addClass('error');
         return $row;
     });
@@ -180,7 +194,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/module_manage
                 $actions->addAction('uninstall', __('Uninstall'))
                         ->setIcon('garbage')
                         ->setURL('/modules/System Admin/module_manage_uninstall.php');
-
+            }
+            if ($row['type'] != 'Core' && $row['update']) {
                 $actions->addAction('update', __('Update'))
                         ->setIcon('delivery2')
                         ->setURL('/modules/System Admin/module_manage_update.php');


### PR DESCRIPTION
This PR adds a `$coreVersion` variable to a module's version.php file. This enables tagging which core version a module requires. If a module does not meet the minimum requirement, it cannot be installed or updated. It currently ignores version.php files that do not have a $coreVersion defined, which will enable us to add them in future module releases.

**Motivation and Context**
Help prevent errors with modules that require a different core version.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="329" alt="Screenshot 2021-03-25 at 11 57 10 AM" src="https://user-images.githubusercontent.com/897700/112416876-7c331a00-8d61-11eb-8ce2-75f701e54b8a.png">

<img width="919" alt="Screenshot 2021-03-25 at 11 53 09 AM" src="https://user-images.githubusercontent.com/897700/112416871-79d0c000-8d61-11eb-96c5-48d330beca06.png">
