### PR TITLE
Fix PHP 8.1 warning deprecated messages in CI test

### DIFF
--- a/modules/Data Updater/data_medicalProcess.php
+++ b/modules/Data Updater/data_medicalProcess.php
@@ -124,10 +124,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
                 $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Medical Form', ['dataUpdater' => 1], $customRequireFail);
 
                 // Check for data changed
-                $existingFields = json_decode($values['fields'], true);
+                $existingFields = isset($values['fields']) ? json_decode($values['fields'], true) : [];
+                $existingFields = is_array($existingFields) ? $existingFields : []; // make sure this is an array
                 $newFields = json_decode($fields, true);
+                $newFields = is_array($newFields) ? $newFields : []; // make sure this is an array
                 foreach ($newFields as $key => $fieldValue) {
-                    if ($existingFields[$key] != $fieldValue) {
+                    if (!isset($existingFields[$key]) || $existingFields[$key] != $fieldValue) {
                         $dataChanged = true;
                     }
                 }

--- a/modules/Data Updater/data_medical_manage_editProcess.php
+++ b/modules/Data Updater/data_medical_manage_editProcess.php
@@ -84,7 +84,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
             }
 
             // CUSTOM FIELDS
-            $data['fields'] = $container->get(CustomFieldHandler::class)->getFieldDataFromDataUpdate('Medical Form', [], $row2['fields']);
+            $data['fields'] = $container->get(CustomFieldHandler::class)->getFieldDataFromDataUpdate('Medical Form', [], $row2['fields'] ?? []);
             $sqlSet .= 'fields=:fields, ';
 
             $partialFail = false;

--- a/modules/Finance/moduleFunctions.php
+++ b/modules/Finance/moduleFunctions.php
@@ -620,7 +620,7 @@ function getNextBudgetCycleID($gibbonFinanceBudgetCycleID, $connection2)
 
 //Make the display for a block, according to the input provided, where $i is a unique number appended to the block's field ids.
 //Mode can be add, edit
