### PR TITLE
Remove gibbon.php include from functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -22,8 +22,6 @@ use Gibbon\Services\Format;
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Domain\System\LogGateway;
 
-require_once dirname(__FILE__).'/gibbon.php';
-
 function getIPAddress() {
     $return = false;
 

--- a/lib/paypal/expresscheckout.php
+++ b/lib/paypal/expresscheckout.php
@@ -1,6 +1,6 @@
 <?php
 
-include "../../functions.php" ;
+require_once __DIR__ . '/../../gibbon.php' ;
 include "../../config.php" ;
 
 @session_start() ;

--- a/lib/paypal/expresscheckout.php
+++ b/lib/paypal/expresscheckout.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../gibbon.php' ;
+require_once __DIR__ . '/../../functions.php' ;
 include "../../config.php" ;
 
 @session_start() ;


### PR DESCRIPTION
**Description**
* With the statement, functions.php can never be included by itself.
  And gibbon.php might not work within the context where functions.php
  could be useful.

* The lib/paypal/expresscheckout.php includes functions.php, which
  in turn includes gibbon.php (which includes functions.php). This is
  purely redundent. Changed to include gibbon.php directly.

**Motivation and Context**
Another piece of my work needs to include the `functions.php` file. But since it includes `gibbon.php`, there are logics that stops things from working in my situation. There is no point blocking the include of `functions.php`. It should be dry and without unnecessary dependencies.

I've only found 1 direct include of `functions.php` in the code base in `lib/paypal/expresscheckout.php`. I figure it might need `gibbon.php` environment to work, so I changed it to directly include `functions.php`.

**How Has This Been Tested?**
CI platform