### PR TITLE
System: fix Select::getLabelContext

### DIFF
--- a/src/Forms/Input/Select.php
+++ b/src/Forms/Input/Select.php
@@ -100,6 +100,7 @@ class Select extends Input
         if ($this->getAttribute('multiple') == true) {
             return __('Use Control, Command and/or Shift to select multiple.');
         }
+        return '';
     }
 
     /**


### PR DESCRIPTION
**Description**
* getLabelContext is documented to return string. It should return
  at least an empty string even if the attribute 'multiple' is not
  true.

**Motivation and Context**
* Fix issue found by PHPStan.

**How Has This Been Tested?**
* Locally with PHPStan.
* CI Environment.