### PR TITLE
Refactor Gibbon\Excel::estimateCellCount to migrate away from Connection::getResult

### DIFF
--- a/modules/Finance/expenses_manage_processBulkExportContents.php
+++ b/modules/Finance/expenses_manage_processBulkExportContents.php
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage.ph
 
 
 		$excel = new Gibbon\Excel('expenses.xlsx');
-		if ($excel->estimateCellCount($pdo) > 8000)    //  If too big, then render csv instead.
+		if ($excel->estimateCellCount($result) > 8000)    //  If too big, then render csv instead.
 			return Gibbon\csv::generate($pdo, 'Invoices');
 		$excel->setActiveSheetIndex(0);
 		$excel->getProperties()->setTitle('Expenses');

--- a/modules/Finance/invoices_manage_processBulkExportContents.php
+++ b/modules/Finance/invoices_manage_processBulkExportContents.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage.ph
 		}
 
 		$excel = new Gibbon\Excel('invoices.xlsx');
-		if ($excel->estimateCellCount($pdo) > 8000)    //  If too big, then render csv instead.
+		if ($excel->estimateCellCount($result) > 8000)    //  If too big, then render csv instead.
 			return Gibbon\csv::generate($pdo, 'Invoices');
 		$excel->setActiveSheetIndex(0);
 		$excel->getProperties()->setTitle('Invoices');

--- a/modules/Library/report_catalogSummaryExportContents.php
+++ b/modules/Library/report_catalogSummaryExportContents.php
@@ -75,7 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/report_catalogSumm
 
 
 	$excel = new Gibbon\Excel('catalogSummary.xlsx');
-	if ($excel->estimateCellCount($pdo) > 8000)    //  If too big, then render csv instead.
+	if ($excel->estimateCellCount($result) > 8000)    //  If too big, then render csv instead.
 		return Gibbon\csv::generate($pdo, 'Catalog Summary');
 	$excel->setActiveSheetIndex(0);
 	$excel->getProperties()->setTitle('Catalog Summary');

--- a/modules/Markbook/markbook_viewExportAllContents.php
+++ b/modules/Markbook/markbook_viewExportAllContents.php
@@ -84,7 +84,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
 
         //Print table header
 		$excel = new Gibbon\Excel('markbookAll.xlsx');
-		if ($excel->estimateCellCount($pdo) > 8000)    //  If too big, then render csv instead.
+		if ($excel->estimateCellCount($result) > 8000)    //  If too big, then render csv instead.
 			return Gibbon\csv::generate($pdo, 'markbookColumn');
 		$excel->setActiveSheetIndex(0);
 		$excel->getProperties()->setTitle('All Markbook Data');
@@ -284,8 +284,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
 
                     // Cumulative Average
                     $cumulativeAverage = $markbook->getCumulativeAverage($rowStudents['gibbonPersonID']);
-                    $cumulativeAverage = is_numeric($cumulativeAverage) 
-                        ? number_format(round($cumulativeAverage, 2),2).$markSuffix 
+                    $cumulativeAverage = is_numeric($cumulativeAverage)
+                        ? number_format(round($cumulativeAverage, 2),2).$markSuffix
                         : $cumulativeAverage.$markSuffix;
                     $excel->getActiveSheet()->setCellValueByColumnAndRow( $finalColumnNum, $r, $cumulativeAverage);
                     $excel->getActiveSheet()->getStyleByColumnAndRow($finalColumnNum, $r)->applyFromArray($style_border);

--- a/modules/Markbook/markbook_viewExportContents.php
+++ b/modules/Markbook/markbook_viewExportContents.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
     } else {
 
 		$excel = new Gibbon\Excel('markbookColumn.xlsx');
-		if ($excel->estimateCellCount($pdo) > 8000)    //  If too big, then render csv instead.
+		if ($excel->estimateCellCount($resultStudents) > 8000)    //  If too big, then render csv instead.
 			return Gibbon\csv::generate($pdo, 'markbookColumn');
 		$excel->setActiveSheetIndex(0);
 		$excel->getProperties()->setTitle('Markbook Data');

--- a/src/Gibbon/Excel.php
+++ b/src/Gibbon/Excel.php
@@ -2,6 +2,7 @@
 namespace Gibbon;
 
 use Gibbon\Contracts\Database\Connection;
+use Gibbon\Database\Result;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
@@ -168,16 +169,29 @@ class Excel extends Spreadsheet
     /**
      * Estimate Cell Count in Spreadsheet
      *
-     * @version	14th April 2016
      * @since	14th April 2016
-     * @param	Object	Connection
-     * return	integer	Estimated Cell Count
+     * @version	v23
+     * @param	\Gibbon\Contracts\Database\Connection|\Gibbon\Database\Result $reference Reference for connection or result.
+     *                                                                                   The use of Connection is deprecated.
+     *
+     * @return	int	Estimated Cell Count
      */
-    public function estimateCellCount(Connection $pdo)
+    public function estimateCellCount($reference)
     {
-        if ($pdo->getResult() !== NULL)
-            return $pdo->getResult()->columnCount (  ) * $pdo->getResult()->rowCount ( );
-        return 0 ;
+        if (!is_object($reference) && !($reference instanceof Connection) && !($reference instanceof Result)) {
+            throw new \InvalidArgumentException('Argument must be an object of ' . Connection::class . ' or ' . Result::class);
+        }
+        if ($reference instanceof Result) {
+            return $reference->columnCount() * $reference->rowCount();
+        }
+        /**
+         * @var \Gibbon\Database\Connection $reference
+         */
+        // TODO: remove the direct use of Connection::getResult for it is obsoleted.
+        if ($reference instanceof Connection && ($result = $reference->getResult()) !== NULL) {
+            return $result->columnCount() * $result->rowCount();
+        }
+        return 0;
     }
 
     /**


### PR DESCRIPTION
**Description**
* Modules: rewrite modules usage of Gibbon\Excel::estimateCellCount  
    * follow the estimateCellCount update to retire use of obsoleted
      Gibbon\Database\Connection::getResult() method.
* System: update Gibbon\Excel::estimateCellCount  
    * Rewrite to accept \Gibbon\Database\Result in addition to the
      original \Gibbon\Contracts\Database\Connection.
    * Should remove the direct use of Connection::getResult in the
      future for it is obsoleted.

**Motivation and Context**
* Connection::getResult is deprecated but the old estimateCellCount logic
  rely on it.

**How Has This Been Tested?**
* Locally.
* CI environment.