### PR TITLE
Remove uses of obsoleted getUserPhoto

### DIFF
--- a/src/UI/Components/Sidebar.php
+++ b/src/UI/Components/Sidebar.php
@@ -25,6 +25,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Forms\OutputableInterface;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
+use Gibbon\Services\Format;
 use League\Container\ContainerAwareTrait;
 use League\Container\ContainerAwareInterface;
 
@@ -123,7 +124,7 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
                 unset($_GET['return']);
 
                 $enablePublicRegistration = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration');
-                
+
                 $form = Form::create('loginForm', $this->session->get('absoluteURL').'/login.php?'.http_build_query($_GET) );
 
                 $form->setFactory(DatabaseFormFactory::create($pdo));
@@ -381,7 +382,7 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
 
                 echo "<p style='padding-top: 0px; text-align: right'>";
                 echo "<a href='".$this->session->get('absoluteURL')."/index.php?q=/modules/Planner/planner_deadlines.php'>";
-                
+
                 echo __('View {homeworkName}', ['homeworkName' => __($homeworkNamePlural)]);
                 echo '</a>';
                 echo '</p>';
@@ -550,7 +551,7 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
         //Show year switcher if user is staff and has access to multiple years
         if ($this->session->exists('username') && $this->category == 'Staff' && $this->session->get('address') == '') {
             //Check for multiple-year login
-            
+
                 $data = array('gibbonRoleID' => $this->session->get('gibbonRoleIDCurrent'));
                 $sql = "SELECT futureYearsLogin, pastYearsLogin FROM gibbonRole WHERE gibbonRoleID=:gibbonRoleID";
                 $result = $connection2->prepare($sql);
@@ -637,7 +638,7 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
 
             } else { //Photo, so show image and removal link
                 $output .= '<p>';
-                $output .= getUserPhoto($guid, $this->session->get('image_240'), 240);
+                $output .= Format::userPhoto($this->session->get('image_240'), 240);
                 $output .= "<div style='margin-left: 220px; margin-top: -50px'>";
                 $output .= "<a href='".$this->session->get('absoluteURL').'/index_parentPhotoDeleteProcess.php?gibbonPersonID='.$this->session->get('gibbonPersonID')."' onclick='return confirm(\"Are you sure you want to delete this record? Unsaved changes will be lost.\")'><img style='margin-bottom: -8px' id='image_240_delete' title='".__('Delete')."' src='./themes/".$this->session->get('gibbonThemeName')."/img/garbage.png'/></a><br/><br/>";
                 $output .= '</div>';

--- a/src/UI/Dashboard/ParentDashboard.php
+++ b/src/UI/Dashboard/ParentDashboard.php
@@ -111,7 +111,7 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                 $output .= '<section class="flex flex-col sm:flex-row">';
 
                 $output .= '<div class="w-24 text-center mx-auto mb-4 sm:ml-0 sm:mr-4">'.
-                    getUserPhoto($guid, $student['image_240'], 75).
+                    Format::userPhoto($student['image_240'], 75).
                     "<div style='height: 5px'></div>".
                     "<span style='font-size: 70%'>".
                     "<a href='".$this->session->get('absoluteURL').'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$student['gibbonPersonID']."'>".__('Student Profile').'</a><br/>';


### PR DESCRIPTION
**Description**
* Replace with Format::userPhoto() calls.

**Motivation and Context**
* The function `getUserPhoto` was marked obsoleted in v16 but found some trace of it.

**How Has This Been Tested?**
* Locally