### PR TITLE
Remote CLI

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -1031,5 +1031,5 @@ ALTER TABLE `gibbonPayment` CHANGE `gateway` `gateway` VARCHAR(30) CHARACTER SET
 UPDATE `gibbonSetting` SET value=REPLACE(value, 'PayPal', 'online') WHERE scope='Application Form' AND name='applicationProcessFeeText';end
 UPDATE `gibbonSetting` SET value='PayPal' WHERE scope='System' AND name='paymentGateway' AND value='';end
 CREATE TABLE `gibbonSession` ( `gibbonSessionID` VARCHAR(255) NOT NULL , `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NULL , `sessionData` TEXT NULL , `timestampCreated` TIMESTAMP NULL , `timestampModified` TIMESTAMP NULL , PRIMARY KEY (`gibbonSessionID`)) ENGINE = InnoDB;end
- 
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('System Admin', 'remoteCLIKey', 'Remote CLI Key', 'Allow command line scripts to be run remotely using a secure key.', '');end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -1031,5 +1031,5 @@ ALTER TABLE `gibbonPayment` CHANGE `gateway` `gateway` VARCHAR(30) CHARACTER SET
 UPDATE `gibbonSetting` SET value=REPLACE(value, 'PayPal', 'online') WHERE scope='Application Form' AND name='applicationProcessFeeText';end
 UPDATE `gibbonSetting` SET value='PayPal' WHERE scope='System' AND name='paymentGateway' AND value='';end
 CREATE TABLE `gibbonSession` ( `gibbonSessionID` VARCHAR(255) NOT NULL , `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NULL , `sessionData` TEXT NULL , `timestampCreated` TIMESTAMP NULL , `timestampModified` TIMESTAMP NULL , PRIMARY KEY (`gibbonSessionID`)) ENGINE = InnoDB;end
-INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('System Admin', 'remoteCLIKey', 'Remote CLI Key', 'Allow command line scripts to be run remotely using a secure key.', '');end
+INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('System Admin', 'remoteCLIKey', 'Remote CLI Key', 'Allow command line scripts to be run remotely using a secure key. The key can be passed as a URL parameter called remoteCLIKey.', '');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ v23.0.00
     Headlines
 
     Significant Changes
+        System: added ability to run CLI scripts remotely, with secure key
 
     Changes With Important Notices
 

--- a/cli/attendance_dailyIncompleteEmail.php
+++ b/cli/attendance_dailyIncompleteEmail.php
@@ -37,7 +37,10 @@ if (!empty($session->get('i18n')['code'])) {
 }
 
 //Check for CLI, so this cannot be run through browser
