### PR TITLE
System: rewrite usage of obsoleted Connection::executeQuery

### DIFF
--- a/src/Data/ImportType.php
+++ b/src/Data/ImportType.php
@@ -333,7 +333,7 @@ class ImportType
     {
         try {
             $sql="SHOW COLUMNS FROM " . $this->getDetail('table');
-            $result = $pdo->executeQuery([], $sql);
+            $result = $pdo->select($sql);
         } catch (\PDOException $e) {
             return false;
         }
@@ -389,7 +389,7 @@ class ImportType
                     AND gibbonAction.name=:action
                     ORDER BY gibbonAction.precedence ASC
                     LIMIT 1";
-            $result = $pdo->executeQuery($data, $sql);
+            $result = $pdo->select($sql, $data);
         } catch (\PDOException $e) {
         }
 
@@ -416,7 +416,7 @@ class ImportType
         if ($this->useYearGroups) {
             try {
                 $sql="SELECT gibbonYearGroupID, nameShort FROM gibbonYearGroup ORDER BY sequenceNumber";
-                $resultYearGroups = $pdo->executeQuery([], $sql);
+                $resultYearGroups = $pdo->select($sql);
             } catch (\PDOException $e) {
             }
 
@@ -431,7 +431,7 @@ class ImportType
         if ($this->useLanguages) {
             try {
                 $sql="SELECT name FROM gibbonLanguage";
-                $resultLanguages = $pdo->executeQuery([], $sql);
+                $resultLanguages = $pdo->select($sql);
             } catch (\PDOException $e) {
             }
 
@@ -446,7 +446,7 @@ class ImportType
         if ($this->useCountries || $this->usePhoneCodes) {
             try {
                 $sql="SELECT printable_name, iddCountryCode FROM gibbonCountry";
-                $resultCountries = $pdo->executeQuery([], $sql);
+                $resultCountries = $pdo->select($sql);
             } catch (\PDOException $e) {
             }
 
@@ -466,7 +466,7 @@ class ImportType
         if ($this->useCustomFields) {
             try {
                 $sql="SELECT gibbonCustomFieldID, name, type, options, required FROM gibbonCustomField where active = 'Y'";
-                $resultCustomFields = $pdo->executeQuery([], $sql);
+                $resultCustomFields = $pdo->select($sql);
             } catch (\PDOException $e) {
             }
 
@@ -747,7 +747,7 @@ class ImportType
     {
         $value = trim($value);
         $defaultValue = $this->getField($fieldName, 'null') == 'YES' ? null : '';
-        
+
         $filter = $this->getField($fieldName, 'filter');
         $strvalue = mb_strtoupper($value);
 
@@ -1230,7 +1230,7 @@ class ImportType
             default:
                 return __(ucfirst($kind));
         }
-        
+
         return '';
     }
 

--- a/src/Data/Importer.php
+++ b/src/Data/Importer.php
@@ -56,7 +56,7 @@ class Importer
     public $mode;
     public $syncField;
     public $syncColumn;
-    
+
     public $outputData = [];
 
     /**
@@ -317,7 +317,7 @@ class Importer
                     $fieldCount++;
                     continue;
                 }
-                
+
                 if ($columnIndex == Importer::COLUMN_DATA_SKIP) {
                     // Skip marked columns
                     $fieldCount++;
@@ -417,7 +417,7 @@ class Importer
                             $relationalSQL = "SELECT {$table}.{$key} FROM {$table} {$tableJoin} WHERE {$relationalField}=:{$fieldNameKey}";
                         }
 
-                        $result = $this->pdo->executeQuery($relationalData, $relationalSQL);
+                        $result = $this->pdo->select($relationalSQL, $relationalData);
 
                         if ($result->rowCount() > 0) {
                             $relationalValue[] = $result->fetchColumn(0);
@@ -433,7 +433,7 @@ class Importer
                                     array('name' => $importType->getField($fieldName, 'name'), 'value' => $value, 'field' => $field, 'table' => $table)
                                 );
                                 $this->debugLog($rowNum, $relationalSQL, $relationalData, 'relational');
-                                
+
                                 $partialFail = true;
                             }
                         }
@@ -614,7 +614,7 @@ class Importer
                     }
 
                     $this->databaseResults['updates'] += 1;
-    
+
                     $sqlData[$primaryKey] = $primaryKeyValue;
                     $sql="UPDATE {$tableName} SET " . $sqlFieldString . " WHERE ".$this->escapeIdentifier($primaryKey)."=:{$primaryKey}" ;
 
@@ -653,7 +653,7 @@ class Importer
                 if (!$liveRun) {
                     continue;
                 }
-                
+
                 $this->pdo->insert($sql, $sqlData);
 
                 if (!$this->pdo->getQuerySuccess()) {

--- a/src/Data/UsernameGenerator.php
+++ b/src/Data/UsernameGenerator.php
@@ -122,7 +122,7 @@ class UsernameGenerator
         // Get the username format data by gibbonRoleID
         $data = array('gibbonRoleID' => $gibbonRoleID);
         $sql = "SELECT gibbonUsernameFormat.*, gibbonRole.name as roleName FROM gibbonUsernameFormat JOIN gibbonRole ON (FIND_IN_SET(gibbonRole.gibbonRoleID, gibbonRoleIDList)) WHERE gibbonRoleID=:gibbonRoleID OR isDefault='Y' ORDER BY FIND_IN_SET(:gibbonRoleID, gibbonRoleIDList) DESC LIMIT 1";
-        $result = $this->pdo->executeQuery($data, $sql);
+        $result = $this->pdo->select($sql, $data);
 
         if ($result->rowCount() > 0) {
             $row = $result->fetch(0);
@@ -138,7 +138,7 @@ class UsernameGenerator
                 $callback = function($number) use (&$pdo, &$row) {
                     $data = array('gibbonUsernameFormatID' => $row['gibbonUsernameFormatID'], 'numericValue' => $number);
                     $sql = "UPDATE gibbonUsernameFormat SET numericValue=:numericValue WHERE gibbonUsernameFormatID=:gibbonUsernameFormatID";
-                    $result = $pdo->executeQuery($data, $sql);
+                    $result = $pdo->select($sql, $data);
                 };
 
                 $this->addNumericToken('number', $row['numericValue'], $row['numericSize'], $row['numericIncrement'], $callback);
@@ -230,7 +230,7 @@ class UsernameGenerator
     {
         $data = array('username' => $username);
         $sql = "SELECT gibbonPersonID from gibbonPerson WHERE username=:username OR username=LOWER(:username)";
-        $result = $this->pdo->executeQuery($data, $sql);
+        $result = $this->pdo->select($sql, $data);
 
         return ($result->rowCount() == 0);
     }

--- a/src/Domain/DataUpdater/DataUpdaterGateway.php
+++ b/src/Domain/DataUpdater/DataUpdaterGateway.php
@@ -31,7 +31,7 @@ class DataUpdaterGateway extends Gateway
 {
     /**
      * Gets a list of users this person can update data for, checking by family. Always returns the user themself even if not in a family.
-     * 
+     *
      * @param string $gibbonPersonID
      * @return \PDOStatement
      */
@@ -40,34 +40,34 @@ class DataUpdaterGateway extends Gateway
         $data = array('gibbonPersonID' => $gibbonPersonID);
         $sql = "
         (SELECT GROUP_CONCAT(gibbonFamily.gibbonFamilyID ORDER BY gibbonFamily.name SEPARATOR ',') as gibbonFamilyID, gibbonPerson.surname, gibbonPerson.preferredName, gibbonPerson.image_240, gibbonPerson.gibbonPersonID, gibbonPerson.dateStart, 0 as sequenceNumber
-            FROM gibbonPerson 
+            FROM gibbonPerson
             LEFT JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID)
             LEFT JOIN gibbonFamily ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID)
             WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID AND gibbonPerson.status='Full' GROUP BY gibbonPerson.gibbonPersonID)
-        UNION ALL 
+        UNION ALL
         (SELECT gibbonFamilyAdult.gibbonFamilyID, child.surname, child.preferredName, child.image_240, child.gibbonPersonID, child.dateStart, 1 as sequenceNumber
-            FROM gibbonFamilyAdult 
-            JOIN gibbonFamily ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID) 
+            FROM gibbonFamilyAdult
+            JOIN gibbonFamily ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID)
             JOIN gibbonFamilyChild ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID)
