### PR TITLE
System: remove unnecessary Formats on date fields

### DIFF
--- a/modules/Activities/report_attendance_byDate.php
+++ b/modules/Activities/report_attendance_byDate.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
         $form->addHiddenValue('address', $session->get('address'));
 
         $row = $form->addRow();
-            $row->addLabel('date', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+            $row->addLabel('date', __('Date'));
             $row->addDate('date')->setValue(Format::date($date))->required();
 
         $sortOptions = array('absent' => __('Absent'), 'surname' => __('Surname'), 'preferredName' => __('Given Name'), 'formGroup' => __('Form Group'));

--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -56,7 +56,7 @@ $form->setClass('noIntBorder fullWidth');
 $form->addHiddenValue('q', '/modules/' . $session->get('module') . '/attendance.php');
 
 $row = $form->addRow();
-$row->addLabel('currentDate', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+$row->addLabel('currentDate', __('Date'));
 $row->addDate('currentDate')->setValue(Format::date($currentDate))->required();
 
 if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_formGroupsNotRegistered_byDate.php')) {

--- a/modules/Attendance/report_courseClassesNotRegistered_byDate.php
+++ b/modules/Attendance/report_courseClassesNotRegistered_byDate.php
@@ -75,11 +75,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_courseCl
     $form->addHiddenValue('q', "/modules/".$session->get('module')."/report_courseClassesNotRegistered_byDate.php");
 
     $row = $form->addRow();
-        $row->addLabel('dateStart', __('Start Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateStart', __('Start Date'));
         $row->addDate('dateStart')->setValue(Format::date($dateStart))->required();
 
     $row = $form->addRow();
-        $row->addLabel('dateEnd', __('End Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateEnd', __('End Date'));
         $row->addDate('dateEnd')->setValue(Format::date($dateEnd))->required();
 
     $row = $form->addRow();

--- a/modules/Attendance/report_formGroupsNotRegistered_byDate.php
+++ b/modules/Attendance/report_formGroupsNotRegistered_byDate.php
@@ -75,11 +75,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_formGrou
     $form->addHiddenValue('q', "/modules/".$session->get('module')."/report_formGroupsNotRegistered_byDate.php");
 
     $row = $form->addRow();
-        $row->addLabel('dateStart', __('Start Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateStart', __('Start Date'));
         $row->addDate('dateStart')->setValue(Format::date($dateStart))->required();
 
     $row = $form->addRow();
-        $row->addLabel('dateEnd', __('End Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateEnd', __('End Date'));
         $row->addDate('dateEnd')->setValue(Format::date($dateEnd))->required();
 
     $row = $form->addRow();

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -84,11 +84,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_graph_by
     $form->addHiddenValue('address', $session->get('address'));
 
     $row = $form->addRow();
-        $row->addLabel('dateStart', __('Start Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateStart', __('Start Date'));
         $row->addDate('dateStart')->setValue(Format::date($dateStart))->required();
 
     $row = $form->addRow();
-        $row->addLabel('dateEnd', __('End Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateEnd', __('End Date'));
         $row->addDate('dateEnd')->setValue(Format::date($dateEnd))->required();
 
     $typeOptions = array_column($attendance->getAttendanceTypes(), 'name');

--- a/modules/Attendance/report_studentsNotInClass_byDate.php
+++ b/modules/Attendance/report_studentsNotInClass_byDate.php
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_students
         $form->addHiddenValue('q', "/modules/".$session->get('module')."/report_studentsNotInClass_byDate.php");
 
         $row = $form->addRow();
-            $row->addLabel('currentDate', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+            $row->addLabel('currentDate', __('Date'));
             $row->addDate('currentDate')->setValue(Format::date($currentDate))->required();
 
         $typeOptions = $container->get(AttendanceCodeGateway::class)->selectAttendanceCodes()->fetchKeyPair();

--- a/modules/Attendance/report_summary_byDate.php
+++ b/modules/Attendance/report_summary_byDate.php
@@ -75,11 +75,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_summary_
     $form->addHiddenValue('q', "/modules/".$session->get('module')."/report_summary_byDate.php");
 
     $row = $form->addRow();
-        $row->addLabel('dateStart', __('Start Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateStart', __('Start Date'));
         $row->addDate('dateStart')->setValue(Format::date($dateStart))->required();
 
     $row = $form->addRow();
-        $row->addLabel('dateEnd', __('End Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dateEnd', __('End Date'));
         $row->addDate('dateEnd')->setValue(Format::date($dateEnd))->required();
 
     $options = array("all" => __('All Students'));

--- a/modules/Behaviour/behaviour_manage_add.php
+++ b/modules/Behaviour/behaviour_manage_add.php
@@ -94,7 +94,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
 
             //Date
             $row = $form->addRow();
-            	$row->addLabel('date', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+            	$row->addLabel('date', __('Date'));
             	$row->addDate('date')->setValue(date($session->get('i18n')['dateFormatPHP']))->required();
 
             //Type

--- a/modules/Behaviour/behaviour_manage_addMulti.php
+++ b/modules/Behaviour/behaviour_manage_addMulti.php
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
 
     //Date
     $row = $form->addRow();
-        $row->addLabel('date', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('date', __('Date'));
         $row->addDate('date')->setValue(date($session->get('i18n')['dateFormatPHP']))->required();
 
     //Type

--- a/modules/Behaviour/behaviour_pattern.php
+++ b/modules/Behaviour/behaviour_pattern.php
@@ -70,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
     }
 
     $row = $form->addRow();
-        $row->addLabel('date', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('date', __('Date'));
         $row->addDate('fromDate')->setValue($fromDate);
 
     $row = $form->addRow();

--- a/modules/Individual Needs/investigations_manage_edit.php
+++ b/modules/Individual Needs/investigations_manage_edit.php
@@ -96,7 +96,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
 
                     //Date
                     $row = $form->addRow();
-                    	$row->addLabel('date', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+                    	$row->addLabel('date', __('Date'));
                     	$row->addDate('date')->setValue(date($session->get('i18n')['dateFormatPHP']))->required()->readonly();
 
             		//Reason

--- a/modules/Individual Needs/investigations_submit_detail.php
+++ b/modules/Individual Needs/investigations_submit_detail.php
@@ -69,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
 
             //Date
             $row = $form->addRow();
-            	$row->addLabel('date', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+            	$row->addLabel('date', __('Date'));
             	$row->addDate('date')->setValue(date($session->get('i18n')['dateFormatPHP']))->required()->readonly();
 
     		//Reason

--- a/modules/Staff/applicationForm.php
+++ b/modules/Staff/applicationForm.php
@@ -166,7 +166,7 @@ if ($proceed == false) {
                 $row->addSelectGender('gender')->required();
 
             $row = $form->addRow();
-                $row->addLabel('dob', __('Date of Birth'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+                $row->addLabel('dob', __('Date of Birth'));
                 $row->addDate('dob')->required();
 
             $form->addRow()->addHeading(__('Background Data'));

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -234,7 +234,7 @@ if ($proceed == false) {
         $row->addSelectGender('gender')->required();
 
     $row = $form->addRow();
-        $row->addLabel('dob', __('Date of Birth'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dob', __('Date of Birth'));
         $row->addDate('dob')->required();
 
     // STUDENT BACKGROUND

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -343,7 +343,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $row->addSelectGender('gender')->required();
 
     $row = $form->addRow();
-        $row->addLabel('dob', __('Date of Birth'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dob', __('Date of Birth'));
         $row->addDate('dob')->required();
 
     // STUDENT BACKGROUND

--- a/modules/Timetable/spaceBooking_manage_add.php
+++ b/modules/Timetable/spaceBooking_manage_add.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                 $row->addSelect('foreignKeyID')->fromArray($facilities)->required()->placeholder()->selected($foreignKeyID);
 
             $row = $form->addRow();
-                $row->addLabel('date', __('Date'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+                $row->addLabel('date', __('Date'));
                 $row->addDate('date')->required()->setValue($date);
 
             $row = $form->addRow();

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -105,7 +105,7 @@ if ($proceed == false) {
         $row->addSelectGender('gender')->required();
 
     $row = $form->addRow();
-        $row->addLabel('dob', __('Date of Birth'))->description($session->get('i18n')['dateFormat'])->prepend(__('Format:'));
+        $row->addLabel('dob', __('Date of Birth'));
         $row->addDate('dob')->required();
 
     $row = $form->addRow();


### PR DESCRIPTION
Cleaning up some redundant code. The Date class in the Form namespace automatically appends a Format: description with the current system date format, so these instances in the code that manually add the format are unnecessary.

**Motivation and Context**
DRY

**How Has This Been Tested?**
Locally

