### PR TITLE
Reports: add new data sources and templates for Internal Assessment and Course Criteria

### DIFF
--- a/modules/Reports/src/Sources/AttendanceByCycle.php
+++ b/modules/Reports/src/Sources/AttendanceByCycle.php
@@ -65,7 +65,7 @@ class AttendanceByCycle extends DataSource
                 JOIN gibbonAttendanceCode ON (gibbonAttendanceCode.gibbonAttendanceCodeID=gibbonAttendanceLogPerson.gibbonAttendanceCodeID)
                 WHERE gibbonReport.gibbonReportID=:gibbonReportID
                 AND gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
-                AND FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, gibbonReportingCycle.gibbonYearGroupIDList)
+                AND FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, gibbonReport.gibbonYearGroupIDList)
                 AND gibbonAttendanceLogPerson.date>=gibbonSchoolYear.firstDay
                 AND gibbonAttendanceLogPerson.date<=CURDATE()
                 GROUP BY gibbonAttendanceLogPerson.gibbonAttendanceLogPersonID
@@ -104,8 +104,8 @@ class AttendanceByCycle extends DataSource
                 }, $endOfClasses);
 
                 // Grab the the absent and late count (school-wide)
-                $absent = ($endOfDay['direction'] == 'Out' && $endOfDay['scope'] == 'Offsite')? 1 : 0;
-                $late = ($endOfDay['scope'] == 'Onsite - Late' || $endOfDay['scope'] == 'Offsite - Late')? 1 : 0;
+                $absent = !empty($endOfDay) && ($endOfDay['direction'] == 'Out' && $endOfDay['scope'] == 'Offsite')? 1 : 0;
+                $late = !empty($endOfDay) && ($endOfDay['scope'] == 'Onsite - Late' || $endOfDay['scope'] == 'Offsite - Late')? 1 : 0;
 
                 // Optionally grab the class absent and late counts too
                 if ($this->countClassAsSchool == 'Y') {

--- a/modules/Reports/src/Sources/CourseCriteriaByCycle.php
+++ b/modules/Reports/src/Sources/CourseCriteriaByCycle.php
@@ -1,0 +1,183 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\Reports\Sources;
+
+use Gibbon\Module\Reports\DataSource;
+
+class CourseCriteriaByCycle extends DataSource
+{
+    public function getSchema()
+    {
+        return [
+            0 => [
+                'courseName' => 'Example Course',
+                'courseNameShort' => 'EXAMPLE',
+                'className' => 'Class 1',
+                'classNameShort' => '1',
+                'teachers'  => $this->getFactory()->get('ClassTeachers')->getSchema(),
+                'perGroup' => [
+                    0 => [
+                        'scopeName'           => 'Course',
+                        'criteriaName'        => 'Course Comment',
+                        'criteriaDescription' => ['sentence'],
+                        'comment'             => ['paragraph', 6],
+                        'valueType'           => 'Comment',
+                        'values' => [
+                            'Cycle 1' => '',
+                            'Cycle 2' => '',
+                            'Cycle 3' => '',
+                        ]
+                    ],
+                ],
+                'perStudent' => [
+
+                    0 => [
+                        'scopeName'           => 'Course',
+                        'criteriaName'        => 'Student Comment',
+                        'criteriaDescription' => ['sentence'],
+                        'comment'             => ['paragraph', 6],
+                        'valueType'           => 'Comment',
+                        'values' => [
+                            'Cycle 1' => '',
+                            'Cycle 2' => '',
+                            'Cycle 3' => '',
+                        ]
+                    ],
+                    1 => [
+                        'scopeName'           => 'Course',
+                        'criteriaName'        => 'Student Grade',
+                        'criteriaDescription' => ['sentence'],
+                        'comment'             => '',
+                        'valueType'           => 'Grade Scale',
+                        'values' => [
+                            'Cycle 1' => [
+                                'value' => ['randomElement', ['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D']],
+                                'descriptor' => ['sameAs', 'value']
+                            ],
+                            'Cycle 2' => [
+                                'value' => ['randomElement', ['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D']],
+                                'descriptor' => ['sameAs', 'value']
+                            ],
+                            'Cycle 3' => [
+                                'value' => ['randomElement', ['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D']],
+                                'descriptor' => ['sameAs', 'value']
+                            ],
+                        ]
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function getData($ids = [])
+    {
+        $data = ['gibbonStudentEnrolmentID' => $ids['gibbonStudentEnrolmentID'], 'gibbonReportID' => $ids['gibbonReportID']];
+        $sql = "SELECT DISTINCT gibbonCourse.gibbonCourseID, gibbonCourseClass.gibbonCourseClassID,
+                    (CASE WHEN gibbonReportingCriteria.target = 'Per Group' THEN 'perGroup' ELSE 'perStudent' END) AS groupBy, 
+                    gibbonReportingCycle.nameShort as cycleName,
+                    gibbonReportingScope.name as scopeName,
+                    gibbonReportingCriteria.name as criteriaName,
+                    gibbonReportingCriteria.description as criteriaDescription, 
+                    gibbonReportingCriteria.gibbonReportingCriteriaID as criteriaID,
+                    gibbonReportingValue.value, 
+                    gibbonReportingValue.comment, 
+                    gibbonScaleGrade.descriptor,
+                    gibbonReportingCriteriaType.valueType, 
+                    gibbonCourse.name as courseName, 
+                    gibbonCourse.nameShort as courseNameShort,
+                    gibbonCourseClass.name as className, 
+                    gibbonCourseClass.nameShort as classNameShort
+                FROM gibbonReport
+                JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonReport.gibbonSchoolYearID)
+                JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
+                JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID)
+                JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
+                LEFT JOIN gibbonReportingCriteria ON (gibbonReportingCriteria.gibbonCourseID=gibbonCourse.gibbonCourseID)
+                LEFT JOIN gibbonReportingCriteriaType ON (gibbonReportingCriteriaType.gibbonReportingCriteriaTypeID=gibbonReportingCriteria.gibbonReportingCriteriaTypeID)
+                LEFT JOIN gibbonReportingScope ON (gibbonReportingScope.gibbonReportingScopeID=gibbonReportingCriteria.gibbonReportingScopeID)
+                LEFT JOIN gibbonReportingCycle ON (gibbonReportingCycle.gibbonReportingCycleID=gibbonReportingScope.gibbonReportingCycleID)
+                LEFT JOIN gibbonReportingValue ON (
+                    gibbonReportingValue.gibbonReportingCriteriaID=gibbonReportingCriteria.gibbonReportingCriteriaID
+                    AND
+                    (
+                        (gibbonReportingCriteria.target='Per Student' AND gibbonReportingValue.gibbonPersonIDStudent=gibbonStudentEnrolment.gibbonPersonID) 
+                        OR (gibbonReportingCriteria.target='Per Group' AND gibbonReportingValue.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
+                    ))
+                LEFT JOIN gibbonReportingProgress ON (gibbonReportingProgress.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND (gibbonReportingProgress.gibbonPersonIDStudent=gibbonStudentEnrolment.gibbonPersonID OR gibbonReportingProgress.gibbonPersonIDStudent=0))
+                LEFT JOIN gibbonScaleGrade ON (gibbonScaleGrade.gibbonScaleID=gibbonReportingCriteriaType.gibbonScaleID AND gibbonScaleGrade.gibbonScaleGradeID=gibbonReportingValue.gibbonScaleGradeID)
+                WHERE gibbonReport.gibbonReportID=:gibbonReportID
+                AND gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
+                AND gibbonCourse.gibbonSchoolYearID=gibbonStudentEnrolment.gibbonSchoolYearID
+                AND FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, gibbonReport.gibbonYearGroupIDList)
+                AND FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, gibbonReportingCycle.gibbonYearGroupIDList)
+                AND gibbonCourseClass.reportable='Y'
+                AND gibbonCourseClassPerson.role='Student'
+                AND gibbonCourseClassPerson.reportable='Y'
+                AND gibbonReportingScope.scopeType='Course'
+                AND ((gibbonReportingProgress.status='Complete' AND gibbonReportingCriteria.target = 'Per Student') 
+                    OR gibbonReportingCriteria.target = 'Per Group') 
+                AND (valueType IS NULL OR valueType <> 'Comment' OR (valueType = 'Comment' AND gibbonReportingCriteria.gibbonReportingCycleID=gibbonReport.gibbonReportingCycleID))
+                ORDER BY gibbonReportingScope.sequenceNumber, gibbonReportingCriteria.sequenceNumber, gibbonCourse.orderBy, gibbonCourse.nameShort, gibbonReportingCriteria.sequenceNumber";
+
+        $courses = $this->db()->select($sql, $data)->fetchAll();
+
+        $courses = array_reduce($courses, function ($group, $item) {
+            $cycle = $item['cycleName'];
+            $courseID = $item['gibbonCourseID'];
+
+            $group[$courseID]['gibbonCourseID'] = $item['gibbonCourseID'];
+            $group[$courseID]['gibbonCourseClassID'] = $item['gibbonCourseClassID'];
+            $group[$courseID]['courseName'] = $item['courseName'];
+            $group[$courseID]['courseNameShort'] = $item['courseNameShort'];
+            $group[$courseID]['className'] = $item['className'];
+            $group[$courseID]['classNameShort'] = $item['classNameShort'];
+
+            $group[$courseID][$item['groupBy']][$item['criteriaName']]['scopeName'] = $item['scopeName'];
+            $group[$courseID][$item['groupBy']][$item['criteriaName']]['criteriaName'] = $item['criteriaName'];
+            $group[$courseID][$item['groupBy']][$item['criteriaName']]['criteriaDescription'] = $item['criteriaDescription'];
+            $group[$courseID][$item['groupBy']][$item['criteriaName']]['comment'] = $item['comment'];
+            $group[$courseID][$item['groupBy']][$item['criteriaName']]['valueType'] = $item['valueType'];
+
+            $values = $group[$courseID][$item['groupBy']][$item['criteriaName']]['values'] ?? [];
+            $values[$cycle] = [
+                'value'      => $item['value'],
+                'descriptor' => $item['descriptor'],
+            ];
+            $group[$courseID][$item['groupBy']][$item['criteriaName']]['values'] = $values;
+
+            if ($item['valueType'] == 'Comment') {
+                $group[$courseID]['hasComments'] = true;
+            }
+            
+            return $group;
+        }, []);
+
+        $courses = array_map(function ($course) use (&$ids) {
+            $ids['gibbonCourseID'] = $course['gibbonCourseID'];
+            $ids['gibbonCourseClassID'] = $course['gibbonCourseClassID'];
+
+            $course['teachers'] = $this->getFactory()->get('ClassTeachers')->getData($ids);
+
+            return $course;
+        }, $courses);
+
+        return $courses;
+    }
+}

--- a/modules/Reports/src/Sources/InternalAssessmentByCourse.php
+++ b/modules/Reports/src/Sources/InternalAssessmentByCourse.php
@@ -1,0 +1,152 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Module\Reports\Sources;
+
+use Gibbon\Module\Reports\DataSource;
+
+class InternalAssessmentByCourse extends DataSource
+{
+    public function getSchema()
+    {
+        return [
+            'assessments' => [
+                'Example Assessment' => [
+                    'name'                 => 'Example Assessment',
+                    'description'          => ['sentence'],
+                    'type'                 => 'Type',
+                    'attainmentActive'     => 'Y',
+                    'effortActive'         => 'Y',
+                ],
+                'Example Assessment 2' => [
+                    'name'                 => 'Example Assessment 2',
+                    'description'          => ['sentence'],
+                    'type'                 => 'Type',
+                    'attainmentActive'     => 'Y',
+                    'effortActive'         => 'Y',
+                ]
+            ],
+            'courses' => [
+                'Example Course' => [
+                    'Example Assessment' => [
+                        'attainmentValue'      => ['randomDigit'],
+                        'attainmentDescriptor' => ['sameAs', 'attainmentValue'],
+                        'effortValue'          => ['randomElement', ['Excellent', 'Very Good', 'Good', 'Satisfactory', 'Needs Improvement']],
+                        'effortDescriptor'     => ['sameAs', 'effortValue'],
+                        'commentActive'        => 'Y',
+                        'comment'              => ['paragraph', 3],
+                        'courseName'           => 'Example Course',
+                        'courseNameShort'      => 'COURSE',
+                        'className'            => 'Example Class',
+                        'classNameShort'       => 'CLASS',
+                    ],
+                    'Example Assessment 2' => [
+                        'attainmentValue'      => ['randomDigit'],
+                        'attainmentDescriptor' => ['sameAs', 'attainmentValue'],
+                        'effortValue'          => ['randomElement', ['Excellent', 'Very Good', 'Good', 'Satisfactory', 'Needs Improvement']],
+                        'effortDescriptor'     => ['sameAs', 'effortValue'],
+                        'commentActive'        => 'Y',
+                        'comment'              => ['paragraph', 3],
+                        'courseName'           => 'Example Course',
+                        'courseNameShort'      => 'COURSE',
+                        'className'            => 'Example Class',
+                        'classNameShort'       => 'CLASS',
+                    ],
+                ],
+                'Example Course 2' => [
+                    'Example Assessment' => [
+                        'attainmentValue'      => ['randomDigit'],
+                        'attainmentDescriptor' => ['sameAs', 'attainmentValue'],
+                        'effortValue'          => ['randomElement', ['Excellent', 'Very Good', 'Good', 'Satisfactory', 'Needs Improvement']],
+                        'effortDescriptor'     => ['sameAs', 'effortValue'],
+                        'commentActive'        => 'Y',
+                        'comment'              => ['paragraph', 3],
+                        'courseName'           => 'Example Course 2',
+                        'courseNameShort'      => 'COURSE2',
+                        'className'            => 'Example Class 2',
+                        'classNameShort'       => 'CLASS2',
+                    ],
+                    'Example Assessment 2' => [
+                        'attainmentValue'      => ['randomDigit'],
+                        'attainmentDescriptor' => ['sameAs', 'attainmentValue'],
+                        'effortValue'          => ['randomElement', ['Excellent', 'Very Good', 'Good', 'Satisfactory', 'Needs Improvement']],
+                        'effortDescriptor'     => ['sameAs', 'effortValue'],
+                        'commentActive'        => 'Y',
+                        'comment'              => ['paragraph', 3],
+                        'courseName'           => 'Example Course 2',
+                        'courseNameShort'      => 'COURSE2',
+                        'className'            => 'Example Class 2',
+                        'classNameShort'       => 'CLASS2',
+                    ],
+                ],
+            ]
+        ];
+    }
+
+    public function getData($ids = [])
+    {
+        $data = array('gibbonStudentEnrolmentID' => $ids['gibbonStudentEnrolmentID'], 'gibbonReportID' => $ids['gibbonReportID'], 'today' => date('Y-m-d'));
+        $sql = "SELECT gibbonCourse.name as groupBy,
+                    gibbonInternalAssessmentColumn.name, 
+                    gibbonInternalAssessmentColumn.description, 
+                    gibbonInternalAssessmentColumn.type, 
+                    gibbonInternalAssessmentColumn.attainment as attainmentActive, 
+                    gibbonInternalAssessmentEntry.attainmentValue, 
+                    gibbonInternalAssessmentEntry.attainmentDescriptor, 
+                    gibbonInternalAssessmentColumn.effort as effortActive, 
+                    gibbonInternalAssessmentEntry.effortValue, 
+                    gibbonInternalAssessmentEntry.effortDescriptor, 
+                    gibbonInternalAssessmentColumn.comment as commentActive, 
+                    gibbonInternalAssessmentEntry.comment, 
+                    gibbonCourse.name as courseName,
+                    gibbonCourse.nameShort AS courseNameShort, 
+                    gibbonCourseClass.name AS className, 
+                    gibbonCourseClass.nameShort AS classNameShort
+                FROM gibbonReport
+                JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonReport.gibbonSchoolYearID)
+                JOIN gibbonInternalAssessmentEntry ON (gibbonInternalAssessmentEntry.gibbonPersonIDStudent=gibbonStudentEnrolment.gibbonPersonID)
+                JOIN gibbonInternalAssessmentColumn ON (gibbonInternalAssessmentEntry.gibbonInternalAssessmentColumnID=gibbonInternalAssessmentColumn.gibbonInternalAssessmentColumnID) 
+                JOIN gibbonCourseClassPerson ON (gibbonInternalAssessmentColumn.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID) 
+                JOIN gibbonCourseClass ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) 
+                JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) 
+                WHERE gibbonReport.gibbonReportID=:gibbonReportID
+                AND gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
+                AND FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, gibbonReport.gibbonYearGroupIDList)
+                AND gibbonCourse.gibbonSchoolYearID=gibbonStudentEnrolment.gibbonSchoolYearID
+                AND gibbonCourseClassPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID
+                AND gibbonInternalAssessmentColumn.complete='Y'
+                AND gibbonInternalAssessmentColumn.completeDate<=:today 
+                ORDER BY gibbonInternalAssessmentColumn.completeDate DESC, gibbonCourse.nameShort, gibbonCourseClass.nameShort";
+
+        $results = $this->db()->select($sql, $data)->fetchAll();
+        $values = ['assessments' => [], 'courses' => []];
+
+        foreach ($results as $result) {
+            $values['assessments'][$result['name']] = [
+                'name'             => $result['name'],
+                'description'      => $result['description'],
+                'attainmentActive' => $result['attainmentActive'],
+                'effortActive'     => $result['effortActive'],
+            ];
+            $values['courses'][$result['courseNameShort']][$result['name']] = $result;
+        }
+
+        return $values;
+    }
+}