-            JOIN gibbonPerson as child ON (gibbonFamilyChild.gibbonPersonID=child.gibbonPersonID) 
-            WHERE gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID 
-            AND gibbonFamilyAdult.childDataAccess='Y' AND child.status='Full') 
-        UNION ALL 
+            JOIN gibbonPerson as child ON (gibbonFamilyChild.gibbonPersonID=child.gibbonPersonID)
+            WHERE gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID
+            AND gibbonFamilyAdult.childDataAccess='Y' AND child.status='Full')
+        UNION ALL
         (SELECT gibbonFamily.gibbonFamilyID, adult.surname, adult.preferredName, adult.image_240, adult.gibbonPersonID, adult.dateStart, 2 as sequenceNumber
-            FROM gibbonFamilyAdult 
+            FROM gibbonFamilyAdult
             JOIN gibbonFamily ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID)
             JOIN gibbonFamilyAdult as familyAdult ON (familyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID AND familyAdult.gibbonPersonID<>:gibbonPersonID)
-            JOIN gibbonPerson as adult ON (familyAdult.gibbonPersonID=adult.gibbonPersonID) 
+            JOIN gibbonPerson as adult ON (familyAdult.gibbonPersonID=adult.gibbonPersonID)
             WHERE gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID AND adult.status='Full')
         ORDER BY sequenceNumber, surname, preferredName
         ";
 
