### PR TITLE
Library - telephone MAC addresses are now correctly stored as strings…

### DIFF
--- a/resources/imports/libraryRecordTelephone.yml
+++ b/resources/imports/libraryRecordTelephone.yml
@@ -127,11 +127,11 @@ table:
     fieldWirelessMACAddress:
         name: "Wireless MAC Address"
         desc: ""
-        args: { filter: date, custom: true, readonly: true, serialize: fields  }
+        args: { filter: string, custom: true, readonly: true, serialize: fields  }
     fieldWiredMACAddress:
         name: "Wired MAC Address"
         desc: ""
-        args: { filter: date, custom: true, readonly: true, serialize: fields  }
+        args: { filter: string, custom: true, readonly: true, serialize: fields  }
     fieldRepairLog:
         name: "Repair Log/Notes"
         desc: ""


### PR DESCRIPTION
…, not dates

<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
Fixing telephone import - MAC addresses are no longer dates!

**Motivation and Context**
<!-- Why is this change suggested? Is there a problem it helps to solve?
If this PR fixes an open issue, please link to the issue here. -->

**How Has This Been Tested?**
<!-- Please describe how you've tested your changes. Include details of 
your testing environment, and any tests you've run to see how your 
change affects other areas of the code. -->

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
