### PR TITLE
Experimental php 8.1 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
         php-version: ["7.3", "7.4", "8.0"]
         experimental: [false]
         name: ["CI Test"]
+        include:
+          - php-version: "8.1"
+            experimental: true
+            name: "CI Test, Experimental"
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
**Description**
Modify GitHub action workflow to add the developing PHP 8.1 as an experimental target. It means that CI workflow will test the target, but failure of it will not stop PR from merging.


**Motivation and Context**
PHP 8.1 is [now supported](https://github.com/marketplace/actions/setup-php-action#tada-php-support) in GitHub Actions. Adding it as a target could provide insight for Gibbon's potential forward compatibility issue, if any. Tests are run in parallel. There should be no perceivable time difference after adding the target.

![2021-04-12 09-48-40 的螢幕擷圖](https://user-images.githubusercontent.com/91274/114330440-5173fe80-9b74-11eb-950f-3fa41df76c04.png)


**How Has This Been Tested?**
In CI environment.