### PR TITLE
Refactor database Connection and MySqlConnector

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -66,11 +66,22 @@ class Connection implements ConnectionInterface
 
     /**
      * Create the connection wrapper around a \PDO instance.
-     * @param \PDO $pdo
+     *
+     * @param \PDO  $pdo     Should be configured to fit Connection use internally.
      * @param array $config
+     *
+     * @throws \InvalidArgumentException Throws if the \PDO is misconfigured.
      */
     public function __construct(PDO $pdo, array $config = [])
     {
+        // Check the statement class. Expect $pdo to be correctly setup.
+        // See MySqlConnector::configureEncoding().
+        $class = $pdo->getAttribute(\PDO::ATTR_STATEMENT_CLASS);
+        if (!is_array($class) || sizeof($class) < 1 || $class[0] !== Result::class) {
+            throw new \InvalidArgumentException('$pdo must be setup to use ' . Result::class . ' as statement.');
+        }
+
+        // Use the PDO as internal connection
         $this->pdo = $pdo;
     }
 


### PR DESCRIPTION
**Description**
* Migrate `MySqlConnector::configureEncoding` to `Connection::configure`.
* Migrate `MySqlConnector::setModes` to `Connection::setModes`.
* Migrate the usage of the above methods into `Connnection::__construct`.

**Motivation and Context**
* Previously, the class `Connection` depends on the convention to use to  `MySqlConnector` the `PDO` object.
* `Connection` do not directly use `MySqlConnector` in anyway. The dependency is not obvious and can cause unexpected behaviour in the future development.
* Migrating the PDO configuration into `Connection` improves that while still preserve the current behaviour.

**How Has This Been Tested?**
* Locally.
* CI Environment.