### PR TITLE
Refactor Locale test

### DIFF
--- a/tests/unit/Gibbon/Locale/MockGibbonTrait.php
+++ b/tests/unit/Gibbon/Locale/MockGibbonTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gibbon;
+
+trait MockGibbonTrait {
+
+    /**
+     * Mock global gibbon object.
+     *
+     * @param object $mockGibbon Object to use for mocking global gibbon object.
+     * @return function Function to restore the original global gibbon object.
+     */
+    private function mockGlobalGibbon(object $mockGibbon)
+    {
+        global $gibbon;
+        $gibbonToRestore = $gibbon ?? false;
+        $gibbon = $mockGibbon; // replace global gibbon with the mock object.
+        return function () use ($gibbonToRestore) {
+            global $gibbon;
+            // Unset global $gibbon if there is nothing to restore to.
+            $gibbon = ($gibbonToRestore !== false) ? $gibbonToRestore : null;
+        };
+    }
+
+}

--- a/tests/unit/Gibbon/Locale/MockGuidTrait.php
+++ b/tests/unit/Gibbon/Locale/MockGuidTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Gibbon;
+
+trait MockGuidTrait {
+
+    /**
+     * Mock global gibbon object.
+     *
+     * @param object $mockGibbon Object to use for mocking global gibbon object.
+     * @return function Function to restore the original global gibbon object.
+     */
+    private function mockGlobalGuid(?string $mockGuid = null)
+    {
+        global $guid;
+        $mockGuid = $mockGuid ?: hash('sha256', time());
+        $guidToRestore = $guid ?? false;
+        $guid = $mockGuid; // replace global gibbon with the mock object.
+
+        return [
+            $mockGuid,
+            function () use ($guidToRestore) {
+                global $guid;
+                // Unset global $guid if there was nothing to restore to.
+                $guid = ($guidToRestore !== false) ? $guidToRestore : null;
+            }
+        ];
+    }
+
+}

--- a/tests/unit/Gibbon/Locale/TranslateNTest.php
+++ b/tests/unit/Gibbon/Locale/TranslateNTest.php
@@ -9,71 +9,59 @@ file that was distributed with this source code.
 
 namespace Gibbon;
 
-use Gibbon\Contracts\Database\Connection;
 use Gibbon\Locale;
-use League\Container\Container;
+use Gibbon\Session;
 use PHPUnit\Framework\TestCase;
 
