### PR TITLE
Reports: add a duplicate action in Template Builder

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -869,4 +869,5 @@ UPDATE gibbonSetting SET name='attendanceCLINotifyByFormGroup' WHERE name='atten
 UPDATE gibbonSetting SET name='defaultFormGroupAttendanceType' WHERE name='defaultRollGroupAttendanceType';end
 UPDATE gibbonModule SET name='Form Groups' WHERE name='Roll Groups';end
 UPDATE `gibbonSetting` SET value='purple' WHERE value='Purple' AND name='themeColour' AND scope='System';end
+UPDATE `gibbonAction` SET URLList='templates_preview.php,templates_manage.php,templates_manage_add.php,templates_manage_edit.php,templates_manage_duplicate.php,templates_manage_delete.php,templates_manage_section_add.php,templates_manage_section_edit.php,templates_manage_section_delete.php,templates_assets.php,templates_assets_components_preview.php,templates_assets_components_add.php,templates_assets_components_edit.php,templates_assets_components_delete.php,templates_assets_components_duplicate.php,templates_assets_fonts_preview.php,templates_assets_fonts_edit.php' WHERE `name`='Template Builder' AND `gibbonModuleID`=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Reports');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ v22.0.00
         Reports: added an option to delete report files from Generate Reports page
         Reports: clear report cache when editing template assets in Production
         Reports: added a download option to the student list of the View by Report page
+        Reports: added a duplicate action in Template Builder
         Students: added Medical Form custom fields to student profile
         Students: updated Medical Data Summary to include medical custom fields
         Students: adjusted student select in Student Enrolment Add to only show unenrolled students

--- a/modules/Reports/templates_manage.php
+++ b/modules/Reports/templates_manage.php
@@ -71,6 +71,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage.p
                     ->addParam('sidebar', 'false')
                     ->setURL('/modules/Reports/templates_manage_edit.php');
 
+            $actions->addAction('copy', __('Duplicate'))
+                    ->setIcon('copy')
+                    ->setURL('/modules/Reports/templates_manage_duplicate.php');
+
             $actions->addAction('delete', __('Delete'))
                     ->setURL('/modules/Reports/templates_manage_delete.php');
         });

--- a/modules/Reports/templates_manage_duplicate.php
+++ b/modules/Reports/templates_manage_duplicate.php
@@ -1,0 +1,76 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Module\Reports\Domain\ReportTemplateGateway;
+
+if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_duplicate.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $page->breadcrumbs
+        ->add(__('Template Builder'), 'templates_manage.php')
+        ->add(__('Duplicate Template'));
+
+    if (isset($_GET['editID'])) {
+        $page->return->setEditLink($gibbon->session->get('absoluteURL').'/index.php?q=/modules/Reports/templates_manage_edit.php&sidebar=false&gibbonReportTemplateID='.$_GET['editID']);
+    }
+
+    $gibbonReportTemplateID = $_GET['gibbonReportTemplateID'] ?? '';
+    $reportTemplateGateway = $container->get(ReportTemplateGateway::class);
+
+    if (empty($gibbonReportTemplateID)) {
+        $page->addError(__('You have not specified one or more required parameters.'));
+        return;
+    }
+
+    $values = $reportTemplateGateway->getByID($gibbonReportTemplateID);
+
+    if (empty($values)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+
+    $form = Form::create('$reportingTemplates', $gibbon->session->get('absoluteURL').'/modules/Reports/templates_manage_duplicateProcess.php');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+    $form->addHiddenValue('address', $gibbon->session->get('address'));
+    $form->addHiddenValue('gibbonReportTemplateID', $gibbonReportTemplateID);
+
+    $row = $form->addRow();
+        $row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
+        $row->addTextField('name')->maxLength(90)->required()->setValue($values['name'].' '.__('Copy'));
+
+    $contexts = [
+        'Reporting Cycle'   => __('Reporting Cycle'),
+        'Student Enrolment' => __('Student Enrolment'),
+        // 'Custom Query' => __('Custom Query'),
+    ];
+    $row = $form->addRow();
+        $row->addLabel('context', __('Context'));
+        $row->addSelect('context')->fromArray($contexts)->required()->placeholder()->selected($values['context']);
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
+}

--- a/modules/Reports/templates_manage_duplicateProcess.php
+++ b/modules/Reports/templates_manage_duplicateProcess.php
@@ -1,0 +1,97 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Services\Format;
+use Gibbon\Module\Reports\Domain\ReportTemplateGateway;
+use Gibbon\Module\Reports\Domain\ReportTemplateSectionGateway;
+
+require_once '../../gibbon.php';
+
+$gibbonReportTemplateID = $_POST['gibbonReportTemplateID'] ?? '';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Reports/templates_manage_duplicate.php&gibbonReportTemplateID='.$gibbonReportTemplateID;
+
+if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_duplicate.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $reportTemplateGateway = $container->get(ReportTemplateGateway::class);
+    $reportTemplateSectionGateway = $container->get(ReportTemplateSectionGateway::class);
+
+    $data = [
+        'name'    => $_POST['name'] ?? '',
+        'context' => $_POST['context'] ?? '',
+    ];
+
+    // Validate the required values are present
+    if (empty($gibbonReportTemplateID) || empty($data['name']) || empty($data['context'])) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+    
+    // Validate the database relationships exist
+    $values = $reportTemplateGateway->getByID($gibbonReportTemplateID);
+    if (empty($values)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Validate that this record is unique
+    if (!$reportTemplateGateway->unique($data, ['name'], $gibbonReportTemplateID)) {
+        $URL .= '&return=error7';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    // Update duplicated values
+    $data['orientation'] = $values['orientation'];
+    $data['pageSize'] = $values['pageSize'];
+    $data['marginX'] = $values['marginX'];
+    $data['marginY'] = $values['marginY'];
+    $data['stylesheet'] = $values['stylesheet'];
+    $data['flags'] = $values['flags'];
+    $data['config'] = $values['config'];
+
+    // Create the record
+    $gibbonReportTemplateIDNew = $reportTemplateGateway->insert($data);
+    $failedSections = 0;
+
+    if (empty($gibbonReportTemplateIDNew)) {
+        $URL .= "&return=error2";
+        header("Location: {$URL}");
+    }
+
+    // Duplicate the template sections
+    $sections = $reportTemplateSectionGateway->selectBy(['gibbonReportTemplateID' => $gibbonReportTemplateID])->fetchAll();
+    foreach ($sections as $sectionData) {
+        $sectionData['gibbonReportTemplateID'] = $gibbonReportTemplateIDNew;
+        $gibbonReportTemplateSectionIDNew = $reportTemplateSectionGateway->insert($sectionData);
+        $failedSections += empty($gibbonReportTemplateSectionIDNew);
+    }
+
+    $URL .= !empty($failedSections)
+        ? "&return=warning1&failedSections=$failedSections"
+        : "&return=success0";
+
+    header("Location: {$URL}&editID=$gibbonReportTemplateIDNew");
+}


### PR DESCRIPTION
This PR adds a duplicate option to the Template Builder.

**Motivation and Context**
Now that we're up and running with the Reports module, it's a common enough occurrence that a template needs changed in some way, while not changing the original copy of the template.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="886" alt="Screenshot 2021-04-22 at 12 01 03 PM" src="https://user-images.githubusercontent.com/897700/115654434-b6dda180-a363-11eb-94c0-c24a1735b957.png">


