### PR TITLE
Docs: form factory and traits phpdocs fix

### DIFF
--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -229,6 +229,9 @@ class FormFactory implements FormFactoryInterface
         return (new Input\Radio($name));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function createSelect($name)
     {
         return new Input\Select($name);

--- a/src/Forms/FormFactoryInterface.php
+++ b/src/Forms/FormFactoryInterface.php
@@ -60,4 +60,13 @@ interface FormFactoryInterface
      * @return \Gibbon\Forms\Layout\Element
      */
     public function createContent($content = ''): Element;
+
+    /**
+     * Create select element from the given name.
+     *
+     * @param string $name
+     *
+     * @return \Gibbon\Forms\Input\Select
+     */
+    public function createSelect($name);
 }

--- a/src/Forms/Traits/MultipleOptionsTrait.php
+++ b/src/Forms/Traits/MultipleOptionsTrait.php
@@ -144,7 +144,8 @@ trait MultipleOptionsTrait
     /**
      * Build an internal options array from the result set of a PDO query.
      * @param   object  $results
-     * @return  string
+     *
+     * @return  self
      */
     public function fromResults($results, $groupBy = false)
     {


### PR DESCRIPTION
**Description**
* Add phpdocs to FormFactoryInterface::createSelect.
* Add phpdocs to FormFactory::createSelect
* Properly document the return value of MultipleOptionsTrait::fromResult

**Motivation and Context**
* Fix IDE support to developers.

**How Has This Been Tested?**
* Locally on VSCode.

**Screenshots**
Before
![2021-09-10 16-19-07 的螢幕擷圖-cropped](https://user-images.githubusercontent.com/91274/132823357-9cb8e8b0-3047-4ca1-b9a1-1b8164664fe9.png)

After
![2021-09-10 16-20-24 的螢幕擷圖-cropped](https://user-images.githubusercontent.com/91274/132823507-b23e727f-f328-4571-bca0-1a2933dd6d7d.png)

