### PR TITLE
Reports: added a help tool with Data Source information to Edit Component page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,8 +43,9 @@ v22.0.00
         Finance: removed student DOB and Gender from Export Invoices
         Formal Assessment: added attainment and effort descriptor as title to Internal Assessment view
         Messenger: updated the send report to list any emails that failed to send
-        Reports: clear report cache when editing template assets in Production
+        Reports: added a help tool with Data Source information to Edit Component page
         Reports: added an option to delete report files from Generate Reports page
+        Reports: clear report cache when editing template assets in Production
         Students: added Medical Form custom fields to student profile
         Students: updated Medical Data Summary to include medical custom fields
         Students: adjusted student select in Student Enrolment Add to only show unenrolled students

--- a/modules/Reports/templates_assets_components_edit.php
+++ b/modules/Reports/templates_assets_components_edit.php
@@ -54,6 +54,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_c
     $form->addHiddenValue('address', $gibbon->session->get('address'));
     $form->addHiddenValue('gibbonReportPrototypeSectionID', $gibbonReportPrototypeSectionID);
 
+    $form->addHeaderAction('help', __('Help'))
+        ->setURL('/modules/Reports/templates_assets_components_help.php')
+        ->setIcon('help')
+        ->addClass('underline')
+        ->displayLabel()
+        ->modalWindow()
+        ->append(' | ');
+
+    $form->addHeaderAction('view', __('Preview'))
+        ->setURL('/modules/Reports/templates_assets_components_preview.php')
+        ->addParam('gibbonReportPrototypeSectionID', $gibbonReportPrototypeSectionID)
+        ->addParam('TB_iframe', 'true')
+        ->modalWindow(1100, 550)
+        ->displayLabel();
+
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
         $row->addTextField('name')->readonly();
@@ -66,11 +81,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_c
 
     $col = $form->addRow()->addColumn();
         $col->addLabel('templateContent', __('Template Code'));
-        $col->addWebLink('<img title="'.__('Preview').'" src="./themes/'.$gibbon->session->get('gibbonThemeName').'/img/plus.png" style="margin-bottom:5px"/>')
-                ->setURL($gibbon->session->get('absoluteURL').'/fullscreen.php?q=/modules/Reports/templates_assets_components_preview.php&width=1100&height=550')
-                ->addParam('gibbonReportPrototypeSectionID', $gibbonReportPrototypeSectionID)
-                ->addParam('TB_iframe', 'true')
-                ->addClass('thickbox float-right -mt-3');
         $col->addCodeEditor('templateContent')->setMode('twig')->setValue($templateContent);
 
     $row = $form->addRow();

