### PR TITLE
System: fix BackgroundProcessor sprintf issue

### DIFF
--- a/src/Services/BackgroundProcessor.php
+++ b/src/Services/BackgroundProcessor.php
@@ -118,7 +118,7 @@ class BackgroundProcessor implements ContainerAwareInterface
             switch ($this->getOS()) {
                 case self::OS_WINDOWS:
                     $command = PHP_BINARY.' '.$argsEscaped;
-                    exec(sprintf('%s &', $command, $phpOutput));
+                    exec(sprintf('%s > NUL &', $command));
                     break;
 
                 case self::OS_NIX:
@@ -156,7 +156,7 @@ class BackgroundProcessor implements ContainerAwareInterface
         if (empty($processData) || empty($processKey)) {
             throw new \InvalidArgumentException();
         }
-        
+
         // Validate against the unique key provided in the process data
         if ($processData['key'] != $processKey || $processData['status'] != 'Ready') {
             throw new \RuntimeException('You do not have access to this action.');
@@ -275,7 +275,7 @@ class BackgroundProcessor implements ContainerAwareInterface
                 return false;
             }
         }
-        
+
         return false;
     }
 
@@ -304,7 +304,7 @@ class BackgroundProcessor implements ContainerAwareInterface
                 return false;
             }
         }
-        
+
         return false;
     }
 


### PR DESCRIPTION
**Description**
* The background command sprintf has more supplied arguments than
  placeholder. Should remove unnecessary ones.
* Use "> /dev/null" for Windows background command.

**Motivation and Context**
* The original sprintf statement has error.
* Windows CMD equivalent of "> /dev/null" would be "> NUL".

**How Has This Been Tested?**
* Locally with PHPStan.