### PR TITLE
Composer: add phpstan test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "test:phpunit": [
             "cd tests && ../vendor/bin/phpunit --verbose --colors=always --configuration phpunit.xml"
         ],
+        "test:phpstan": [
+            "vendor/bin/phpstan analyse --ansi --no-progress --no-interaction --autoload-file=functions.php src"
+        ],
         "test:codesniffer": [
           "vendor/bin/phpcs --standard=PSR2 modules/Library/" 
         ]
@@ -61,7 +64,8 @@
         "codeception/module-phpbrowser": "^1.0",
         "codeception/module-db": "^1.1",
         "codeception/module-filesystem": "^1.0",
-        "codeception/module-asserts": "^1.3"
+        "codeception/module-asserts": "^1.3",
+        "phpstan/phpstan": "^0.12.98"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a731e49a745a02b45e99db8a0358730a",
+    "content-hash": "17ab13b2d34793ef336e6690f06f6a31",
     "packages": [
         {
             "name": "aura/sqlquery",
@@ -3674,6 +3674,70 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
             "time": "2021-03-17T13:42:18+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.98",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "3bb7cc246c057405dd5e290c3ecc62ab51d57e00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3bb7cc246c057405dd5e290c3ecc62ab51d57e00",
+                "reference": "3bb7cc246c057405dd5e290c3ecc62ab51d57e00",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.98"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-02T12:33:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
**Description**
* Add [phpstan](https://phpstan.org/) as development dependency.
* Add `composer test:phpstan` script target.
* Did **NOT** add this to default test target. So will **NOT** be run in CI for now.

**Motivation and Context**
* PHPStan scan and catches PHP issues for the corner cases that user would rarely run into. Have a test like this can improve our overall robustness.
* Will gradually fix all the potential errors found by PHPStan in the code base. When all errors are fixed, can add this into regular test target.

**How Has This Been Tested?**
* Locally with the `composer test:phpstan` command.

**Screenshots**
![2021-09-10 17-52-29 的螢幕擷圖](https://user-images.githubusercontent.com/91274/132835844-b7d2ced8-0297-4353-9e7c-0b34a0e75365.png)
