### PR TITLE
System: fix InvalidArgumentException use in class

### DIFF
--- a/src/Data/UsernameGenerator.php
+++ b/src/Data/UsernameGenerator.php
@@ -62,7 +62,7 @@ class UsernameGenerator
     public function addToken($name, $value)
     {
         if (empty($name)) {
-            throw new InvalidArgumentException();
+            throw new \InvalidArgumentException();
         }
 
         $this->tokens[$name] = array(
@@ -84,7 +84,7 @@ class UsernameGenerator
     public function addNumericToken($name, $value, $size, $increment, $callback = null)
     {
         if (empty($name)) {
-            throw new InvalidArgumentException();
+            throw new \InvalidArgumentException();
         }
 
         $this->tokens[$name] = array(
@@ -247,7 +247,7 @@ class UsernameGenerator
         $number = $this->getToken($name);
 
         if (empty($number) || $number['type'] != 'numeric') {
-            throw new InvalidArgumentException();
+            throw new \InvalidArgumentException();
         }
 
         // Increment value and format result


### PR DESCRIPTION
**Description**
* fix \InvalidArgumentException reference in Gibbon\Data\UsernameGenerator. The root class reference was without the "\" prefix.

**Motivation and Context**
* Found this bug in the middle of other project.

**How Has This Been Tested?**
* Locally in VSCode.