### PR TITLE
Test: Fix typo in class name

### DIFF
--- a/tests/unit/Gibbon/FileUploaderTest.php
+++ b/tests/unit/Gibbon/FileUploaderTest.php
@@ -37,7 +37,7 @@ class FileUploaderTest extends TestCase
                       ->willReturn($mockResults);
 
         // Create a stub for the Gibbon\session class
-        $this->mockSession = $this->createMock(session::class);
+        $this->mockSession = $this->createMock(Session::class);
         $this->mockSession->method('get')
                           ->willReturn(__DIR__);
 


### PR DESCRIPTION
**Description**
* The mocked class name hould be "Session" instead of "session".

**Motivation and Context**
Working on some unit-test-related refactor. Came across this typo. Might have been tolerated by Windows or specific container setup. But was not suppose to work.

**How Has This Been Tested?**
* Local CI test.
* CI environment.