-        return $this->db()->executeQuery($data, $sql);
+        return $this->db()->select($sql, $data);
     }
 
     /**
      * Gets a list of data updates and the last updated timestamp for a given user.
-     * 
+     *
      * @param string $gibbonPersonID
      * @return \PDOStatement
      */
@@ -76,48 +76,48 @@ class DataUpdaterGateway extends Gateway
         $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonPersonIDSource' => $gibbonPersonIDSource);
         $sql = "
         (SELECT 'Personal' as type, gibbonPerson.gibbonPersonID as id, 'gibbonPersonID' as idType, IFNULL(timestamp, 0) as lastUpdated, '' as name
-            FROM gibbonPerson 
-            LEFT JOIN gibbonPersonUpdate ON (gibbonPersonUpdate.gibbonPersonID=gibbonPerson.gibbonPersonID) 
+            FROM gibbonPerson
+            LEFT JOIN gibbonPersonUpdate ON (gibbonPersonUpdate.gibbonPersonID=gibbonPerson.gibbonPersonID)
             WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID ORDER BY timestamp DESC LIMIT 1)
         UNION ALL
         (SELECT 'Medical' as type, gibbonPerson.gibbonPersonID as id, 'gibbonPersonID' as idType, IFNULL(timestamp, 0) as lastUpdated, '' as name
-            FROM gibbonPerson 
+            FROM gibbonPerson
             JOIN gibbonRole ON (FIND_IN_SET(gibbonRole.gibbonRoleID, gibbonPerson.gibbonRoleIDAll))
-            LEFT JOIN gibbonPersonMedicalUpdate ON (gibbonPersonMedicalUpdate.gibbonPersonID=gibbonPerson.gibbonPersonID) 
+            LEFT JOIN gibbonPersonMedicalUpdate ON (gibbonPersonMedicalUpdate.gibbonPersonID=gibbonPerson.gibbonPersonID)
             WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID AND gibbonRole.category='Student'
             ORDER BY timestamp DESC LIMIT 1)
         UNION ALL
         (SELECT 'Finance' as type, gibbonFinanceInvoicee.gibbonFinanceInvoiceeID as id, 'gibbonFinanceInvoiceeID' as idType, IFNULL(timestamp, 0) as lastUpdated, '' as name
-            FROM gibbonPerson 
+            FROM gibbonPerson
             JOIN gibbonFinanceInvoicee ON (gibbonFinanceInvoicee.gibbonPersonID=gibbonPerson.gibbonPersonID)
-            LEFT JOIN gibbonFinanceInvoiceeUpdate ON (gibbonFinanceInvoiceeUpdate.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID) 
-            WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID 
-            ORDER BY timestamp DESC LIMIT 1)    
+            LEFT JOIN gibbonFinanceInvoiceeUpdate ON (gibbonFinanceInvoiceeUpdate.gibbonFinanceInvoiceeID=gibbonFinanceInvoicee.gibbonFinanceInvoiceeID)
+            WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID
+            ORDER BY timestamp DESC LIMIT 1)
         UNION ALL
         (SELECT 'Family' as type, gibbonFamilyAdult.gibbonFamilyID as id, 'gibbonFamilyID' as idType, IFNULL(timestamp, 0) as lastUpdated, gibbonFamily.name
-            FROM gibbonFamilyAdult 
+            FROM gibbonFamilyAdult
             JOIN gibbonFamily ON (gibbonFamily.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID)
-            LEFT JOIN gibbonFamilyUpdate ON (gibbonFamilyUpdate.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID) 
+            LEFT JOIN gibbonFamilyUpdate ON (gibbonFamilyUpdate.gibbonFamilyID=gibbonFamilyAdult.gibbonFamilyID)
             WHERE gibbonFamilyAdult.gibbonPersonID=:gibbonPersonID ORDER BY timestamp DESC LIMIT 1)
         UNION ALL
         (SELECT 'Family' as type, gibbonFamilyChild.gibbonFamilyID as id, 'gibbonFamilyID' as idType, IFNULL(timestamp, 0) as lastUpdated, gibbonFamily.name
-            FROM gibbonFamilyChild 
+            FROM gibbonFamilyChild
             JOIN gibbonFamily ON (gibbonFamily.gibbonFamilyID=gibbonFamilyChild.gibbonFamilyID)
             JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID)
