### PR TITLE
System: correct phpdocs in Gibbon\Excel::exportWithQuery

### DIFF
--- a/src/Gibbon/Excel.php
+++ b/src/Gibbon/Excel.php
@@ -31,11 +31,11 @@ class Excel extends Spreadsheet
         header("Cache-Control: private", false);
     }
     /**
-     * Export with Query
+     * Export with Query. Will print output directly.
      *
      * @version	27th May 2016
      * @since	8th April 2016
-     * @return	string	Export to Browser.
+     * @return	void
      */
     function exportWithQuery($result, $excel_file_name)
     {


### PR DESCRIPTION
**Description**
* Change the `@return` of Excel::exportWithQuery from `string` to `void`.

**Motivation and Context**
* Gibbon\Excel::exportWithQuery does not return anything. The
  string result is directly output to STDOUT stream of
  cgi / fastcgi server. The phpdocs should reflect that.

**How Has This Been Tested?**
* Locally on VSCode.
* Locally with PHPStan.