### PR TITLE
Test: phpstan to use config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ indent_size = 4
 
 [*.yml]
 indent_size = 2
+
+[*.neon]
+indent_style = tab
+indent_size = 4

--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,4 @@
-<FilesMatch "\.(htaccess|htpasswd|ini|log|sh|inc|bak|sql)$">
+<FilesMatch "\.(htaccess|htpasswd|ini|log|sh|inc|bak|sql|neon)$">
 Order Allow,Deny
 Deny from all
 </FilesMatch>

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
             "cd tests && ../vendor/bin/phpunit --verbose --colors=always --configuration phpunit.xml"
         ],
         "test:phpstan": [
-            "vendor/bin/phpstan analyse --ansi --no-progress --no-interaction --autoload-file=functions.php src"
+            "vendor/bin/phpstan analyse --ansi --no-progress --no-interaction -c phpstan.neon"
         ],
         "test:codesniffer": [
           "vendor/bin/phpcs --standard=PSR2 modules/Library/" 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,32 @@
+parameters:
+	level: 0
+	paths:
+		- src
+	ignoreErrors:
+		- '#Unsafe usage of new static\(\)#'
+	scanFiles:
+		- functions.php
+		- modules/Activities/moduleFunctions.php
+		- modules/Attendance/moduleFunctions.php
+		- modules/Behaviour/moduleFunctions.php
+		- modules/Crowd Assessment/moduleFunctions.php
+		- modules/Data Updater/moduleFunctions.php
+		- modules/Departments/moduleFunctions.php
+		- modules/Finance/moduleFunctions.php
+		- modules/Form Groups/moduleFunctions.php
+		- modules/Formal Assessment/moduleFunctions.php
+		- modules/Individual Needs/moduleFunctions.php
+		- modules/Library/moduleFunctions.php
+		- modules/Markbook/moduleFunctions.php
+		- modules/Messenger/moduleFunctions.php
+		- modules/Planner/moduleFunctions.php
+		- modules/Reports/moduleFunctions.php
+		- modules/Rubrics/moduleFunctions.php
+		- modules/School Admin/moduleFunctions.php
+		- modules/Staff/moduleFunctions.php
+		- modules/Students/moduleFunctions.php
+		- modules/System Admin/moduleFunctions.php
+		- modules/Timetable Admin/moduleFunctions.php
+		- modules/Timetable/moduleFunctions.php
+		- modules/Tracking/moduleFunctions.php
+		- modules/User Admin/moduleFunctions.php


### PR DESCRIPTION
**Description**
* Use phpstan.neon to config the behaviour instead of using the
  CLI arguments. Much cleaner and more readable.
* Define how to format a .neon file in .editorconfig to ensure
  consistancy.

**Motivation and Context**
* The old way misses all moduleFunctions.php when scanning for functions. Adding all those files to command argument would be a huge pain in the ass. Using a config file is more sensible.

**How Has This Been Tested?**
* Locally.
* CI environment.