-            LEFT JOIN gibbonFamilyUpdate ON (gibbonFamilyUpdate.gibbonFamilyID=gibbonFamilyChild.gibbonFamilyID) 
-            WHERE gibbonFamilyChild.gibbonPersonID=:gibbonPersonID AND gibbonFamilyAdult.gibbonPersonID=:gibbonPersonIDSource 
+            LEFT JOIN gibbonFamilyUpdate ON (gibbonFamilyUpdate.gibbonFamilyID=gibbonFamilyChild.gibbonFamilyID)
+            WHERE gibbonFamilyChild.gibbonPersonID=:gibbonPersonID AND gibbonFamilyAdult.gibbonPersonID=:gibbonPersonIDSource
             ORDER BY timestamp DESC LIMIT 1)
         UNION ALL
         (SELECT 'Staff' as type, gibbonPerson.gibbonPersonID as id, 'gibbonPersonID' as idType, IFNULL(gibbonStaffUpdate.timestamp, 0) as lastUpdated, '' as name
-            FROM gibbonPerson 
+            FROM gibbonPerson
             JOIN gibbonRole ON (FIND_IN_SET(gibbonRole.gibbonRoleID, gibbonPerson.gibbonRoleIDAll))
-            LEFT JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) 
-            LEFT JOIN gibbonStaffUpdate ON (gibbonStaffUpdate.gibbonStaffID=gibbonStaff.gibbonStaffID) 
+            LEFT JOIN gibbonStaff ON (gibbonStaff.gibbonPersonID=gibbonPerson.gibbonPersonID)
+            LEFT JOIN gibbonStaffUpdate ON (gibbonStaffUpdate.gibbonStaffID=gibbonStaff.gibbonStaffID)
             WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID AND gibbonRole.category='Staff'
             ORDER BY timestamp DESC LIMIT 1)
         ";
 
-        return $this->db()->executeQuery($data, $sql);
+        return $this->db()->select($sql, $data);
     }
 
     public function countAllRequiredUpdatesByPerson($gibbonPersonID)
@@ -131,13 +131,13 @@ class DataUpdaterGateway extends Gateway
         $requiredUpdatesByType = explode(',', $requiredUpdatesByType);
 
         if (empty($requiredUpdatesByType) || empty($cutoffDate)) return 0;
