### PR TITLE
System: improved the appearance of the fatal error message page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ v23.0.00
 
     Tweaks & Additions
         System: updated table actions to enable additional modules to use their own icon paths
+        System: improved the appearance of the fatal error message page
         Students: updated student enrolment dropdown to include students with Expected status
 
     Bug Fixes

--- a/error.php
+++ b/error.php
@@ -18,11 +18,54 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 ?>
 
-<h1>
-	<?php echo __('Oh no!'); ?><br/>
-</h1>
-<p>
-	<?php echo __('Something has gone wrong: the Gibbons have escaped!') ?><br/>
-	<br/>
-	<?php echo __('An error has occurred. This could mean a number of different things, but generally indicates that you have a misspelt address, or are trying to access a page that you are not permitted to access.').' '.__('If you cannot solve this problem by retyping the address, or through other means, please contact your system administrator.') ?><br/>
-</p>
+<!DOCTYPE html>
+<html lang="">
+    <head>
+        <title></title>
+
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+        <meta http-equiv="content-language" content="{{ locale }}"/>
+        <meta name="author" content="Ross Parker, International College Hong Kong"/>
+        <meta name="robots" content="noindex"/>
+        <meta name="Referrer‐Policy" value="no‐referrer | same‐origin"/>
+        <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico"/>
+
+        <link rel="stylesheet" href="./themes/Default/css/main.css" type="text/css" media="all">
+        <link rel="stylesheet" href="./resources/assets/css/core.min.css" type="text/css" media="all">
+    </head>
+
+    <body class="h-screen flex flex-col font-sans body-gradient-purple m-0 p-0" style="background: radial-gradient(80% 1000px at 20% 500px, #ef99c7 0%, #794d95 100%) no-repeat fixed ;">
+
+        <div class="px-4 sm:px-6 lg:px-12 pb-24">
+            <div id="header" class="relative flex justify-between items-center">
+
+                <a id="header-logo" class="block my-4 max-w-xs sm:max-w-full leading-none" href="http://localhost:8888/gibbon">
+                    <img class="block max-w-full h-20 mt-4 mb-4" alt="DEMO Logo" src="./themes/Default/img/logo.png" style="max-height:100px;">
+                </a>
+
+                <div class="flex-grow flex items-center justify-end text-right text-sm text-purple-200">               
+                </div> 
+            </div>
+        </div>
+
+        <div id="wrapOuter" class="flex-1 pt-24 bg-transparent-100">
+            <div id="wrap" class="px-0 sm:px-6 lg:px-12 -mt-48">
+                <div id="content-wrap" class="relative w-full min-h-1/2 flex content-start flex-coll lg:flex-row clearfix">
+
+                    <div id="content" class="max-w-full w-full shadow bg-white sm:rounded px-8 pt-2 pb-6">
+                        <h1>
+                            Oh no!<br/>
+                        </h1>
+                        <p>
+                            <?php echo !empty($error) ? $error : 'Something has gone wrong: the Gibbons have escaped!' ?><br/>
+                            <br/>
+                            <?php echo !empty($message) ? $message : 'An error has occurred. This could mean a number of different things, but generally indicates that you have a misspelt address, or are trying to access a page that you are not permitted to access. If you cannot solve this problem by retyping the address, or through other means, please contact your system administrator.' ?><br/>
+                        </p>
+                        </body>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/error.php
+++ b/error.php
@@ -33,6 +33,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
         <link rel="stylesheet" href="./themes/Default/css/main.css" type="text/css" media="all">
         <link rel="stylesheet" href="./resources/assets/css/core.min.css" type="text/css" media="all">
+        <link rel="stylesheet" href="./resources/assets/css/theme.min.css" type="text/css" media="all">
     </head>
 
     <body class="h-screen flex flex-col font-sans body-gradient-purple m-0 p-0" style="background: radial-gradient(80% 1000px at 20% 500px, #ef99c7 0%, #794d95 100%) no-repeat fixed ;">

--- a/fullscreen.php
+++ b/fullscreen.php
@@ -62,7 +62,7 @@ if (empty($address)) {
     if (is_file('./'.$address)) {
         $page->writeFromFile('./'.$address, $globals);
     } else {
-        $page->writeFromFile('./error.php', $globals);
+        $page->writeFromTemplate('error.twig.html');
     }
 }
 

--- a/gibbon.php
+++ b/gibbon.php
@@ -20,6 +20,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\View\Page;
 use Gibbon\View\View;
 
