### PR TITLE
Markbook, Messenger - null coalesce second pass

### DIFF
--- a/modules/Markbook/markbook_edit_addMultiProcess.php
+++ b/modules/Markbook/markbook_edit_addMultiProcess.php
@@ -25,7 +25,8 @@ $enableEffort = getSettingByScope($connection2, 'Markbook', 'enableEffort');
 $enableRubrics = getSettingByScope($connection2, 'Markbook', 'enableRubrics');
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['address'])."/markbook_edit_addMulti.php&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_GET['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/markbook_edit_addMulti.php&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_addMulti.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Markbook/markbook_edit_addProcess.php
+++ b/modules/Markbook/markbook_edit_addProcess.php
@@ -25,7 +25,8 @@ $enableEffort = getSettingByScope($connection2, 'Markbook', 'enableEffort');
 $enableRubrics = getSettingByScope($connection2, 'Markbook', 'enableRubrics');
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['address'])."/markbook_edit_add.php&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_GET['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/markbook_edit_add.php&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Markbook/markbook_edit_dataProcess.php
+++ b/modules/Markbook/markbook_edit_dataProcess.php
@@ -29,7 +29,8 @@ $enableModifiedAssessment = getSettingByScope($connection2, 'Markbook', 'enableM
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
 $gibbonMarkbookColumnID = $_GET['gibbonMarkbookColumnID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['address'])."/markbook_edit_data.php&gibbonMarkbookColumnID=$gibbonMarkbookColumnID&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_GET['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/markbook_edit_data.php&gibbonMarkbookColumnID=$gibbonMarkbookColumnID&gibbonCourseClassID=$gibbonCourseClassID";
 
 $personalisedWarnings = getSettingByScope($connection2, 'Markbook', 'personalisedWarnings');
 

--- a/modules/Markbook/markbook_edit_deleteProcess.php
+++ b/modules/Markbook/markbook_edit_deleteProcess.php
@@ -21,8 +21,9 @@ include '../../gibbon.php';
 
 $gibbonCourseClassID = $_POST['gibbonCourseClassID'] ?? '';
 $gibbonMarkbookColumnID = $_GET['gibbonMarkbookColumnID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/markbook_edit_delete.php&gibbonMarkbookColumnID=$gibbonMarkbookColumnID&gibbonCourseClassID=$gibbonCourseClassID";
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/markbook_view.php&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/markbook_edit_delete.php&gibbonMarkbookColumnID=$gibbonMarkbookColumnID&gibbonCourseClassID=$gibbonCourseClassID";
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/markbook_view.php&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Markbook/markbook_edit_editProcess.php
+++ b/modules/Markbook/markbook_edit_editProcess.php
@@ -26,13 +26,14 @@ $enableRubrics = getSettingByScope($connection2, 'Markbook', 'enableRubrics');
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
 $gibbonMarkbookColumnID = $_GET['gibbonMarkbookColumnID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['address'])."/markbook_edit_edit.php&gibbonMarkbookColumnID=$gibbonMarkbookColumnID&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_GET['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/markbook_edit_edit.php&gibbonMarkbookColumnID=$gibbonMarkbookColumnID&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edit.php') == false) {
     $URL .= '&return=error0';
     header("Location: {$URL}");
 } else {
-    $highestAction = getHighestGroupedAction($guid, $_GET['address'], $connection2);
+    $highestAction = getHighestGroupedAction($guid, $address, $connection2);
     if ($highestAction == false) {
         $URL .= '&return=error0';
         header("Location: {$URL}");

--- a/modules/Markbook/markbook_edit_targetsProcess.php
+++ b/modules/Markbook/markbook_edit_targetsProcess.php
@@ -20,7 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/markbook_edit_targets.php&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/markbook_edit_targets.php&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_targets.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Markbook/weighting_manage_addProcess.php
+++ b/modules/Markbook/weighting_manage_addProcess.php
@@ -20,7 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/weighting_manage.php&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/weighting_manage.php&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_add.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Markbook/weighting_manage_deleteProcess.php
+++ b/modules/Markbook/weighting_manage_deleteProcess.php
@@ -21,8 +21,9 @@ include '../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
 $gibbonMarkbookWeightID = $_POST['gibbonMarkbookWeightID'] ?? null;
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/weighting_manage_delete.php&gibbonCourseClassID=$gibbonCourseClassID&gibbonMarkbookWeightID=$gibbonMarkbookWeightID";
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/weighting_manage.php&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/weighting_manage_delete.php&gibbonCourseClassID=$gibbonCourseClassID&gibbonMarkbookWeightID=$gibbonMarkbookWeightID";
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/weighting_manage.php&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Markbook/weighting_manage_editProcess.php
+++ b/modules/Markbook/weighting_manage_editProcess.php
@@ -20,7 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/weighting_manage.php&gibbonCourseClassID=$gibbonCourseClassID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/weighting_manage.php&gibbonCourseClassID=$gibbonCourseClassID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/cannedResponse_manage_addProcess.php
+++ b/modules/Messenger/cannedResponse_manage_addProcess.php
@@ -19,7 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 include '../../gibbon.php';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/cannedResponse_manage_add.php';
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address).'/cannedResponse_manage_add.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_manage_add.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/cannedResponse_manage_deleteProcess.php
+++ b/modules/Messenger/cannedResponse_manage_deleteProcess.php
@@ -20,8 +20,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 $gibbonMessengerCannedResponseID = $_GET['gibbonMessengerCannedResponseID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/cannedResponse_manage_delete.php&gibbonMessengerCannedResponseID='.$gibbonMessengerCannedResponseID;
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/cannedResponse_manage.php';
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address).'/cannedResponse_manage_delete.php&gibbonMessengerCannedResponseID='.$gibbonMessengerCannedResponseID;
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address).'/cannedResponse_manage.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_manage_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/cannedResponse_manage_editProcess.php
+++ b/modules/Messenger/cannedResponse_manage_editProcess.php
@@ -20,7 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 $gibbonMessengerCannedResponseID = $_GET['gibbonMessengerCannedResponseID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/cannedResponse_manage_edit.php&gibbonMessengerCannedResponseID='.$gibbonMessengerCannedResponseID;
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address).'/cannedResponse_manage_edit.php&gibbonMessengerCannedResponseID='.$gibbonMessengerCannedResponseID;
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/cannedResponse_manage_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/groups_manageProcessBulk.php
+++ b/modules/Messenger/groups_manageProcessBulk.php
@@ -21,7 +21,8 @@ use Gibbon\Domain\Messenger\GroupGateway;
 
 include '../../gibbon.php';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage.php";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/groups_manage.php";
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/groups_manage_addProcess.php
+++ b/modules/Messenger/groups_manage_addProcess.php
@@ -21,7 +21,8 @@ use Gibbon\Domain\Messenger\GroupGateway;
 
 include '../../gibbon.php';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage_add.php";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/groups_manage_add.php";
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_add.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/groups_manage_deleteProcess.php
+++ b/modules/Messenger/groups_manage_deleteProcess.php
@@ -26,8 +26,9 @@ require_once __DIR__ . '/moduleFunctions.php';
 
 $gibbonGroupID = $_GET['gibbonGroupID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage_delete.php&gibbonGroupID=$gibbonGroupID";
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage.php&gibbonGroupID=$gibbonGroupID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/groups_manage_delete.php&gibbonGroupID=$gibbonGroupID";
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/groups_manage.php&gibbonGroupID=$gibbonGroupID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/groups_manage_editProcess.php
+++ b/modules/Messenger/groups_manage_editProcess.php
@@ -22,7 +22,8 @@ use Gibbon\Domain\Messenger\GroupGateway;
 include '../../gibbon.php';
 
 $gibbonGroupID = $_GET['gibbonGroupID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage_edit.php&gibbonGroupID=$gibbonGroupID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/groups_manage_edit.php&gibbonGroupID=$gibbonGroupID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/groups_manage_edit_deleteProcess.php
+++ b/modules/Messenger/groups_manage_edit_deleteProcess.php
@@ -24,8 +24,9 @@ include '../../gibbon.php';
 $gibbonGroupID = $_GET['gibbonGroupID'] ?? '';
 $gibbonPersonID = $_GET['gibbonPersonID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage_edit_delete.php&gibbonGroupID=$gibbonGroupID&gibbonPersonID=$gibbonPersonID";
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/groups_manage_edit.php&gibbonGroupID=$gibbonGroupID";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/groups_manage_edit_delete.php&gibbonGroupID=$gibbonGroupID&gibbonPersonID=$gibbonPersonID";
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/groups_manage_edit.php&gibbonGroupID=$gibbonGroupID";
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/groups_manage_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Messenger/messenger_manage_deleteProcess.php
+++ b/modules/Messenger/messenger_manage_deleteProcess.php
@@ -22,14 +22,15 @@ include '../../gibbon.php';
 $gibbonMessengerID = $_GET['gibbonMessengerID'] ?? '';
 $search = $_GET['search'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/messenger_manage_delete.php&search=$search&gibbonMessengerID=".$gibbonMessengerID;
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/messenger_manage.php&search=$search";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/messenger_manage_delete.php&search=$search&gibbonMessengerID=".$gibbonMessengerID;
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/messenger_manage.php&search=$search";
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_manage_delete.php') == false) {
     $URL .= '&return=error0';
     header("Location: {$URL}");
 } else {
-    $highestAction = getHighestGroupedAction($guid, $_POST['address'], $connection2);
+    $highestAction = getHighestGroupedAction($guid, $address, $connection2);
     if ($highestAction == false) {
         $URL .= "&return=error0$params";
         header("Location: {$URL}");

--- a/modules/Messenger/messenger_manage_editProcess.php
+++ b/modules/Messenger/messenger_manage_editProcess.php
@@ -25,7 +25,8 @@ include '../../gibbon.php';
 $gibbonMessengerID=$_POST["gibbonMessengerID"] ?? '';
 $search=$_GET["search"] ?? '';
 
-$URL=$session->get('absoluteURL') . "/index.php?q=/modules/" . getModuleName($_POST["address"]) . "/messenger_manage_edit.php&sidebar=true&search=$search&gibbonMessengerID=" . $gibbonMessengerID ;
+$address = $_POST['address'] ?? '';
+$URL=$session->get('absoluteURL') . "/index.php?q=/modules/" . getModuleName($address) . "/messenger_manage_edit.php&sidebar=true&search=$search&gibbonMessengerID=" . $gibbonMessengerID ;
 $time=time() ;
 
 if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_manage_edit.php")==FALSE) {
@@ -50,7 +51,7 @@ else {
             $validator = $container->get(Validator::class);
             $_POST = $validator->sanitize($_POST, ['body' => 'HTML']);
 
-            $messageWall=$_POST["messageWall"] ;
+            $messageWall=$_POST["messageWall"] ?? '';
             $messageWallPin = ($messageWall == "Y" && isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_manage.php", "Manage Messages_all") & !empty($_POST['messageWallPin'])) ? $_POST['messageWallPin'] : 'N' ;
             $date1=NULL ;
             if (isset($_POST["date1"])) {

--- a/modules/Messenger/messenger_manage_report_processBulk.php
+++ b/modules/Messenger/messenger_manage_report_processBulk.php
@@ -44,10 +44,7 @@ if ($gibbonMessengerID == '' or $action != 'resend') { echo 'Fatal error loading
             exit;
         }
 
-        $gibbonMessengerReceiptIDs = array();
-        if (isset($_POST['gibbonMessengerReceiptIDs'])) {
-            $gibbonMessengerReceiptIDs = $_POST['gibbonMessengerReceiptIDs'];
-        }
+        $gibbonMessengerReceiptIDs = $_POST['gibbonMessengerReceiptIDs'] ?? array();
 
         if (count($gibbonMessengerReceiptIDs) < 1) {
             $URL .= '&return=error1';
@@ -79,7 +76,7 @@ if ($gibbonMessengerID == '' or $action != 'resend') { echo 'Fatal error loading
                     //Prep message
                     $emailCount = 0;
                     $bodyReminder = "<p style='font-style: italic; font-weight: bold'>" . __('This is a reminder for an email that requires your action. Please look for the link in the email, and click it to confirm receipt and reading of this email.') ."</p>" ;
-                    
+
                     $mail= $container->get(Mailer::class);
                     $mail->SMTPKeepAlive = true;
     				$mail->SetFrom($session->get('email'), $session->get('preferredName') . ' ' . $session->get('surname'));

--- a/modules/Messenger/messenger_postPreProcess.php
+++ b/modules/Messenger/messenger_postPreProcess.php
@@ -24,7 +24,8 @@ use Gibbon\Domain\Messenger\MessengerGateway;
 
 include '../../gibbon.php';
 
-$URL = $session->get('absoluteURL') . "/index.php?q=/modules/" . getModuleName($_POST["address"]) . "/messenger_post.php";
+$address = $_POST['address'] ?? '';
+$URL = $session->get('absoluteURL') . "/index.php?q=/modules/" . getModuleName($address) . "/messenger_post.php";
 
 if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php") == false) {
     $URL .= "&addReturn=fail0";
@@ -35,10 +36,10 @@ if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.p
 
     $validator = $container->get(Validator::class);
     $_POST = $validator->sanitize($_POST, ['body' => 'HTML']);
-    
+
     $from = $_POST['from'] ?? '';
     $data = [
-        'gibbonSchoolYearID'=> $gibbon->session->get('gibbonSchoolYearID'), 
+        'gibbonSchoolYearID'=> $gibbon->session->get('gibbonSchoolYearID'),
         'email'             => $_POST['email'] ?? 'N',
         'messageWall'       => $_POST['messageWall'] ?? 'N',
         'messageWallPin'    => $_POST['messageWallPin'] ?? 'N',
@@ -53,7 +54,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.p
         'gibbonPersonID'    => $session->get('gibbonPersonID'),
         'timestamp'         => date('Y-m-d H:i:s'),
     ];
-  
+
     // Validate that the required values are present
     if (empty($data['subject']) || empty($data['body']) || ($data['email'] == 'Y' && $from == '') || ($data['emailReceipt'] == 'Y' && $data['emailReceiptText'] == '')) {
         $URL .= "&addReturn=fail3";

--- a/modules/Messenger/messenger_postQuickWallProcess.php
+++ b/modules/Messenger/messenger_postQuickWallProcess.php
@@ -25,7 +25,8 @@ include '../../gibbon.php';
 //Module includes
 include './moduleFunctions.php';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['address']).'/messenger_postQuickWall.php';
+$address = $_GET['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address).'/messenger_postQuickWall.php';
 $time = time();
 
 if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_postQuickWall.php') == false) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
Second pass of null coalesce in Markbook and Messenger modules, mainly updating URLs.

**Motivation and Context**
<!-- Why is this change suggested? Is there a problem it helps to solve?
If this PR fixes an open issue, please link to the issue here. -->

**How Has This Been Tested?**
<!-- Please describe how you've tested your changes. Include details of 
your testing environment, and any tests you've run to see how your 
change affects other areas of the code. -->

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