-if (!isCommandLineInterface()) { echo __('This script cannot be run from a browser, only via CLI.');
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
+    echo __('This script cannot be run from a browser, only via CLI.');
 } else {
     $currentDate = date('Y-m-d');
 

--- a/cli/attendance_dailyIncompleteEmail_byClass.php
+++ b/cli/attendance_dailyIncompleteEmail_byClass.php
@@ -37,7 +37,10 @@ if (!empty($session->get('i18n')['code'])) {
 }
 
 //Check for CLI, so this cannot be run through browser
-if (!isCommandLineInterface()) { echo __('This script cannot be run from a browser, only via CLI.');
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
+    echo __('This script cannot be run from a browser, only via CLI.');
 } else {
     $currentDate = date('Y-m-d');
 

--- a/cli/attendance_weeklySummaryEmail.php
+++ b/cli/attendance_weeklySummaryEmail.php
@@ -28,7 +28,9 @@ require getcwd().'/../gibbon.php';
 setCurrentSchoolYear($guid, $connection2);
 
 //Check for CLI, so this cannot be run through browser
-if (!isCommandLineInterface()) {
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
     echo __('This script cannot be run from a browser, only via CLI.');
 } else {
     setCurrentSchoolYear($guid, $connection2);

--- a/cli/behaviour_dailySummaryEmail.php
+++ b/cli/behaviour_dailySummaryEmail.php
@@ -35,7 +35,10 @@ if (!empty($session->get('i18n')['code'])) {
 }
 
 //Check for CLI, so this cannot be run through browser
-if (!isCommandLineInterface()) { echo __('This script cannot be run from a browser, only via CLI.');
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
+    echo __('This script cannot be run from a browser, only via CLI.');
 } else {
     $currentDate = date('Y-m-d');
 

--- a/cli/behaviour_letters.php
+++ b/cli/behaviour_letters.php
@@ -38,7 +38,10 @@ if (!empty($session->get('i18n')['code'])) {
 }
 
 //Check for CLI, so this cannot be run through browser
-if (!isCommandLineInterface()) { echo __('This script cannot be run from a browser, only via CLI.');
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
+    echo __('This script cannot be run from a browser, only via CLI.');
 } else {
     $emailSendCount = 0;
     $emailFailCount = 0;

--- a/cli/library_overdueNotification.php
+++ b/cli/library_overdueNotification.php
@@ -36,7 +36,9 @@ if (!empty($session->get('i18n')['code'])) {
 }
 
 //Check for CLI, so this cannot be run through browser
-if (!isCommandLineInterface()) {
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
 	print __("This script cannot be run from a browser, only via CLI.") ;
 }
 else {

--- a/cli/schoolAdmin_parentDailyEmailSummary.php
+++ b/cli/schoolAdmin_parentDailyEmailSummary.php
@@ -33,7 +33,10 @@ getSystemSettings($guid, $connection2);
 setCurrentSchoolYear($guid, $connection2);
 Format::setupFromSession($container->get('session'));
 
-if (!isCommandLineInterface()) {
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+
+if (!isCommandLineInterface() OR (!empty($remoteCLIKey) AND $remoteCLIKey != $remoteCLIKeyInput)) {
     echo __('This script cannot be run from a browser, only via CLI.');
     return;
 }

--- a/cli/schoolAdmin_parentDailyEmailSummary.php
+++ b/cli/schoolAdmin_parentDailyEmailSummary.php
@@ -33,10 +33,10 @@ getSystemSettings($guid, $connection2);
 setCurrentSchoolYear($guid, $connection2);
 Format::setupFromSession($container->get('session'));
 
+//Check for CLI, so this cannot be run through browser
 $remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
 $remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
-
-if (!isCommandLineInterface() OR (!empty($remoteCLIKey) AND $remoteCLIKey != $remoteCLIKeyInput)) {
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
     echo __('This script cannot be run from a browser, only via CLI.');
     return;
 }

--- a/cli/schoolAdmin_parentWeeklyEmailSummary.php
+++ b/cli/schoolAdmin_parentWeeklyEmailSummary.php
@@ -35,7 +35,10 @@ getSystemSettings($guid, $connection2);
 setCurrentSchoolYear($guid, $connection2);
 Format::setupFromSession($container->get('session'));
 
-if (!isCommandLineInterface()) {
+//Check for CLI, so this cannot be run through browser
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
     echo __('This script cannot be run from a browser, only via CLI.');
     return;
 }

--- a/cli/schoolAdmin_tutorDailyEmailSummary.php
+++ b/cli/schoolAdmin_tutorDailyEmailSummary.php
@@ -36,7 +36,10 @@ getSystemSettings($guid, $connection2);
 setCurrentSchoolYear($guid, $connection2);
 Format::setupFromSession($container->get('session'));
 
-if (!isCommandLineInterface()) {
+//Check for CLI, so this cannot be run through browser
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
     print __('This script cannot be run from a browser, only via CLI.');
     return;
 }

--- a/cli/userAdmin_statusCheckAndFix.php
+++ b/cli/userAdmin_statusCheckAndFix.php
@@ -34,7 +34,10 @@ if (!empty($session->get('i18n')['code'])) {
 }
 
 //Check for CLI, so this cannot be run through browser
-if (!isCommandLineInterface()) { echo __('This script cannot be run from a browser, only via CLI.');
+$remoteCLIKey = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey');
+$remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
+if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
+    echo __('This script cannot be run from a browser, only via CLI.');
 } else {
     $count = 0;
 

--- a/modules/System Admin/privacySettings.php
+++ b/modules/System Admin/privacySettings.php
@@ -66,6 +66,11 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/privacySettin
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addNumber($setting['name'])->setValue($setting['value'])->minimum(1200)->maxLength(50)->required();
 
+    $setting = getSettingByScope($connection2, 'System Admin', 'remoteCLIKey', true);
+    $row = $form->addRow();
+        $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
+        $row->addTextField($setting['name'])->maxLength(60)->setValue($setting['value']);
+
     // PRIVACY
     $form->addRow()->addHeading(__('Privacy Settings'));
 

--- a/modules/System Admin/privacySettingsProcess.php
+++ b/modules/System Admin/privacySettingsProcess.php
@@ -48,6 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/privacySettin
             'cookieConsentEnabled' => 'required',
             'cookieConsentText' => 'skip-empty',
             'privacyPolicy' => '',
+            'remoteCLIKey' => '',
         ],
     ];
 


### PR DESCRIPTION
**Description**
Allows administrators to set a key to enable CLI scripts to be run via HTTP/S. Off by default.

**Motivation and Context**
Sometimes it is not possible to run CLI scripts locally due to hosting constraints. This allows them to be run remotely with a reason level of security.

**How Has This Been Tested?**
Locally