-        
+
         $count = 0;
 
         // Loop over each updatable person to look for required updates
         foreach ($updatablePeople as $person) {
             $dataUpdatesByType = $this->selectDataUpdatesByPerson($person['gibbonPersonID'], $gibbonPersonID);
-            
+
             if (!$this->db()->getQuerySuccess()) return 0;
 
             $dataUpdatesByType = $dataUpdatesByType->fetchGrouped();

--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -76,7 +76,7 @@ class DatabaseFormFactory extends FormFactory
             default:
                 $sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear ORDER BY sequenceNumber $orderBy"; break;
         }
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
@@ -87,7 +87,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectYearGroup($name, $all = false)
     {
         $sql = "SELECT gibbonYearGroupID as value, name FROM gibbonYearGroup ORDER BY sequenceNumber";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         if (!$all)
             return $this->createSelect($name)->fromResults($results)->placeholder();
@@ -102,7 +102,7 @@ class DatabaseFormFactory extends FormFactory
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
         $sql = "SELECT gibbonFormGroupID as value, name FROM gibbonFormGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY LENGTH(name), name";
-        $results = $this->pdo->executeQuery($data, $sql);
+        $results = $this->pdo->select($sql, $data);
 
         if (!$all)
             return $this->createSelect($name)->fromResults($results)->placeholder();
@@ -117,18 +117,18 @@ class DatabaseFormFactory extends FormFactory
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
-    
+
     public function createSelectCourseByYearGroup($name, $gibbonSchoolYearID, $gibbonYearGroupIDList = '')
     {
         $data = ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonYearGroupIDList' => $gibbonYearGroupIDList];
-        $sql = "SELECT gibbonCourse.gibbonCourseID as value, CONCAT(gibbonCourse.nameShort, ' - ', gibbonCourse.name) as name 
-                FROM gibbonCourse 
-                JOIN gibbonYearGroup ON (FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, gibbonCourse.gibbonYearGroupIDList)) 
-                WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID 
-                AND FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, :gibbonYearGroupIDList) 
+        $sql = "SELECT gibbonCourse.gibbonCourseID as value, CONCAT(gibbonCourse.nameShort, ' - ', gibbonCourse.name) as name
+                FROM gibbonCourse
+                JOIN gibbonYearGroup ON (FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, gibbonCourse.gibbonYearGroupIDList))
+                WHERE gibbonCourse.gibbonSchoolYearID=:gibbonSchoolYearID
+                AND FIND_IN_SET(gibbonYearGroup.gibbonYearGroupID, :gibbonYearGroupIDList)
                 GROUP BY gibbonCourse.gibbonCourseID
                 ORDER BY gibbonCourse.nameShort";
-        $results = $this->pdo->executeQuery($data, $sql);
+        $results = $this->pdo->select($sql, $data);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
@@ -141,7 +141,7 @@ class DatabaseFormFactory extends FormFactory
 
         if (!empty($gibbonPersonID) && !empty($params['courseFilter'])) {
             $data = ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonID' => $gibbonPersonID, 'courseFilter' => '%'.$params['courseFilter'].'%'];
-            $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS class 
+            $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS class
                 FROM gibbonCourse
                 JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
                 JOIN gibbonCourseClassPerson ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID )
@@ -159,7 +159,7 @@ class DatabaseFormFactory extends FormFactory
 
         if (!empty($gibbonPersonID) && !empty($params['departments'])) {
             $data = ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonPersonID' => $gibbonPersonID, 'gibbonDepartmentIDList' => $params['departments']];
-            $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS class 
+            $sql = "SELECT gibbonCourseClass.gibbonCourseClassID, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS class
                 FROM gibbonCourse
                 JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
                 JOIN gibbonCourseClassPerson ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID )
