### PR TITLE
Refactor Session constructor

### DIFF
--- a/src/Gibbon/Session.php
+++ b/src/Gibbon/Session.php
@@ -215,8 +215,9 @@ class Session implements SessionInterface
     public function loadSystemSettings(Connection $pdo)
     {
         // System settings from gibbonSetting
-        $sql = "SELECT name, value FROM gibbonSetting WHERE scope='System'";
-        $result = $pdo->executeQuery(array(), $sql);
+        $result = $pdo->select('SELECT name, value FROM gibbonSetting WHERE scope=:scope', [
+            ':scope' => 'System',
+        ]);
 
         while ($row = $result->fetch()) {
             $this->set($row['name'], $row['value']);
@@ -226,8 +227,9 @@ class Session implements SessionInterface
     public function loadLanguageSettings(Connection $pdo)
     {
         // Language settings from gibboni18n
-        $sql = "SELECT * FROM gibboni18n WHERE systemDefault='Y'";
-        $result = $pdo->executeQuery(array(), $sql);
+        $result = $pdo->select('SELECT * FROM gibboni18n WHERE systemDefault=:systemDefault', [
+            ':systemDefault' => 'Y',
+        ]);
 
         while ($row = $result->fetch()) {
             $this->set('i18n', $row);

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -88,7 +88,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
         $container = $this->getContainer();
 
         $container->share('config', new Core($this->absolutePath));
-        $container->share('session', new Session($container));
+        $container->share('session', Session::create($container));
         $container->share('locale', new Locale($this->absolutePath, $container->get('session')));
 
         $container->share(\Gibbon\Contracts\Services\Session::class, $container->get('session'));
@@ -109,7 +109,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
         $session = $container->get('session');
 
         // Logging removed until properly setup & tested
-        
+
         // $container->share('gibbon_logger', function () use ($container) {
         //     $factory = new LoggerFactory($container->get(SettingGateway::class));
         //     return $factory->getLogger('gibbon');
@@ -182,12 +182,12 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
                 'moduleName'   => $session->get('module'),
                 'gibbonRoleID' => $session->get('gibbonRoleIDCurrent'),
             ];
-            $sql = "SELECT gibbonAction.* 
+            $sql = "SELECT gibbonAction.*
                     FROM gibbonAction
                     JOIN gibbonModule ON (gibbonModule.gibbonModuleID=gibbonAction.gibbonModuleID)
                     LEFT JOIN gibbonPermission ON (gibbonPermission.gibbonActionID=gibbonAction.gibbonActionID AND gibbonPermission.gibbonRoleID=:gibbonRoleID)
                     LEFT JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPermission.gibbonRoleID)
-                    WHERE gibbonAction.URLList LIKE :actionName 
+                    WHERE gibbonAction.URLList LIKE :actionName
                     AND gibbonModule.name=:moduleName";
 
             $actionData = $this->getContainer()->get('db')->selectOne($sql, $data);

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -85,7 +85,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
      */
     public function boot()
     {
-        $container = $this->getContainer();
+        $container = $this->getLeagueContainer();
 
         $container->share('config', new Core($this->absolutePath));
         $container->share('session', Session::create($container));
@@ -104,7 +104,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
      */
     public function register()
     {
-        $container = $this->getContainer();
+        $container = $this->getLeagueContainer();
         $absolutePath = $this->absolutePath;
         $session = $container->get('session');
 


### PR DESCRIPTION
**Description**
* Extract container and environment / side-effect dependent logics into Session::create.
* Be specific about the variables that Session needed in its constructor.
* Changed the `CoreServiceProvider` to adapt it.

**Motivation and Context**
* `Session::__construct` was heavily depending on the environment and specific container setup.
* By separating the container dependency, now the Session is dry and easy to mock. It's much easier to debug, too.

**How Has This Been Tested?**
In CI environment.