### PR TITLE
Core: fix phpdoc for database connection select()

### DIFF
--- a/src/Contracts/Database/Connection.php
+++ b/src/Contracts/Database/Connection.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 namespace Gibbon\Contracts\Database;
 
 /**
- * Database Connection Interface 
+ * Database Connection Interface
  * Borrowed in part from Illuminate\Database\ConnectionInterface
  *
  * @version	v16
@@ -49,7 +49,8 @@ interface Connection
      *
      * @param  string  $query
      * @param  array   $bindings
-     * @return object
+     *
+     * @return \Gibbon\Database\Result Result of the database query.
      */
     public function select($query, $bindings = []);
 
@@ -121,8 +122,8 @@ interface Connection
 
     /**
      * @deprecated
-     * Backwards compatability for the old Gibbon\sqlConnection class. 
-     * Replaced with more expressive method names. Also because the 
+     * Backwards compatability for the old Gibbon\sqlConnection class.
+     * Replaced with more expressive method names. Also because the
      * parameters are backwards. Hoping to phase this one out in v17.
      *
      * @param  string  $query

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -100,11 +100,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Run a select statement against the database.
-     *
-     * @param  string  $query
-     * @param  array   $bindings
-     * @return object
+     * {@inheritDoc}
      */
     public function select($query, $bindings = [])
     {
@@ -180,9 +176,8 @@ class Connection implements ConnectionInterface
      *
      * @param  string  $query
      * @param  array   $bindings
-     * @return mixed
      *
-     * @throws \PDOException
+     * @return \Gibbon\Database\Result The database query result.
      */
     protected function run($query, $bindings = [])
     {
@@ -250,7 +245,7 @@ class Connection implements ConnectionInterface
     {
         return $this->result;
     }
-    
+
     /**
      * Start a new database transaction.
      *


### PR DESCRIPTION
**Description**
* Fix phpdocs for better IDE support.

**Motivation and Context**
* The original return was ambiguously "mixed", which was not very helpful describing what the select method would return.
* Especially annoying when I was working on rewriting some obsoleted `executeQuery()` calls to `select()`. VSCode complains that it does not know any method of the select result.

**How Has This Been Tested?**
* Locally on my VSCode.

**Screenshots**
![cropped-3](https://user-images.githubusercontent.com/91274/126056424-5387bff1-8256-4803-895e-776f9e5086d0.png)
![cropped-2](https://user-images.githubusercontent.com/91274/126056423-dad7fcf4-f382-4b6b-8fc8-6bd72ed08074.png)
![cropped-1](https://user-images.githubusercontent.com/91274/126056422-efb84f62-bbb6-48ea-bd67-70edc0daf909.png)
