### PR TITLE
System Admin: fix missing Custom Imports Folder setting

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -1011,4 +1011,5 @@ UPDATE `gibbonEmailTemplate` SET `templateName`=`templateType` WHERE `templateNa
 UPDATE `gibbonAction` SET `URLList` = 'emailTemplates_manage.php,emailTemplates_manage_duplicate.php,emailTemplates_manage_edit.php,emailTemplates_manage_delete.php' WHERE `name`='Email Templates' AND `gibbonModuleID`=(SELECT gibbonModuleID FROM gibbonModule WHERE name='System Admin');end
 ALTER TABLE `gibbonEmailTemplate` DROP INDEX `templateName`, ADD UNIQUE `moduleTemplate` (`templateName`, `moduleName`) USING BTREE;end
 ALTER TABLE `gibbonEmailTemplate` ADD `type` ENUM('Core','Additional','Custom') NOT NULL DEFAULT 'Core' AFTER `gibbonEmailTemplateID`;end
+INSERT INTO `gibbonSetting` (`scope` ,`name` ,`nameDisplay` ,`description` ,`value`) VALUES ('System Admin', 'importCustomFolderLocation', 'Custom Imports Folder', 'Path to custom import types folder, relative to uploads.', '/imports');end
 ";

--- a/modules/System Admin/import_manage.php
+++ b/modules/System Admin/import_manage.php
@@ -17,11 +17,13 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Data\ImportType;
-use Gibbon\Tables\DataTable;
-use Gibbon\Services\Format;
+use Gibbon\Forms\Form;
 use Gibbon\Domain\DataSet;
+use Gibbon\Data\ImportType;
+use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
 use Gibbon\Domain\System\LogGateway;
+use Gibbon\Domain\System\SettingGateway;
 
 require __DIR__ . '/moduleFunctions.php';
 
@@ -33,6 +35,20 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_manage
 
     $logGateway = $container->get(LogGateway::class);
     $logsByType = $logGateway->selectLogsByModuleAndTitle('System Admin', 'Import - %')->fetchGrouped();
+
+    $form = Form::create('settings', $session->get('absoluteURL').'/modules/System Admin/import_manageProcess.php');
+    $form->addHiddenValue('address', $session->get('address'));
+
+    $setting = $container->get(SettingGateway::class)->getSettingByScope('System Admin', 'importCustomFolderLocation', true);
+        $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description($setting['description']);
+        $row->addTextField($setting['name'])->required()->setValue($setting['value']);
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
 
     // Get a list of available import options
     $importTypeList = ImportType::loadImportTypeList($pdo, false);

--- a/modules/System Admin/import_manageProcess.php
+++ b/modules/System Admin/import_manageProcess.php
@@ -1,0 +1,59 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\System\SettingGateway;
+
+require_once '../../gibbon.php';
+
+$URL = $gibbon->session->get('absoluteURL').'/index.php?q=/modules/System Admin/import_manage.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/System Admin/import_manage.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    //Proceed!
+    $partialFail = false;
+    $settingGateway = $container->get(SettingGateway::class);
+
+    $settingsToUpdate = [
+        'System Admin' => [
+            'importCustomFolderLocation'
+        ],
+    ];
+
+    $_POST['importCustomFolderLocation'] = '/'.trim($_POST['importCustomFolderLocation'], '/');
+
+    if (!is_dir($gibbon->session->get('absolutePath').'/uploads/'.$_POST['importCustomFolderLocation'])) {
+        mkdir($gibbon->session->get('absolutePath').'/uploads/'.$_POST['importCustomFolderLocation'], 0755);
+    }
+
+    foreach ($settingsToUpdate as $scope => $settings) {
+        foreach ($settings as $name) {
+            $value = $_POST[$name] ?? '';
+
+            $updated = $settingGateway->updateSettingByScope($scope, $name, $value);
+            $partialFail &= !$updated;
+        }
+    }
+   
+    $URL .= $partialFail
+        ? '&return=error2'
+        : '&return=success0';
+    header("Location: {$URL}");
+}

--- a/src/Data/ImportType.php
+++ b/src/Data/ImportType.php
@@ -209,7 +209,7 @@ class ImportType
 
     public static function getCustomImportTypeDir(Connection $pdo)
     {
-        $customFolder = getSettingByScope($pdo->getConnection(), 'Data Admin', 'importCustomFolderLocation');
+        $customFolder = getSettingByScope($pdo->getConnection(), 'System Admin', 'importCustomFolderLocation');
 
         return self::getBaseDir($pdo).'/uploads/'.trim($customFolder, '/ ');
     }


### PR DESCRIPTION
The importCustomFolderLocation setting was previously attached to Data Admin, but after moving the functionality in to the core, the core ImportType.php file was still referencesing the Data Admin setting. This prevented anyone without Data Admin installed from changing the setting. I've fixed ImportType.php and added the setting as a small form at the top of the Import from File page.

**Motivation and Context**
Fixes #1391 

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="922" alt="Screenshot 2021-08-30 at 1 56 04 PM" src="https://user-images.githubusercontent.com/897700/131292329-27105990-9abe-4788-9daa-0eb06959f51d.png">

