### PR TITLE
System Admin: add a migration to remove citizenship fields, make Personal Documents scrubbable

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -986,5 +986,7 @@ UPDATE `gibbonPlannerEntry` SET `gibbonUnitID`=NULL WHERE `gibbonUnitID`=0;end
 UPDATE `gibbonUnit` SET `gibbonPersonIDLastEdit`=gibbonPersonIDCreator WHERE `gibbonPersonIDLastEdit`=0;end
 UPDATE `gibbonStaffApplicationForm` SET `gibbonPersonID`=NULL WHERE `gibbonPersonID`=0;end
 UPDATE `gibbonTTDayRowClass` SET `gibbonSpaceID`=NULL WHERE `gibbonSpaceID`=0;end
+UPDATE `gibbonPerson` SET `dob`=NULL WHERE `dob`='0000-00-00';end
+UPDATE `gibbonPersonUpdate` SET `dob`=NULL WHERE `dob`='0000-00-00';end
 
 ";

--- a/src/Database/Migrations/2021-05-20-PersonalDocuments.php
+++ b/src/Database/Migrations/2021-05-20-PersonalDocuments.php
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http: //www.gnu.org/licenses/>.
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Database\Migrations\Migration;
@@ -31,7 +31,7 @@ class PersonalDocuments extends Migration
 
     public function __construct(UserGateway $userGateway, PersonalDocumentGateway $personalDocumentGateway)
     {
-        $this->userGateway             = $userGateway;
+        $this->userGateway = $userGateway;
         $this->personalDocumentGateway = $personalDocumentGateway;
     }   
 

--- a/src/Database/Migrations/2021-05-20-PersonalDocuments.php
+++ b/src/Database/Migrations/2021-05-20-PersonalDocuments.php
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <http: //www.gnu.org/licenses/>.
 */
 
 use Gibbon\Database\Migrations\Migration;
@@ -31,7 +31,7 @@ class PersonalDocuments extends Migration
 
     public function __construct(UserGateway $userGateway, PersonalDocumentGateway $personalDocumentGateway)
     {
-        $this->userGateway = $userGateway;
+        $this->userGateway             = $userGateway;
         $this->personalDocumentGateway = $personalDocumentGateway;
     }   
 
@@ -39,9 +39,10 @@ class PersonalDocuments extends Migration
     {
         $partialFail = false;
 
-        $users = $this->userGateway->selectBy([]); 
+        $users = $this->userGateway->selectBy([]);
 
         foreach ($users as $user) {
+            $timestamp = !empty($user['lastTimestamp']) ? $user['lastTimestamp'] : date('Y-m-d H:i:s');
 
             // Citizenship 1
             $data = [
@@ -56,6 +57,7 @@ class PersonalDocuments extends Migration
                     'gibbonPersonalDocumentTypeID' => 001,
                     'foreignTable'                 => 'gibbonPerson',
                     'foreignTableID'               => $user['gibbonPersonID'],
+                    'timestamp'                    => $timestamp,
                 ]);
             }
 
@@ -71,6 +73,7 @@ class PersonalDocuments extends Migration
                     'gibbonPersonalDocumentTypeID' => 002,
                     'foreignTable'                 => 'gibbonPerson',
                     'foreignTableID'               => $user['gibbonPersonID'],
+                    'timestamp'                    => $timestamp,
                 ]);
             }
 
@@ -85,6 +88,7 @@ class PersonalDocuments extends Migration
                     'gibbonPersonalDocumentTypeID' => 003,
                     'foreignTable'                 => 'gibbonPerson',
                     'foreignTableID'               => $user['gibbonPersonID'],
+                    'timestamp'                    => $timestamp,
                 ]);
             }
 
@@ -99,6 +103,7 @@ class PersonalDocuments extends Migration
                     'gibbonPersonalDocumentTypeID' => 004,
                     'foreignTable'                 => 'gibbonPerson',
                     'foreignTableID'               => $user['gibbonPersonID'],
+                    'timestamp'                    => $timestamp,
                 ]);
             }
 
@@ -113,6 +118,7 @@ class PersonalDocuments extends Migration
                     'gibbonPersonalDocumentTypeID' => 005,
                     'foreignTable'                 => 'gibbonPerson',
                     'foreignTableID'               => $user['gibbonPersonID'],
+                    'timestamp'                    => $timestamp,
                 ]);
             }
         }

