### PR TITLE
System: fix incorrect phpdocs for Result::toDataSet

### DIFF
--- a/src/Contracts/Database/Result.php
+++ b/src/Contracts/Database/Result.php
@@ -108,7 +108,7 @@ interface Result
     /**
      * Fetches all results and returns it as a DataSet object.
      *
-     * @return array
+     * @return \Gibbon\Domain\DataSet  The DataSet object of all the fetched results.
      */
     public function toDataSet();
 }

--- a/src/Database/Result.php
+++ b/src/Database/Result.php
@@ -80,9 +80,7 @@ class Result extends PDOStatement implements ResultContract
     }
 
     /**
-     * Fetches all results and returns it as a DataSet object.
-     *
-     * @return array
+     * {@inheritDoc}
      */
     public function toDataSet()
     {


### PR DESCRIPTION
**Description**
* Fix documentation error.

**Motivation and Context**
* The return type specified was array while it returns
  \Gibbon\Domain\DataSet.

**How Has This Been Tested?**
* Locally with VSCode.