--- a/modules/Reports/src/Sources/ReportingCycle.php
+++ b/modules/Reports/src/Sources/ReportingCycle.php
@@ -53,13 +53,16 @@ class ReportingCycle extends DataSource
         $values = $this->db()->selectOne($sql, $data);
 
 
-        $data = ['gibbonReportID' => $ids['gibbonReportID']];
-        $sql = "SELECT allCycles.cycleNumber, allCycles.name
+        $data = ['gibbonStudentEnrolmentID' => $ids['gibbonStudentEnrolmentID'], 'gibbonReportID' => $ids['gibbonReportID']];
+        $sql = "SELECT allCycles.cycleNumber, allCycles.nameShort
                 FROM gibbonReport 
-                JOIN gibbonReportingCycle AS currentCycle ON (currentCycle.gibbonReportingCycleID=gibbonReport.gibbonReportingCycleID)
-                JOIN gibbonYearGroup ON (FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, currentCycle.gibbonYearGroupIDList))
-                JOIN gibbonReportingCycle AS allCycles ON (FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, allCycles.gibbonYearGroupIDList))
+                JOIN gibbonYearGroup ON (FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, gibbonReport.gibbonYearGroupIDList))
+                JOIN gibbonReportingCycle AS allCycles ON (allCycles.gibbonSchoolYearID=gibbonReport.gibbonSchoolYearID)
+                JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonReport.gibbonSchoolYearID)
                 WHERE gibbonReport.gibbonReportID=:gibbonReportID
