### PR TITLE
Attendance studentHistoryData - date format

### DIFF
--- a/modules/Attendance/src/StudentHistoryData.php
+++ b/modules/Attendance/src/StudentHistoryData.php
@@ -155,7 +155,7 @@ class StudentHistoryData
 
                 $dayData = [
                     'date'            => $dateYmd,
-                    'dateDisplay'     => Format::date($date),
+                    'dateDisplay'     => Format::date($dateYmd),
                     'logs'            => $logs[$dateYmd] ?? [],
                     'classLogs'       => $classLogs[$dateYmd] ?? [],
                     'endOfDay'        => $endOfDay,


### PR DESCRIPTION
**Motivation and Context**
The $date is a object of class DateTimeImmutable, so it couldn't be converted to string 

**How Has This Been Tested?**
Local and Travis

**Screenshots**
![studentHistory](https://user-images.githubusercontent.com/1969911/112900934-7ff4d280-90ba-11eb-9bc8-cde9069a1dcc.png)