--- a/src/Database/Migrations/2021-06-03-RemoveCitizenshipFields.php
+++ b/src/Database/Migrations/2021-06-03-RemoveCitizenshipFields.php
@@ -1,0 +1,66 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http: //www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Contracts\Database\Connection;
+use Gibbon\Database\Migrations\Migration;
+
+/**
+ * Remove Citizenship Fields Migration - remove the citizenship, id card, visa and residency fields no longer needed.
+ */
+class RemoveCitizenshipFields extends Migration
+{
+    protected $db;
+
+    public function __construct(Connection $db)
+    {
+        $this->db = $db;
+    }   
+
+    public function migrate()
+    {
+        $partialFail = false;
+
+        // gibbonPerson
+        $sql = "ALTER TABLE `gibbonPerson` DROP `citizenship1`, DROP `citizenship1Passport`, DROP `citizenship1PassportExpiry`, DROP `citizenship1PassportScan`, DROP `citizenship2`, DROP `citizenship2Passport`, DROP `citizenship2PassportExpiry`, DROP `nationalIDCardNumber`, DROP `nationalIDCardScan`, DROP `residencyStatus`, DROP `visaExpiryDate`;";
+
+        $success = $this->db->statement($sql);
+        $partialFail &= !$success;
+
+        // gibbonPersonUpdate
+        $sql = "ALTER TABLE `gibbonPersonUpdate` DROP `citizenship1`, DROP `citizenship1Passport`, DROP `citizenship1PassportExpiry`, DROP `citizenship2`, DROP `citizenship2Passport`, DROP `citizenship2PassportExpiry`, DROP `nationalIDCardCountry`, DROP `nationalIDCardNumber`, DROP `residencyStatus`, DROP `visaExpiryDate`;";
+
+        $success = $this->db->statement($sql);
+        $partialFail &= !$success;
+
+
+        // gibbonApplicationForm
+        $sql = "ALTER TABLE `gibbonApplicationForm` DROP `citizenship1`, DROP `citizenship1Passport`, DROP `citizenship1PassportExpiry`, DROP `nationalIDCardNumber`, DROP `residencyStatus`, DROP `visaExpiryDate`, DROP `parent1citizenship1`, DROP `parent1nationalIDCardNumber`, DROP `parent1residencyStatus`, DROP `parent1visaExpiryDate`, DROP `parent2citizenship1`, DROP `parent2nationalIDCardNumber`, DROP `parent2residencyStatus`, DROP `parent2visaExpiryDate`;";
+
+        $success = $this->db->statement($sql);
+        $partialFail &= !$success;
+
+        // gibbonStaffApplicationForm
+        $sql = "ALTER TABLE `gibbonStaffApplicationForm` DROP `citizenship1`, DROP `citizenship1Passport`, DROP `nationalIDCardNumber`, DROP `residencyStatus`, DROP `visaExpiryDate`;";
+
+        $success = $this->db->statement($sql);
+        $partialFail &= !$success;
+
+        return !$partialFail;
+    }
+}

--- a/src/Domain/System/DataRetentionGateway.php
+++ b/src/Domain/System/DataRetentionGateway.php
@@ -33,6 +33,7 @@ use Gibbon\Domain\IndividualNeeds\INGateway;
 use Gibbon\Domain\Staff\StaffAbsenceGateway;
 use Gibbon\Domain\Behaviour\BehaviourGateway;
 use Gibbon\Domain\Students\StudentNoteGateway;
+use Gibbon\Domain\User\PersonalDocumentGateway;
 use Gibbon\Domain\DataUpdater\FamilyUpdateGateway;
 use Gibbon\Domain\DataUpdater\PersonUpdateGateway;
 use Gibbon\Domain\Students\ApplicationFormGateway;
@@ -66,6 +67,12 @@ class DataRetentionGateway extends QueryableGateway
     public function getDomains()
     {
         return [
+            'Personal Documents' => [
+                'description' => __('Clear all personal documents such as passports, ID cards, birth certificates and visas.'),
+                'gateways' => [
+                    PersonalDocumentGateway::class,
+                ],
+            ],
             'Student Personal Data' => [
                 'description' => __('Clear personal data such as passwords, addresses, phone numbers, id numbers, etc.'),
                 'context' => ['Student'],

--- a/src/Domain/User/PersonalDocumentGateway.php
+++ b/src/Domain/User/PersonalDocumentGateway.php
@@ -22,20 +22,28 @@ namespace Gibbon\Domain\User;
 use Gibbon\Services\Format;
 use Gibbon\Domain\QueryCriteria;
 use Gibbon\Domain\QueryableGateway;
+use Gibbon\Domain\ScrubbableGateway;
+use Gibbon\Domain\Traits\Scrubbable;
 use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\Traits\ScrubByTimestamp;
 
 /**
  * @version v22
  * @since   v22
  */
-class PersonalDocumentGateway extends QueryableGateway
+class PersonalDocumentGateway extends QueryableGateway implements ScrubbableGateway
 {
     use TableAware;
+    use Scrubbable;
+    use ScrubByTimestamp;
 
     private static $tableName = 'gibbonPersonalDocument';
     private static $primaryKey = 'gibbonPersonalDocumentID';
 
     private static $searchableColumns = [];
+
+    private static $scrubbableKey = 'timestamp';
+    private static $scrubbableColumns = ['documentNumber' => null,'documentName' => null,'documentType' => null,'dateIssue' => null,'dateExpiry' => null,'filePath' => 'deleteFile','country' => null];
 
     /**
      * @param QueryCriteria $criteria


### PR DESCRIPTION
This PR removes the citizenship fields from the database, since the data has already been migrated into personal document records. Also updates the PersonalDocument gateway to make it scrubbable. 

Requires #1360 (tests will fail until merged)

**How Has This Been Tested?**
Locally