+                AND gibbonStudentEnrolment.gibbonStudentEnrolmentID=:gibbonStudentEnrolmentID
+                AND FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, allCycles.gibbonYearGroupIDList)
+                AND FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, allCycles.gibbonYearGroupIDList)
                 GROUP BY allCycles.gibbonReportingCycleID
                 ORDER BY allCycles.sequenceNumber, allCycles.cycleNumber";
 

--- a/modules/Reports/templates/reports/attendance.twig.html
+++ b/modules/Reports/templates/reports/attendance.twig.html
@@ -23,7 +23,8 @@ sources:
             {% set width = 100 / reportingCycle.cycleTotal %}
 
             {% for cycleNum in range(1, reportingCycle.cycleTotal|default(1)) %}
-            <td class="header bg-primary border" style="width:{{ width }}%; line-height: 1.9; text-align: center;" colspan="2">Term {{ cycleNum }} Attendance</td>
+                {% set cycleName = reportingCycle.cycles[cycleNum] %}
+                <td class="header bg-primary border" style="width:{{ width }}%; line-height: 1.9; text-align: center;" colspan="2">{{ cycleName }} Attendance</td>
             {% endfor %}
         </tr>
         <tr>

--- a/modules/Reports/templates/reports/courseCriteriaByCycle.twig.html
+++ b/modules/Reports/templates/reports/courseCriteriaByCycle.twig.html
@@ -1,0 +1,87 @@
+{#<!--
+name: Report - Courses by Cycle
+category: Reporting Cycle
+types: Body
+sources:
+    student: Student
+    reportingCycle: ReportingCycle
+    courseCriteriaByCycle: CourseCriteriaByCycle
+-->#}
+{{- stylesheet ? include(stylesheet) -}}
+
+{% for course in courseCriteriaByCycle %}
+
+{% if not loop.first %}
+    <table cellspacing="0" cellpadding="4"><tr><td style="font-size: 1px;">&nbsp;</td></tr></table>
+{% endif %}
+
+<table class="w-full table" cellspacing="0" cellpadding="10" nobr="true">
+    <tr>
+        <td class="header bg-primary border-top border-bottom border-left" style="width:50%;" rowspan="2">
+            {{- course.courseName }}
+        </td>
+        <td class="subheader bg-primary border-top border-bottom border-right" style="width:50%;text-align:right;" colspan="{{ reportingCycle.cycleTotal }}">
+            {% for teacher in course.teachers %}
+                {{- teacher.fullName -}}
+                {{ not loop.last ? ',' }}
+            {% endfor %}
+        </td>
+    </tr>
+
+    <tr>
+        {% for cycleNum in range(1, reportingCycle.cycleTotal|default(1)) %}
+            {% set cycleName = reportingCycle.cycles[cycleNum] %}
+            <td class="border" >
+                {{- cycleName -}}
+            </td>
+        {% endfor %}
+    </tr>
+    
+    {%- for criteria in course.perStudent -%}
+        {% if criteria.valueType != 'Comment' %}
+        <tr>
+            <td class="border" >
+                {{- criteria.criteriaName }}
+            </td>
+            {% for cycleNum in range(1, reportingCycle.cycleTotal|default(1)) %}
+                {% set cycleName = reportingCycle.cycles[cycleNum] %}
+                <td class="border" >
+                    {{- criteria.values[cycleName].descriptor ?? criteria.values[cycleName].value }}
+                </td>
+            {% endfor %}
+        </tr>
+        {% endif %}
+    {%- endfor -%}
+
+    {% if course.hasComments %}
+    <tr>
+        <td class="border w-full" colspan="{{ reportingCycle.cycleTotal + 1 }}">
+            <table style="width: 100%; padding: 0;" class="w-full" cellspacing="0" cellpadding="0">
+            {%- for criteria in []|merge(course.perGroup|default([]))|merge(course.perStudent|default([])) -%}
+            {% set nextComment = false %}
+            
+                {% if criteria.valueType == 'Comment' %}
+                    {% if nextComment %}
+                    <tr><td style="font-size: 1px;">&nbsp;</td></tr>
+                    {% endif %}
+                    <tr>
+                        <td class="w-full header" style="line-height:1.8;">
+                            {{- criteria.criteriaName -}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="w-full" style="font-size: 9pt" >
+                            {{- criteria.comment -}}
+                        </td>
+                    </tr>
+                    {% set nextComment = true %}
+                {% endif %}
+            
+            {%- endfor -%}
+        </table>
+        </td>
+    </tr>
+    {% endif %}
+</table>
+{% endfor %}
+<br/>

--- a/modules/Reports/templates/reports/internalAssessmentByCourse.twig.html
+++ b/modules/Reports/templates/reports/internalAssessmentByCourse.twig.html
@@ -1,0 +1,100 @@
+{#<!--
+name: Internal Assessment by Course
+category: Student Data
+types: Body
+sources:
+    student: Student
+    internalAssessmentByCourse: InternalAssessmentByCourse
+config:
+    includeAverage:
+        label: Include Average Attainment?
+        type: yesno
+        default: N
+-->#}
+{{- stylesheet ? include(stylesheet) -}}
+
+{% set totalArray = [] %}
+
+<table class="w-full table" cellspacing="0" cellpadding="10" nobr="true">
+    <tr>
+        <td class="header bg-primary border-top border-bottom border-left" rowspan="2">
+            {{ __('Courses') }}
+        </td>
+        {% for assessment in internalAssessmentByCourse.assessments %}
+            {% set colspan = assessment.attainmentActive == 'Y' and assessment.effortActive == 'Y' ? 2 : 1 %}
+            <td class="header bg-primary border-top border-bottom {{ loop.last ? 'border-right' }}" colspan="{{ colspan }}">
+                {{- assessment.name -}}
+            </td>
+        {% endfor %}
+    </tr>
+
+    <tr>
+        {% for assessment in internalAssessmentByCourse.assessments %}
+            {% set colspan = assessment.attainmentActive == 'Y' and assessment.effortActive == 'Y' ? 2 : 1 %}
+
+            {% if assessment.attainmentActive == 'Y' %}
+                <td class="border-top border-bottom border-left {{ loop.last and colspan == 1 ? 'border-right' }}">
+                    {{- __('Attainment') }}
+                </td>
+            {% endif %}
+
+            {% if assessment.effortActive == 'Y' %}
+                <td class="border-top border-bottom {{ colspan == 1 ? 'border-left' }} {{ loop.last ? 'border-right' }}">
+                    {{- __('Effort') }}
+                </td>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    
+
+    {% for course, assessments in internalAssessmentByCourse.courses %}
+    <tr>
+        <td class="border-top border-bottom border-left">
+            {{ course }}
+        </td>
+        {% for key, assessment in internalAssessmentByCourse.assessments %}
+            {% set colspan = assessment.attainmentActive == 'Y' and assessment.effortActive == 'Y' ? 2 : 1 %}
+
+            {% if assessment.attainmentActive == 'Y' %}
+                <td class="border-top border-bottom border-left {{ loop.last and colspan == 1 ? 'border-right' }}">
+                    {{- assessments[assessment.name].attainmentDescriptor ?? assessments[assessment.name].attainmentValue }}
+                </td>
+
+                {% set total = totalArray[assessment.name] %}
+                {% set totalArray = totalArray|merge({ (assessment.name) : total + assessments[assessment.name].attainmentValue|number_format}) %}
+            {% endif %}
+
+            {% if assessment.effortActive == 'Y' %}
+                <td class="border-top border-bottom {{ colspan == 1 ? 'border-left' }} {{ loop.last ? 'border-right' }}">
+                    {{- assessments[assessment.name].effortDescriptor ?? assessments[assessment.name].effortValue }}
+                </td>
+            {% endif %}
+        {% endfor %}
+    </tr> 
+    {% endfor %}
+
+    {% if config.includeAverage == 'Y' %}
+    <tr>
+        <td class="border-top border-bottom border-left">
+            <b>{{ __('Average') }}</b>
+        </td>
+        {% for assessment in internalAssessmentByCourse.assessments %}
+            {% set colspan = assessment.attainmentActive == 'Y' and assessment.effortActive == 'Y' ? 2 : 1 %}
+
+            {% if assessment.attainmentActive == 'Y' %}
+                <td class="border-top border-bottom border-left {{ loop.last and colspan == 1 ? 'border-right' }}">
+                {{- (totalArray[assessment.name] / internalAssessmentByCourse.courses|length)|round(1) }}
+                </td>
+            {% endif %}
+
+            {% if assessment.effortActive == 'Y' %}
+                <td class="border-top border-bottom {{ colspan == 1 ? 'border-left' }} {{ loop.last ? 'border-right' }}">
+                    &nbsp;
+                </td>
+            {% endif %}
+        {% endfor %}
+    </tr>
+    {% endif %}
+</table>
+
+<br/>


### PR DESCRIPTION
This PR adds to new sections to the Template Builder: Courses by Cycle and Internal Assessments by Course. These sections each include a new data source and a new template. They provide an example for displaying grades or criteria in a two-dimensional table. 

For the internal assessment example, assessments across multiple courses are displayed side-by-side. For the courses example, grades from previous reporting cycles are displayed side-by-side. Comments are still only shown for the current reporting cycle.

**Motivation and Context**
To assist schools in setting up their own reports with similar requirements.

**How Has This Been Tested?**
Locally

**Screenshots**
Example report:
<img width="889" alt="Screenshot 2021-03-25 at 4 59 43 PM" src="https://user-images.githubusercontent.com/897700/112447172-f7112a80-8d8b-11eb-9743-6f2042cf323c.png">