### PR TITLE
Messenger: update the send report to list any emails that failed to send

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ v22.0.00
         System: added Somali as language option in dropdown menus
         Finance: removed student DOB and Gender from Export Invoices
         Formal Assessment: added attainment and effort descriptor as title to Internal Assessment view
+        Messenger: updated the send report to list any emails that failed to send
         Reports: clear report cache when editing template assets in Production
         Students: added Medical Form custom fields to student profile
         Students: updated Medical Data Summary to include medical custom fields

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -1953,6 +1953,7 @@ else {
 			if ($email=="Y") {
 				//Set up email
 				$emailCount=0 ;
+                $emailErrors = [];
 				$mail= $container->get(Mailer::class);
                 $mail->SMTPKeepAlive = true;
                 $mail->SMTPDebug = 1;
@@ -2058,6 +2059,7 @@ else {
 						if(!$mail->Send()) {
                             $partialFail = TRUE ;
 							$logGateway->addLog($_SESSION[$guid]['gibbonSchoolYearIDCurrent'], getModuleID($connection2, $_POST["address"]), $_SESSION[$guid]['gibbonPersonID'], 'Email Send Status', array('Status' => 'Not OK', 'Result' => $mail->ErrorInfo, 'Recipients' => $reportEntry[4]));
+                            $emailErrors[] = $reportEntry[4];
 						}
 					}
                 }
@@ -2114,19 +2116,13 @@ else {
 				}
 			}
 
-			if ($partialFail == TRUE) {
-				//Fail 4
-                return ['return' => 'fail4'];
-			}
-			else {
-                return [
-                    'return' => 'success0',
-                    'emailCount' => $emailCount,
-                    'smsCount' => $smsCount,
-                    'smsBatchCount' => $smsBatchCount,
-                ];
-			}
+            return [
+                'return'        => $partialFail ? 'fail4' : 'success0',
+                'emailCount'    => $emailCount ?? 0,
+                'emailErrors'   => $emailErrors ?? [],
+                'smsCount'      => $smsCount ?? 0,
+                'smsBatchCount' => $smsBatchCount ?? 0,
+            ];
 		}
 	}
 }
-?>

--- a/modules/Messenger/src/MessageProcess.php
+++ b/modules/Messenger/src/MessageProcess.php
@@ -19,12 +19,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Module\Messenger;
 
-use Gibbon\Services\BackgroundProcess;
-use Gibbon\Contracts\Database\Connection;
-use League\Container\ContainerAwareInterface;
-use League\Container\ContainerAwareTrait;
+use Gibbon\Services\Format;
 use Gibbon\Domain\User\UserGateway;
 use Gibbon\Comms\NotificationSender;
+use Gibbon\Services\BackgroundProcess;
+use Gibbon\Contracts\Database\Connection;
+use League\Container\ContainerAwareTrait;
+use League\Container\ContainerAwareInterface;
 
 /**
  * MessageProcess
@@ -102,6 +103,11 @@ class MessageProcess extends BackgroundProcess implements ContainerAwareInterfac
             default:
                 $actionText = __('Your request was completed successfully, but some or all messages could not be delivered.');
                 break;
+        }
+
+        if (!empty($sendResult['emailErrors'])) {
+            $actionText .= '<br/><br/>' .__('You message failed to deliver to the following recipients. This can happen because the email is invalid or the receiving mail server did not respond.').'<br/>';
+            $actionText .= Format::list($sendResult['emailErrors']);
         }
 
         $notificationSender = $this->getContainer()->get(NotificationSender::class);


### PR DESCRIPTION
Updates the send report email from Messenger to include any email addresses that failed to send.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="629" alt="Screenshot 2021-03-25 at 2 05 19 PM" src="https://user-images.githubusercontent.com/897700/112426843-970e8a00-8d73-11eb-8df0-c67bacff83bc.png">