--- a/modules/Reports/templates_assets_components_help.php
+++ b/modules/Reports/templates_assets_components_help.php
@@ -1,0 +1,129 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Services\Format;
+use Gibbon\Module\Reports\DataFactory;
+use Gibbon\Domain\System\SettingGateway;
+
+if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_components_edit.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    echo '<h1>';
+    echo __('Help');
+    echo '</h1>';
+
+    echo '<p>';
+    echo __("This help page gives a listing of all data sources, core and additional. Data sources need to be added to the front matter of a template before they are available within that template. For each data source there is a listing of all available fields. Some fields are arrays, which require a loop in the template to access the fields in that array.");
+    echo '</p>';
+
+    echo '<input type="text" class="w-full" id="helpFilter" placeholder="'.__('Filter by data source name').'"/>';
+
+    $displaySchema = function ($schema) use (&$displaySchema) {
+        foreach ($schema as $key => $value) {
+            if (is_array($value) && is_string($value[0] ?? null)) {
+                // Associative array
+                $value = $value[0] ?? '';
+                echo "<li>{$key}</li>";
+            } elseif (is_array($value)) {
+                // Numeric array: recurse
+                echo '<li>';
+                echo $key.' => Array [';
+                echo '<ul class="list-disc font-mono text-sm leading-normal">';
+                $displaySchema($value);
+                echo '</ul>';
+                echo ']';
+                echo '</li>';
+            } else {
+                // Non-array
+                echo "<li>{$key}</li>";
+            }
+        }
+    };
+
+    $customAssetPath = $container->get(SettingGateway::class)->getSettingByScope('Reports', 'customAssetPath');
+    $dataFactory = $container->get(DataFactory::class);
+    $dataFactory->setAssetPath($gibbon->session->get('absolutePath').$customAssetPath);
+
+    $coreSources = glob(__DIR__ . '/src/Sources/*.php');
+    
+    if (!empty($coreSources)) {
+        echo '<h2>';
+        echo __('Core');
+        echo '</h2>';
+        
+        foreach ($coreSources as $sourcePath) {
+            $className = strchr(basename($sourcePath), '.', true);
+            $source = $dataFactory->get($className);
+
+            if (empty($source)) continue;
+
+            echo '<div class="source">';
+            echo '<h3 class="sourceName" style="text-transform: none;">';
+            echo $className;
+            echo '</h3>';
+
+            echo '<ul class="list-disc font-mono text-sm leading-normal">';
+            $displaySchema($source->getSchema());
+            echo '</ul>';
+            echo '</div>';
+        }
+    }
+
+    $additionalSources = glob($gibbon->session->get('absolutePath').'/'.$customAssetPath.'/sources/*.php');
+
+    if (!empty($additionalSources)) {
+        echo '<h2>';
+        echo __('Additional');
+        echo '</h2>';
+
+        foreach ($additionalSources as $sourcePath) {
+            $className = strchr(basename($sourcePath), '.', true);
+            $source = $dataFactory->get($className);
+
+            if (empty($source)) continue;
+
+            echo '<div class="source">';
+            echo '<h3 class="sourceName" style="text-transform: none;">';
+            echo $className;
+            echo '</h3>';
+
+            echo '<ul class="list-disc font-mono text-sm leading-normal">';
+            $displaySchema($source->getSchema());
+            echo '</ul>';
+            echo '</div>';
+        }
+    }
+}
+?>
+
+<script type="text/javascript">
+    $( document ).ready(function() {
+        $('#helpFilter').keyup(function() {
+            var value = $(this).val();
+            var exp = new RegExp(value, 'i');
+
+            $('.source').each(function() {
+                var isMatch = exp.test($('.sourceName', this).text());
+                $(this).toggle(isMatch);
+            });
+        });
+    });
+</script>

--- a/modules/Reports/templates_assets_components_preview.php
+++ b/modules/Reports/templates_assets_components_preview.php
@@ -19,9 +19,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Faker\Factory;
 use Gibbon\Domain\System\SettingGateway;
-use Gibbon\Module\Reports\DataFactory;
-use Gibbon\Module\Reports\ReportRenderer;
-use Gibbon\Module\Reports\ReportTemplate;
 use Gibbon\Module\Reports\ReportBuilder;
 use Gibbon\Module\Reports\Domain\ReportPrototypeSectionGateway;
 use Gibbon\Module\Reports\Domain\ReportTemplateGateway;
@@ -40,8 +37,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_c
         $page->getModule()->stylesheets->remove('module');
     }
 
+    $debugMode = $container->get(SettingGateway::class)->getSettingByScope('Reports', 'debugMode');
     $prototypeGateway = $container->get(ReportPrototypeSectionGateway::class);
-    $settingGateway = $container->get(SettingGateway::class);
     $twig = $container->get('twig');
 
     $gibbonReportTemplateID = $_GET['gibbonReportTemplateID'] ?? '';
@@ -80,6 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets_c
             'prototype' => true,
             'marginX' => '10',
             'marginY' => '5',
+            'debugData' => $debugMode ? print_r($reports[0], true) : null,
         ]);
     } else {
         $filename = preg_replace('/[^a-zA-Z0-9-_]/', '', $prototypeSection['name']).__('Preview').'.pdf';


### PR DESCRIPTION
This PR adds additional tools to help users when editing or creating their own template components. The first tool is a Help button at the top of the Edit Component page, which lists all available data sources and their available fields. The second tool is an Inspect option, similar to the Preview HTML page, which displays the data schema available to that template component.

**How Has This Been Tested?**
Locally

**Screenshots**'
Help button along with Preview button:
<img width="1271" alt="Screenshot 2021-03-26 at 9 59 27 AM" src="https://user-images.githubusercontent.com/897700/112566452-f9ba6100-8e19-11eb-8b41-34e4301a3ec1.png">

Help page:
<img width="730" alt="Screenshot 2021-03-26 at 9 47 12 AM" src="https://user-images.githubusercontent.com/897700/112566290-a21bf580-8e19-11eb-8b89-8c113d43cfce.png">

Preview page:
<img width="892" alt="Screenshot 2021-03-26 at 9 49 58 AM" src="https://user-images.githubusercontent.com/897700/112566302-a516e600-8e19-11eb-83b9-1a41fc03ff96.png">