@@ -222,7 +222,7 @@ class DatabaseFormFactory extends FormFactory
     public function createCheckboxYearGroup($name)
     {
         $sql = "SELECT gibbonYearGroupID as `value`, name FROM gibbonYearGroup ORDER BY sequenceNumber";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         // Get the yearGroups in a $key => $value array
         $yearGroups = ($results && $results->rowCount() > 0)? $results->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
@@ -234,7 +234,7 @@ class DatabaseFormFactory extends FormFactory
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
         $sql = "SELECT gibbonSchoolYearTermID as `value`, name FROM gibbonSchoolYearTerm WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY sequenceNumber";
-        $results = $this->pdo->executeQuery($data, $sql);
+        $results = $this->pdo->select($sql, $data);
 
         // Get the terms in a $key => $value array
         $terms = ($results && $results->rowCount() > 0)? $results->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
@@ -245,7 +245,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectDepartment($name)
     {
         $sql = "SELECT type, gibbonDepartmentID as value, name FROM gibbonDepartment ORDER BY name";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         $departments = array();
 
@@ -262,7 +262,7 @@ class DatabaseFormFactory extends FormFactory
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
         $sql = "SELECT gibbonSchoolYearTermID as `value`, name FROM gibbonSchoolYearTerm WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY sequenceNumber";
-        $results = $this->pdo->executeQuery($data, $sql);
+        $results = $this->pdo->select($sql, $data);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
@@ -270,7 +270,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectTheme($name)
     {
         $sql = "SELECT gibbonThemeID as value, (CASE WHEN active='Y' THEN CONCAT(name, ' (', '".__('System Default')."', ')') ELSE name END) AS name FROM gibbonTheme ORDER BY name";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
@@ -293,7 +293,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectLanguage($name)
     {
         $sql = "SELECT name as value, name FROM gibbonLanguage ORDER BY name";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
@@ -301,7 +301,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectCountry($name)
     {
         $sql = "SELECT printable_name as value, printable_name as name FROM gibbonCountry ORDER BY printable_name";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
@@ -309,7 +309,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectRole($name)
     {
         $sql = "SELECT gibbonRoleID as value, name FROM gibbonRole ORDER BY name";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }
@@ -331,7 +331,7 @@ class DatabaseFormFactory extends FormFactory
 
     public function createSelectStaff($name)
     {
-        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, username 
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, username
                 FROM gibbonPerson JOIN gibbonStaff ON (gibbonPerson.gibbonPersonID=gibbonStaff.gibbonPersonID)
                 WHERE status='Full' ORDER BY surname, preferredName";
 
@@ -347,7 +347,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectUsersFromList($name, $people = [])
     {
         $data = ['gibbonPersonIDList' => implode(',', $people)];
-        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, username 
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, username
                 FROM gibbonPerson
                 WHERE status='Full'
                 AND FIND_IN_SET(gibbonPersonID, :gibbonPersonIDList)
@@ -385,7 +385,6 @@ class DatabaseFormFactory extends FormFactory
         }
 
         if ($params['includeStudents'] == true) {
-            $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID, 'date' => date('Y-m-d'));
             $sql = "SELECT gibbonPerson.gibbonPersonID, preferredName, surname, username, gibbonFormGroup.name AS formGroupName
                     FROM gibbonPerson
                     JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
@@ -395,7 +394,7 @@ class DatabaseFormFactory extends FormFactory
                     AND gibbonPerson.status='FULL'
                     AND (dateStart IS NULL OR dateStart<=:date) AND (dateEnd IS NULL  OR dateEnd>=:date)
                     ORDER BY formGroupName, gibbonPerson.surname, gibbonPerson.preferredName";
-            $result = $this->pdo->executeQuery($data, $sql);
+            $result = $this->pdo->select($sql, ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'date' => date('Y-m-d')]);
 
             if ($result->rowCount() > 0) {
                 $users[__('Enrolable Students')] = array_reduce($result->fetchAll(), function($group, $item) {
@@ -410,7 +409,7 @@ class DatabaseFormFactory extends FormFactory
                 JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary)
                 WHERE status='Full' OR status='Expected'
                 ORDER BY surname, preferredName";
-        $result = $this->pdo->executeQuery(array(), $sql);
+        $result = $this->pdo->select($sql);
 
         if ($result->rowCount() > 0) {
             $users[__('All Users')] = array_reduce($result->fetchAll(), function ($group, $item) {
@@ -476,7 +475,7 @@ class DatabaseFormFactory extends FormFactory
                     ORDER BY name, surname, preferredName";
             }
 
-            $results = $this->pdo->executeQuery($data, $sql);
+            $results = $this->pdo->select($sql, $data);
 
             if ($results && $results->rowCount() > 0) {
                 while ($row = $results->fetch()) {
@@ -520,7 +519,7 @@ class DatabaseFormFactory extends FormFactory
                     ORDER BY surname, preferredName";
             }
 
-            $results = $this->pdo->executeQuery($data, $sql);
+            $results = $this->pdo->select($sql, $data);
 
             if ($results && $results->rowCount() > 0) {
                 while ($row = $results->fetch()) {
@@ -564,7 +563,7 @@ class DatabaseFormFactory extends FormFactory
 
         $data = array('gibbonScaleID' => $gibbonScaleID);
         $sql = "SELECT gibbonScaleGradeID, value, descriptor, isDefault FROM gibbonScaleGrade WHERE gibbonScaleID=:gibbonScaleID ORDER BY sequenceNumber";
-        $results = $this->pdo->executeQuery($data, $sql);
+        $results = $this->pdo->select($sql, $data);
 
         $grades = ($results->rowCount() > 0)? $results->fetchAll() : array();
         $gradeOptions = array_reduce($grades, function ($group, $item) use ($params) {
@@ -614,7 +613,7 @@ class DatabaseFormFactory extends FormFactory
 
         if (empty($countryCodes)) {
             $sql = 'SELECT iddCountryCode, printable_name FROM gibbonCountry ORDER BY printable_name';
-            $results = $this->pdo->executeQuery(array(), $sql);
+            $results = $this->pdo->select($sql);
             if ($results && $results->rowCount() > 0) {
                 $countryCodes = $results->fetchAll();
 
@@ -636,7 +635,7 @@ class DatabaseFormFactory extends FormFactory
 
         $data = array('sequenceNumber' => $sequenceNumber);
         $sql = "SELECT GROUP_CONCAT(DISTINCT `{$columnName}` SEPARATOR '\',\'') FROM `{$tableName}` WHERE (`{$columnName}` IS NOT NULL AND `{$columnName}` <> :sequenceNumber) ORDER BY `{$columnName}`";
-        $results = $this->pdo->executeQuery($data, $sql);
+        $results = $this->pdo->select($sql, $data);
 
         $field = $this->createNumber($name)->minimum(1)->onlyInteger(true);
 
@@ -648,7 +647,7 @@ class DatabaseFormFactory extends FormFactory
             $field->setValue($sequenceNumber);
         } else {
             $sql = "SELECT MAX(`{$columnName}`) FROM `{$tableName}`";
-            $results = $this->pdo->executeQuery(array(), $sql);
+            $results = $this->pdo->select($sql);
             $sequenceNumber = ($results && $results->rowCount() > 0)? $results->fetchColumn(0) : 1;
 
             $field->setValue($sequenceNumber+1);
@@ -663,7 +662,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectTransport($name, $all = false)
     {
         $sql = "SELECT DISTINCT transport AS value, transport AS name FROM gibbonPerson WHERE status='Full' AND NOT transport='' ORDER BY transport";
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         if (!$all)
             return $this->createSelect($name)->fromResults($results)->placeholder();
@@ -676,15 +675,15 @@ class DatabaseFormFactory extends FormFactory
         $params = array_replace(array(
             'byType' => true,
         ), $params);
-        
+
         if ($params['byType'] == true) {
             $sql = "SELECT gibbonSpaceID as value, name, type as groupBy FROM gibbonSpace ORDER BY type, name";
-            $results = $this->pdo->executeQuery(array(), $sql);
+            $results = $this->pdo->select($sql);
             return $this->createSelect($name)->fromResults($results, 'groupBy')->placeholder();
-        
+
         } else {
             $sql = "SELECT gibbonSpaceID as value, name FROM gibbonSpace ORDER BY name";
-            $results = $this->pdo->executeQuery(array(), $sql);
+            $results = $this->pdo->select($sql);
             return $this->createSelect($name)->fromResults($results)->placeholder();
         }
     }
@@ -692,7 +691,7 @@ class DatabaseFormFactory extends FormFactory
     public function createTextFieldDistrict($name)
     {
         $sql = "SELECT DISTINCT name FROM gibbonDistrict ORDER BY name";
-        $result = $this->pdo->executeQuery(array(), $sql);
+        $result = $this->pdo->select($sql);
         $districts = ($result && $result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_COLUMN) : array();
 
         return $this->createTextField($name)->maxLength(30)->autocomplete($districts);
@@ -701,7 +700,7 @@ class DatabaseFormFactory extends FormFactory
     public function createSelectAlert($name)
     {
         $sql = 'SELECT gibbonAlertLevelID AS value, name FROM gibbonAlertLevel ORDER BY sequenceNumber';
-        $results = $this->pdo->executeQuery(array(), $sql);
+        $results = $this->pdo->select($sql);
 
         return $this->createSelect($name)->fromResults($results)->placeholder();
     }

--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -126,10 +126,10 @@ class Select extends Input
      */
     public function fromQueryChained(Connection $pdo, $sql, $data = array(), $chainedToID = false, $groupBy = false)
     {
-        $results = $pdo->executeQuery($data, $sql);
+        $results = $pdo->select($sql, $data);
         $this->fromResults($results, $groupBy);
 
-        $results = $pdo->executeQuery($data, $sql);
+        $results = $pdo->select($sql, $data);
 
         if ($results && $results->rowCount() > 0) {
             $chainedOptions = array_reduce($results->fetchAll(), function($group, $item) {

--- a/src/Forms/Traits/MultipleOptionsTrait.php
+++ b/src/Forms/Traits/MultipleOptionsTrait.php
@@ -93,14 +93,14 @@ trait MultipleOptionsTrait
 
     /**
      * Build an internal options array from an SQL query with required value and name fields
-     * @param   Connection  $pdo
+     * @param   Connection  $conn
      * @param   string      $sql
      * @param   array      $data
      * @return  self
      */
-    public function fromQuery(Connection $pdo, $sql, $data = array(), $groupBy = false)
+    public function fromQuery(Connection $conn, $sql, $data = [], $groupBy = false)
     {
-        $results = $pdo->executeQuery($data, $sql);
+        $results = $conn->select($sql, $data);
 
         return $this->fromResults($results, $groupBy);
     }

--- a/src/Gibbon/FileUploader.php
+++ b/src/Gibbon/FileUploader.php
@@ -227,7 +227,7 @@ class FileUploader
                 if (substr($zip->getNameIndex($i), 0, 8) == '__MACOSX') {
                     continue;
                 }
-                
+
                 $filename = $zip->getNameIndex($i);
                 $extension = mb_substr(mb_strrchr(strtolower($filename), '.'), 1);
 
@@ -381,7 +381,7 @@ class FileUploader
                 $sql = "SELECT LOWER(extension) FROM gibbonFileExtension ORDER BY type, name";
             }
 
-            $result = $this->pdo->executeQuery($data, $sql);
+            $result = $this->pdo->select($sql, $data);
 
             if ($result && $result->rowCount() > 0) {
                 $fileExtensionsPreFilter = $result->fetchAll(\PDO::FETCH_COLUMN, 0);

--- a/src/Gibbon/Locale.php
+++ b/src/Gibbon/Locale.php
@@ -163,7 +163,7 @@ class Locale implements LocaleInterface
                 $data = array();
                 $sql="SELECT original, replacement, mode, caseSensitive FROM gibbonString ORDER BY priority DESC, original";
 
-                $result = $pdo->executeQuery($data, $sql);
+                $result = $pdo->select($sql, $data);
 
                 if ($result->rowCount()>0) {
                     $stringReplacements = $result->fetchAll();

--- a/src/Gibbon/Session.php
+++ b/src/Gibbon/Session.php
@@ -32,14 +32,14 @@ use Psr\Container\ContainerInterface;
 class Session implements SessionInterface
 {
     /**
-     * string
+     * @var string
      */
-    private	$guid ;
+    private	$guid;
 
     /**
-     * Gibbon\Contracts\Database\Connection
+     * @var \Gibbon\Contracts\Database\Connection
      */
-    private	$pdo ;
+    private	$pdo;
 
     /**
      * Construct
@@ -342,7 +342,7 @@ class Session implements SessionInterface
                 AND gibbonPermission.gibbonRoleID=:gibbonRoleID
                 ORDER BY name";
 
-        $result = $this->pdo->executeQuery($data, $sql);
+        $result = $this->pdo->select($sql, $data);
 
         if ($result->rowCount() > 0) {
             $actions = array();


### PR DESCRIPTION
**Description**
* Replace all usage of obsoleted Connection::executeQuery to
  Connection::select in the core.

**Motivation and Context**
* Connection::executeQuery is obsoleted since v16. It's usages should be rewritten with Connection::select.

**How Has This Been Tested?**
* Locally.
* CI Environment.