+// Require the system-wide functions.
+require_once __DIR__.'/../../../../functions.php';
+
+// Require trait for testing.
+require_once __DIR__ . '/MockGibbonTrait.php';
+
 /**
- * @covers Locale
+ * @covers \Gibbon\Locale::translateN
+ * @covers __n function
  *
  * Test against PO file generated LocaleTest.sh in
  * the folder containing this file.
  */
 class TranslateNTest extends TestCase
 {
-    private $mockPDO;
-    private $mockSession;
+    use MockGibbonTrait;
 
+    /**
+     * Locale object to test with.
+     *
+     * @var \Gibbon\Locale
+     */
     private $locale;
-    private $gibbonToRestore;
 
     public function setUp(): void
     {
-
-        // Setup the composer autoloader
-        $autoloader = require_once __DIR__.'/../../../../vendor/autoload.php';
-
-        // Require the system-wide functions
-        require_once __DIR__.'/../../../../functions.php';
-
-        // Create a stub for the Gibbon\session class
-        $this->mockSession = $this->createMock(session::class);
-        $this->mockSession
+        // Create a stub for the Gibbon\Session class
+        $mockSession = $this->createMock(Session::class);
+        $mockSession
             ->method('get')
             ->willReturn(null); // always return null
 
         // mocked locale object
         $i18ncode = 'es_ES';
-        $locale = new Locale(__DIR__ . '/mock', $this->mockSession);
+        $locale = new Locale(__DIR__ . '/mock', $mockSession);
         $locale->setLocale($i18ncode);
         $locale->setSystemTextDomain(__DIR__ . '/mock');
-
-        // mocked global gibbon object
-        global $gibbon;
-        $this->gibbonToRestore = isset($gibbon) ? $gibbon : null;
-        $gibbon = (object) [
-            'locale' => $locale,
-        ];
+        $this->locale = $locale;
     }
 
-    public function tearDown(): void
-    {
-        global $gibbon;
-        unset($gibbon);
-        if (isset($this->gibbonToRestore)) {
-            $gibbon = $this->gibbonToRestore; // restore gibbon before test
-        }
-    }
-
+    /**
+     * @covers \Gibbon\Locale::translateN
+     */
     public function testTranslateN()
     {
-        global $gibbon;
-
         $this->assertEquals(
             'I have an orange',
             # L10N: Untranslated plural string with string placeholder
-            $gibbon->locale->translateN('I have an orange', 'I have {num} oranges', 1, [
+            $this->locale->translateN('I have an orange', 'I have {num} oranges', 1, [
                 'num' => 1,
             ]),
             'Untranslated plural string with string placeholder, with n=1'
@@ -82,7 +70,7 @@ class TranslateNTest extends TestCase
         $this->assertEquals(
             'I have 3 oranges',
             # L10N: Untranslated plural string with string placeholder
-            $gibbon->locale->translateN('I have an orange', 'I have {num} oranges', 3, [
+            $this->locale->translateN('I have an orange', 'I have {num} oranges', 3, [
                 'num' => 3,
             ]),
             'Untranslated plural string with string placeholder, with n=3'
@@ -91,7 +79,7 @@ class TranslateNTest extends TestCase
         $this->assertEquals(
             'Yo quiero una manzana',
             # L10N: Translated plural string with string placeholder
-            $gibbon->locale->translateN('I have an apple', 'I have {num} apples', 1, [
+            $this->locale->translateN('I have an apple', 'I have {num} apples', 1, [
                 'num' => 1,
             ]),
             'Translated plural string with string placeholder, with n=1'
@@ -100,49 +88,98 @@ class TranslateNTest extends TestCase
         $this->assertEquals(
             'Yo quiero 3 manzanas',
             # L10N: Translated plural string with string placeholder
-            $gibbon->locale->translateN('I have an apple', 'I have {num} apples', 3, [
+            $this->locale->translateN('I have an apple', 'I have {num} apples', 3, [
                 'num' => 3,
             ]),
             'Translated plural string with string placeholder, with n=3'
         );
     }
 
-    public function testShortcut()
+    /**
+     * @covers __n(string $singular, string $plural, int $n)
+     */
+    public function testShortcutBasic()
     {
-        $this->assertEquals(
-            'I have an orange',
-            # L10N: Untranslated plural string with string placeholder
-            __n('I have an orange', 'I have {num} oranges', 1, [
-                'num' => 1,
-            ]),
-            'Untranslated plural string with string placeholder, with n=1'
-        );
+        $n = rand(1, 4096);
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translateN')
+                ->with(
+                     $this->equalTo('Some text to translate'),
+                     $this->equalTo('Some text to translate for plural'),
+                     $this->equalTo($n),
+                     $this->equalTo([]),
+                     $this->equalTo([])
+                )
+                ->willReturn('Some translation result');
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
 
         $this->assertEquals(
-            'I have 3 oranges',
-            # L10N: Untranslated plural string with string placeholder
-            __n('I have an orange', 'I have {num} oranges', 3, [
-                'num' => 3,
-            ]),
-            'Untranslated plural string with string placeholder, with n=3'
+            'Some translation result',
+            __n('Some text to translate', 'Some text to translate for plural', $n),
+            '__n() calls $ibbon->locale->translateN()'
         );
-
-        $this->assertEquals(
-            'Yo quiero una manzana',
-            # L10N: Translated plural string with string placeholder
-            __n('I have an apple', 'I have {num} apples', 1, [
-                'num' => 1,
-            ]),
-            'Translated plural string with string placeholder, with n=1'
-        );
-
-        $this->assertEquals(
-            'Yo quiero 3 manzanas',
-            # L10N: Translated plural string with string placeholder
-            __n('I have an apple', 'I have {num} apples', 3, [
-                'num' => 3,
-            ]),
-            'Translated plural string with string placeholder, with n=3'
-        );
+        $restoreGibbon();
     }
+
+    /**
+     * @covers __n(string $singular, string $plural, int $n, array $params)
+     */
+    public function testShortcutTextWithParams()
+    {
+        $n = rand(1, 4096);
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translateN')
+                ->with(
+                    $this->equalTo('Some text to translate'),
+                    $this->equalTo('Some text to translate for plural'),
+                    $this->equalTo($n),
+                    $this->equalTo(['some', 'param']),
+                    $this->equalTo([])
+                )
+                ->willReturn('Some translation result');
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
+
+        $this->assertEquals(
+            'Some translation result',
+            __n('Some text to translate', 'Some text to translate for plural', $n, ['some', 'param']),
+            '__n() calls $ibbon->locale->translateN()'
+        );
+        $restoreGibbon();
+    }
+
+    /**
+     * @covers __n(string $singular, string $plural, int $n, array $params, array $options)
+     */
+    public function testShortcutWithParamsAndOptions()
+    {
+        $n = rand(1, 4096);
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translateN')
+                ->with(
+                    $this->equalTo('Some text to translate'),
+                    $this->equalTo('Some text to translate for plural'),
+                    $this->equalTo($n),
+                    $this->equalTo(['some', 'param']),
+                    $this->equalTo(['some', 'options'])
+                )
+                ->willReturn('Some translation result');
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
+
+        $this->assertEquals(
+            'Some translation result',
+            __n('Some text to translate', 'Some text to translate for plural', $n, ['some', 'param'], ['some', 'options']),
+            '__n() calls $ibbon->locale->translateN()'
+        );
+        $restoreGibbon();
+    }
+
 }

--- a/tests/unit/Gibbon/Locale/TranslateTest.php
+++ b/tests/unit/Gibbon/Locale/TranslateTest.php
@@ -9,78 +9,70 @@ file that was distributed with this source code.
 
 namespace Gibbon;
 
-use Gibbon\Contracts\Database\Connection;
 use Gibbon\Locale;
-use League\Container\Container;
+use Gibbon\Session;
 use PHPUnit\Framework\TestCase;
 
+// Require the system-wide functions.
+require_once __DIR__.'/../../../../functions.php';
+
+// Require trait for testing.
+require_once __DIR__ . '/MockGibbonTrait.php';
+require_once __DIR__ . '/MockGuidTrait.php';
+
 /**
- * @covers Locale
+ * @covers \Gibbon\Locale::translate
+ * @covers __ function
  *
  * Test against PO file generated LocaleTest.sh in
  * the folder containing this file.
  */
 class TranslateTest extends TestCase
 {
-    private $mockPDO;
-    private $mockSession;
 
+    use MockGibbonTrait;
+    use MockGuidTrait;
+
+    /**
+     * Locale object to test with.
+     *
+     * @var \Gibbon\Locale
+     */
     private $locale;
-    private $gibbonToRestore;
 
     public function setUp(): void
     {
-
-        // Setup the composer autoloader
-        $autoloader = require_once __DIR__.'/../../../../vendor/autoload.php';
-
-        // Require the system-wide functions
-        require_once __DIR__.'/../../../../functions.php';
-
-        // Create a stub for the Gibbon\session class
-        $this->mockSession = $this->createMock(session::class);
-        $this->mockSession
+        // Create a stub for the Gibbon\Session class
+        $mockSession = $this->createMock(Session::class);
+        $mockSession
             ->method('get')
             ->willReturn(null); // always return null
 
         // mocked locale object
         $i18ncode = 'zh_TW';
-        $locale = new Locale(__DIR__ . '/mock', $this->mockSession);
+        $locale = new Locale(__DIR__ . '/mock', $mockSession);
         $locale->setLocale($i18ncode);
         $locale->setSystemTextDomain(__DIR__ . '/mock');
 
-        // mocked global gibbon object
-        global $gibbon;
-        $this->gibbonToRestore = isset($gibbon) ? $gibbon : null;
-        $gibbon = (object) [
-            'locale' => $locale,
-        ];
+        $this->locale = $locale;
     }
 
-    public function tearDown(): void
-    {
-        global $gibbon;
-        unset($gibbon);
-        if (isset($this->gibbonToRestore)) {
-            $gibbon = $this->gibbonToRestore; // restore gibbon before test
-        }
-    }
-
+    /**
+     * @covers \Gibbon\Locale::translate
+     */
     public function testTranslate()
     {
-        global $gibbon;
-
         $this->assertEquals(
             'Not translated',
             # L10N: Untranslated plain text.
-            $gibbon->locale->translate('Not translated'),
+            $this->locale->translate('Not translated'),
             'Untranslated string stays untranslated'
         );
 
         $this->assertEquals(
             'Untranslated hello world',
             # L10N: Untranslated string for string replacement.
-            $gibbon->locale->translate('Untranslated {action} {name}', [
+            $this->locale->translate('Untranslated {action} {name}', [
                 'action' => 'hello',
                 'name' => 'world',
             ]),
@@ -90,14 +82,14 @@ class TranslateTest extends TestCase
         $this->assertEquals(
             '你好世界',
             # L10N: Translated plain text.
-            $gibbon->locale->translate('Hello world'),
+            $this->locale->translate('Hello world'),
             'Translated plain text'
         );
 
         $this->assertEquals(
             '你好，來自 earth 的 stranger',
             # L10N: Translated string for string replacement.
-            $gibbon->locale->translate('Hello {name} from {planet}', [
+            $this->locale->translate('Hello {name} from {planet}', [
                 'name' => 'stranger',
                 'planet' => 'earth',
             ]),
@@ -107,7 +99,7 @@ class TranslateTest extends TestCase
         $this->assertEquals(
             '你好，來自 earth 的 stranger',
             # L10N: Translated string for numerical replacement.
-            $gibbon->locale->translate('Hello {0} from {1}', [
+            $this->locale->translate('Hello {0} from {1}', [
                 'stranger',
                 'earth',
             ]),
@@ -117,7 +109,7 @@ class TranslateTest extends TestCase
         $this->assertEquals(
             '你好，來自 earth 的 stranger。今天是 monday。',
             # L10N: Translated string with mixed numerical and string placeholder.
-            $gibbon->locale->translate('Hello {0} from {1}. Today is {dayOfWeek}.', [
+            $this->locale->translate('Hello {0} from {1}. Today is {dayOfWeek}.', [
                 'stranger',
                 'dayOfWeek' => 'monday',
                 'earth',
@@ -126,61 +118,139 @@ class TranslateTest extends TestCase
         );
     }
 
-    public function testShortcut()
+    /**
+     * @covers __(string $text)
+     */
+    public function testShortcutBasic()
     {
-        $this->assertEquals(
-            'Not translated',
-            # L10N: Untranslated plain text.
-            __('Not translated'),
-            'Untranslated string stays untranslated'
-        );
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translate')
+                ->with(
+                     $this->equalTo('Some text to translate'),
+                     $this->equalTo([]),
+                     $this->equalTo([])
+                )
+                ->willReturn('Some translation result');
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
 
         $this->assertEquals(
-            'Untranslated hello world',
-            # L10N: Untranslated string for string replacement.
-            __('Untranslated {action} {name}', [
-                'action' => 'hello',
-                'name' => 'world',
-            ]),
-            'Named string replacement works on untranslated strings'
+            'Some translation result',
+            __('Some text to translate'),
+            '__() calls $gibbon->locale->translate()'
         );
+        $restoreGibbon();
+    }
+
+    /**
+     * @covers __(string $text, array $params)
+     */
+    public function testShortcutTextWithParams()
+    {
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translate')
+                ->with(
+                     $this->equalTo('Some text to translate'),
+                     $this->equalTo(['some', 'param']),
+                     $this->equalTo([])
+                )
+                ->willReturn('Some translation result');
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
 
         $this->assertEquals(
-            '你好世界',
-            # L10N: Translated plain text.
-            __('Hello world'),
-            'Translated plain text'
+            'Some translation result',
+            __('Some text to translate', ['some', 'param']),
+            '__() calls $gibbon->locale->translate()'
         );
+        $restoreGibbon();
+    }
+
+    /**
+     * @covers __(string $text, array $params, array $options)
+     */
+    public function testShortcutWithParamsAndOptions()
+    {
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translate')
+                ->with(
+                     $this->equalTo('Some text to translate'),
+                     $this->equalTo(['some', 'param']),
+                     $this->equalTo(['some', 'options'])
+                )
+                ->willReturn('Some translation result');
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
 
         $this->assertEquals(
-            '你好，來自 earth 的 stranger',
-            # L10N: Translated string for string replacement.
-            __('Hello {name} from {planet}', [
-                'name' => 'stranger',
-                'planet' => 'earth',
-            ]),
-            'Translated string with named string replacement'
+            'Some translation result',
+            __('Some text to translate', ['some', 'param'], ['some', 'options']),
+            '__() calls $gibbon->locale->translate()'
         );
+        $restoreGibbon();
+    }
+
+    /**
+     * @covers __(string $guid, string $text)
+     */
+    public function testShortcutUsingGuid()
+    {
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translate')
+                ->with(
+                     $this->equalTo('Some text to translate'),
+                     $this->equalTo([]),
+                     $this->equalTo([])
+                )
+                ->willReturn('Some translation result');
+        list($guid, $restoreGuid) = $this->mockGlobalGuid();
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
 
         $this->assertEquals(
-            '你好，來自 earth 的 stranger',
-            # L10N: Translated string for numerical placeholder replacement.
-            __('Hello {0} from {1}', [
-                'stranger',
-                'earth',
-            ]),
-            'Translated string with numerical placeholder replacement'
+            'Some translation result',
+            __($guid, 'Some text to translate'),
+            '__() with $guid calls $gibbon->locale->translate() in backward compatible way'
         );
 
+        $restoreGibbon();
+        $restoreGuid();
+    }
+
+    /**
+     * @covers __(string $guid, string $text, string $domain)
+     */
+    public function testShortcutUsingGuidWithDomainString()
+    {
+        $localeObserver = $this->createMock(Locale::class);
+        $localeObserver->expects($this->once())
+                ->method('translate')
+                ->with(
+                     $this->equalTo('Some text to translate'),
+                     $this->equalTo([]),
+                     $this->equalTo(['domain' => 'bogus_domain'])
+                )
+                ->willReturn('Some translation result');
+        list($guid, $restoreGuid) = $this->mockGlobalGuid();
+        $restoreGibbon = $this->mockGlobalGibbon((object) [
+            'locale' => $localeObserver,
+        ]);
+
         $this->assertEquals(
-            '你好，來自 earth 的 stranger。今天是 monday。',
-            # L10N: Translated string with mixed numerical and string placeholder.
-            __('Hello {0} from {1}. Today is {dayOfWeek}.', [
-                'stranger',
-                'dayOfWeek' => 'monday',
-                'earth',
-            ]),
-            'Translated string with mixed numerical and string placeholder'
+            'Some translation result',
+            __($guid, 'Some text to translate', 'bogus_domain'),
+            '__() with $guid calls $gibbon->locale->translate() in backward compatible way and returns the result'
         );
+
+        $restoreGibbon();
+        $restoreGuid();
     }
 }

--- a/tests/unit/Gibbon/Locale/mock/i18n/es_ES/LC_MESSAGES/gibbon.po
+++ b/tests/unit/Gibbon/Locale/mock/i18n/es_ES/LC_MESSAGES/gibbon.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gibbon v17.0.00\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-21 12:14+0800\n"
+"POT-Creation-Date: 2021-09-13 17:43+0800\n"
 "PO-Revision-Date: 2018-11-21 10:36+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,48 +18,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. L10N: Untranslated plural string with string placeholder
-#: TranslateNTest.php:76 TranslateNTest.php:85 TranslateNTest.php:115
-#: TranslateNTest.php:124
+#: TranslateNTest.php:64 TranslateNTest.php:73
 msgid "I have an orange"
 msgid_plural "I have {num} oranges"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10N: Translated plural string with string placeholder
-#: TranslateNTest.php:94 TranslateNTest.php:103 TranslateNTest.php:133
-#: TranslateNTest.php:142
+#: TranslateNTest.php:82 TranslateNTest.php:91
 msgid "I have an apple"
 msgid_plural "I have {num} apples"
 msgstr[0] "Yo quiero una manzana"
 msgstr[1] "Yo quiero {num} manzanas"
 
+#: TranslateNTest.php:121 TranslateNTest.php:150 TranslateNTest.php:179
+#: TranslateTest.php:141 TranslateTest.php:167 TranslateTest.php:193
+msgid "Some text to translate"
+msgid_plural "Some text to translate for plural"
+msgstr[0] ""
+msgstr[1] ""
+
 #. L10N: Untranslated plain text.
-#: TranslateTest.php:76 TranslateTest.php:134
+#: TranslateTest.php:68
 msgid "Not translated"
 msgstr ""
 
 #. L10N: Untranslated string for string replacement.
-#: TranslateTest.php:83 TranslateTest.php:141
+#: TranslateTest.php:75
 msgid "Untranslated {action} {name}"
 msgstr ""
 
 #. L10N: Translated plain text.
-#: TranslateTest.php:93 TranslateTest.php:151
+#: TranslateTest.php:85
 msgid "Hello world"
 msgstr ""
 
 #. L10N: Translated string for string replacement.
-#: TranslateTest.php:100 TranslateTest.php:158
+#: TranslateTest.php:92
 msgid "Hello {name} from {planet}"
 msgstr ""
 
 #. L10N: Translated string for numerical replacement.
-#. L10N: Translated string for numerical placeholder replacement.
-#: TranslateTest.php:110 TranslateTest.php:168
+#: TranslateTest.php:102
 msgid "Hello {0} from {1}"
 msgstr ""
 
 #. L10N: Translated string with mixed numerical and string placeholder.
-#: TranslateTest.php:120 TranslateTest.php:178
+#: TranslateTest.php:112
 msgid "Hello {0} from {1}. Today is {dayOfWeek}."
 msgstr ""

--- a/tests/unit/Gibbon/Locale/mock/i18n/gibbon.pot
+++ b/tests/unit/Gibbon/Locale/mock/i18n/gibbon.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gibbon v17.0.00\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-21 12:15+0800\n"
+"POT-Creation-Date: 2021-09-13 17:43+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,48 +19,52 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #. L10N: Untranslated plural string with string placeholder
-#: TranslateNTest.php:76 TranslateNTest.php:85 TranslateNTest.php:115
-#: TranslateNTest.php:124
+#: TranslateNTest.php:64 TranslateNTest.php:73
 msgid "I have an orange"
 msgid_plural "I have {num} oranges"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10N: Translated plural string with string placeholder
-#: TranslateNTest.php:94 TranslateNTest.php:103 TranslateNTest.php:133
-#: TranslateNTest.php:142
+#: TranslateNTest.php:82 TranslateNTest.php:91
 msgid "I have an apple"
 msgid_plural "I have {num} apples"
 msgstr[0] ""
 msgstr[1] ""
 
+#: TranslateNTest.php:121 TranslateNTest.php:150 TranslateNTest.php:179
+#: TranslateTest.php:141 TranslateTest.php:167 TranslateTest.php:193
+msgid "Some text to translate"
+msgid_plural "Some text to translate for plural"
+msgstr[0] ""
+msgstr[1] ""
+
 #. L10N: Untranslated plain text.
-#: TranslateTest.php:76 TranslateTest.php:134
+#: TranslateTest.php:68
 msgid "Not translated"
 msgstr ""
 
 #. L10N: Untranslated string for string replacement.
-#: TranslateTest.php:83 TranslateTest.php:141
+#: TranslateTest.php:75
 msgid "Untranslated {action} {name}"
 msgstr ""
 
 #. L10N: Translated plain text.
-#: TranslateTest.php:93 TranslateTest.php:151
+#: TranslateTest.php:85
 msgid "Hello world"
 msgstr ""
 
 #. L10N: Translated string for string replacement.
-#: TranslateTest.php:100 TranslateTest.php:158
+#: TranslateTest.php:92
 msgid "Hello {name} from {planet}"
 msgstr ""
 
 #. L10N: Translated string for numerical replacement.
-#. L10N: Translated string for numerical placeholder replacement.
-#: TranslateTest.php:110 TranslateTest.php:168
+#: TranslateTest.php:102
 msgid "Hello {0} from {1}"
 msgstr ""
 
 #. L10N: Translated string with mixed numerical and string placeholder.
-#: TranslateTest.php:120 TranslateTest.php:178
+#: TranslateTest.php:112
 msgid "Hello {0} from {1}. Today is {dayOfWeek}."
 msgstr ""

--- a/tests/unit/Gibbon/Locale/mock/i18n/zh_TW/LC_MESSAGES/gibbon.po
+++ b/tests/unit/Gibbon/Locale/mock/i18n/zh_TW/LC_MESSAGES/gibbon.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gibbon v17.0.00\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-21 12:14+0800\n"
+"POT-Creation-Date: 2021-09-13 17:43+0800\n"
 "PO-Revision-Date: 2018-11-17 10:35+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -18,48 +18,52 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. L10N: Untranslated plural string with string placeholder
-#: TranslateNTest.php:76 TranslateNTest.php:85 TranslateNTest.php:115
-#: TranslateNTest.php:124
+#: TranslateNTest.php:64 TranslateNTest.php:73
 msgid "I have an orange"
 msgid_plural "I have {num} oranges"
 msgstr[0] ""
 msgstr[1] ""
 
 #. L10N: Translated plural string with string placeholder
-#: TranslateNTest.php:94 TranslateNTest.php:103 TranslateNTest.php:133
-#: TranslateNTest.php:142
+#: TranslateNTest.php:82 TranslateNTest.php:91
 msgid "I have an apple"
 msgid_plural "I have {num} apples"
 msgstr[0] ""
 msgstr[1] ""
 
+#: TranslateNTest.php:121 TranslateNTest.php:150 TranslateNTest.php:179
+#: TranslateTest.php:141 TranslateTest.php:167 TranslateTest.php:193
+msgid "Some text to translate"
+msgid_plural "Some text to translate for plural"
+msgstr[0] ""
+msgstr[1] ""
+
 #. L10N: Untranslated plain text.
-#: TranslateTest.php:76 TranslateTest.php:134
+#: TranslateTest.php:68
 msgid "Not translated"
 msgstr ""
 
 #. L10N: Untranslated string for string replacement.
-#: TranslateTest.php:83 TranslateTest.php:141
+#: TranslateTest.php:75
 msgid "Untranslated {action} {name}"
 msgstr ""
 
 #. L10N: Translated plain text.
-#: TranslateTest.php:93 TranslateTest.php:151
+#: TranslateTest.php:85
 msgid "Hello world"
 msgstr "你好世界"
 
 #. L10N: Translated string for string replacement.
-#: TranslateTest.php:100 TranslateTest.php:158
+#: TranslateTest.php:92
 msgid "Hello {name} from {planet}"
 msgstr "你好，來自 {planet} 的 {name}"
 
 #. L10N: Translated string for numerical replacement.
-#. L10N: Translated string for numerical placeholder replacement.
-#: TranslateTest.php:110 TranslateTest.php:168
+#: TranslateTest.php:102
 msgid "Hello {0} from {1}"
 msgstr "你好，來自 {1} 的 {0}"
 
 #. L10N: Translated string with mixed numerical and string placeholder.
-#: TranslateTest.php:120 TranslateTest.php:178
+#: TranslateTest.php:112
 msgid "Hello {0} from {1}. Today is {dayOfWeek}."
 msgstr "你好，來自 {1} 的 {0}。今天是 {dayOfWeek}。"


### PR DESCRIPTION
**Description**
* Mock global $gibbon and $guid locally in the test class and restore original after the test.
* Simplify Locale shortcut test to test only how it uses `$gibbon->locale->translate` and
  `$gibbon->locale->translateN`. Not the actual result.

**Motivation and Context**
* Remove the dependency on bootstraped global $gibbon for Locale related tests.
* Simplify tests.

**How Has This Been Tested?**
* Locally.
* CI environment.