### PR TITLE
Comment fix

### DIFF
--- a/modules/Activities/activities_manage_delete.php
+++ b/modules/Activities/activities_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonActivityID specified
     $gibbonActivityID = $_GET['gibbonActivityID'];
     if ($gibbonActivityID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Activities/activities_manage_edit.php
+++ b/modules/Activities/activities_manage_edit.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     
     $page->return->addReturns(['error3' => __('Your request failed due to an attachment error.')]);
 
-    //Check if school year specified
+    //Check if gibbonActivityID specified
     $gibbonActivityID = $_GET['gibbonActivityID'];
     if ($gibbonActivityID == 'Y') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Activities/activities_manage_editProcess.php
+++ b/modules/Activities/activities_manage_editProcess.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonActivityID specified
     $activityGateway = $container->get(ActivityGateway::class);
 
     if (!$activityGateway->exists($gibbonActivityID)) {

--- a/modules/Activities/activities_manage_enrolment.php
+++ b/modules/Activities/activities_manage_enrolment.php
@@ -51,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         ->add(__('Manage Activities'), 'activities_manage.php')
         ->add(__('Activity Enrolment'));    
 
-    //Check if school year specified
+    //Check if gibbonActivityID specified
     if ($gibbonActivityID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Activities/activities_manage_enrolment_delete.php
+++ b/modules/Activities/activities_manage_enrolment_delete.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         }
     }
 
-    //Check if school year specified
+    //Check if gibbonActivityID and gibbonPersonID specified
     $gibbonActivityID = $_GET['gibbonActivityID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];
     if ($gibbonPersonID == '' or $gibbonActivityID == '') {

--- a/modules/Activities/activities_manage_enrolment_edit.php
+++ b/modules/Activities/activities_manage_enrolment_edit.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         ->add(__('Activity Enrolment'), 'activities_manage_enrolment.php',  $urlParams)
         ->add(__('Edit Enrolment'));
 
-    //Check if school year specified
+    //Check if gibbonActivityID and gibbonPersonID specified
     $gibbonActivityID = $_GET['gibbonActivityID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];
     if ($gibbonPersonID == '' or $gibbonActivityID == '') {

--- a/modules/Activities/activities_manage_enrolment_editProcess.php
+++ b/modules/Activities/activities_manage_enrolment_editProcess.php
@@ -34,7 +34,7 @@ if ($gibbonActivityID == '' or $gibbonPersonID == '') { echo 'Fatal error loadin
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if status specified
         $status = $_POST['status'] ?? '';
         if ($status == '') {
             $URL .= '&return=error1';

--- a/modules/Activities/activities_view_register.php
+++ b/modules/Activities/activities_view_register.php
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
                 echo __('Registration is closed, or you do not have permission to register.');
                 echo '</div>';
             } else {
-                //Check if school year specified
+                //Check if gibbonActivityID specified
                 $gibbonActivityID = $_GET['gibbonActivityID'];
                 if ($gibbonActivityID == 'Y') {
                     echo "<div class='error'>";

--- a/modules/Activities/activities_view_registerProcess.php
+++ b/modules/Activities/activities_view_registerProcess.php
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonActivityID and gibbonPersonID specified
             if ($gibbonActivityID == '' or $gibbonPersonID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Attendance/attendance_take_byCourseClassProcess.php
+++ b/modules/Attendance/attendance_take_byCourseClassProcess.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
 }
 else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonCourseClassID and currentDate specified
     if ($gibbonCourseClassID=="" AND $currentDate=="") {
         //Fail1
         $URL.="&return=error1" ;

--- a/modules/Attendance/attendance_take_byFormGroupProcess.php
+++ b/modules/Attendance/attendance_take_byFormGroupProcess.php
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
         echo '</div>';
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonFormGroupID and currentDate specified
         if ($gibbonFormGroupID == '' and $currentDate == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Attendance/attendance_take_byPersonProcess.php
+++ b/modules/Attendance/attendance_take_byPersonProcess.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonID and currentDate specified
     if ($gibbonPersonID == '' and $currentDate == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Behaviour/behaviour_manage_delete.php
+++ b/modules/Behaviour/behaviour_manage_delete.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
         echo '</div>';
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonBehaviourID specified
         $gibbonBehaviourID = $_GET['gibbonBehaviourID'];
         if ($gibbonBehaviourID == '') {
             echo "<div class='error'>";

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             ->add(__('Manage Behaviour Records'), 'behaviour_manage.php')
             ->add(__('Edit'));
 
-        //Check if school year specified
+        //Check if gibbonBehaviourID specified
         $gibbonBehaviourID = $_GET['gibbonBehaviourID'];
         if ($gibbonBehaviourID == '') {
             echo "<div class='error'>";

--- a/modules/Behaviour/behaviour_manage_editProcess.php
+++ b/modules/Behaviour/behaviour_manage_editProcess.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonBehaviourID specified
         if ($gibbonBehaviourID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Crowd Assessment/crowdAssess_view_discuss_postProcess.php
+++ b/modules/Crowd Assessment/crowdAssess_view_discuss_postProcess.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Crowd Assessment/crowdAsse
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPlannerEntryID, gibbonPlannerEntryHomeworkID, and gibbonPersonID specified
     if ($gibbonPlannerEntryID == '' or $gibbonPlannerEntryHomeworkID == '' or $gibbonPersonID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Data Updater/data_familyProcess.php
+++ b/modules/Data Updater/data_familyProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFamilyID specified
     if ($gibbonFamilyID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Data Updater/data_family_manage_delete.php
+++ b/modules/Data Updater/data_family_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_m
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFamilyUpdateID specified
     $gibbonFamilyUpdateID = $_GET['gibbonFamilyUpdateID'];
     if ($gibbonFamilyUpdateID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_family_manage_edit.php
+++ b/modules/Data Updater/data_family_manage_edit.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_m
         ->add(__('Family Data Updates'), 'data_family_manage.php', $urlParams)
         ->add(__('Edit Request'));
 
-    //Check if school year specified
+    //Check if gibbonFamilyUpdateID specified
     $gibbonFamilyUpdateID = $_GET['gibbonFamilyUpdateID'];
     if ($gibbonFamilyUpdateID == 'Y') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_family_manage_editProcess.php
+++ b/modules/Data Updater/data_family_manage_editProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family_m
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if sgibbonFamilyUpdateID and gibbonFamilyID specified
     if ($gibbonFamilyUpdateID == '' or $gibbonFamilyID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Data Updater/data_financeProcess.php
+++ b/modules/Data Updater/data_financeProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceInvoiceeID specified
     if ($gibbonFinanceInvoiceeID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Data Updater/data_finance_manage_delete.php
+++ b/modules/Data Updater/data_finance_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceInvoiceeUpdateID specified
     $gibbonFinanceInvoiceeUpdateID = $_GET['gibbonFinanceInvoiceeUpdateID'];
     if ($gibbonFinanceInvoiceeUpdateID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_finance_manage_edit.php
+++ b/modules/Data Updater/data_finance_manage_edit.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
         ->add(__('Finance Data Updates'), 'data_finance_manage.php', $urlParams)
         ->add(__('Edit Request'));
 
-    //Check if school year specified
+    //Check if gibbonFinanceInvoiceeUpdateID specified
     $gibbonFinanceInvoiceeUpdateID = $_GET['gibbonFinanceInvoiceeUpdateID'];
     if ($gibbonFinanceInvoiceeUpdateID == 'Y') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_finance_manage_editProcess.php
+++ b/modules/Data Updater/data_finance_manage_editProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance_
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceInvoiceeUpdateID and gibbonFinanceInvoiceeID specified
     if ($gibbonFinanceInvoiceeUpdateID == '' or $gibbonFinanceInvoiceeID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Data Updater/data_medicalProcess.php
+++ b/modules/Data Updater/data_medicalProcess.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonPersonID specified
         if ($gibbonPersonID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Data Updater/data_medical_manage_delete.php
+++ b/modules/Data Updater/data_medical_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonMedicalUpdateID specified
     $gibbonPersonMedicalUpdateID = $_GET['gibbonPersonMedicalUpdateID'];
     if ($gibbonPersonMedicalUpdateID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_medical_manage_edit.php
+++ b/modules/Data Updater/data_medical_manage_edit.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
         ->add(__('Medical Data Updates'), 'data_medical_manage.php', $urlParams)
         ->add(__('Edit Request'));
 
-    //Check if school year specified
+    //Check if gibbonPersonMedicalUpdateID specified
     $gibbonPersonMedicalUpdateID = $_GET['gibbonPersonMedicalUpdateID'];
     if ($gibbonPersonMedicalUpdateID == 'Y') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_medical_manage_editProcess.php
+++ b/modules/Data Updater/data_medical_manage_editProcess.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonMedicalUpdateID specified
     if ($gibbonPersonMedicalUpdateID == '' or $gibbonPersonID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Data Updater/data_personalProcess.php
+++ b/modules/Data Updater/data_personalProcess.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonID specified
     if ($gibbonPersonID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Data Updater/data_personal_manage_delete.php
+++ b/modules/Data Updater/data_personal_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonUpdateID specified
     $gibbonPersonUpdateID = $_GET['gibbonPersonUpdateID'];
     if ($gibbonPersonUpdateID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_personal_manage_edit.php
+++ b/modules/Data Updater/data_personal_manage_edit.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
         ->add(__('Personal Data Updates'), 'data_personal_manage.php', $urlParams)
         ->add(__('Edit Request'));
 
-    //Check if school year specified
+    //Check if gibbonPersonUpdateID specified
     $gibbonPersonUpdateID = $_GET['gibbonPersonUpdateID'];
     if ($gibbonPersonUpdateID == 'Y') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Data Updater/data_personal_manage_editProcess.php
+++ b/modules/Data Updater/data_personal_manage_editProcess.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonUpdateID specified
     if ($gibbonPersonUpdateID == '' or $gibbonPersonID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Departments/department_edit_resource_deleteProcess.php
+++ b/modules/Departments/department_edit_resource_deleteProcess.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_edi
 } else {
     //Proceed!
 
-    //Check if school year specified
+    //Check if gibbonDepartmentID specified
     if ($gibbonDepartmentID == '' or $gibbonDepartmentResourceID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/billingSchedule_manage_add.php
+++ b/modules/Finance/billingSchedule_manage_add.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/billingSchedule_ma
 
     $page->return->setEditLink($editLink);
 
-    //Check if school year specified
+    //Check if search and gibbonSchoolYearID specified
     $search = $_GET['search'];
     if ($gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/billingSchedule_manage_edit.php
+++ b/modules/Finance/billingSchedule_manage_edit.php
@@ -25,7 +25,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/billingSchedule_ma
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
 
     $urlParams = compact('gibbonSchoolYearID');
@@ -36,6 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/billingSchedule_ma
 
     $gibbonFinanceBillingScheduleID = $_GET['gibbonFinanceBillingScheduleID'];
     $search = $_GET['search'];
+    //Check if gibbonFinanceBillingScheduleID and gibbonSchoolYearID  specified
     if ($gibbonFinanceBillingScheduleID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Finance/budgetCycles_manage_delete.php
+++ b/modules/Finance/budgetCycles_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetCycleID specified
     $gibbonFinanceBudgetCycleID = $_GET['gibbonFinanceBudgetCycleID'];
     if ($gibbonFinanceBudgetCycleID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/budgetCycles_manage_deleteProcess.php
+++ b/modules/Finance/budgetCycles_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetCycleID specified
     if ($gibbonFinanceBudgetCycleID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/budgetCycles_manage_edit.php
+++ b/modules/Finance/budgetCycles_manage_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
         ->add(__('Manage Budget Cycles'), 'budgetCycles_manage.php')
         ->add(__('Edit Budget Cycle'));
 
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetCycleID specified
     $gibbonFinanceBudgetCycleID = $_GET['gibbonFinanceBudgetCycleID'];
     if ($gibbonFinanceBudgetCycleID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/budgetCycles_manage_editProcess.php
+++ b/modules/Finance/budgetCycles_manage_editProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetCycleID specified
     if ($gibbonFinanceBudgetCycleID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/budgets_manage_delete.php
+++ b/modules/Finance/budgets_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_del
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetID specified
     $gibbonFinanceBudgetID = $_GET['gibbonFinanceBudgetID'];
     if ($gibbonFinanceBudgetID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/budgets_manage_edit.php
+++ b/modules/Finance/budgets_manage_edit.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
 
     $page->return->addReturns(['error4' => __('Your request failed due to an attachment error.')]);
 
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetID specified
     $gibbonFinanceBudgetID = $_GET['gibbonFinanceBudgetID'];
     if ($gibbonFinanceBudgetID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/budgets_manage_editProcess.php
+++ b/modules/Finance/budgets_manage_editProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetID specified
     if ($gibbonFinanceBudgetID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/budgets_manage_edit_staff_deleteProcess.php
+++ b/modules/Finance/budgets_manage_edit_staff_deleteProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
 } else {
     //Proceed!
 
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetID specified
     if ($gibbonFinanceBudgetID == '' or $gibbonFinanceBudgetPersonID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/expenseApprovers_manage_delete.php
+++ b/modules/Finance/expenseApprovers_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceExpenseApproverID specified
     $gibbonFinanceExpenseApproverID = $_GET['gibbonFinanceExpenseApproverID'];
     if ($gibbonFinanceExpenseApproverID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/expenseApprovers_manage_deleteProcess.php
+++ b/modules/Finance/expenseApprovers_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceExpenseApproverID specified
     if ($gibbonFinanceExpenseApproverID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/expenseApprovers_manage_edit.php
+++ b/modules/Finance/expenseApprovers_manage_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
         ->add(__('Manage Expense Approvers'),'expenseApprovers_manage.php')
         ->add(__('Edit Expense Approver'));
 
-    //Check if school year specified
+    //Check if gibbonFinanceExpenseApproverID specified
     $gibbonFinanceExpenseApproverID = $_GET['gibbonFinanceExpenseApproverID'];
     if ($gibbonFinanceExpenseApproverID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/expenseApprovers_manage_editProcess.php
+++ b/modules/Finance/expenseApprovers_manage_editProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseApprovers_m
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceExpenseApproverID specified
     if ($gibbonFinanceExpenseApproverID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/expenseRequest_manage_add.php
+++ b/modules/Finance/expenseRequest_manage_add.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
     $page->return->addReturns(['success1' => __('Your request was completed successfully, but notifications could not be sent out.')]);
 
-    //Check if school year specified
+    //Check if gibbonFinanceBudgetCycleID specified
     $status2 = $_GET['status2'];
     $gibbonFinanceBudgetID2 = $_GET['gibbonFinanceBudgetID2'];
     if ($gibbonFinanceBudgetCycleID == '') {

--- a/modules/Finance/expenses_manage_add.php
+++ b/modules/Finance/expenses_manage_add.php
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
         $page->return->setEditLink($editLink);
 
 
-        //Check if school year specified
+        //Check if gibbonFinanceBudgetCycleID specified
         $status2 = $_GET['status2'];
         $gibbonFinanceBudgetID2 = $_GET['gibbonFinanceBudgetID2'];
         if ($gibbonFinanceBudgetCycleID == '') {

--- a/modules/Finance/feeCategories_manage_delete.php
+++ b/modules/Finance/feeCategories_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceFeeCategoryID specified
     $gibbonFinanceFeeCategoryID = $_GET['gibbonFinanceFeeCategoryID'];
     if ($gibbonFinanceFeeCategoryID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/feeCategories_manage_edit.php
+++ b/modules/Finance/feeCategories_manage_edit.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
         ->add(__('Manage Fee Categories'),'feeCategories_manage.php')
         ->add(__('Edit Category'));
 
-    //Check if school year specified
+    //Check if gibbonFinanceFeeCategoryID specified
     $gibbonFinanceFeeCategoryID = $_GET['gibbonFinanceFeeCategoryID'];
     if ($gibbonFinanceFeeCategoryID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Finance/feeCategories_manage_editProcess.php
+++ b/modules/Finance/feeCategories_manage_editProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/feeCategories_mana
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceFeeCategoryID specified
     if ($gibbonFinanceFeeCategoryID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/invoicees_manage_editProcess.php
+++ b/modules/Finance/invoicees_manage_editProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoicees_manage_e
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFinanceInvoiceeID specified
     if ($gibbonFinanceInvoiceeID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -27,7 +27,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
     $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
     $status = isset($_GET['status'])? $_GET['status'] : '';
     $gibbonFinanceInvoiceeID = isset($_GET['gibbonFinanceInvoiceeID'])? $_GET['gibbonFinanceInvoiceeID'] : '';

--- a/modules/Finance/invoices_manage_delete.php
+++ b/modules/Finance/invoices_manage_delete.php
@@ -26,7 +26,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_de
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
     $gibbonFinanceInvoiceID = $_GET['gibbonFinanceInvoiceID'];
     $status = $_GET['status'];
@@ -36,6 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_de
     $gibbonFinanceFeeCategoryID = $_GET['gibbonFinanceFeeCategoryID'];
 
     //Proceed!
+    //Check if gibbonFinanceInvoiceID and gibbonSchoolYearID specified
     if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Finance/invoices_manage_edit.php
+++ b/modules/Finance/invoices_manage_edit.php
@@ -28,7 +28,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
     $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
     $gibbonFinanceInvoiceID = isset($_GET['gibbonFinanceInvoiceID'])? $_GET['gibbonFinanceInvoiceID'] : '';
     $status = isset($_GET['status'])? $_GET['status'] : '';

--- a/modules/Finance/invoices_manage_issue.php
+++ b/modules/Finance/invoices_manage_issue.php
@@ -29,7 +29,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
     $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
     $gibbonFinanceInvoiceID = isset($_GET['gibbonFinanceInvoiceID'])? $_GET['gibbonFinanceInvoiceID'] : '';
     $status = isset($_GET['status'])? $_GET['status'] : '';
@@ -50,6 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
 
     $page->return->addReturns(['error4' => 'Some aspects of your request failed, but others were successful. Because of the errors, the system did not attempt to send any requested emails.']);
 
+    //Check if gibbonFinanceInvoiceID and gibbonSchoolYearID specified
     if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Finance/invoices_manage_print.php
+++ b/modules/Finance/invoices_manage_print.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_pr
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
     $gibbonFinanceInvoiceID = $_GET['gibbonFinanceInvoiceID'];
     $status = $_GET['status'];
@@ -41,6 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_pr
         ->add(__('Manage Invoices'), 'invoices_manage.php', $urlParams)
         ->add(__('Print Invoices, Receipts & Reminders'));    
 
+    //Check if gibbonFinanceInvoiceID and gibbonSchoolYearID specified
     if ($gibbonFinanceInvoiceID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Formal Assessment/externalAssessment_manage_details_delete.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_delete.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
     $search = $_GET['search'] ?? '';
     $allStudents = $_GET['allStudents'] ?? '';
 
-    //Check if school year specified
+    //Check if gibbonExternalAssessmentStudentID specified
     if ($gibbonExternalAssessmentStudentID == '' or $gibbonPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Formal Assessment/externalAssessment_manage_details_deleteProcess.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_deleteProcess.php
@@ -35,7 +35,7 @@ if ($gibbonPersonID == '' or $gibbonExternalAssessmentStudentID == '') { echo 'F
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonExternalAssessmentStudentID specified
         if ($gibbonExternalAssessmentStudentID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Formal Assessment/externalAssessment_manage_details_edit.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_edit.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
         ->add(__('Student Details'), 'externalAssessment_details.php', ['gibbonPersonID' => $gibbonPersonID])
         ->add(__('Edit Assessment'));
 
-    //Check if school year specified
+    //Check if gibbonExternalAssessmentStudentID and gibbonPersonID specified
     if ($gibbonExternalAssessmentStudentID == '' or $gibbonPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Formal Assessment/internalAssessment_manage_delete.php
+++ b/modules/Formal Assessment/internalAssessment_manage_delete.php
@@ -26,7 +26,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonCourseClassID and gibbonInternalAssessmentColumnID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
     $gibbonInternalAssessmentColumnID = $_GET['gibbonInternalAssessmentColumnID'];
     if ($gibbonCourseClassID == '' or $gibbonInternalAssessmentColumnID == '') {

--- a/modules/Formal Assessment/internalAssessment_manage_deleteProcess.php
+++ b/modules/Formal Assessment/internalAssessment_manage_deleteProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonInternalAssessmentColumnID and gibbonCourseClassID specified
     if ($gibbonInternalAssessmentColumnID == '' or $gibbonCourseClassID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Formal Assessment/internalAssessment_manage_edit.php
+++ b/modules/Formal Assessment/internalAssessment_manage_edit.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonCourseClassID and gibbonInternalAssessmentColumnID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
     $gibbonInternalAssessmentColumnID = $_GET['gibbonInternalAssessmentColumnID'] ?? '';
     if ($gibbonCourseClassID == '' or $gibbonInternalAssessmentColumnID == '') {

--- a/modules/Formal Assessment/internalAssessment_manage_editProcess.php
+++ b/modules/Formal Assessment/internalAssessment_manage_editProcess.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonInternalAssessmentColumnID and gibbonCourseClassID specified
         if ($gibbonInternalAssessmentColumnID == '' or $gibbonCourseClassID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Formal Assessment/internalAssessment_write_data.php
+++ b/modules/Formal Assessment/internalAssessment_write_data.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
         echo __('The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        //Check if school year specified
+        //Check if gibbonCourseClassID and gibbonInternalAssessmentColumnID specified
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
         $gibbonInternalAssessmentColumnID = $_GET['gibbonInternalAssessmentColumnID'] ?? '';
         if ($gibbonCourseClassID == '' or $gibbonInternalAssessmentColumnID == '') {

--- a/modules/Formal Assessment/internalAssessment_write_dataProcess.php
+++ b/modules/Formal Assessment/internalAssessment_write_dataProcess.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonInternalAssessmentColumnID and gibbonCourseClassID specified
         if ($gibbonInternalAssessmentColumnID == '' or $gibbonCourseClassID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Library/library_lending_item.php
+++ b/modules/Library/library_lending_item.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonLibraryItemID specified
     $gibbonLibraryItemID = $_GET['gibbonLibraryItemID'];
     if ($gibbonLibraryItemID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Library/library_lending_item_return.php
+++ b/modules/Library/library_lending_item_return.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonLibraryItemEventID specified
     if (empty($gibbonLibraryItemEventID) or empty($gibbonLibraryItemID)) {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Library/library_manage_catalog_delete.php
+++ b/modules/Library/library_manage_catalog_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonLibraryItemID specified
     $gibbonLibraryItemID = $_GET['gibbonLibraryItemID'] ?? '';
     $name = $_GET['name'] ?? '';
     $gibbonLibraryTypeID = $_GET['gibbonLibraryTypeID'] ?? '';

--- a/modules/Library/library_manage_catalog_duplicate.php
+++ b/modules/Library/library_manage_catalog_duplicate.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonLibraryItemID specified
     $gibbonLibraryItemID = $_GET['gibbonLibraryItemID'];
     if ($gibbonLibraryItemID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Library/library_manage_catalog_duplicateProcess.php
+++ b/modules/Library/library_manage_catalog_duplicateProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonLibraryItemID specified
     if ($gibbonLibraryItemID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Library/library_manage_catalog_edit.php
+++ b/modules/Library/library_manage_catalog_edit.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonLibraryItemID specified
     $gibbonLibraryItemID = $_GET['gibbonLibraryItemID'];
     if ($gibbonLibraryItemID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Library/library_manage_catalog_editProcess.php
+++ b/modules/Library/library_manage_catalog_editProcess.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonLibraryItemID specified
     if ($gibbonLibraryItemID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Markbook/markbook_edit_copy.php
+++ b/modules/Markbook/markbook_edit_copy.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_cop
         echo __('The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        //Check if school year specified
+        //Check if gibbonCourseClassID and gibbonMarkbookCopyClassID specified
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
         $gibbonMarkbookCopyClassID = (isset($_POST['gibbonMarkbookCopyClassID']))? $_POST['gibbonMarkbookCopyClassID'] : null;
 

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -117,7 +117,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
         echo __('The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        //Check if school year specified
+        //Check if gibbonCourseClassID and gibbonMarkbookColumnID specified
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
         $gibbonMarkbookColumnID = $_GET['gibbonMarkbookColumnID'] ?? '';
         if ($gibbonCourseClassID == '' or $gibbonMarkbookColumnID == '') {

--- a/modules/Markbook/markbook_edit_dataProcess.php
+++ b/modules/Markbook/markbook_edit_dataProcess.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonMarkbookColumnID and gibbonCourseClassID specified
         if ($gibbonMarkbookColumnID == '' or $gibbonCourseClassID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Markbook/markbook_edit_delete.php
+++ b/modules/Markbook/markbook_edit_delete.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_del
         echo __('The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        //Check if school year specified
+        //Check if gibbonCourseClassID and gibbonMarkbookColumnID specified
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
         $gibbonMarkbookColumnID = $_GET['gibbonMarkbookColumnID'] ?? '';
         if ($gibbonCourseClassID == '' or $gibbonMarkbookColumnID == '') {

--- a/modules/Markbook/markbook_edit_deleteProcess.php
+++ b/modules/Markbook/markbook_edit_deleteProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_del
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonMarkbookColumnID and gibbonCourseClassID specified
     if ($gibbonMarkbookColumnID == '' or $gibbonCourseClassID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Markbook/markbook_edit_edit.php
+++ b/modules/Markbook/markbook_edit_edit.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
         echo __('The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        //Check if school year specified
+        //Check if gibbonCourseClassID and gibbonMarkbookColumnID specified
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
         $gibbonMarkbookColumnID = $_GET['gibbonMarkbookColumnID'] ?? '';
         if ($gibbonCourseClassID == '' or $gibbonMarkbookColumnID == '') {

--- a/modules/Markbook/markbook_edit_editProcess.php
+++ b/modules/Markbook/markbook_edit_editProcess.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonMarkbookColumnID and gibbonCourseClassID specified
             if ($gibbonMarkbookColumnID == '' or $gibbonCourseClassID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Markbook/markbook_edit_targets.php
+++ b/modules/Markbook/markbook_edit_targets.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_tar
         echo __('The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        //Check if school year specified
+        //Check if gibbonCourseClassID specified
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
         if ($gibbonCourseClassID == '') {
             echo "<div class='error'>";

--- a/modules/Markbook/markbook_edit_targetsProcess.php
+++ b/modules/Markbook/markbook_edit_targetsProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_tar
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonCourseClassID specified
     if ($gibbonCourseClassID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Markbook/markbook_view_rubric.php
+++ b/modules/Markbook/markbook_view_rubric.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
     echo '</div>';
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonCourseClassID and gibbonMarkbookColumnID and gibbonPersonID and gibbonRubricID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
     $gibbonMarkbookColumnID = $_GET['gibbonMarkbookColumnID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];

--- a/modules/Messenger/cannedResponse_manage_delete.php
+++ b/modules/Messenger/cannedResponse_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_m
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonMessengerCannedResponseID specified
     $gibbonMessengerCannedResponseID = $_GET['gibbonMessengerCannedResponseID'];
     if ($gibbonMessengerCannedResponseID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Messenger/cannedResponse_manage_edit.php
+++ b/modules/Messenger/cannedResponse_manage_edit.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_m
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonMessengerCannedResponseID specified
     $gibbonMessengerCannedResponseID = $_GET['gibbonMessengerCannedResponseID'];
     if ($gibbonMessengerCannedResponseID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Messenger/groups_manage_edit.php
+++ b/modules/Messenger/groups_manage_edit.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_ed
     //Proceed!
     $gibbonGroupID = (isset($_GET['gibbonGroupID']))? $_GET['gibbonGroupID'] : null;
 
-    //Check if school year specified
+    //Check if gibbonGroupID specified
     if ($gibbonGroupID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Messenger/messenger_manage_delete.php
+++ b/modules/Messenger/messenger_manage_delete.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_manage
         //Proceed!
         $search = isset($_GET['search']) ? $_GET['search'] : null;
 
-        //Check if school year specified
+        //Check if gibbonMessengerID specified
         $gibbonMessengerID = $_GET['gibbonMessengerID'];
         if ($gibbonMessengerID == '') {
             echo "<div class='error'>";

--- a/modules/Messenger/messenger_manage_deleteProcess.php
+++ b/modules/Messenger/messenger_manage_deleteProcess.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_manage
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonMessengerID specified
         if ($gibbonMessengerID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Messenger/messenger_manage_edit.php
+++ b/modules/Messenger/messenger_manage_edit.php
@@ -70,7 +70,7 @@ else {
 			print "</div>" ;
 		}
 
-		//Check if school year specified
+		//Check if gibbonMessengerID specified
 		$gibbonMessengerID=$_GET["gibbonMessengerID"] ;
 		if ($gibbonMessengerID=="") {
 			print "<div class='error'>" ;

--- a/modules/Planner/outcomes_delete.php
+++ b/modules/Planner/outcomes_delete.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_delete.ph
                 $filter2 = $_GET['filter2'];
             }
 
-            //Check if school year specified
+            //Check if gibbonOutcomeID specified
             $gibbonOutcomeID = $_GET['gibbonOutcomeID'];
             if ($gibbonOutcomeID == '') {
                 echo "<div class='error'>";

--- a/modules/Planner/outcomes_edit.php
+++ b/modules/Planner/outcomes_edit.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_edit.php'
                 echo '</div>';
             }
 
-            //Check if school year specified
+            //Check if gibbonOutcomeID specified
             $gibbonOutcomeID = $_GET['gibbonOutcomeID'];
             if ($gibbonOutcomeID == '') {
                 echo "<div class='error'>";

--- a/modules/Planner/outcomes_editProcess.php
+++ b/modules/Planner/outcomes_editProcess.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_edit.php'
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonOutcomeID specified
             if ($gibbonOutcomeID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Planner/planner_bump.php
+++ b/modules/Planner/planner_bump.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_bump.php')
             list($todayYear, $todayMonth, $todayDay) = explode('-', $today);
             $todayStamp = mktime(12, 0, 0, $todayMonth, $todayDay, $todayYear);
 
-            //Check if school year specified
+            //Check if gibbonPlannerEntryID and gibbonCourseClassID specified
             $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
             $gibbonPlannerEntryID = $_GET['gibbonPlannerEntryID'];
             if ($gibbonPlannerEntryID == '' or ($viewBy == 'class' and $gibbonCourseClassID == 'Y')) {

--- a/modules/Planner/planner_delete.php
+++ b/modules/Planner/planner_delete.php
@@ -88,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_delete.php
         list($todayYear, $todayMonth, $todayDay) = explode('-', $today);
         $todayStamp = mktime(12, 0, 0, $todayMonth, $todayDay, $todayYear);
 
-        //Check if school year specified
+        //Check if gibbonPlannerEntryID and gibbonCourseClassID specified
         $gibbonCourseClassID = isset($_GET['gibbonCourseClassID'])? $_GET['gibbonCourseClassID'] : '';
         $gibbonPlannerEntryID = isset($_GET['gibbonPlannerEntryID'])? $_GET['gibbonPlannerEntryID'] : '';
         if ($gibbonPlannerEntryID == '' or ($viewBy == 'class' and $gibbonCourseClassID == 'Y')) {

--- a/modules/Planner/planner_deleteProcess.php
+++ b/modules/Planner/planner_deleteProcess.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_delete.php
     } else {
         //Proceed!
 
-        //Check if school year specified
+        //Check if gibbonPlannerEntryID and gibbonCourseClassID specified
         if ($gibbonPlannerEntryID == '' or ($viewBy == 'class' and $gibbonCourseClassID == 'Y')) {
             $URL .= "&return=error1$params";
             header("Location: {$URL}");

--- a/modules/Planner/planner_duplicate.php
+++ b/modules/Planner/planner_duplicate.php
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.
         list($todayYear, $todayMonth, $todayDay) = explode('-', $today);
         $todayStamp = mktime(12, 0, 0, $todayMonth, $todayDay, $todayYear);
 
-        //Check if school year specified
+        ///Check if gibbonPlannerEntryID and gibbonCourseClassID specified
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
         $gibbonPlannerEntryID = $_GET['gibbonPlannerEntryID'];
         if ($gibbonPlannerEntryID == '' or ($viewBy == 'class' and $gibbonCourseClassID == 'Y')) {

--- a/modules/Planner/planner_edit.php
+++ b/modules/Planner/planner_edit.php
@@ -88,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
         list($todayYear, $todayMonth, $todayDay) = explode('-', $today);
         $todayStamp = mktime(12, 0, 0, $todayMonth, $todayDay, $todayYear);
 
-        //Check if school year specified
+        //Check if gibbonPlannerEntryID and gibbonCourseClassID specified
         $gibbonCourseClassID = null;
         if (isset($_GET['gibbonCourseClassID'])) {
             $gibbonCourseClassID = $_GET['gibbonCourseClassID'];

--- a/modules/Planner/planner_editProcess.php
+++ b/modules/Planner/planner_editProcess.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonPlannerEntryID and gibbonCourseClassID specified
             if ($gibbonPlannerEntryID == '' or ($viewBy == 'class' and $gibbonCourseClassID == '')) {
                 $URL .= "&return=error1$params";
                 header("Location: {$URL}");

--- a/modules/Planner/planner_edit_guest_deleteProcess.php
+++ b/modules/Planner/planner_edit_guest_deleteProcess.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
     } else {
         //Proceed!
 
-        //Check if school year specified
+        //Check if gibbonPlannerEntryID and gibbonCourseClassID specified
         if ($gibbonPlannerEntryID == '' or $gibbonPlannerEntryGuestID == '' or ($viewBy == 'class' and $gibbonCourseClassID == 'Y')) {
             $URL .= "&return=error1$params";
             header("Location: {$URL}");

--- a/modules/Planner/resources_manage_edit.php
+++ b/modules/Planner/resources_manage_edit.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_e
         echo '</div>';
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonResourceID specified
         $gibbonResourceID = $_GET['gibbonResourceID'];
         if ($gibbonResourceID == 'Y') {
             echo "<div class='error'>";

--- a/modules/Planner/resources_manage_editProcess.php
+++ b/modules/Planner/resources_manage_editProcess.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_e
             exit;
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonResourceID specified
             if ($gibbonResourceID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Rubrics/rubrics_delete.php
+++ b/modules/Rubrics/rubrics_delete.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_delete.php
             echo '</div>';
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             $gibbonRubricID = $_GET['gibbonRubricID'];
             if ($gibbonRubricID == '') {
                 echo "<div class='error'>";

--- a/modules/Rubrics/rubrics_duplicate.php
+++ b/modules/Rubrics/rubrics_duplicate.php
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_duplicate.
                 ->add(__('Manage Rubrics'), 'rubrics.php', ['search' => $search, 'filter2' => $filter2])
                 ->add(__('Duplicate Rubric'));
 
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             $gibbonRubricID = $_GET['gibbonRubricID'];
             if ($gibbonRubricID == '') {
                 echo "<div class='error'>";

--- a/modules/Rubrics/rubrics_duplicateProcess.php
+++ b/modules/Rubrics/rubrics_duplicateProcess.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_duplicate.
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             if ($gibbonRubricID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Rubrics/rubrics_edit.php
+++ b/modules/Rubrics/rubrics_edit.php
@@ -148,7 +148,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
                 echo '</div>';
             }
 
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             $gibbonRubricID = $_GET['gibbonRubricID'];
             if ($gibbonRubricID == '') {
                 echo "<div class='error'>";

--- a/modules/Rubrics/rubrics_editProcess.php
+++ b/modules/Rubrics/rubrics_editProcess.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             if ($gibbonRubricID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Rubrics/rubrics_edit_deleteColumnProcess.php
+++ b/modules/Rubrics/rubrics_edit_deleteColumnProcess.php
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonRubricID and gibbonRubricColumnID specified
             if ($gibbonRubricID == '' or $gibbonRubricColumnID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Rubrics/rubrics_edit_deleteRowProcess.php
+++ b/modules/Rubrics/rubrics_edit_deleteRowProcess.php
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonRubricID and gibbonRubricRowID specified
             if ($gibbonRubricID == '' or $gibbonRubricRowID == '') {
                 $URL .= '&&return=error1';
                 header("Location: {$URL}");

--- a/modules/Rubrics/rubrics_edit_editCellProcess.php
+++ b/modules/Rubrics/rubrics_edit_editCellProcess.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             if ($gibbonRubricID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Rubrics/rubrics_edit_editRowsColumns.php
+++ b/modules/Rubrics/rubrics_edit_editRowsColumns.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
                 echo '</div>';
             }
 
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             $gibbonRubricID = $_GET['gibbonRubricID'];
             if ($gibbonRubricID == '') {
                 echo "<div class='error'>";

--- a/modules/Rubrics/rubrics_edit_editRowsColumnsProcess.php
+++ b/modules/Rubrics/rubrics_edit_editRowsColumnsProcess.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
             header("Location: {$URL}");
         } else {
             //Proceed!
-            //Check if school year specified
+            //Check if gibbonRubricID specified
             if ($gibbonRubricID == '') {
                 $URL .= '&return=error1';
                 header("Location: {$URL}");

--- a/modules/Rubrics/rubrics_view_full.php
+++ b/modules/Rubrics/rubrics_view_full.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_view_full.
     echo '</div>';
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonRubricID specified
     $gibbonRubricID = $_GET['gibbonRubricID'];
     if ($gibbonRubricID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/attendanceSettings_manage_delete.php
+++ b/modules/School Admin/attendanceSettings_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonAttendanceCodeID specified
     $gibbonAttendanceCodeID = (isset($_GET['gibbonAttendanceCodeID']))? $_GET['gibbonAttendanceCodeID'] : NULL;
     if ($gibbonAttendanceCodeID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/attendanceSettings_manage_deleteProcess.php
+++ b/modules/School Admin/attendanceSettings_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonAttendanceCodeID specified
     if ($gibbonAttendanceCodeID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/department_manage_delete.php
+++ b/modules/School Admin/department_manage_delete.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
     echo '</div>';
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonDepartmentID specified
     $gibbonDepartmentID = $_GET['gibbonDepartmentID'];
     if ($gibbonDepartmentID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/department_manage_edit.php
+++ b/modules/School Admin/department_manage_edit.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
         ->add(__('Manage Departments'), 'department_manage.php')
         ->add(__('Edit Department'));
 
-    //Check if school year specified
+    //Check if gibbonDepartmentID specified
     $gibbonDepartmentID = $_GET['gibbonDepartmentID'];
     if ($gibbonDepartmentID == 'Y') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/department_manage_editProcess.php
+++ b/modules/School Admin/department_manage_editProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
     exit();
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonDepartmentID specified
     if ($gibbonDepartmentID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/department_manage_edit_staff_deleteProcess.php
+++ b/modules/School Admin/department_manage_edit_staff_deleteProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
 } else {
     //Proceed!
 
-    //Check if school year specified
+    //Check if gibbonDepartmentID specified
     if ($gibbonDepartmentID == '' or $gibbonDepartmentStaffID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/externalAssessments_manage_delete.php
+++ b/modules/School Admin/externalAssessments_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonExternalAssessmentID specified
     $gibbonExternalAssessmentID = $_GET['gibbonExternalAssessmentID'];
     if ($gibbonExternalAssessmentID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/externalAssessments_manage_edit.php
+++ b/modules/School Admin/externalAssessments_manage_edit.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
         ->add(__('Manage External Assessments'), 'externalAssessments_manage.php')
         ->add(__('Edit External Assessment'));
 
-    //Check if school year specified
+    //Check if gibbonExternalAssessmentID specified
     $gibbonExternalAssessmentID = $_GET['gibbonExternalAssessmentID'];
     if ($gibbonExternalAssessmentID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/externalAssessments_manage_edit_field_delete.php
+++ b/modules/School Admin/externalAssessments_manage_edit_field_delete.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonExternalAssessmentFieldID and gibbonExternalAssessmentID specified
     $gibbonExternalAssessmentFieldID = $_GET['gibbonExternalAssessmentFieldID'] ?? '';
     $gibbonExternalAssessmentID = $_GET['gibbonExternalAssessmentID'] ?? '';
     if ($gibbonExternalAssessmentFieldID == '' or $gibbonExternalAssessmentID == '') {

--- a/modules/School Admin/externalAssessments_manage_edit_field_deleteProcess.php
+++ b/modules/School Admin/externalAssessments_manage_edit_field_deleteProcess.php
@@ -32,7 +32,7 @@ if ($gibbonExternalAssessmentID == '') { echo 'Fatal error loading this page!';
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonExternalAssessmentFieldID specified
         if ($gibbonExternalAssessmentFieldID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/School Admin/externalAssessments_manage_edit_field_edit.php
+++ b/modules/School Admin/externalAssessments_manage_edit_field_edit.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/externalAsses
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonExternalAssessmentFieldID and gibbonExternalAssessmentID specified
     $gibbonExternalAssessmentFieldID = $_GET['gibbonExternalAssessmentFieldID'] ?? '';
     $gibbonExternalAssessmentID = $_GET['gibbonExternalAssessmentID'] ?? '';
     if ($gibbonExternalAssessmentFieldID == '' or $gibbonExternalAssessmentID == '') {

--- a/modules/School Admin/fileExtensions_manage_delete.php
+++ b/modules/School Admin/fileExtensions_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFileExtensionID specified
     $gibbonFileExtensionID = $_GET['gibbonFileExtensionID'];
     if ($gibbonFileExtensionID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/fileExtensions_manage_deleteProcess.php
+++ b/modules/School Admin/fileExtensions_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFileExtensionID specified
     if ($gibbonFileExtensionID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/fileExtensions_manage_edit.php
+++ b/modules/School Admin/fileExtensions_manage_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
         ->add(__('Manage File Extensions'), 'fileExtensions_manage.php')
         ->add(__('Edit File Extensions'));
 
-    //Check if school year specified
+    //Check if gibbonFileExtensionID specified
     $gibbonFileExtensionID = $_GET['gibbonFileExtensionID'];
     if ($gibbonFileExtensionID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/fileExtensions_manage_editProcess.php
+++ b/modules/School Admin/fileExtensions_manage_editProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/fileExtension
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFileExtensionID specified
     if ($gibbonFileExtensionID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/formGroup_manage_delete.php
+++ b/modules/School Admin/formGroup_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/formGroup_man
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
     $gibbonFormGroupID = $_GET['gibbonFormGroupID'] ?? '';
 
-    //Check if school year specified
+    //Check if gibbonFormGroupID specified
     if ($gibbonFormGroupID == '' and $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/School Admin/formGroup_manage_deleteProcess.php
+++ b/modules/School Admin/formGroup_manage_deleteProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/formGroup_man
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFormGroupID specified
     if ($gibbonFormGroupID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/formGroup_manage_edit.php
+++ b/modules/School Admin/formGroup_manage_edit.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/formGroup_man
         ->add(__('Manage Form Groups'), 'formGroup_manage.php', ['gibbonSchoolYearID' => $gibbonSchoolYearID])
         ->add(__('Edit Form Group'));
 
-    //Check if school year specified
+    //Check if gibbonFormGroupID and gibbonSchoolYearID specified
     if ($gibbonFormGroupID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/School Admin/formGroup_manage_editProcess.php
+++ b/modules/School Admin/formGroup_manage_editProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/formGroup_man
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFormGroupID and gibbonSchoolYearID specified
     if ($gibbonFormGroupID == '' or $gibbonSchoolYearID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/gradeScales_manage_delete.php
+++ b/modules/School Admin/gradeScales_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonScaleID specified
     $gibbonScaleID = $_GET['gibbonScaleID'];
     if ($gibbonScaleID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/gradeScales_manage_deleteProcess.php
+++ b/modules/School Admin/gradeScales_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonScaleID specified
     if ($gibbonScaleID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/gradeScales_manage_edit.php
+++ b/modules/School Admin/gradeScales_manage_edit.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
         ->add(__('Manage Grade Scales'), 'gradeScales_manage.php')
         ->add(__('Edit Grade Scale'));
 
-    //Check if school year specified
+    //Check if gibbonScaleID specified
     $gibbonScaleID = (isset($_GET['gibbonScaleID']))? $_GET['gibbonScaleID'] : null;
     if (empty($gibbonScaleID)) {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/gradeScales_manage_edit_grade_delete.php
+++ b/modules/School Admin/gradeScales_manage_edit_grade_delete.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonScaleGradeID and gibbonScaleID specified
     $gibbonScaleGradeID = $_GET['gibbonScaleGradeID'] ?? '';
     $gibbonScaleID = $_GET['gibbonScaleID'] ?? '';
     if ($gibbonScaleGradeID == '' or $gibbonScaleID == '') {

--- a/modules/School Admin/gradeScales_manage_edit_grade_deleteProcess.php
+++ b/modules/School Admin/gradeScales_manage_edit_grade_deleteProcess.php
@@ -32,7 +32,7 @@ if ($gibbonScaleID == '') { echo 'Fatal error loading this page!';
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonScaleGradeID specified
         if ($gibbonScaleGradeID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/School Admin/gradeScales_manage_edit_grade_edit.php
+++ b/modules/School Admin/gradeScales_manage_edit_grade_edit.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/gradeScales_m
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonScaleGradeID and gibbonScaleID specified
     $gibbonScaleGradeID = $_GET['gibbonScaleGradeID'] ?? '';
     $gibbonScaleID = $_GET['gibbonScaleID'] ?? '';
     if ($gibbonScaleGradeID == '' or $gibbonScaleID == '') {

--- a/modules/School Admin/house_manage_delete.php
+++ b/modules/School Admin/house_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonHouseID specified
     $gibbonHouseID = $_GET['gibbonHouseID'];
     if ($gibbonHouseID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/house_manage_deleteProcess.php
+++ b/modules/School Admin/house_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonHouseID specified
     if ($gibbonHouseID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/house_manage_edit.php
+++ b/modules/School Admin/house_manage_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
         ->add(__('Manage Houses'), 'house_manage.php')
         ->add(__('Edit House'));
 
-    //Check if school year specified
+    //Check if gibbonHouseID specified
     $gibbonHouseID = $_GET['gibbonHouseID'];
     if ($gibbonHouseID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/house_manage_editProcess.php
+++ b/modules/School Admin/house_manage_editProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/house_manage_
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonHouseID specified
     if ($gibbonHouseID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/inSettings_delete.php
+++ b/modules/School Admin/inSettings_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/inSettings_de
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonINDescriptorID specified
     $gibbonINDescriptorID = $_GET['gibbonINDescriptorID'];
     if ($gibbonINDescriptorID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/inSettings_deleteProcess.php
+++ b/modules/School Admin/inSettings_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/inSettings_de
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonINDescriptorID specified
     if ($gibbonINDescriptorID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/inSettings_edit.php
+++ b/modules/School Admin/inSettings_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/inSettings_ed
         ->add(__('Individual Needs Settings'), 'inSettings.php')
         ->add(__('Edit Descriptor'));
 
-    //Check if school year specified
+    //Check if gibbonINDescriptorID specified
     $gibbonINDescriptorID = $_GET['gibbonINDescriptorID'];
     if ($gibbonINDescriptorID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/inSettings_editProcess.php
+++ b/modules/School Admin/inSettings_editProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/inSettings_ed
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonINDescriptorID specified
     if ($gibbonINDescriptorID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/schoolYearSpecialDay_manage_delete.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
     $gibbonSchoolYearSpecialDayID = $_GET['gibbonSchoolYearSpecialDayID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
 
-    //Check if school year specified
+    //Check if gibbonSchoolYearSpecialDayID specified
     if ($gibbonSchoolYearSpecialDayID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/School Admin/schoolYearSpecialDay_manage_deleteProcess.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSchoolYearSpecialDayID specified
     if ($gibbonSchoolYearSpecialDayID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/schoolYearSpecialDay_manage_edit.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_edit.php
@@ -25,7 +25,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSchoolYearSpecialDayID and gibbonSchoolYearID specified
     $gibbonSchoolYearSpecialDayID = $_GET['gibbonSchoolYearSpecialDayID'] ?? '';
     $gibbonSchoolYearTermID = $_GET['gibbonSchoolYearTermID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/School Admin/schoolYearTerm_manage_delete.php
+++ b/modules/School Admin/schoolYearTerm_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSchoolYearTermID specified
     $gibbonSchoolYearTermID = $_GET['gibbonSchoolYearTermID'];
     if ($gibbonSchoolYearTermID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/schoolYearTerm_manage_deleteProcess.php
+++ b/modules/School Admin/schoolYearTerm_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSchoolYearTermID specified
     if ($gibbonSchoolYearTermID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/schoolYearTerm_manage_edit.php
+++ b/modules/School Admin/schoolYearTerm_manage_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
         ->add(__('Manage Terms'), 'schoolYearTerm_manage.php')
         ->add(__('Edit Term'));
 
-    //Check if school year specified
+    //Check if gibbonSchoolYearTermID specified
     $gibbonSchoolYearTermID = $_GET['gibbonSchoolYearTermID'];
     if ($gibbonSchoolYearTermID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/schoolYearTerm_manage_editProcess.php
+++ b/modules/School Admin/schoolYearTerm_manage_editProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearTer
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSchoolYearTermID specified
     if ($gibbonSchoolYearTermID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/space_manage_delete.php
+++ b/modules/School Admin/space_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSpaceID specified
     $gibbonSpaceID = $_GET['gibbonSpaceID'];
     if ($gibbonSpaceID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/space_manage_deleteProcess.php
+++ b/modules/School Admin/space_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSpaceID specified
     if ($gibbonSpaceID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/space_manage_edit.php
+++ b/modules/School Admin/space_manage_edit.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
         ->add(__('Manage Facilities'), 'space_manage.php')
         ->add(__('Edit Facility'));
 
-    //Check if school year specified
+    //Check if gibbonSpaceID specified
     $gibbonSpaceID = $_GET['gibbonSpaceID'];
     if ($gibbonSpaceID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/space_manage_editProcess.php
+++ b/modules/School Admin/space_manage_editProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSpaceID specified
     if ($gibbonSpaceID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/yearGroup_manage_delete.php
+++ b/modules/School Admin/yearGroup_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonYearGroupID specified
     $gibbonYearGroupID = $_GET['gibbonYearGroupID'];
     if ($gibbonYearGroupID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/yearGroup_manage_deleteProcess.php
+++ b/modules/School Admin/yearGroup_manage_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonYearGroupID specified
     if ($gibbonYearGroupID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/School Admin/yearGroup_manage_edit.php
+++ b/modules/School Admin/yearGroup_manage_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
         ->add(__('Manage Year Groups'), 'yearGroup_manage.php')
         ->add(__('Edit Year Group'));
 
-    //Check if school year specified
+    //Check if gibbonYearGroupID specified
     $gibbonYearGroupID = $_GET['gibbonYearGroupID'];
     if ($gibbonYearGroupID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/School Admin/yearGroup_manage_editProcess.php
+++ b/modules/School Admin/yearGroup_manage_editProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/yearGroup_man
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonYearGroupID specified
     if ($gibbonYearGroupID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Staff/applicationForm_manage_accept.php
+++ b/modules/Staff/applicationForm_manage_accept.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
         ->add(__('Manage Applications'), 'applicationForm_manage.php')
         ->add(__('Accept Application'));
 
-    //Check if school year specified
+    //Check if gibbonStaffApplicationFormID specified
     $gibbonStaffApplicationFormID = $_GET['gibbonStaffApplicationFormID'];
     $search = $_GET['search'];
     if ($gibbonStaffApplicationFormID == '') {

--- a/modules/Staff/applicationForm_manage_delete.php
+++ b/modules/Staff/applicationForm_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStaffApplicationFormID specified
     $gibbonStaffApplicationFormID = $_GET['gibbonStaffApplicationFormID'];
     $search = $_GET['search'];
     if ($gibbonStaffApplicationFormID == '') {

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
         ->add(__('Manage Applications'), 'applicationForm_manage.php')
         ->add(__('Edit Form'));
 
-    //Check if school year specified
+    //Check if gibbonStaffApplicationFormID specified
     $gibbonStaffApplicationFormID = $_GET['gibbonStaffApplicationFormID'];
     $search = $_GET['search'];
     if ($gibbonStaffApplicationFormID == '') {

--- a/modules/Staff/applicationForm_manage_editProcess.php
+++ b/modules/Staff/applicationForm_manage_editProcess.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStaffApplicationFormID specified
 
     if ($gibbonStaffApplicationFormID == '') {
         $URL .= '&return=error1';

--- a/modules/Staff/applicationForm_manage_reject.php
+++ b/modules/Staff/applicationForm_manage_reject.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
         ->add(__('Manage Applications'), 'applicationForm_manage.php')
         ->add(__('Reject Application'));
 
-    //Check if school year specified
+    //Check if gibbonStaffApplicationFormID specified
     $gibbonStaffApplicationFormID = $_GET['gibbonStaffApplicationFormID'];
     $search = $_GET['search'];
     if ($gibbonStaffApplicationFormID == '') {

--- a/modules/Staff/applicationForm_manage_rejectProcess.php
+++ b/modules/Staff/applicationForm_manage_rejectProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStaffApplicationFormID specified
 
     if ($gibbonStaffApplicationFormID == '') {
         $URL .= '&return=error1';

--- a/modules/Staff/jobOpenings_manage_delete.php
+++ b/modules/Staff/jobOpenings_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage_d
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStaffJobOpeningID specified
     $gibbonStaffJobOpeningID = $_GET['gibbonStaffJobOpeningID'];
     if ($gibbonStaffJobOpeningID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Staff/jobOpenings_manage_edit.php
+++ b/modules/Staff/jobOpenings_manage_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/jobOpenings_manage_e
         ->add(__('Job Openings'), 'jobOpenings_manage.php')
         ->add(__('Edit Job Opening'));
 
-    //Check if school year specified
+    //Check if gibbonStaffJobOpeningID specified
     $gibbonStaffJobOpeningID = $_GET['gibbonStaffJobOpeningID'];
     if ($gibbonStaffJobOpeningID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Staff/staff_manage_delete.php
+++ b/modules/Staff/staff_manage_delete.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_delete.
     $allStaff = $_GET['allStaff'] ?? '';
     $search = $_GET['search'] ?? '' ;
 
-    //Check if school year specified
+    //Check if gibbonStaffID specified
     $gibbonStaffID = $_GET['gibbonStaffID'];
     if ($gibbonStaffID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Staff/staff_manage_deleteProcess.php
+++ b/modules/Staff/staff_manage_deleteProcess.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_delete.
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStaffID specified
     if ($gibbonStaffID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Staff/staff_manage_edit.php
+++ b/modules/Staff/staff_manage_edit.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
             ->add(__('Manage Staff'), 'staff_manage.php', ['search' => $search, 'allStaff' => $allStaff])
             ->add(__('Edit Staff'), 'staff_manage_edit.php');
 
-        //Check if school year specified
+        //Check if gibbonStaffID specified
         $gibbonStaffID = $_GET['gibbonStaffID'];
         if ($gibbonStaffID == '') {
             echo "<div class='error'>";

--- a/modules/Staff/staff_manage_editProcess.php
+++ b/modules/Staff/staff_manage_editProcess.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStaffID specified
     if ($gibbonStaffID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Staff/staff_manage_edit_contract_add.php
+++ b/modules/Staff/staff_manage_edit_contract_add.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_co
     }
     $page->return->setEditLink($editLink);
 
-    //Check if school year specified
+    //Check if gibbonStaffID specified
     if ($gibbonStaffID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Staff/staff_manage_edit_contract_edit.php
+++ b/modules/Staff/staff_manage_edit_contract_edit.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_co
         ->add(__('Edit Staff'), 'staff_manage_edit.php', ['gibbonStaffID' => $gibbonStaffID])
         ->add(__('Edit Contract'));
 
-    //Check if school year specified
+    //Check if gibbonStaffID and gibbonStaffContractID specified
     if ($gibbonStaffID == '' or $gibbonStaffContractID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Staff/staff_manage_edit_facility_add.php
+++ b/modules/Staff/staff_manage_edit_facility_add.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_fa
         ->add(__('Edit Staff'), 'staff_manage_edit.php', ['gibbonStaffID' => $gibbonStaffID, 'gibbonSpacePersonID' => $gibbonSpacePersonID])
         ->add(__('Add Facility'));
 
-    //Check if school year specified
+    //Check if gibbonStaffID and gibbonPersonIDspecified
     if ($gibbonStaffID == '' or $gibbonPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Staff/staff_manage_edit_facility_delete.php
+++ b/modules/Staff/staff_manage_edit_facility_delete.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_fa
         $search = $_GET['search'];
     }
 
-    //Check if school year specified
+    //Check if gibbonStaffID and gibbonSpacePersonID specified
     if ($gibbonSpacePersonID == '' or $gibbonStaffID =='') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Staff/staff_manage_edit_facility_deleteProcess.php
+++ b/modules/Staff/staff_manage_edit_facility_deleteProcess.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit_fa
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonSpacePersonID and gibbonStaffID specified
     if ($gibbonSpacePersonID == '' and $gibbonStaffID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         ->add(__('Manage Applications'), 'applicationForm_manage.php', ['gibbonSchoolYearID' => $gibbonSchoolYearID])
         ->add(__('Accept Application'));
 
-    //Check if school year specified
+    //Check if gibbonApplicationFormID and gibbonSchoolYearID specified
     if ($gibbonApplicationFormID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Students/applicationForm_manage_delete.php
+++ b/modules/Students/applicationForm_manage_delete.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
     $search = $_GET['search'] ?? '';
 
-    //Check if school year specified
+    //Check if gibbonApplicationFormID and gibbonSchoolYearID specified
     if ($gibbonApplicationFormID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         ->add(__('Manage Applications'), 'applicationForm_manage.php', ['gibbonSchoolYearID' => $gibbonSchoolYearID])
         ->add(__('Edit Form'));
 
-    //Check if school year specified
+    //Check if gibbonApplicationFormID and gibbonSchoolYearID specified
     if ($gibbonApplicationFormID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
         return;

--- a/modules/Students/applicationForm_manage_editProcess.php
+++ b/modules/Students/applicationForm_manage_editProcess.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonApplicationFormID and gibbonSchoolYearID specified
 
     if ($gibbonApplicationFormID == '' or $gibbonSchoolYearID == '') {
         $URL .= '&return=error1';

--- a/modules/Students/applicationForm_manage_reject.php
+++ b/modules/Students/applicationForm_manage_reject.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         ->add(__('Manage Applications'), 'applicationForm_manage.php', ['gibbonSchoolYearID' => $gibbonSchoolYearID])
         ->add(__('Reject Application'));
 
-    //Check if school year specified
+    //Check if gibbonApplicationFormID and gibbonSchoolYearID specified
     if ($gibbonApplicationFormID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Students/applicationForm_manage_rejectProcess.php
+++ b/modules/Students/applicationForm_manage_rejectProcess.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonApplicationFormID and gibbonSchoolYearID specified
 
     if ($gibbonApplicationFormID == '' or $gibbonSchoolYearID == '') {
         $URL .= '&return=error1';

--- a/modules/Students/firstAidRecord_editProcess.php
+++ b/modules/Students/firstAidRecord_editProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFirstAidID specified
     if ($gibbonFirstAidID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Students/medicalForm_manage_condition_add.php
+++ b/modules/Students/medicalForm_manage_condition_add.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     }
     $page->return->setEditLink($editLink);
 
-    //Check if school year specified
+    //Check if gibbonPersonMedicalID specified
     $gibbonPersonMedicalID = $_GET['gibbonPersonMedicalID'];
     $search = $_GET['search'];
     if ($gibbonPersonMedicalID == '') {

--- a/modules/Students/medicalForm_manage_condition_delete.php
+++ b/modules/Students/medicalForm_manage_condition_delete.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     $gibbonPersonMedicalConditionID = $_GET['gibbonPersonMedicalConditionID'] ?? '';
     $search = $_GET['search'] ?? '';
 
-    //Check if school year specified
+    //Check if gibbonPersonMedicalID and gibbonPersonMedicalConditionID specified
     if ($gibbonPersonMedicalID == '' or $gibbonPersonMedicalConditionID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Students/medicalForm_manage_condition_deleteProcess.php
+++ b/modules/Students/medicalForm_manage_condition_deleteProcess.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 include '../../gibbon.php';
 
-//Check if school year specified
+//Check if gibbonPersonMedicalID and gibbonPersonMedicalConditionID specified
 $gibbonPersonMedicalID = $_GET['gibbonPersonMedicalID'] ?? '';
 $gibbonPersonMedicalConditionID = $_GET['gibbonPersonMedicalConditionID'] ?? '';
 $search = $_GET['search'] ?? '';

--- a/modules/Students/medicalForm_manage_delete.php
+++ b/modules/Students/medicalForm_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonMedicalID specified
     $gibbonPersonMedicalID = $_GET['gibbonPersonMedicalID'];
     $search = $_GET['search'];
     if ($gibbonPersonMedicalID == '') {

--- a/modules/Students/studentEnrolment_manage_delete.php
+++ b/modules/Students/studentEnrolment_manage_delete.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
     $gibbonStudentEnrolmentID = $_GET['gibbonStudentEnrolmentID'] ?? '';
     $search = $_GET['search'] ?? '';
 
-    //Check if school year specified
+    //Check if gibbonStudentEnrolmentID and gibbonSchoolYearID specified
     if ($gibbonStudentEnrolmentID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Students/studentEnrolment_manage_edit.php
+++ b/modules/Students/studentEnrolment_manage_edit.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/studentEnrolment_
         ->add(__('Student Enrolment'), 'studentEnrolment_manage.php', ['gibbonSchoolYearID' => $gibbonSchoolYearID])
         ->add(__('Edit Student Enrolment'));
 
-    //Check if school year specified
+    //Check if gibbonStudentEnrolmentID and gibbonSchoolYearID specified
     if ($gibbonStudentEnrolmentID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Students/student_view_details_notes_edit.php
+++ b/modules/Students/student_view_details_notes_edit.php
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         ->add(Format::name('', $student['preferredName'], $student['surname'], 'Student'), 'student_view_details.php', ['gibbonPersonID' => $gibbonPersonID, 'subpage' => $subpage, 'allStudents' => $allStudents])
                         ->add(__('Edit Student Note'));
 
-                    //Check if school year specified
+                    //Check if gibbonStudentNoteID specified
                     $gibbonStudentNoteID = $_GET['gibbonStudentNoteID'];
                     if ($gibbonStudentNoteID == '') {
                         echo "<div class='error'>";

--- a/modules/System Admin/i18n_manage_install.php
+++ b/modules/System Admin/i18n_manage_install.php
@@ -25,7 +25,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/i18n_manage.p
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibboni18nID specified
     $gibboni18nID = isset($_GET['gibboni18nID'])? $_GET['gibboni18nID'] : '';
     $mode = isset($_GET['mode'])? $_GET['mode'] : 'install';
 

--- a/modules/System Admin/stringReplacement_manage_delete.php
+++ b/modules/System Admin/stringReplacement_manage_delete.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
         $search = $_GET['search'];
     }
 
-    //Check if school year specified
+    //Check if gibbonStringID specified
     $gibbonStringID = $_GET['gibbonStringID'];
     if ($gibbonStringID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/System Admin/stringReplacement_manage_deleteProcess.php
+++ b/modules/System Admin/stringReplacement_manage_deleteProcess.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStringID specified
     if ($gibbonStringID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonID and gibbonSchoolYearID specified
     $gibbonPersonID = isset($_GET['gibbonPersonID'])? $_GET['gibbonPersonID'] : '';
     $gibbonSchoolYearID = isset($_GET['gibbonSchoolYearID'])? $_GET['gibbonSchoolYearID'] : '';
     $type = isset($_GET['type'])? $_GET['type'] : '';

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonPersonID, gibbonCourseClassID, and gibbonSchoolYearID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
     $gibbonPersonID = $_GET['gibbonPersonID'] ?? '';

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_deleteProcess.php
@@ -36,7 +36,7 @@ if ($gibbonPersonID == '' or $gibbonCourseClassID == '' or $gibbonSchoolYearID =
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonPersonID specified
         if ($gibbonPersonID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonPersonID, gibbonCourseClassID and gibbonSchoolYearID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
     $gibbonPersonID = $_GET['gibbonPersonID'] ?? '';

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonCourseID, gibbonSchoolYearID, and gibbonCourseClassID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
     $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_deleteProcess.php
@@ -35,7 +35,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonCourseClassPersonID specified
         if ($gibbonCourseClassPersonID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonCourseClassID, gibbonCourseID, gibbonSchoolYearID, and gibbonCourseClassPersonID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
     $gibbonCourseID = $_GET['gibbonCourseID'];
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];

--- a/modules/Timetable Admin/course_manage_class_delete.php
+++ b/modules/Timetable Admin/course_manage_class_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonCourseClassID, gibbonCourseID and gibbonSchoolYearID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
     $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/course_manage_class_deleteProcess.php
+++ b/modules/Timetable Admin/course_manage_class_deleteProcess.php
@@ -33,7 +33,7 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonCourseClassID specified
         if ($gibbonCourseClassID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/course_manage_class_edit.php
+++ b/modules/Timetable Admin/course_manage_class_edit.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         ->add(__('Edit Course & Classes'), 'course_manage_edit.php', ['gibbonCourseID' => $gibbonCourseID, 'gibbonSchoolYearID' => $gibbonSchoolYearID])
         ->add(__('Edit Class'));
 
-    //Check if school year specified
+    //Check if gibbonCourseClassID, gibbonCourseID, and gibbonSchoolYearID specified
     if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Timetable Admin/course_manage_delete.php
+++ b/modules/Timetable Admin/course_manage_delete.php
@@ -25,7 +25,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 } else {
     //Proceed!
     $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';
-    //Check if school year specified
+    //Check if gibbonCourseID specified
     if ($gibbonCourseID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {

--- a/modules/Timetable Admin/course_manage_edit.php
+++ b/modules/Timetable Admin/course_manage_edit.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         echo '</div>';
     }
 
-    //Check if school year specified
+    //Check if gibbonCourseID specified
     $gibbonCourseID = $_GET['gibbonCourseID'];
     if ($gibbonCourseID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Timetable Admin/ttColumn_delete.php
+++ b/modules/Timetable Admin/ttColumn_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_d
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonTTColumnID specified
     $gibbonTTColumnID = $_GET['gibbonTTColumnID'];
     if ($gibbonTTColumnID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Timetable Admin/ttColumn_deleteProcess.php
+++ b/modules/Timetable Admin/ttColumn_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_d
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonTTColumnID specified
     if ($gibbonTTColumnID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Timetable Admin/ttColumn_edit.php
+++ b/modules/Timetable Admin/ttColumn_edit.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
 
     $ttColumnGateway = $container->get(TimetableColumnGateway::class);
 
-    //Check if school year specified
+    //Check if gibbonTTColumnID specified
     $gibbonTTColumnID = $_GET['gibbonTTColumnID'];
     if ($gibbonTTColumnID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Timetable Admin/ttColumn_edit_row_delete.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_delete.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTColumnRowID and gibbonTTColumnID specified
     $gibbonTTColumnRowID = $_GET['gibbonTTColumnRowID'] ?? '';
     $gibbonTTColumnID = $_GET['gibbonTTColumnID'] ?? '';
     if ($gibbonTTColumnRowID == '' or $gibbonTTColumnID == '') {

--- a/modules/Timetable Admin/ttColumn_edit_row_deleteProcess.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_deleteProcess.php
@@ -32,7 +32,7 @@ if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTColumnRowID specified
         if ($gibbonTTColumnRowID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/ttColumn_edit_row_edit.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_edit.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTColumnRowID and gibbonTTColumnID specified
     $gibbonTTColumnRowID = $_GET['gibbonTTColumnRowID'] ?? '';
     $gibbonTTColumnID = $_GET['gibbonTTColumnID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/ttDates_edit.php
+++ b/modules/Timetable Admin/ttDates_edit.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
         ->add(__('Tie Days to Dates'), 'ttDates.php', ['gibbonSchoolYearID' => $gibbonSchoolYearID])
         ->add(__('Edit Days in Date'));
 
-    //Check if school year specified
+    //Check if gibbonSchoolYearID and dateStamp specified
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
     $dateStamp = $_GET['dateStamp'];
     if ($gibbonSchoolYearID == '' or $dateStamp == '') {

--- a/modules/Timetable Admin/ttDates_edit_delete.php
+++ b/modules/Timetable Admin/ttDates_edit_delete.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonSchoolYearID, dateStamp, and gibbonTTDayID specified
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
     $dateStamp = $_GET['dateStamp'] ?? '';
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';

--- a/modules/Timetable Admin/ttDates_edit_deleteProcess.php
+++ b/modules/Timetable Admin/ttDates_edit_deleteProcess.php
@@ -32,7 +32,7 @@ if ($gibbonSchoolYearID == '' or $dateStamp == '') { echo 'Fatal error loading t
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_delete.php
+++ b/modules/Timetable Admin/tt_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonTTID specified
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     if ($gibbonTTID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/Timetable Admin/tt_deleteProcess.php
+++ b/modules/Timetable Admin/tt_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonTTID specified
     if ($gibbonTTID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_edit.php
+++ b/modules/Timetable Admin/tt_edit.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
 
     $timetableGateway = $container->get(TimetableGateway::class);
 
-    //Check if school year specified
+    //Check if gibbonTTID and gibbonSchoolYearID specified
     $gibbonTTID = $_GET['gibbonTTID'];
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
     if ($gibbonTTID == '' || $gibbonSchoolYearID == '') {

--- a/modules/Timetable Admin/tt_edit_day_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_delete.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, and gibbonSchoolYearID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_deleteProcess.php
@@ -33,7 +33,7 @@ if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading 
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_edit_day_edit.php
+++ b/modules/Timetable Admin/tt_edit_day_edit.php
@@ -26,7 +26,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, and gibbonSchoolYearID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class.php
@@ -26,7 +26,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, gibbonSchoolYearID, and gibbonTTColumnRowID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'];
     $gibbonTTID = $_GET['gibbonTTID'];
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];

--- a/modules/Timetable Admin/tt_edit_day_edit_class_add.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_add.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, gibbonSchoolYearID, and gibbonTTColumnRowID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_addProcess.php
@@ -36,7 +36,7 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_edit_day_edit_class_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_delete.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, gibbonSchoolYearID, gibbonTTColumnRowID, and gibbonCourseClassID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'];
     $gibbonTTID = $_GET['gibbonTTID'];
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];

--- a/modules/Timetable Admin/tt_edit_day_edit_class_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_deleteProcess.php
@@ -36,7 +36,7 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_edit_day_edit_class_edit.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_edit.php
@@ -23,7 +23,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, gibbonSchoolYearID, gibbonTTColumnRowID, and gibbonCourseClassID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class_editProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_editProcess.php
@@ -37,7 +37,7 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
         //Proceed!
         $gibbonSpaceID = !empty($_POST['gibbonSpaceID']) ? $_POST['gibbonSpaceID'] : null;
 
-        //Check if school year specified
+        //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception.php
@@ -26,7 +26,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, gibbonSchoolYearID, gibbonTTColumnRowID, and gibbonCourseClassID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
@@ -25,7 +25,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, gibbonSchoolYearID, gibbonTTColumnRowID, and gibbonCourseClassID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_addProcess.php
@@ -35,7 +35,7 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonTTDayID, gibbonTTID, gibbonSchoolYearID, gibbonTTColumnRowID, gibbonCourseClassID, gibbonTTDayRowClassID, and gibbonTTDayRowClassExceptionID specified
     $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_deleteProcess.php
@@ -37,7 +37,7 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable Admin/tt_import.php
+++ b/modules/Timetable Admin/tt_import.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
         echo '</div>';
     }
 
-    //Check if school year specified
+    //Check if gibbonTTID and gibbonSchoolYearID specified
     $gibbonTTID = $_GET['gibbonTTID'];
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'];
     if ($gibbonTTID == '' or $gibbonSchoolYearID == '') {

--- a/modules/Timetable/spaceBooking_manage_delete.php
+++ b/modules/Timetable/spaceBooking_manage_delete.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
         echo '</div>';
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTSpaceBookingID specified
         $gibbonTTSpaceBookingID = $_GET['gibbonTTSpaceBookingID'];
         if ($gibbonTTSpaceBookingID == '') {
             echo "<div class='error'>";

--- a/modules/Timetable/spaceBooking_manage_deleteProcess.php
+++ b/modules/Timetable/spaceBooking_manage_deleteProcess.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTSpaceBookingID specified
         if ($gibbonTTSpaceBookingID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable/spaceChange_manage_delete.php
+++ b/modules/Timetable/spaceChange_manage_delete.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
         echo '</div>';
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTSpaceChangeID and gibbonCourseClassID specified
         $gibbonTTSpaceChangeID = $_GET['gibbonTTSpaceChangeID'];
         $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
         if ($gibbonTTSpaceChangeID == '' OR $gibbonCourseClassID == '') {

--- a/modules/Timetable/spaceChange_manage_deleteProcess.php
+++ b/modules/Timetable/spaceChange_manage_deleteProcess.php
@@ -35,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonTTSpaceChangeID and gibbonCourseClassID specified
         if ($gibbonTTSpaceChangeID == '' OR $gibbonCourseClassID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/Timetable/studentEnrolment_manage_edit.php
+++ b/modules/Timetable/studentEnrolment_manage_edit.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonCourseClassID and gibbonCourseID specified
     $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
     $gibbonSchoolYearID = $gibbon->session->get('gibbonSchoolYearID');
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'];

--- a/modules/Timetable/studentEnrolment_manage_edit_edit.php
+++ b/modules/Timetable/studentEnrolment_manage_edit_edit.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/studentEnrolment
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    //Check if school year specified
+    //Check if gibbonCourseClassID, gibbonCourseID, and gibbonPersonID specified
     $gibbonCourseClassID = $_GET['gibbonCourseClassID'];
     $gibbonCourseID = $_GET['gibbonCourseID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];

--- a/modules/User Admin/district_manage_delete.php
+++ b/modules/User Admin/district_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonDistrictID specified
     $gibbonDistrictID = $_GET['gibbonDistrictID'];
     if ($gibbonDistrictID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/district_manage_edit.php
+++ b/modules/User Admin/district_manage_edit.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/district_manage
         ->add(__('Manage Districts'), 'district_manage.php')
         ->add(__('Edit District'));        
 
-    //Check if school year specified
+    //Check if gibbonDistrictID specified
     $gibbonDistrictID = $_GET['gibbonDistrictID'];
     if ($gibbonDistrictID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/family_manage_delete.php
+++ b/modules/User Admin/family_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_d
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFamilyID specified
     $gibbonFamilyID = $_GET['gibbonFamilyID'] ?? '';
     $search = $_GET['search'] ?? '';
     if ($gibbonFamilyID == '') {

--- a/modules/User Admin/family_manage_edit.php
+++ b/modules/User Admin/family_manage_edit.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
         ->add(__('Manage Families'), 'family_manage.php')
         ->add(__('Edit Family'));        
 
-    //Check if school year specified
+    //Check if search and gibbonFamilyID specified
     $gibbonFamilyID = $_GET['gibbonFamilyID'];
     $search = '';
     if (isset($_GET['search'])) {

--- a/modules/User Admin/family_manage_edit_deleteAdult.php
+++ b/modules/User Admin/family_manage_edit_deleteAdult.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonFamilyID and gibbonPersonID specified
     $gibbonFamilyID = $_GET['gibbonFamilyID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];
     $search = $_GET['search'];

--- a/modules/User Admin/family_manage_edit_deleteAdultProcess.php
+++ b/modules/User Admin/family_manage_edit_deleteAdultProcess.php
@@ -33,7 +33,7 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonPersonID specified
         if ($gibbonPersonID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/User Admin/family_manage_edit_deleteChild.php
+++ b/modules/User Admin/family_manage_edit_deleteChild.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonID and gibbonFamilyID specified
     $gibbonFamilyID = $_GET['gibbonFamilyID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];
     $search = $_GET['search'];

--- a/modules/User Admin/family_manage_edit_deleteChildProcess.php
+++ b/modules/User Admin/family_manage_edit_deleteChildProcess.php
@@ -33,7 +33,7 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
         header("Location: {$URL}");
     } else {
         //Proceed!
-        //Check if school year specified
+        //Check if gibbonPersonID specified
         if ($gibbonPersonID == '') {
             $URL .= '&return=error1';
             header("Location: {$URL}");

--- a/modules/User Admin/family_manage_edit_editAdult.php
+++ b/modules/User Admin/family_manage_edit_editAdult.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
         ->add(__('Edit Family'), 'family_manage_edit.php', $urlParams)
         ->add(__('Edit Adult'));  
 
-    //Check if school year specified
+    //Check if gibbonPersonID and gibbonFamilyID specified
     $gibbonFamilyID = $_GET['gibbonFamilyID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];
     $search = $_GET['search'];

--- a/modules/User Admin/family_manage_edit_editChild.php
+++ b/modules/User Admin/family_manage_edit_editChild.php
@@ -32,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
         ->add(__('Edit Family'), 'family_manage_edit.php', $urlParams)
         ->add(__('Edit Child'));  
 
-    //Check if school year specified
+    //Check if gibbonPersonID and gibbonFamilyID specified
     $gibbonFamilyID = $_GET['gibbonFamilyID'];
     $gibbonPersonID = $_GET['gibbonPersonID'];
     $search = $_GET['search'];

--- a/modules/User Admin/role_manage_delete.php
+++ b/modules/User Admin/role_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_del
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonRoleID specified
     $gibbonRoleID = $_GET['gibbonRoleID'];
     if ($gibbonRoleID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/role_manage_edit.php
+++ b/modules/User Admin/role_manage_edit.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_edi
         ->add(__('Manage Roles'),'role_manage.php')
         ->add(__('Edit Role'));     
 
-    //Check if school year specified
+    //Check if gibbonRoleID specified
     $gibbonRoleID = $_GET['gibbonRoleID'];
     if ($gibbonRoleID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/studentsSettings_noteCategory_delete.php
+++ b/modules/User Admin/studentsSettings_noteCategory_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStudentNoteCategoryID specified
     $gibbonStudentNoteCategoryID = $_GET['gibbonStudentNoteCategoryID'];
     if ($gibbonStudentNoteCategoryID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/studentsSettings_noteCategory_deleteProcess.php
+++ b/modules/User Admin/studentsSettings_noteCategory_deleteProcess.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStudentNoteCategoryID specified
     if ($gibbonStudentNoteCategoryID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/User Admin/studentsSettings_noteCategory_edit.php
+++ b/modules/User Admin/studentsSettings_noteCategory_edit.php
@@ -29,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
     $page->breadcrumbs
         ->add(__('Students Settings'), 'studentsSettings.php')
         ->add(__('Edit Note Category'));
-    //Check if school year specified
+    //Check if gibbonStudentNoteCategoryID specified
     $gibbonStudentNoteCategoryID = $_GET['gibbonStudentNoteCategoryID'];
     if ($gibbonStudentNoteCategoryID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/studentsSettings_noteCategory_editProcess.php
+++ b/modules/User Admin/studentsSettings_noteCategory_editProcess.php
@@ -27,7 +27,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonStudentNoteCategoryID specified
     if ($gibbonStudentNoteCategoryID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/User Admin/user_manage_delete.php
+++ b/modules/User Admin/user_manage_delete.php
@@ -24,7 +24,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_del
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonID specified
     $gibbonPersonID = $_GET['gibbonPersonID'];
     if ($gibbonPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/user_manage_deleteProcess.php
+++ b/modules/User Admin/user_manage_deleteProcess.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_del
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonID specified
     if ($gibbonPersonID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
     $returns['warning1'] = __('Your request was completed successfully, but one or more images were the wrong size and so were not saved.');
     $page->return->addReturns($returns);
 
-    //Check if school year specified
+    //Check if gibbonPersonID specified
     $gibbonPersonID = $_GET['gibbonPersonID'] ?? '';
     if ($gibbonPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));

--- a/modules/User Admin/user_manage_editProcess.php
+++ b/modules/User Admin/user_manage_editProcess.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
     header("Location: {$URL}");
 } else {
     //Proceed!
-    //Check if school year specified
+    //Check if gibbonPersonID specified
     if ($gibbonPersonID == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");

--- a/modules/User Admin/user_manage_password.php
+++ b/modules/User Admin/user_manage_password.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
     $returns['error6'] = __('Your request failed because your password does not meet the minimum requirements for strength.');
     $page->return->addReturns($returns);
 
-    //Check if school year specified
+    //Check if gibbonPersonID specified
     $gibbonPersonID = $_GET['gibbonPersonID'] ?? '';
     if ($gibbonPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));


### PR DESCRIPTION
**Description**
This PR fixes a couple hundred comments that were incorrectly stating that the code was checking if school year specified.

**Motivation and Context**
In working on some code in the library module I noticed something was off with a comment, determined that it had likely been copy pasted from another piece of code, and then wondered how many times it had happened.. The answer was at least 260 times in the core.
![image](https://user-images.githubusercontent.com/48048360/123796099-56488300-d917-11eb-8c98-79e3af213717.png)
![image](https://user-images.githubusercontent.com/48048360/123796244-8001aa00-d917-11eb-923f-cdc991ab9281.png)

**How Has This Been Tested?**
As the only changes have been to comments the functionality of the code should remain unchanged, hopefully Github Actiosn will agree with me on this.
