### PR TITLE
Reports: added an option to delete report files from Generate Reports page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ v22.0.00
         Finance: removed student DOB and Gender from Export Invoices
         Formal Assessment: added attainment and effort descriptor as title to Internal Assessment view
         Reports: clear report cache when editing template assets in Production
+        Reports: added an option to delete report files from Generate Reports page
         Students: added Medical Form custom fields to student profile
         Students: updated Medical Data Summary to include medical custom fields
         Students: adjusted student select in Student Enrolment Add to only show unenrolled students

--- a/modules/Reports/reports_generate_batch.php
+++ b/modules/Reports/reports_generate_batch.php
@@ -70,14 +70,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
 
     $bulkActions = array(
         'Generate' => __('Generate'),
+        'Delete' => __('Delete'),
     );
 
     $col = $form->createBulkActionColumn($bulkActions);
         $col->addSelect('status')
             ->fromArray(['Draft' => __('Draft'), 'Final' => __('Final')])
             ->required()
-            ->setClass('w-32');
+            ->setClass('status w-32');
         $col->addSubmit(__('Go'));
+
+    $form->toggleVisibilityByClass('status')->onSelect('action')->when('Generate');
 
     // Data TABLE
     $table = $form->addRow()->addDataTable('reportsGenerate', $criteria)->withData($reports);

--- a/modules/Reports/reports_generate_single.php
+++ b/modules/Reports/reports_generate_single.php
@@ -71,14 +71,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
 
     $bulkActions = array(
         'Generate' => __('Generate'),
+        'Delete' => __('Delete'),
     );
 
     $col = $form->createBulkActionColumn($bulkActions);
         $col->addSelect('status')
             ->fromArray(['Draft' => __('Draft'), 'Final' => __('Final')])
             ->required()
-            ->setClass('w-32');
+            ->setClass('status w-32');
         $col->addSubmit(__('Go'));
+
+    $form->toggleVisibilityByClass('status')->onSelect('action')->when('Generate');
 
     // Data TABLE
     $table = $form->addRow()->addDataTable('reportsGenerate', $reportGateway->newQueryCriteria(true))->withData(new DataSet($ids));

--- a/modules/Reports/reports_generate_singleProcess.php
+++ b/modules/Reports/reports_generate_singleProcess.php
@@ -31,7 +31,8 @@ require_once '../../gibbon.php';
 $gibbonReportID = $_POST['gibbonReportID'] ?? '';
 $contextData = $_POST['contextData'] ?? '';
 $identifiers = $_POST['identifier'] ?? [];
-$status = $_POST['status'] ?? [];
+$status = $_POST['status'] ?? 'Draft';
+$action = $_POST['action'] ?? '';
 
 $URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Reports/reports_generate_single.php&gibbonReportID='.$gibbonReportID.'&contextData='.$contextData;
 
@@ -52,48 +53,85 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_b
     $report = $reportGateway->getByID($gibbonReportID);
 
     // Validate the database relationships exist