-function makeFeeBlock($guid, $connection2, $i, $mode = 'add', $feeType, $gibbonFinanceFeeID, $name = '', $description = '', $gibbonFinanceFeeCategoryID = '', $fee = '', $category = '', $outerBlock = true)
+function makeFeeBlock($guid, $connection2, $i, $mode, $feeType, $gibbonFinanceFeeID, $name = '', $description = '', $gibbonFinanceFeeCategoryID = '', $fee = '', $category = '', $outerBlock = true)
 {
     if ($outerBlock) {
         echo "<div id='blockOuter$i' class='blockOuter'>";

--- a/modules/Markbook/markbook_edit_dataProcess.php
+++ b/modules/Markbook/markbook_edit_dataProcess.php
@@ -264,6 +264,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
 
                             // Create a log of failed uploads
                             $errorMessage = $fileUploader->getLastError();
+                            if (empty($errorMessage) && !file_exists($attachment)) {
+                                $errorMessage = __('Uploaded file not found in the system.');
+                            }
                             if (!empty($errorMessage) || filesize($attachment) === 0) {
                                 $gibbonModuleID = getModuleIDFromName($connection2, 'Markbook');
                                 $logGateway->addLog($gibbon->session->get('gibbonSchoolYearID'), $gibbonModuleID, $gibbon->session->get('gibbonPersonID'), 'Uploaded Response Failed', [

--- a/modules/School Admin/daysOfWeek_manage.php
+++ b/modules/School Admin/daysOfWeek_manage.php
@@ -28,7 +28,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
     //Proceed!
     $page->breadcrumbs->add(__('Days of the Week'));
 
-    
+
         $data = array();
         $sql = "SELECT * FROM gibbonDaysOfWeek WHERE name='Monday' OR name='Tuesday' OR name='Wednesday' OR name='Thursday' OR name='Friday' OR name='Saturday' OR name='Sunday' ORDER BY sequenceNumber";
         $result = $connection2->prepare($sql);
@@ -52,6 +52,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
         $minutes = implode(',', $minutesArray);
 
         while ($day = $result->fetch()) {
+            $schoolOpen = $day['schoolOpen'] ?? '';
+            $schoolStart = $day['schoolStart'] ?? '';
+            $schoolEnd = $day['schoolEnd'] ?? '';
+            $schoolClose = $day['schoolClose'] ?? '';
+
             $form->addHiddenValue($day['name'].'sequenceNumber', $day['sequenceNumber']);
 
             $form->addRow()->addHeading(__($day['name']).' ('.__($day['nameShort']).')');
@@ -70,12 +75,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                     ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
-                    ->selected(substr($day['schoolOpen'], 0, 2));
+                    ->selected(substr($schoolOpen, 0, 2));
                 $col->addSelect($day['name'].'schoolOpenM')
                     ->fromString($minutes)
                     ->setClass('shortWidth')
                     ->placeholder(__('Minutes'))
-                    ->selected(substr($day['schoolOpen'], 3, 2));
+                    ->selected(substr($schoolOpen, 3, 2));
 
             $row = $form->addRow()->addClass($day['name']);
                 $row->addLabel($day['name'].'schoolStart', __('School Starts'));
@@ -85,12 +90,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                     ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
-                    ->selected(substr($day['schoolStart'], 0, 2));
+                    ->selected(substr($schoolStart, 0, 2));
                 $col->addSelect($day['name'].'schoolStartM')
                     ->fromString($minutes)
                     ->setClass('shortWidth')
                     ->placeholder(__('Minutes'))
-                    ->selected(substr($day['schoolStart'], 3, 2));
+                    ->selected(substr($schoolStart, 3, 2));
 
             $row = $form->addRow()->addClass($day['name']);
                 $row->addLabel($day['name'].'schoolEnd', __('School Ends'));
@@ -100,12 +105,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                     ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
-                    ->selected(substr($day['schoolEnd'], 0, 2));
+                    ->selected(substr($schoolEnd, 0, 2));
                 $col->addSelect($day['name'].'schoolEndM')
                     ->fromString($minutes)
                     ->setClass('shortWidth')
                     ->placeholder(__('Minutes'))
-                    ->selected(substr($day['schoolEnd'], 3, 2));
+                    ->selected(substr($schoolEnd, 3, 2));
 
             $row = $form->addRow()->addClass($day['name']);
                 $row->addLabel($day['name'].'schoolClose', __('School Closes'));
@@ -115,12 +120,12 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
                     ->required()
                     ->setClass('shortWidth')
                     ->placeholder(__('Hours'))
-                    ->selected(substr($day['schoolClose'], 0, 2));
+                    ->selected(substr($schoolClose, 0, 2));
                 $col->addSelect($day['name'].'schoolCloseM')
                     ->fromString($minutes)
                     ->setClass('shortWidth')
                     ->placeholder(__('Minutes'))
-                    ->selected(substr($day['schoolClose'], 3, 2));
+                    ->selected(substr($schoolClose, 3, 2));
         }
 
         $row = $form->addRow();

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -885,7 +885,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $form->addRow()->addSubheading(__('Privacy'))->append($privacyBlurb);
 
         $options = array_map('trim', explode(',', $privacyOptions));
-        $checked = array_map('trim', explode(',', $application['privacy']));
+        $checked = !empty($application['privacy']) ? array_map('trim', explode(',', $application['privacy'])) : [];
 
         $row = $form->addRow();
             $row->addLabel('privacyOptions[]', __('Privacy'));

--- a/modules/System Admin/customFields_addProcess.php
+++ b/modules/System Admin/customFields_addProcess.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     //Proceed!
     $enablePublicRegistration = getSettingByScope($connection2, 'User Admin', 'enablePublicRegistration');
     $customFieldGateway = $container->get(CustomFieldGateway::class);
-    
+
     $data = [
         'context'                  => $_POST['context'] ?? '',
         'name'                     => $_POST['name'] ?? '',
@@ -53,6 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     // Add this field to the bottom of the current sequenceNumber for this context
     $sequenceCheck = $customFieldGateway->selectBy(['context' => $data['context']], ['sequenceNumber'])->fetch();
+    if ($sequenceCheck === false) $sequenceCheck = ['sequenceNumber' => 0]; // defaults to 0 if there is no existing sequence number
     $data['sequenceNumber'] = $sequenceCheck['sequenceNumber'] + 1;
 
     if ($data['type'] == 'varchar') $data['options'] = min(max(0, intval($data['options'])), 255);
@@ -64,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $data['activePersonStaff'] = in_array('activePersonStaff', $roleCategories);
     $data['activePersonParent'] = in_array('activePersonParent', $roleCategories);
     $data['activePersonOther'] = in_array('activePersonOther', $roleCategories);
-    
+
     // Validate the required values are present
     if (empty($data['context']) || empty($data['name']) || empty($data['active']) || empty($data['type']) || empty($data['required'])) {
         $URL .= '&return=error1';

--- a/modules/System Admin/moduleFunctions.php
+++ b/modules/System Admin/moduleFunctions.php
@@ -292,7 +292,7 @@ function i18nCheckAndUpdateVersion($container, $version = null)
         $fileExists = i18nFileExists($absolutePath, $i18n['code']);
 
         if ($i18n['installed'] == 'N' && $fileExists) {
-            $versionUpdate = version_compare($version, $i18n['version'], '>') ? $version : $i18n['version'];
+            $versionUpdate = version_compare((string) $version, $i18n['version'], '>') ? $version : $i18n['version'];
             $data = ['installed' => 'Y', 'version' => $versionUpdate];
             $i18nGateway->update($i18n['gibboni18nID'], $data);
         } else if ($i18n['installed'] == 'Y' && !$fileExists) {

--- a/modules/System Admin/moduleFunctions.php
+++ b/modules/System Admin/moduleFunctions.php
@@ -290,9 +290,10 @@ function i18nCheckAndUpdateVersion($container, $version = null)
 
     foreach ($i18nList as $i18n) {
         $fileExists = i18nFileExists($absolutePath, $i18n['code']);
+        $i18nVersion = $i18n['version'] ?? '';
 
         if ($i18n['installed'] == 'N' && $fileExists) {
-            $versionUpdate = version_compare((string) $version, $i18n['version'], '>') ? $version : $i18n['version'];
+            $versionUpdate = version_compare((string) $version, $i18nVersion, '>') ? $version : $i18nVersion;
             $data = ['installed' => 'Y', 'version' => $versionUpdate];
             $i18nGateway->update($i18n['gibboni18nID'], $data);
         } else if ($i18n['installed'] == 'Y' && !$fileExists) {

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -47,7 +47,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
     if ($gibbonPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonPersonID' => $gibbonPersonID);
             $sql = 'SELECT * FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID';
             $result = $connection2->prepare($sql);
@@ -80,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
                 echo "<a href='".$session->get('absoluteURL').'/index.php?q=/modules/User Admin/user_manage.php&search='.$search."'>".__('Back to Search Results').'</a>';
                 echo '</div>';
             }
-            
+
             $scrubbed = $container->get(DataRetentionGateway::class)->selectBy(['gibbonPersonID' => $gibbonPersonID])->fetch();
             if (!empty($scrubbed)) {
                 echo Format::alert(__("This user's personal data was cleared on {date} as part of a data retention action. The following database tables were cleared: {tables}", ['date' => Format::date($scrubbed['timestamp']), 'tables' => Format::list(json_decode($scrubbed['tables']), 'ul', 'text-xs mb-0')] ), 'warning');
@@ -270,7 +270,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 				$row->addSelectCountry('address1Country');
 
 			if ($values['address1'] != '') {
-				
+
 					$dataAddress = array('gibbonPersonID' => $values['gibbonPersonID'], 'addressMatch' => '%'.strtolower(preg_replace('/ /', '%', preg_replace('/,/', '%', $values['address1']))).'%');
 					$sqlAddress = "SELECT gibbonPersonID, title, preferredName, surname, category FROM gibbonPerson JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE status='Full' AND address1 LIKE :addressMatch AND NOT gibbonPersonID=:gibbonPersonID ORDER BY surname, preferredName";
 					$resultAddress = $connection2->prepare($sqlAddress);
@@ -528,7 +528,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
 				if ($privacySetting == 'Y' && !empty($privacyOptions)) {
                     $options = array_map('trim', explode(',', $privacyOptions));
-                    $values['privacyOptions'] = array_map('trim', explode(',', $values['privacy']));
+                    $values['privacyOptions'] = isset($values['privacy']) ? array_map('trim', explode(',', $values['privacy'])) : [];
 
 					$row = $form->addRow();
 						$row->addLabel('privacyOptions[]', __('Privacy'))->description(__('Check to indicate which privacy options are required.'));

--- a/src/Domain/DataSet.php
+++ b/src/Domain/DataSet.php
@@ -25,13 +25,13 @@ namespace Gibbon\Domain;
 class DataSet implements \Countable, \IteratorAggregate
 {
     protected $data;
-    
-    protected $resultCount; 
-    protected $totalCount; 
 
-    protected $page; 
-    protected $pageSize; 
-    
+    protected $resultCount;
+    protected $totalCount;
+
+    protected $page;
+    protected $pageSize;
+
     /**
      * Creates a new data set from an array and calculates the result counts and pagination based on array size.
      *
@@ -81,7 +81,7 @@ class DataSet implements \Countable, \IteratorAggregate
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }
@@ -117,7 +117,7 @@ class DataSet implements \Countable, \IteratorAggregate
     }
 
     /**
-     * The total un-paginated number of rows for this data set. 
+     * The total un-paginated number of rows for this data set.
      * Will be less than the totalCount if the results have criteria applied.
      *
      * @return int

--- a/src/Domain/DataSet.php
+++ b/src/Domain/DataSet.php
@@ -91,7 +91,7 @@ class DataSet implements \Countable, \IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->data);
     }

--- a/src/Forms/Input/Checkbox.php
+++ b/src/Forms/Input/Checkbox.php
@@ -92,10 +92,10 @@ class Checkbox extends Input
 
         if (is_array($values)) {
             foreach ($values as $key => $value) {
-                $this->checked[trim($key)] = (!is_array($value))? trim($value) : $value;
+                $this->checked[trim($key)] = (!is_array($value))? trim((string) $value) : $value;
             }
         } else {
-            $this->checked = array(trim($values));
+            $this->checked = array(trim((string) $values));
         }
 
         return $this;
@@ -208,7 +208,7 @@ class Checkbox extends Input
             if ($hasMultiple) {
                 $output .= '<fieldset id="'.$this->getID().'"  style="border: 0px;">';
             }
-            
+
             if (!empty($this->checkall)) {
                 $checked = (count($this->options) == count($this->checked))? 'checked' : '';
                 $output .= '<div class="flex mt-1 '.($this->align == 'right' ? 'justify-end text-right' : '').'">';
@@ -226,7 +226,7 @@ class Checkbox extends Input
                     : $this->options;
 
             foreach ($optionGroups as $group => $options) {
-            
+
                 if (!empty($group)) {
                     $output .= '<label class="flex font-bold pb-1 border-b border-gray-400">'.$group.'</label>';
                 }

--- a/src/Forms/Input/TextArea.php
+++ b/src/Forms/Input/TextArea.php
@@ -112,7 +112,7 @@ class TextArea extends Input
         $this->setAttribute('value', '');
 
         $output = '<textarea '.$this->getAttributeString().'>';
-        $output .= htmlentities($text, ENT_QUOTES, 'UTF-8');
+        $output .= htmlentities((string) $text, ENT_QUOTES, 'UTF-8');
         $output .= '</textarea>';
 
         if ($this->autosize) {

--- a/src/Forms/Layout/Column.php
+++ b/src/Forms/Layout/Column.php
@@ -113,6 +113,6 @@ class Column extends Row implements OutputableInterface, ValidatableInterface
     {
         if (!method_exists($element, 'getClass')) return '';
 
-        return str_replace('standardWidth', '', $element->getClass());
+        return str_replace('standardWidth', '', (string) $element->getClass());
     }
 }

--- a/src/Forms/PersonalDocumentHandler.php
+++ b/src/Forms/PersonalDocumentHandler.php
@@ -123,7 +123,7 @@ class PersonalDocumentHandler
         }
     }
 
-    public function addPersonalDocumentsToForm(&$form, $foreignTable = null, $foreignTableID = null, $params)
+    public function addPersonalDocumentsToForm(&$form, $foreignTable = null, $foreignTableID = null, $params = [])
     {
         $documents = $this->personalDocumentGateway->selectPersonalDocuments($foreignTable, $foreignTableID, $params)->fetchAll();
         if (empty($documents)) return;

--- a/src/Forms/Traits/MultipleOptionsTrait.php
+++ b/src/Forms/Traits/MultipleOptionsTrait.php
@@ -107,12 +107,12 @@ trait MultipleOptionsTrait
 
     /**
      * Build options array from a DataSet, as provided by <b>Domain</b> gateways
-     * 
+     *
      * @param Dataset $dataset
      * @param string $valCol
      * @param string $nameCol
      * @param string $groupBy
-     * 
+     *
      * @return self
      */
     public function fromDataSet(Dataset $dataset, $valCol, $nameCol, $groupBy = false)
@@ -158,7 +158,9 @@ trait MultipleOptionsTrait
             });
 
             foreach ($options as $option) {
-                $option = array_map('trim', $option);
+                $option = array_map(function ($item) {
+                    return trim((string) $item);
+                }, $option);
 
                 if ($groupBy !== false) {
                     $this->options[$option[$groupBy]][$option['value']] = __($option['name']);

--- a/src/Services/CoreServiceProvider.php
+++ b/src/Services/CoreServiceProvider.php
@@ -133,7 +133,7 @@ class CoreServiceProvider extends AbstractServiceProvider implements BootableSer
 
             $enableDebug = $session->get('installType') == 'Development';
             // Override caching on systems during upgrades, when the system version is higher than database version
-            if (version_compare($this->getContainer()->get('config')->getVersion(), $session->get('version'), '>')) {
+            if (version_compare((string) $this->getContainer()->get('config')->getVersion(), (string) $session->get('version'), '>')) {
                 $enableDebug = true;
             }
 

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -747,6 +747,7 @@ class Format
                 $imageSize = $size;
         }
 
+        $path = (string) $path;
         if (preg_match('/^http[s]*/', $path)) {
             return sprintf('<img class="%1$s" src="%2$s">', $class, $path);
         } else {

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -61,7 +61,7 @@ class Format
         $settings['absolutePath'] = $session->get('absolutePath');
         $settings['absoluteURL'] = $session->get('absoluteURL');
         $settings['gibbonThemeName'] = $session->get('gibbonThemeName');
-        $settings['currency'] = $session->get('currency');
+        $settings['currency'] = $session->get('currency') ?? '';
         $settings['currencySymbol'] = !empty(substr($settings['currency'], 4)) ? substr($settings['currency'], 4) : '';
         $settings['currencyName'] = substr($settings['currency'], 0, 3);
         $settings['nameFormatStaffInformal'] = $session->get('nameFormatStaffInformal');
@@ -355,10 +355,10 @@ class Format
             'Other'       => __('Other'),
             'Unspecified' => __('Unspecified')
             ];
-        
+
         return $translate ? __($genderNames[$value]) : $genderNames[$value];
-    }    
-    
+    }
+
     /**
      * Formats a filesize in bytes to display in KB, MB, etc.
      *

--- a/src/Tables/Columns/DraggableColumn.php
+++ b/src/Tables/Columns/DraggableColumn.php
@@ -33,7 +33,7 @@ class DraggableColumn extends Column
     /**
      * Creates a pre-defined column for drag-drop row sorting.
      */
-    public function __construct($id, $ajaxURL, $data = [], DataTable $table)
+    public function __construct($id, $ajaxURL, array $data, DataTable $table)
     {
         parent::__construct('draggable');
         $this->sortable(false)

--- a/src/UI/Components/Header.php
+++ b/src/UI/Components/Header.php
@@ -50,7 +50,7 @@ class Header
         $tray = [];
         $guid = $this->session->get('guid');
         $connection2 = $this->db->getConnection();
-        
+
         // Message Wall
         if (isActionAccessible($guid, $connection2, '/modules/Messenger/messageWall_view.php')) {
             $tray['messageWall'] = [
@@ -83,7 +83,7 @@ class Header
 
         // Links for logged in users
         if ($this->session->has('username')) {
-            
+
             $links['logout'] = [
                 'name' => __('Logout'),
                 'url'  => $this->session->get('absoluteURL').'/logout.php',
@@ -168,7 +168,7 @@ class Header
             'image_240'     => $this->session->get('image_240'),
             'houseName'     => $this->session->get('gibbonHouseIDName'),
             'houseLogo'     => $this->session->get('gibbonHouseIDLogo'),
-            'messengerRead' => strtotime($this->session->get('messengerLastRead')) >= $messageWallLatestPost,
+            'messengerRead' => strtotime((string) $this->session->get('messengerLastRead')) >= $messageWallLatestPost,
         ];
     }
 }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -126,6 +126,7 @@ class View implements \ArrayAccess
      * @param  string  $key
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key) : bool
     {
         return array_key_exists($key, $this->data);
@@ -137,6 +138,7 @@ class View implements \ArrayAccess
      * @param  string  $key
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->data[$key];
@@ -148,6 +150,7 @@ class View implements \ArrayAccess
      * @param  string  $key
      * @param  mixed   $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->data[$key] = $value;
@@ -158,6 +161,7 @@ class View implements \ArrayAccess
      *
      * @param  string  $key
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->data[$key]);


### PR DESCRIPTION
**Description**
Fix PHP code issues that causes any PHP Deprecated or Warning messages in CI test server_log.

**Motivation and Context**
* Improve forward compatibility with PHP 8.1 and PHP 9.0.
* Improve code quality and robustness.

**How Has This Been Tested?**
* CI environment
* Run `grep 'PHP Warning\|PHP Deprecated' server_log` against the PHP 8.1 test artifacts. The total number of error and warning in it reduced from 4208 lines to 2018 lines. The remaining lines are mostly contributed by Twig, which will most likely have full PHP 8.1 support in the upcoming release (version v3.3.3 or v3.4.0).