### PR TITLE
Reporting: fix issue with empty milestone

### DIFF
--- a/modules/Reports/reporting_cycles_manage_editProcess.php
+++ b/modules/Reports/reporting_cycles_manage_editProcess.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_cycles_m
         'cycleNumber'           => $_POST['cycleNumber'] ?? '1',
         'cycleTotal'            => $_POST['cycleTotal'] ?? '1',
         'notes'                 => $_POST['notes'] ?? '',
-        'milestones'            => $_POST['milestones'] ?? '',
+        'milestones'            => $_POST['milestones'] ?? [],
     ];
 
     $data['dateStart'] = Format::dateConvert($data['dateStart']);
@@ -56,10 +56,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_cycles_m
         $item['milestoneDate'] = Format::dateConvert($item['milestoneDate']);
         return $item;
     }, $data['milestones']);
-    $data['milestones'] = array_combine(array_keys($_POST['order']), array_values($data['milestones']));
+    $data['milestones'] = array_combine(array_keys($_POST['order'] ?? []), array_values($data['milestones']));
     ksort($data['milestones']);
     $data['milestones'] = json_encode($data['milestones']);
-    
+
     // Validate the required values are present
     if (empty($gibbonReportingCycleID) || empty($gibbonSchoolYearID) || empty($data['name']) || empty($data['nameShort'])) {
         $URL .= '&return=error1';


### PR DESCRIPTION
**Description**
* In Reporting ([reporting_cycles_manage_editProcess.php](https://github.com/GibbonEdu/core/blob/v22.0.00/modules/Reports/reporting_cycles_manage_editProcess.php#L55-L58)), the submitted value `$_POST['milestones']` is supposed to be an array. However, if there is no milestone submitted, the value `$_POST['milestones']` would be not set.
* The null coercion in [line 48](https://github.com/GibbonEdu/core/blob/v22.0.00/modules/Reports/reporting_cycles_manage_editProcess.php#L48) would provide an empty string as the fallback value, which is not an array. This would cause issue in the array_map in [line 55-58](https://github.com/GibbonEdu/core/blob/v22.0.00/modules/Reports/reporting_cycles_manage_editProcess.php#L55-L58).
* Changing the fallback value from an empty string could fix the issue. (Need original reporter @tr-j verification)
* Best if we can have this in our acceptance test. But there is currently no acceptance test for it. And I'm not familiar with the module enough to write one.

**Motivation and Context**
Fix #1378.

**How Has This Been Tested?**
* Not tested yet. Pending on @tr-j hands-on testing.