-    if (empty($gibbonReportID) || empty($report)) {
+    if (empty($gibbonReportID) || empty($report) || empty($identifiers)) {
         $URL .= '&return=error2';
         header("Location: {$URL}");
         exit;
     }
 
-    // Set reports to cache in a separate location
-    $cachePath = $gibbon->session->has('cachePath') ? $gibbon->session->get('cachePath').'/reports' : '/uploads/cache';
-    $container->get('twig')->setCache($gibbon->session->get('absolutePath').$cachePath);
+    if ($action == 'Generate') {
+        // Set reports to cache in a separate location
+        $cachePath = $gibbon->session->has('cachePath') ? $gibbon->session->get('cachePath').'/reports' : '/uploads/cache';
+        $container->get('twig')->setCache($gibbon->session->get('absolutePath').$cachePath);
 
-    $reportBuilder = $container->get(ReportBuilder::class);
-    $archive = $container->get(ReportArchiveGateway::class)->getByID($report['gibbonReportArchiveID']);
-    $archiveFile = $container->get(ArchiveFile::class);
-    
-    $template = $reportBuilder->buildTemplate($report['gibbonReportTemplateID'], $status == 'Draft');
-    $renderer = $container->get($template->getData('flags') == 1 ? MpdfRenderer::class : TcpdfRenderer::class);
+        $reportBuilder = $container->get(ReportBuilder::class);
+        $archive = $container->get(ReportArchiveGateway::class)->getByID($report['gibbonReportArchiveID']);
+        $archiveFile = $container->get(ArchiveFile::class);
+        
+        $template = $reportBuilder->buildTemplate($report['gibbonReportTemplateID'], $status == 'Draft');
+        $renderer = $container->get($template->getData('flags') == 1 ? MpdfRenderer::class : TcpdfRenderer::class);
 
-    foreach ($identifiers as $identifier) {
+        foreach ($identifiers as $identifier) {
 
-        $ids = ['gibbonStudentEnrolmentID' => $identifier, 'gibbonReportingCycleID' => $report['gibbonReportingCycleID']];
-        $reports = $reportBuilder->buildReportSingle($template, $report, $ids);
+            $ids = ['gibbonStudentEnrolmentID' => $identifier, 'gibbonReportingCycleID' => $report['gibbonReportingCycleID']];
+            $reports = $reportBuilder->buildReportSingle($template, $report, $ids);
 
-        // Archive
-        if ($student = $studentGateway->getByID($identifier)) {
-            $path = $archiveFile->getSingleFilePath($gibbonReportID, $student['gibbonYearGroupID'], $identifier);
-            $renderer->render($template, $reports, $gibbon->session->get('absolutePath').$archive['path'].'/'.$path);
+            // Archive
+            if ($student = $studentGateway->getByID($identifier)) {
+                $path = $archiveFile->getSingleFilePath($gibbonReportID, $student['gibbonYearGroupID'], $identifier);
+                $renderer->render($template, $reports, $gibbon->session->get('absolutePath').$archive['path'].'/'.$path);
 
-            $reportArchiveEntryGateway->insertAndUpdate([
-                'reportIdentifier'      => $report['name'],
-                'gibbonReportID'        => $gibbonReportID,
-                'gibbonReportArchiveID' => $report['gibbonReportArchiveID'],
-                'gibbonSchoolYearID'    => $student['gibbonSchoolYearID'],
-                'gibbonYearGroupID'     => $student['gibbonYearGroupID'],
-                'gibbonRollGroupID'     => $student['gibbonRollGroupID'],
-                'gibbonPersonID'        => $student['gibbonPersonID'],
-                'type'                  => 'Single',
-                'status'                => $status,
-                'filePath'              => $path,
-            ], ['status' => $status, 'timestampModified' => date('Y-m-d H:i:s'), 'filePath' => $path]);
-        } else {
-            $partialFail = true;
+                $reportArchiveEntryGateway->insertAndUpdate([
+                    'reportIdentifier'      => $report['name'],
+                    'gibbonReportID'        => $gibbonReportID,
+                    'gibbonReportArchiveID' => $report['gibbonReportArchiveID'],
+                    'gibbonSchoolYearID'    => $student['gibbonSchoolYearID'],
+                    'gibbonYearGroupID'     => $student['gibbonYearGroupID'],
+                    'gibbonRollGroupID'     => $student['gibbonRollGroupID'],
+                    'gibbonPersonID'        => $student['gibbonPersonID'],
+                    'type'                  => 'Single',
+                    'status'                => $status,
+                    'filePath'              => $path,
+                ], ['status' => $status, 'timestampModified' => date('Y-m-d H:i:s'), 'filePath' => $path]);
+            } else {
+                $partialFail = true;
+            }
         }
+    } else if ($action == 'Delete') {
+        $archive = $container->get(ReportArchiveGateway::class)->getByID($report['gibbonReportArchiveID']);
+
+        foreach ($identifiers as $identifier) {
+            if ($student = $studentGateway->getByID($identifier)) {
+                $entry = $reportArchiveEntryGateway->selectBy([
+                    // 'reportIdentifier'      => $report['name'],
+                    'gibbonReportID'        => $gibbonReportID,
+                    'gibbonReportArchiveID' => $report['gibbonReportArchiveID'],
+                    'gibbonSchoolYearID'    => $student['gibbonSchoolYearID'],
+                    'gibbonYearGroupID'     => $student['gibbonYearGroupID'],
+                    'gibbonRollGroupID'     => $student['gibbonRollGroupID'],
+                    'gibbonPersonID'        => $student['gibbonPersonID'],
+                    'type'                  => 'Single',
+                ])->fetch();
+
+                if (!empty($entry)) {
+                    // Remove the file itself
+                    $path = $gibbon->session->get('absolutePath').$archive['path'].'/'.$entry['filePath'];
+                    if (!empty($archive) && file_exists($path)) {
+                        unlink($path);
+                    }
+                    
+                    // Then remove the archive entry
+                    $deleted = $reportArchiveEntryGateway->delete($entry['gibbonReportArchiveEntryID']);
+                    $partialFail &= !$deleted;
+                }
+            } else {
+                $partialFail = true;
+            }
+        }
+    } else {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
     }
 
     $URL .= $partialFail


### PR DESCRIPTION
Currently there is no way to delete reports once generated. This PR adds Delete as a bulk action to the Generate Reports page, on the bulk and single report generation pages. Deleting a report removes it from the archive and also deletes the PDF from the server. It is not necessary to delete a report before re-generating it, as it will be overwritten in that case.

I placed it in Generate Reports, rather than anywhere else, because there should be very few reasons to delete a report, and the only ones doing so should also be the ones able to create reports.

**Motivation and Context**
Occasionally, you may generate a report, draft or not, that you'd rather not show up in the report archive. This often happens during testing or debugging of reports, but can also occur in production.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="911" alt="Screenshot 2021-03-25 at 12 56 03 PM" src="https://user-images.githubusercontent.com/897700/112421564-3cbcfb80-8d6a-11eb-9c28-ae1cce5ec790.png">