+// Handle fatal errors more gracefully
+register_shutdown_function(function () {
+    $lastError = error_get_last();
+    if ($lastError && ($lastError['type'] === E_ERROR || $lastError['type'] === E_CORE_ERROR || $lastError['type'] === E_COMPILE_ERROR) ) {
+        include __DIR__.'/error.php';
+    }
+    exit;
+});
+
 // Check for the autoloader file
 if (!file_exists(__DIR__.'/vendor/autoload.php')) {
     $message = 'Fatal Error: Missing composer autoloader. Your vendor folder is likely not installed. If you are running cutting edge code, navigate to your base dir in a terminal window and run the "composer install" command. See the Cutting Edge Code documentation for more information: https://docs.gibbonedu.org/administrators/getting-started/installing-gibbon/cutting-edge-code/';

--- a/gibbon.php
+++ b/gibbon.php
@@ -22,7 +22,9 @@ use Gibbon\View\View;
 
 // Check for the autoloader file
 if (!file_exists(__DIR__.'/vendor/autoload.php')) {
-    die('Fatal Error: Missing composer autoloader. Your vendor folder is likely not installed. If you are running cutting edge code, navigate to your base dir in a terminal window and run the "composer install" command. See the Cutting Edge Code documentation for more information: https://docs.gibbonedu.org/administrators/getting-started/installing-gibbon/cutting-edge-code/');
+    $message = 'Fatal Error: Missing composer autoloader. Your vendor folder is likely not installed. If you are running cutting edge code, navigate to your base dir in a terminal window and run the "composer install" command. See the Cutting Edge Code documentation for more information: https://docs.gibbonedu.org/administrators/getting-started/installing-gibbon/cutting-edge-code/';
+    include __DIR__.'/error.php';
+    exit;
 }
 
 // Setup the composer autoloader

--- a/index.php
+++ b/index.php
@@ -671,7 +671,7 @@ if (!$session->has('address')) {
         if (is_file('./'.$address)) {
             $page->writeFromFile('./'.$address, $globals);
         } else {
-            $page->writeFromFile('./error.php', $globals);
+            $page->writeFromTemplate('error.twig.html');
         }
     }
 }

--- a/report.php
+++ b/report.php
@@ -60,7 +60,7 @@ if (empty($address)) {
     if (is_file('./'.$address)) {
         $page->writeFromFile('./'.$address, $globals);
     } else {
-        $page->writeFromFile('./error.php', $globals);
+        $page->writeFromTemplate('error.twig.html');
     }
 }
 

--- a/resources/templates/error.twig.html
+++ b/resources/templates/error.twig.html
@@ -5,7 +5,7 @@ Copyright (C) 2010, Ross Parker
 This is a Gibbon template file, written in HTML and Twig syntax.
 For info about editing, see: https://twig.symfony.com/doc/2.x/
 -->#}
-<h1>
+<h1 class="mt-6 pt-1">
     {{ __('Oh no!') }}
 </h1>
 <p>

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -348,16 +348,12 @@ class Page extends View
             'gibbonThemeName' => 'Default',
             'absolutePath'    => $absolutePath,
             'absoluteURL'     => $absoluteURL,
+            'themeColour'     => 'purple',
         ]);
 
         $this->stylesheets->add('main', 'themes/Default/css/main.css');
         $this->stylesheets->add('theme', 'resources/assets/css/theme.min.css');
         $this->stylesheets->add('core', 'resources/assets/css/core.min.css', ['weight' => 10]);
-        $this->stylesheets->add(
-            'personal-background',
-            'body { background: url("'.$absoluteURL.'/themes/Default/img/backgroundPage.jpg'.'") repeat fixed center top #626cd3!important; }',
-            ['type' => 'inline']
-        );
 
         return $this;
     }


### PR DESCRIPTION
In the past, we've moved the error message page into a template, which is a nice way to ensure it's formatted and looks good. However, in the event that a fatal error occurs, the current error message may be plain text and looks jarring, especially if font-end users see it. 

This PR adjusts the error messages so that the soft-fail messages will use the template, but any hard-fail states will default back to an error.php page that contains enough HTML to render and still look okay. The error.php page does not depend on any functions or libraries, and should always be renderable.

**Screenshots**
Soft-fail:
<img width="1255" alt="Screenshot 2021-06-25 at 2 14 00 PM" src="https://user-images.githubusercontent.com/897700/123379370-967acf00-d5c0-11eb-8cef-76451f6b41d8.png">

Hard-fail:
<img width="1254" alt="Screenshot 2021-06-25 at 2 13 54 PM" src="https://user-images.githubusercontent.com/897700/123379379-9a0e5600-d5c0-11eb-91f4-bfe7edead993.png">
