### PR TITLE
Timeable: improve View Available Facilities/Teachers reports and Add Facility Change

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,7 @@ v23.0.00
         System Admin: added link to Import History at the top of Import from File
         Timetable: added a copy to clipboard option for View Available Facilities/Teachers reports
         Timetable: added timetable day heading colours to View Timetable by Facility
+        Timetable: added an ajax check for availability when making a facility change
         Timetable Admin: adjusted interface strings in timetable import
 
     Bug Fixes

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,7 +42,7 @@ v23.0.00
         Students: updated student enrolment dropdown to include students with Expected status
         System Admin: enabled creating multiple different email templates per type
         System Admin: added link to Import History at the top of Import from File
-        Timetable: added a copy to clipboard option for View Available Facilities/Teachers reports
+        Timetable: added an option to click for more information in View Available Facilities/Teachers reports
         Timetable: added timetable day heading colours to View Timetable by Facility
         Timetable: added an ajax check for availability when making a facility change
         Timetable Admin: adjusted interface strings in timetable import

--- a/modules/Timetable/report_viewAvailableSpace_view.php
+++ b/modules/Timetable/report_viewAvailableSpace_view.php
@@ -1,0 +1,69 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Domain\School\FacilityGateway;
+use Gibbon\Domain\Timetable\FacilityBookingGateway;
+
+//Module includes
+require_once __DIR__ . '/moduleFunctions.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvailableSpaces.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    
+    $date = $_GET['date'] ?? '';
+    $period = $_GET['period'] ?? '';
+    $facilityNameList = $_GET['ids'] ?? [];
+
+    $facilityGateway = $container->get(FacilityGateway::class);
+    $facilities = $facilityGateway->selectFacilityInfoByName($facilityNameList)->fetchAll();
+
+    // DATA TABLE
+    $table = DataTable::create('facilityList');
+    $table->setTitle(Format::dateReadable($date). ' - '. $period);
+    $table->setDescription(__('View Available Facilities'));
+
+    $table->addColumn('name', __('Name'));
+    $table->addColumn('type', __('Type'));
+    $table->addColumn('capacity', __('Capacity'));
+    $table->addColumn('facilities', __('Facilities'))
+        ->notSortable()
+        ->format(function($values) {
+            $return = null;
+            $return .= ($values['computer'] == 'Y') ? __('Teaching computer').'<br/>':'';
+            $return .= ($values['computerStudent'] > 0) ? $values['computerStudent'].' '.__('student computers').'<br/>':'';
+            $return .= ($values['projector'] == 'Y') ? __('Projector').'<br/>':'';
+            $return .= ($values['tv'] == 'Y') ? __('TV').'<br/>':'';
+            $return .= ($values['dvd'] == 'Y') ? __('DVD Player').'<br/>':'';
+            $return .= ($values['hifi'] == 'Y') ? __('Hifi').'<br/>':'';
+            $return .= ($values['speakers'] == 'Y') ? __('Speakers').'<br/>':'';
+            $return .= ($values['iwb'] == 'Y') ? __('Interactive White Board').'<br/>':'';
+            $return .= ($values['phoneInternal'] != '') ? __('Extension Number').': '.$values['phoneInternal'].'<br/>':'';
+            $return .= ($values['phoneExternal'] != '') ? __('Phone Number').': '.Format::phone($values['phoneExternal']).'<br/>':'';
+            return $return;
+        });
+    $table->addColumn('comment', __('Comment'))->format(Format::using('truncate', ['comment', 120]));
+
+    echo $table->render($facilities);
+
+}

--- a/modules/Timetable/report_viewAvailableSpace_view.php
+++ b/modules/Timetable/report_viewAvailableSpace_view.php
@@ -17,11 +17,9 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Domain\School\FacilityGateway;
-use Gibbon\Domain\Timetable\FacilityBookingGateway;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -43,7 +41,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
     $table->setTitle(Format::dateReadable($date). ' - '. $period);
     $table->setDescription(__('View Available Facilities'));
 
-    $table->addColumn('name', __('Name'));
+    $table->addColumn('name', __('Name'))
+        ->format(function($values) use ($date) {
+            return Format::link('./index.php?q=/modules/Timetable/tt_space_view.php&gibbonSpaceID='.$values['gibbonSpaceID'].'&ttDate='.$date, $values['name']);
+        });
     $table->addColumn('type', __('Type'));
     $table->addColumn('capacity', __('Capacity'));
     $table->addColumn('facilities', __('Facilities'))

--- a/modules/Timetable/report_viewAvailableSpaces.php
+++ b/modules/Timetable/report_viewAvailableSpaces.php
@@ -30,28 +30,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 } else {
     $page->breadcrumbs->add(__('View Available Facilities'));
 
-    echo '<h2>';
-    echo __('Choose Options');
-    echo '</h2>';
+    $gibbonTTID = $_GET['gibbonTTID'] ?? '';
+    $spaceType = $_GET['spaceType'] ?? '';
+    $ttDate = $_GET['ttDate'] ?? '';
 
-    $gibbonTTID = null;
-    if (isset($_GET['gibbonTTID'])) {
-        $gibbonTTID = $_GET['gibbonTTID'];
-    }
-    $spaceType = null;
-    if (isset($_GET['spaceType'])) {
-        $spaceType = $_GET['spaceType'];
-    }
-
-    $ttDate = null;
-    if (isset($_GET['ttDate'])) {
-        $ttDate = $_GET['ttDate'];
-    }
-    if ($ttDate == '') {
-        $ttDate = date($session->get('i18n')['dateFormatPHP']);
+    if (empty($ttDate)) {
+        $ttDate = Format::date(date('Y-m-d'));
     }
 
     $form = Form::create('viewAvailableFacilities', $session->get('absoluteURL').'/index.php', 'get');
+    $form->setTitle(__('Choose Options'));
 
     $form->addHiddenValue('q', '/modules/'.$session->get('module').'/report_viewAvailableSpaces.php');
 
@@ -63,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
         $row->addSelect('gibbonTTID')->fromQuery($pdo, $sql, $data)->required()->placeholder(__('Please select...'))->selected($gibbonTTID);
 
     $facilityTypes = getSettingByScope($connection2, 'School Admin', 'facilityTypes');
-    $facilityTypes = (!empty($facilityTypes))? explode(',', $facilityTypes) : array();
+    $facilityTypes = (!empty($facilityTypes))? explode(',', $facilityTypes) : [];
 
     $row = $form->addRow();
         $row->addLabel('spaceType', __('Facility Type'));
@@ -83,13 +71,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
         echo __('Report Data');
         echo '</h2>';
 
-        echo '<p>'.__('Click the timetable to view information about the available facilities.').'</p>';
-
+        echo '<p>'.__('Click the timetable to view availability details.').'</p>';
         
-            $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonTTID' => $gibbonTTID);
-            $sql = 'SELECT * FROM gibbonTT WHERE gibbonTTID=:gibbonTTID AND gibbonSchoolYearID=:gibbonSchoolYearID';
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
+        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonTTID' => $gibbonTTID);
+        $sql = 'SELECT * FROM gibbonTT WHERE gibbonTTID=:gibbonTTID AND gibbonSchoolYearID=:gibbonSchoolYearID';
+        $result = $pdo->select($sql, $data);
 
         if ($result->rowCount() != 1) {
             echo "<div class='error'>";
@@ -101,16 +87,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
             //Check which days are school days
             $daysInWeek = 0;
-            $days = array();
+            $days = [];
             $timeStart = '';
             $timeEnd = '';
             
-                $dataDays = array();
-                $sqlDays = "SELECT * FROM gibbonDaysOfWeek WHERE schoolDay='Y' ORDER BY sequenceNumber";
-                $resultDays = $connection2->prepare($sqlDays);
-                $resultDays->execute($dataDays);
-            $days = $resultDays->fetchAll();
-            $daysInWeek = $resultDays->rowCount();
+            $sqlDays = "SELECT * FROM gibbonDaysOfWeek WHERE schoolDay='Y' ORDER BY sequenceNumber";
+            $days = $pdo->select($sqlDays)->fetchAll();
+            $daysInWeek = count($days);
+
             foreach ($days as $day) {
                 if ($timeStart == '' or $timeEnd == '') {
                     $timeStart = $day['schoolStart'];
@@ -141,7 +125,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
             $facilityBookingGateway = $container->get(FacilityBookingGateway::class);
             $facilityBookings = $facilityBookingGateway->queryFacilityBookingsByDate($startDate, $endDate)->fetchAll();
 
-            $bookings = array();
+            $bookings = [];
             foreach ($facilityBookings as $facilityBooking) {
                 $bookings[$facilityBooking['date']][$facilityBooking['gibbonSpaceID']][]=array('timeStart' => $facilityBooking['timeStart'], 'timeEnd' => $facilityBooking['timeEnd']);
             }
@@ -151,16 +135,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
             //Max diff time for week based on timetables
             
-                $dataDiff = array('date1' => date('Y-m-d', ($startDayStamp + (86400 * 0))), 'date2' => date('Y-m-d', ($endDayStamp + (86400 * 1))), 'gibbonTTID' => $row['gibbonTTID']);
-                $sqlDiff = 'SELECT DISTINCT gibbonTTColumn.gibbonTTColumnID FROM gibbonTTDay JOIN gibbonTTDayDate ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayDate.gibbonTTDayID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) WHERE (date>=:date1 AND date<=:date2) AND gibbonTTID=:gibbonTTID';
-                $resultDiff = $connection2->prepare($sqlDiff);
-                $resultDiff->execute($dataDiff);
+            $dataDiff = array('date1' => date('Y-m-d', ($startDayStamp + (86400 * 0))), 'date2' => date('Y-m-d', ($endDayStamp + (86400 * 1))), 'gibbonTTID' => $row['gibbonTTID']);
+            $sqlDiff = 'SELECT DISTINCT gibbonTTColumn.gibbonTTColumnID FROM gibbonTTDay JOIN gibbonTTDayDate ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayDate.gibbonTTDayID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) WHERE (date>=:date1 AND date<=:date2) AND gibbonTTID=:gibbonTTID';
+            $resultDiff = $pdo->select($sqlDiff, $dataDiff);
             while ($rowDiff = $resultDiff->fetch()) {
                 
-                    $dataDiffDay = array('gibbonTTColumnID' => $rowDiff['gibbonTTColumnID']);
-                    $sqlDiffDay = 'SELECT * FROM gibbonTTColumnRow WHERE gibbonTTColumnID=:gibbonTTColumnID ORDER BY timeStart';
-                    $resultDiffDay = $connection2->prepare($sqlDiffDay);
-                    $resultDiffDay->execute($dataDiffDay);
+                $dataDiffDay = array('gibbonTTColumnID' => $rowDiff['gibbonTTColumnID']);
+                $sqlDiffDay = 'SELECT * FROM gibbonTTColumnRow WHERE gibbonTTColumnID=:gibbonTTColumnID ORDER BY timeStart';
+                $resultDiffDay = $pdo->select($sqlDiffDay, $dataDiffDay);
+
                 while ($rowDiffDay = $resultDiffDay->fetch()) {
                     if ($rowDiffDay['timeStart'] < $timeStart) {
                         $timeStart = $rowDiffDay['timeStart'];
@@ -223,12 +206,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
             echo '</div>';
             echo '</td>';
 
-			//Check to see if week is at all in term time...if it is, then display the grid
-			$isWeekInTerm = false;
+            //Check to see if week is at all in term time...if it is, then display the grid
+            $isWeekInTerm = false;
             $dataTerm = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
             $sqlTerm = 'SELECT gibbonSchoolYearTerm.firstDay, gibbonSchoolYearTerm.lastDay FROM gibbonSchoolYearTerm, gibbonSchoolYear WHERE gibbonSchoolYearTerm.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID';
-            $resultTerm = $connection2->prepare($sqlTerm);
-            $resultTerm->execute($dataTerm);
+            $resultTerm = $pdo->select($sqlTerm, $dataTerm);
+
             $weekStart = date('Y-m-d', ($startDayStamp + (86400 * 0)));
             $weekEnd = date('Y-m-d', ($startDayStamp + (86400 * 6)));
             while ($rowTerm = $resultTerm->fetch()) {
@@ -244,182 +227,163 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
                 $blank = false;
             }
 
-			//Run through days of the week
-			foreach ($days as $day) {
-				$dayOut = '';
-				if ($day['schoolDay'] == 'Y') {
-					$dateCorrection = ($day['sequenceNumber'] - 1)-($firstSequence-1);
+            //Run through days of the week
+            foreach ($days as $day) {
+                $dayOut = '';
+                if ($day['schoolDay'] == 'Y') {
+                    $dateCorrection = ($day['sequenceNumber'] - 1)-($firstSequence-1);
                     $date = date('Y-m-d', ($startDayStamp + (86400 * $dateCorrection)));
 
-					//Check to see if day is term time
-					$isDayInTerm = false;
+                    //Check to see if day is term time
+                    $isDayInTerm = false;
                     $dataTerm = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
                     $sqlTerm = 'SELECT gibbonSchoolYearTerm.firstDay, gibbonSchoolYearTerm.lastDay FROM gibbonSchoolYearTerm, gibbonSchoolYear WHERE gibbonSchoolYearTerm.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonSchoolYear.gibbonSchoolYearID=:gibbonSchoolYearID';
-                    $resultTerm = $connection2->prepare($sqlTerm);
-                    $resultTerm->execute($dataTerm);
-					while ($rowTerm = $resultTerm->fetch()) {
-						if ($date >= $rowTerm['firstDay'] and $date <= $rowTerm['lastDay']) {
-							$isDayInTerm = true;
-						}
-					}
+                    $resultTerm = $pdo->select($sqlTerm, $dataTerm);
+                    while ($rowTerm = $resultTerm->fetch()) {
+                        if ($date >= $rowTerm['firstDay'] and $date <= $rowTerm['lastDay']) {
+                            $isDayInTerm = true;
+                        }
+                    }
 
-					if ($isDayInTerm == true) {
-						//Check for school closure day
-						
-							$dataClosure = array('date' => $date);
-							$sqlClosure = "SELECT * FROM gibbonSchoolYearSpecialDay WHERE date=:date and type='School Closure'";
-							$resultClosure = $connection2->prepare($sqlClosure);
-							$resultClosure->execute($dataClosure);
-						if ($resultClosure->rowCount() == 1) {
-							$rowClosure = $resultClosure->fetch();
-							$dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";
-							$dayOut .= "<div style='position: relative'>";
-							$dayOut .= "<div style='z-index: 1; position: absolute; top: 0; width: $width ; border: 1px solid rgba(136,136,136,$ttAlpha); height: ".ceil($diffTime / 60)."px; margin: 0px; padding: 0px; background-color: rgba(255,196,202,$ttAlpha)'>";
-							$dayOut .= "<div style='position: relative; top: 50%'>";
-							$dayOut .= "<span style='color: rgba(255,0,0,$ttAlpha);'>".$rowClosure['name'].'</span>';
-							$dayOut .= '</div>';
-							$dayOut .= '</div>';
-							$dayOut .= '</div>';
-							$dayOut .= '</td>';
-						} else {
-							$schoolCalendarAlpha = 0.85;
-							$ttAlpha = 1.0;
+                    if ($isDayInTerm == true) {
+                        //Check for school closure day
+                        $dataClosure = array('date' => $date);
+                        $sqlClosure = "SELECT * FROM gibbonSchoolYearSpecialDay WHERE date=:date and type='School Closure'";
+                        $resultClosure = $pdo->select($sqlClosure, $dataClosure);
 
-							$output = '';
-							$blank = true;
+                        if ($resultClosure->rowCount() == 1) {
+                            $rowClosure = $resultClosure->fetch();
+                            $dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";
+                            $dayOut .= "<div style='position: relative'>";
+                            $dayOut .= "<div style='z-index: 1; position: absolute; top: 0; width: $width ; border: 1px solid rgba(136,136,136,$ttAlpha); height: ".ceil($diffTime / 60)."px; margin: 0px; padding: 0px; background-color: rgba(255,196,202,$ttAlpha)'>";
+                            $dayOut .= "<div style='position: relative; top: 50%'>";
+                            $dayOut .= "<span style='color: rgba(255,0,0,$ttAlpha);'>".$rowClosure['name'].'</span>';
+                            $dayOut .= '</div>';
+                            $dayOut .= '</div>';
+                            $dayOut .= '</div>';
+                            $dayOut .= '</td>';
+                        } else {
+                            $schoolCalendarAlpha = 0.85;
+                            $ttAlpha = 1.0;
 
-							//Make array of space changes
-							$spaceChanges = array();
-							
-								$dataSpaceChange = array('date' => $date);
-								$sqlSpaceChange = 'SELECT gibbonTTSpaceChange.*, gibbonSpace.name AS space, phoneInternal FROM gibbonTTSpaceChange LEFT JOIN gibbonSpace ON (gibbonTTSpaceChange.gibbonSpaceID=gibbonSpace.gibbonSpaceID) WHERE date=:date';
-								$resultSpaceChange = $connection2->prepare($sqlSpaceChange);
-								$resultSpaceChange->execute($dataSpaceChange);
-							while ($rowSpaceChange = $resultSpaceChange->fetch()) {
-								$spaceChanges[$rowSpaceChange['gibbonTTDayRowClassID']][0] = $rowSpaceChange['space'];
-								$spaceChanges[$rowSpaceChange['gibbonTTDayRowClassID']][1] = $rowSpaceChange['phoneInternal'];
-							}
+                            $output = '';
+                            $blank = true;
 
-							//Get day start and end!
-							$dayTimeStart = '';
-							$dayTimeEnd = '';
-							
-								$dataDiff = array('date' => $date, 'gibbonTTID' => $gibbonTTID);
-								$sqlDiff = 'SELECT timeStart, timeEnd FROM gibbonTTDay JOIN gibbonTTDayDate ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayDate.gibbonTTDayID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) JOIN gibbonTTColumnRow ON (gibbonTTColumn.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID) WHERE date=:date AND gibbonTTID=:gibbonTTID';
-								$resultDiff = $connection2->prepare($sqlDiff);
-								$resultDiff->execute($dataDiff);
-							while ($rowDiff = $resultDiff->fetch()) {
-								if ($dayTimeStart == '') {
-									$dayTimeStart = $rowDiff['timeStart'];
-								}
-								if ($rowDiff['timeStart'] < $dayTimeStart) {
-									$dayTimeStart = $rowDiff['timeStart'];
-								}
-								if ($dayTimeEnd == '') {
-									$dayTimeEnd = $rowDiff['timeEnd'];
-								}
-								if ($rowDiff['timeEnd'] > $dayTimeEnd) {
-									$dayTimeEnd = $rowDiff['timeEnd'];
-								}
-							}
+                            //Make array of space changes
+                            $spaceChanges = [];
+                            
+                            $dataSpaceChange = array('date' => $date);
+                            $sqlSpaceChange = 'SELECT gibbonTTSpaceChange.*, gibbonSpace.name AS space, phoneInternal FROM gibbonTTSpaceChange LEFT JOIN gibbonSpace ON (gibbonTTSpaceChange.gibbonSpaceID=gibbonSpace.gibbonSpaceID) WHERE date=:date';
+                            $resultSpaceChange = $pdo->select($sqlSpaceChange, $dataSpaceChange);
+                            while ($rowSpaceChange = $resultSpaceChange->fetch()) {
+                                $spaceChanges[$rowSpaceChange['gibbonTTDayRowClassID']][0] = $rowSpaceChange['space'];
+                                $spaceChanges[$rowSpaceChange['gibbonTTDayRowClassID']][1] = $rowSpaceChange['phoneInternal'];
+                            }
 
-							$dayDiffTime = strtotime($dayTimeEnd) - strtotime($dayTimeStart);
+                            //Get day start and end!
+                            $dayTimeStart = '';
+                            $dayTimeEnd = '';
+                            
+                            $dataDiff = array('date' => $date, 'gibbonTTID' => $gibbonTTID);
+                            $sqlDiff = 'SELECT timeStart, timeEnd FROM gibbonTTDay JOIN gibbonTTDayDate ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayDate.gibbonTTDayID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) JOIN gibbonTTColumnRow ON (gibbonTTColumn.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID) WHERE date=:date AND gibbonTTID=:gibbonTTID';
+                            $resultDiff = $pdo->select($sqlDiff, $dataDiff);
+                            while ($rowDiff = $resultDiff->fetch()) {
+                                if ($dayTimeStart == '') {
+                                    $dayTimeStart = $rowDiff['timeStart'];
+                                }
+                                if ($rowDiff['timeStart'] < $dayTimeStart) {
+                                    $dayTimeStart = $rowDiff['timeStart'];
+                                }
+                                if ($dayTimeEnd == '') {
+                                    $dayTimeEnd = $rowDiff['timeEnd'];
+                                }
+                                if ($rowDiff['timeEnd'] > $dayTimeEnd) {
+                                    $dayTimeEnd = $rowDiff['timeEnd'];
+                                }
+                            }
 
-							$startPad = strtotime($dayTimeStart) - strtotime($timeStart);
+                            $dayDiffTime = strtotime($dayTimeEnd) - strtotime($dayTimeStart);
 
-							$dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";
-							try {
-								$dataDay = array('gibbonTTID' => $gibbonTTID, 'date' => $date);
-								$sqlDay = 'SELECT gibbonTTDay.gibbonTTDayID FROM gibbonTTDayDate JOIN gibbonTTDay ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) WHERE gibbonTTID=:gibbonTTID AND date=:date';
-								$resultDay = $connection2->prepare($sqlDay);
-								$resultDay->execute($dataDay);
-							} catch (PDOException $e) {
-								$dayOut .= "<div class='error'>".$e->getMessage().'</div>';
-							}
+                            $startPad = strtotime($dayTimeStart) - strtotime($timeStart);
 
-							if ($resultDay->rowCount() == 1) {
-								$rowDay = $resultDay->fetch();
-								$zCount = 0;
-								$dayOut .= "<div style='position: relative;'>";
+                            $dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";
 
-								//Draw outline of the day
-								try {
-									$dataPeriods = array('gibbonTTDayID' => $rowDay['gibbonTTDayID'], 'date' => $date);
-									$sqlPeriods = 'SELECT gibbonTTColumnRow.gibbonTTColumnRowID, gibbonTTColumnRow.name, timeStart, timeEnd, type, date FROM gibbonTTDay JOIN gibbonTTDayDate ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayDate.gibbonTTDayID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) WHERE gibbonTTDayDate.gibbonTTDayID=:gibbonTTDayID AND date=:date ORDER BY timeStart, timeEnd';
-									$resultPeriods = $connection2->prepare($sqlPeriods);
-									$resultPeriods->execute($dataPeriods);
-								} catch (PDOException $e) {
-									$dayOut .= "<div class='error'>".$e->getMessage().'</div>';
-								}
-								while ($rowPeriods = $resultPeriods->fetch()) {
-									$isSlotInTime = false;
-									if ($rowPeriods['timeStart'] <= $dayTimeStart and $rowPeriods['timeEnd'] > $dayTimeStart) {
-										$isSlotInTime = true;
-									} elseif ($rowPeriods['timeStart'] >= $dayTimeStart and $rowPeriods['timeEnd'] <= $dayTimeEnd) {
-										$isSlotInTime = true;
-									} elseif ($rowPeriods['timeStart'] < $dayTimeEnd and $rowPeriods['timeEnd'] >= $dayTimeEnd) {
-										$isSlotInTime = true;
-									}
+                            $dataDay = array('gibbonTTID' => $gibbonTTID, 'date' => $date);
+                            $sqlDay = 'SELECT gibbonTTDay.gibbonTTDayID FROM gibbonTTDayDate JOIN gibbonTTDay ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) WHERE gibbonTTID=:gibbonTTID AND date=:date';
+                            $resultDay = $pdo->select($sqlDay, $dataDay);
 
-									if ($isSlotInTime == true) {
-										$effectiveStart = $rowPeriods['timeStart'];
-										$effectiveEnd = $rowPeriods['timeEnd'];
-										if ($dayTimeStart > $rowPeriods['timeStart']) {
-											$effectiveStart = $dayTimeStart;
-										}
-										if ($dayTimeEnd < $rowPeriods['timeEnd']) {
-											$effectiveEnd = $dayTimeEnd;
-										}
+                            if ($resultDay->rowCount() == 1) {
+                                $rowDay = $resultDay->fetch();
+                                $zCount = 0;
+                                $dayOut .= "<div style='position: relative;'>";
 
-										$width = (ceil(690 / $daysInWeek) - 20).'px';
-										$height = ceil((strtotime($effectiveEnd) - strtotime($effectiveStart)) / 60).'px';
-										$top = ceil(((strtotime($effectiveStart) - strtotime($dayTimeStart)) + $startPad) / 60).'px';
-										$bg = "bg-gray-200";
-										if ((date('H:i:s') > $effectiveStart) and (date('H:i:s') < $effectiveEnd) and $rowPeriods['date'] == date('Y-m-d')) {
-											$bg = "bg-green-200";
-										}
-										$style = '';
-										if ($rowPeriods['type'] == 'Lesson') {
-											$style = '';
-										}
-										$availability = [];
-										if ($rowPeriods['type'] == 'Lesson') {
-											$vacancies = '';
-											try {
+                                //Draw outline of the day
+                                $dataPeriods = array('gibbonTTDayID' => $rowDay['gibbonTTDayID'], 'date' => $date);
+                                $sqlPeriods = 'SELECT gibbonTTColumnRow.gibbonTTColumnRowID, gibbonTTColumnRow.name, timeStart, timeEnd, type, date FROM gibbonTTDay JOIN gibbonTTDayDate ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayDate.gibbonTTDayID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) WHERE gibbonTTDayDate.gibbonTTDayID=:gibbonTTDayID AND date=:date ORDER BY timeStart, timeEnd';
+                                $resultPeriods = $pdo->select($sqlPeriods, $dataPeriods);
 
-												$dataSelect = array();
-												$sqlSelect = 'SELECT * FROM gibbonSpace ORDER BY name';
+                                while ($rowPeriods = $resultPeriods->fetch()) {
+                                    $isSlotInTime = false;
+                                    if ($rowPeriods['timeStart'] <= $dayTimeStart and $rowPeriods['timeEnd'] > $dayTimeStart) {
+                                        $isSlotInTime = true;
+                                    } elseif ($rowPeriods['timeStart'] >= $dayTimeStart and $rowPeriods['timeEnd'] <= $dayTimeEnd) {
+                                        $isSlotInTime = true;
+                                    } elseif ($rowPeriods['timeStart'] < $dayTimeEnd and $rowPeriods['timeEnd'] >= $dayTimeEnd) {
+                                        $isSlotInTime = true;
+                                    }
 
-												$resultSelect = $connection2->prepare($sqlSelect);
-												$resultSelect->execute($dataSelect);
-											} catch (PDOException $e) {}
-											$removers = array();
-											$adders = array();
-											while ($rowSelect = $resultSelect->fetch()) {
-												
-												$dataUnique = array('gibbonTTDayID' => $rowDay['gibbonTTDayID'], 'gibbonTTColumnRowID' => $rowPeriods['gibbonTTColumnRowID'], 'gibbonSpaceID' => $rowSelect['gibbonSpaceID']);
-												$sqlUnique = 'SELECT gibbonTTDayRowClass.*, gibbonSpace.name AS roomName FROM gibbonTTDayRowClass JOIN gibbonSpace ON (gibbonTTDayRowClass.gibbonSpaceID=gibbonSpace.gibbonSpaceID) WHERE gibbonTTDayID=:gibbonTTDayID AND gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonTTDayRowClass.gibbonSpaceID=:gibbonSpaceID';
+                                    if ($isSlotInTime == true) {
+                                        $effectiveStart = $rowPeriods['timeStart'];
+                                        $effectiveEnd = $rowPeriods['timeEnd'];
+                                        if ($dayTimeStart > $rowPeriods['timeStart']) {
+                                            $effectiveStart = $dayTimeStart;
+                                        }
+                                        if ($dayTimeEnd < $rowPeriods['timeEnd']) {
+                                            $effectiveEnd = $dayTimeEnd;
+                                        }
+
+                                        $width = (ceil(690 / $daysInWeek) - 20).'px';
+                                        $height = ceil((strtotime($effectiveEnd) - strtotime($effectiveStart)) / 60).'px';
+                                        $top = ceil(((strtotime($effectiveStart) - strtotime($dayTimeStart)) + $startPad) / 60).'px';
+                                        $bg = "bg-gray-200";
+                                        if ((date('H:i:s') > $effectiveStart) and (date('H:i:s') < $effectiveEnd) and $rowPeriods['date'] == date('Y-m-d')) {
+                                            $bg = "bg-green-200";
+                                        }
+
+                                        $availability = [];
+                                        $vacancies = '';
+                                        if ($rowPeriods['type'] == 'Lesson') {
+                                            
+                                            $sqlSelect = 'SELECT * FROM gibbonSpace ORDER BY name';
+                                            $resultSelect = $pdo->select($sqlSelect);
+
+                                            $removers = [];
+                                            $adders = [];
+                                            while ($rowSelect = $resultSelect->fetch()) {
+                                                
+                                                $dataUnique = array('gibbonTTDayID' => $rowDay['gibbonTTDayID'], 'gibbonTTColumnRowID' => $rowPeriods['gibbonTTColumnRowID'], 'gibbonSpaceID' => $rowSelect['gibbonSpaceID']);
+                                                $sqlUnique = 'SELECT gibbonTTDayRowClass.*, gibbonSpace.name AS roomName FROM gibbonTTDayRowClass JOIN gibbonSpace ON (gibbonTTDayRowClass.gibbonSpaceID=gibbonSpace.gibbonSpaceID) WHERE gibbonTTDayID=:gibbonTTDayID AND gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonTTDayRowClass.gibbonSpaceID=:gibbonSpaceID';
 
                                                 $rowUnique = $pdo->selectOne($sqlUnique, $dataUnique);
 
                                                 $matchingType = empty($spaceType) || (!empty($spaceType) && $spaceType == $rowSelect['type']);
                                                 
-												if (empty($rowUnique)) {
+                                                if (empty($rowUnique)) {
                                                     if ($matchingType) {
-													    $vacancies .= $rowSelect['name'].', ';
+                                                        $vacancies .= $rowSelect['name'].', ';
                                                     }
-												} else {
-													//Check if space freed up here
-													if (!empty($spaceChanges[$rowUnique['gibbonTTDayRowClassID']])) {
-														//Save newly used space
-														$removers[$spaceChanges[$rowUnique['gibbonTTDayRowClassID']][0]] = $spaceChanges[$rowUnique['gibbonTTDayRowClassID']][0];
+                                                } else {
+                                                    //Check if space freed up here
+                                                    if (!empty($spaceChanges[$rowUnique['gibbonTTDayRowClassID']])) {
+                                                        //Save newly used space
+                                                        $removers[$spaceChanges[$rowUnique['gibbonTTDayRowClassID']][0]] = $spaceChanges[$rowUnique['gibbonTTDayRowClassID']][0];
 
-														//Save newly freed space
+                                                        //Save newly freed space
                                                         if ($matchingType) {
-														    $adders[$rowUnique['roomName']] = $rowUnique['roomName'];
+                                                            $adders[$rowUnique['roomName']] = $rowUnique['roomName'];
                                                         }
-													}
-												}
+                                                    }
+                                                }
 
                                                 //Add any bookings to removers
                                                 if (!empty($bookings[$date][$rowSelect['gibbonSpaceID']]) && is_array($bookings[$date][$rowSelect['gibbonSpaceID']])) {
@@ -430,35 +394,35 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
                                                         }
                                                     }
                                                 }
-											}
+                                            }
 
-											//Remove any cancelling moves
-											foreach ($removers as $remove) {
-												if (isset($adders[$remove])) {
-													$adders[$remove] = null;
-													$removers[$remove] = null;
-												}
-											}
-											foreach ($adders as $adds) {
-												if ($adds != '') {
-													$vacancies .= $adds.', ';
-												}
-											}
-											foreach ($removers as $remove) {
-												if ($remove != '') {
-													$vacancies = str_replace($remove.', ', '', $vacancies);
-												}
-											}
+                                            //Remove any cancelling moves
+                                            foreach ($removers as $remove) {
+                                                if (isset($adders[$remove])) {
+                                                    $adders[$remove] = null;
+                                                    $removers[$remove] = null;
+                                                }
+                                            }
+                                            foreach ($adders as $adds) {
+                                                if ($adds != '') {
+                                                    $vacancies .= $adds.', ';
+                                                }
+                                            }
+                                            foreach ($removers as $remove) {
+                                                if ($remove != '') {
+                                                    $vacancies = str_replace($remove.', ', '', $vacancies);
+                                                }
+                                            }
 
-											//Explode vacancies into array and sort, get ready to output
-											$availability = array_map('trim', explode(',', substr($vacancies, 0, -2)));
-											natcasesort($availability);
-										}
+                                            //Explode vacancies into array and sort, get ready to output
+                                            $availability = array_map('trim', explode(',', substr($vacancies, 0, -2)));
+                                            natcasesort($availability);
+                                        }
 
-                                        $dayOut .= "<a class='thickbox hover:bg-blue-200 $bg' href='".$session->get('absoluteURL')."/fullscreen.php?q=/modules/Timetable/report_viewAvailableSpace_view.php&width=800&height=550&".http_build_query(['ids' => $availability, 'date' => $rowPeriods['date'], 'period' => $rowPeriods['name']])."' style='color: rgba(0,0,0,$ttAlpha); z-index: $zCount; position: absolute; left: 0; top: $top; width: $width ; border: 1px solid rgba(136,136,136, $ttAlpha); height: $height; margin: 0px; padding: 0px; color: rgba(136,136,136, $ttAlpha) $style'>";
-										if ($height > 15) {
-											$dayOut .= $rowPeriods['name'].'<br/>';
-										}
+                                        $dayOut .= "<a class='thickbox hover:bg-blue-200 $bg' href='".$session->get('absoluteURL')."/fullscreen.php?q=/modules/Timetable/report_viewAvailableSpace_view.php&width=800&height=550&".http_build_query(['ids' => $availability, 'date' => $rowPeriods['date'], 'period' => $rowPeriods['name']])."' style='color: rgba(0,0,0,$ttAlpha); z-index: $zCount; position: absolute; left: 0; top: $top; width: $width ; border: 1px solid rgba(136,136,136, $ttAlpha); height: $height; margin: 0px; padding: 0px; color: rgba(136,136,136, $ttAlpha)'>";
+                                        if ($height > 15) {
+                                            $dayOut .= $rowPeriods['name'].'<br/>';
+                                        }
 
                                         $vacanciesOutput = implode(', ', $availability);
                                         $dayOut .= "<div title='".htmlPrep($vacanciesOutput)."' style='color: black; font-weight: normal; line-height: 0.9'>";
@@ -470,34 +434,34 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
                                         $dayOut .= '</div>';
 
-										$dayOut .= '</a>';
-										++$zCount;
-									}
-								}
-							}
-							$dayOut .= '</td>';
-						}
-					} else {
-						$dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";
-						$dayOut .= "<div style='position: relative'>";
-						$dayOut .= "<div style='position: absolute; top: 0; width: $width ; border: 1px solid rgba(136,136,136,$ttAlpha); height: ".ceil($diffTime / 60)."px; margin: 0px; padding: 0px; background-color: rgba(255,196,202,$ttAlpha)'>";
-						$dayOut .= "<div style='position: relative; top: 50%'>";
-						$dayOut .= "<span style='color: rgba(255,0,0,$ttAlpha);'>".__('School Closed').'</span>';
-						$dayOut .= '</div>';
-						$dayOut .= '</div>';
-						$dayOut .= '</div>';
-						$dayOut .= '</td>';
-					}
+                                        $dayOut .= '</a>';
+                                        ++$zCount;
+                                    }
+                                }
+                            }
+                            $dayOut .= '</td>';
+                        }
+                    } else {
+                        $dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";
+                        $dayOut .= "<div style='position: relative'>";
+                        $dayOut .= "<div style='position: absolute; top: 0; width: $width ; border: 1px solid rgba(136,136,136,$ttAlpha); height: ".ceil($diffTime / 60)."px; margin: 0px; padding: 0px; background-color: rgba(255,196,202,$ttAlpha)'>";
+                        $dayOut .= "<div style='position: relative; top: 50%'>";
+                        $dayOut .= "<span style='color: rgba(255,0,0,$ttAlpha);'>".__('School Closed').'</span>';
+                        $dayOut .= '</div>';
+                        $dayOut .= '</div>';
+                        $dayOut .= '</div>';
+                        $dayOut .= '</td>';
+                    }
 
-					if ($dayOut == '') {
-						$dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'></td>";
-					}
+                    if ($dayOut == '') {
+                        $dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'></td>";
+                    }
 
-					echo $dayOut;
+                    echo $dayOut;
 
-					++$count;
-				}
-			}
+                    ++$count;
+                }
+            }
 
             echo '</tr>';
             echo "<tr style='height: 1px'>";

--- a/modules/Timetable/report_viewAvailableTeachers_view.php
+++ b/modules/Timetable/report_viewAvailableTeachers_view.php
@@ -1,0 +1,62 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Domain\Staff\StaffGateway;
+
+//Module includes
+require_once __DIR__ . '/moduleFunctions.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvailableTeachers.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    
+    $date = $_GET['date'] ?? '';
+    $period = $_GET['period'] ?? '';
+    $gibbonPersonIDList = $_GET['ids'] ?? [];
+
+    $staffGateway = $container->get(StaffGateway::class);
+    $teachers = $staffGateway->selectStaffByID($gibbonPersonIDList)->fetchAll();
+
+    // DATA TABLE
+    $table = DataTable::create('teacherList');
+    $table->setTitle(Format::dateReadable($date). ' - '. $period);
+    $table->setDescription(__('View Available Teachers'));
+
+    // COLUMNS
+    $table->addColumn('image_240', __('Photo'))
+        ->context('primary')
+        ->width('10%')
+        ->notSortable()
+        ->format(Format::using('userPhoto', ['image_240', 'sm']));
+
+    $table->addColumn('fullName', __('Name'))
+        ->context('primary')
+        ->width('30%')
+        ->sortable(['surname', 'preferredName'])
+        ->format(Format::using('nameLinked', ['gibbonPersonID', 'title', 'preferredName', 'surname', 'Staff', true, true]));
+
+    $table->addColumn('jobTitle', __('Job Title'));
+
+    $table->addColumn('username', __('Username'))->context('primary');
+
+    echo $table->render($teachers);
+}

--- a/modules/Timetable/spaceBooking_manage_addAjax.php
+++ b/modules/Timetable/spaceBooking_manage_addAjax.php
@@ -1,0 +1,59 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Services\Format;
+use Gibbon\Domain\School\FacilityGateway;
+use Gibbon\Domain\Timetable\TimetableDayDateGateway;
+
+include '../../gibbon.php';
+
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable/spaceBooking_manage_add.php';
+
+if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_manage_add.php') == false) {
+    echo Format::alert(__('You do not have access to this action.'));
+} else {
+    
+    $gibbonTTDayRowClassID = substr($_POST['gibbonTTDayRowClassID'] ?? '', 0, 12);
+    $date = substr($_POST['gibbonTTDayRowClassID'] ?? '', 13);
+    $gibbonSpaceID = $_POST['gibbonSpaceID'] ?? '';
+
+    if (empty($gibbonTTDayRowClassID) || empty($date) || empty($gibbonSpaceID)) {
+        echo Format::alert(__('You have not specified one or more required parameters.'));
+        return;
+    }
+
+    $facilityGateway = $container->get(FacilityGateway::class);
+    $ttDayDateGateway = $container->get(TimetableDayDateGateway::class);
+
+    $period = $ttDayDateGateway->getTimetablePeriodByDayRowClass($gibbonTTDayRowClassID);
+
+    if (empty($period)) {
+        echo Format::alert(__('You have not specified one or more required parameters.'));
+        return;
+    }
+
+    $inUse = $facilityGateway->selectFacilityInUseByDateAndTime($gibbonSpaceID, $date, $period['timeStart'], $period['timeEnd'])->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+    if (!empty($inUse)) {
+        echo Format::alert(__('In Use by {name}', ['name' => implode(', ', $inUse)]), 'error');
+    } else {
+        echo Format::alert(__('Available'), 'success');
+    }
+    
+}

--- a/modules/Timetable/spaceChange_manage_add.php
+++ b/modules/Timetable/spaceChange_manage_add.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
 
@@ -131,6 +132,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
             } else {
                 $rowSelect = $resultSelect->fetch();
 
+                $studentCount = $container->get(CourseEnrolmentGateway::class)->getClassStudentCount($gibbonCourseClassID);
+
                 $form = Form::create('spaceChangeStep2', $session->get('absoluteURL').'/modules/'.$session->get('module').'/spaceChange_manage_addProcess.php');
                 $form->setFactory(DatabaseFormFactory::create($pdo));
 
@@ -140,6 +143,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
                 $row = $form->addRow();
                     $row->addLabel('class', __('Class'));
                     $row->addTextField('class')->readonly()->setValue($rowSelect['course'].'.'.$rowSelect['class']);
+
+                $row = $form->addRow();
+                    $row->addLabel('students', __('Students'));
+                    $row->addTextField('students')->readonly()->setValue($studentCount);
 
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'date1' => date('Y-m-d'), 'date2' => date('Y-m-d'), 'time' => date('H:i:s'));
                 $sql = 'SELECT gibbonTTDayRowClass.gibbonTTDayRowClassID, gibbonTTColumnRow.name AS period, timeStart, timeEnd, gibbonTTDay.name AS day, gibbonTTDayDate.date, gibbonTTSpaceChangeID FROM gibbonTTDayRowClass JOIN gibbonCourseClass ON (gibbonTTDayRowClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonTTColumnRow ON (gibbonTTDayRowClass.gibbonTTColumnRowID=gibbonTTColumnRow.gibbonTTColumnRowID) JOIN gibbonTTDay ON (gibbonTTDayRowClass.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) JOIN gibbonTTDayDate ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) LEFT JOIN gibbonTTSpaceChange ON (gibbonTTSpaceChange.gibbonTTDayRowClassID=gibbonTTDayRowClass.gibbonTTDayRowClassID AND gibbonTTSpaceChange.date=gibbonTTDayDate.date) WHERE gibbonTTDayRowClass.gibbonCourseClassID=:gibbonCourseClassID AND (gibbonTTDayDate.date>:date1 OR (gibbonTTDayDate.date=:date2 AND timeEnd>:time)) ORDER BY gibbonTTDayDate.date, timeStart';

--- a/modules/Timetable/spaceChange_manage_add.php
+++ b/modules/Timetable/spaceChange_manage_add.php
@@ -158,7 +158,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
 
                 $row = $form->addRow();
                     $row->addLabel('gibbonSpaceID', __('Facility'));
-                    $row->addSelectSpace('gibbonSpaceID');
+                    $col = $row->addColumn()->addClass('flex-col');
+                    $col->addSelectSpace('gibbonSpaceID')->addClass('flex-1');
+                    $col->addContent('<br/><div id="facilityStatus"></div>');
 
                 $row = $form->addRow();
                     $row->addFooter();
@@ -169,3 +171,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
         }
     }
 }
+?>
+
+<script>
+
+$(document).ready(function() {
+    $('#gibbonSpaceID').on('change', function() {
+        $.ajax({
+            url: './modules/Timetable/spaceBooking_manage_addAjax.php',
+            data: {
+                gibbonTTDayRowClassID: $('#gibbonTTDayRowClassID').val(),    
+                gibbonSpaceID: $('#gibbonSpaceID').val(),
+            },
+            type: 'POST',
+            success: function(data) {
+                $('#facilityStatus').html(data);
+            }
+        });
+    });
+}) ;
+
+</script>

--- a/modules/Timetable/spaceChange_manage_add.php
+++ b/modules/Timetable/spaceChange_manage_add.php
@@ -178,7 +178,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceChange_mana
 $(document).ready(function() {
     $('#gibbonSpaceID').on('change', function() {
         $.ajax({
-            url: './modules/Timetable/spaceBooking_manage_addAjax.php',
+            url: './modules/Timetable/spaceChange_manage_addAjax.php',
             data: {
                 gibbonTTDayRowClassID: $('#gibbonTTDayRowClassID').val(),    
                 gibbonSpaceID: $('#gibbonSpaceID').val(),

--- a/modules/Timetable/spaceChange_manage_addAjax.php
+++ b/modules/Timetable/spaceChange_manage_addAjax.php
@@ -19,7 +19,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Services\Format;
 use Gibbon\Domain\School\FacilityGateway;
-use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
 use Gibbon\Domain\Timetable\TimetableDayDateGateway;
 
 include '../../gibbon.php';
@@ -53,9 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
     $inUse = $facilityGateway->selectFacilityInUseByDateAndTime($gibbonSpaceID, $date, $period['timeStart'], $period['timeEnd'])->fetchAll(\PDO::FETCH_COLUMN, 0);
 
     if (!empty($inUse)) {
-        $classParticipants = $container->get(CourseEnrolmentGateway::class)->selectClassParticipantsByDate($period['gibbonCourseClassID'], $date, $period['timeStart'], $period['timeEnd'])->fetchAll();
-
-        echo Format::alert(__('In Use by {name} (In Room: {count}, Capacity: {capacity})', ['name' => implode(', ', $inUse), 'count' => count($classParticipants), 'capacity' => $facility['capacity']]), 'error');
+        echo Format::alert(__('In Use by {name} (Capacity: {capacity})', ['name' => implode(', ', $inUse), 'capacity' => $facility['capacity']]), 'error');
     } else {
         echo Format::alert(__('Available (Capacity: {capacity})', ['capacity' => $facility['capacity']]), 'success');
     }

--- a/src/Domain/School/FacilityGateway.php
+++ b/src/Domain/School/FacilityGateway.php
@@ -51,4 +51,16 @@ class FacilityGateway extends QueryableGateway
 
         return $this->runQuery($query, $criteria);
     }
+
+    public function selectFacilityInfoByName($gibbonSpaceNameList)
+    {
+        $gibbonSpaceNameList = is_array($gibbonSpaceNameList) ? implode(',', $gibbonSpaceNameList) : $gibbonSpaceNameList;
+
+        $data = ['gibbonSpaceNameList' => $gibbonSpaceNameList];
+        $sql = "SELECT * FROM gibbonSpace 
+                WHERE FIND_IN_SET(name, :gibbonSpaceNameList) 
+                ORDER BY name";
+
+        return $this->db()->select($sql, $data);
+    }
 }

--- a/src/Domain/School/FacilityGateway.php
+++ b/src/Domain/School/FacilityGateway.php
@@ -106,8 +106,8 @@ class FacilityGateway extends QueryableGateway
                 WHERE gibbonTTDayDate.date=:date
                 AND gibbonTTDayRowClass.gibbonSpaceID=:gibbonSpaceID
                 AND (
-                    (gibbonTTColumnRow.timeStart >= :timeStart AND gibbonTTColumnRow.timeStart <= :timeEnd)
-                    OR (:timeStart >= gibbonTTColumnRow.timeStart AND :timeStart <= gibbonTTColumnRow.timeEnd)
+                    (gibbonTTColumnRow.timeStart >= :timeStart AND gibbonTTColumnRow.timeStart < :timeEnd)
+                    OR (:timeStart >= gibbonTTColumnRow.timeStart AND :timeStart < gibbonTTColumnRow.timeEnd)
                 )
                 AND (SELECT gibbonTTSpaceChangeID FROM gibbonTTSpaceChange AS roomReleased JOIN gibbonTTDayRowClass AS roomTT ON (roomTT.gibbonTTDayRowClassID=roomReleased.gibbonTTDayRowClassID) WHERE roomReleased.date=:date AND roomReleased.gibbonTTDayRowClassID=gibbonTTDayRowClass.gibbonTTDayRowClassID AND roomTT.gibbonSpaceID=:gibbonSpaceID LIMIT 1) IS NULL
             )";

--- a/src/Domain/School/FacilityGateway.php
+++ b/src/Domain/School/FacilityGateway.php
@@ -63,4 +63,55 @@ class FacilityGateway extends QueryableGateway
 
         return $this->db()->select($sql, $data);
     }
+
+    public function selectFacilityInUseByDateAndTime($gibbonSpaceID, $date, $timeStart, $timeEnd)
+    {
+        $data = ['gibbonSpaceID' => $gibbonSpaceID, 'date' => $date, 'timeStart' => $timeStart, 'timeEnd' => $timeEnd];
+        $sql = "(
+                SELECT CONCAT(gibbonPerson.preferredName, ' ', gibbonPerson.surname) AS name
+                FROM gibbonTTSpaceBooking 
+                JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID = gibbonTTSpaceBooking.gibbonPersonID )
+                WHERE foreignKey='gibbonSpaceID' 
+                AND foreignKeyID=:gibbonSpaceID 
+                AND date=:date 
+                AND (
+                    (gibbonTTSpaceBooking.timeStart > :timeStart AND gibbonTTSpaceBooking.timeStart < :timeEnd)
+                    OR (:timeStart > gibbonTTSpaceBooking.timeStart AND :timeStart < gibbonTTSpaceBooking.timeEnd)
+                )
+            )
+            UNION ALL
+            (
+                SELECT CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name
+                FROM gibbonTTSpaceChange
+                JOIN gibbonTTDayRowClass ON (gibbonTTDayRowClass.gibbonTTDayRowClassID=gibbonTTSpaceChange.gibbonTTDayRowClassID)
+                JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID)
+                JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonTTDayRowClass.gibbonCourseClassID)
+                JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
+                WHERE gibbonTTSpaceChange.date=:date
+                AND gibbonTTSpaceChange.gibbonSpaceID=:gibbonSpaceID
+                AND (
+                    (gibbonTTColumnRow.timeStart >= :timeStart AND gibbonTTColumnRow.timeStart <= :timeEnd)
+                    OR (:timeStart >= gibbonTTColumnRow.timeStart AND :timeStart <= gibbonTTColumnRow.timeEnd)
+                )
+            )
+            UNION ALL
+            (
+                SELECT CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name
+                FROM gibbonTTDayRowClass
+                JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID)
+                JOIN gibbonTTDay ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID)
+                JOIN gibbonTTDayDate ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID)
+                JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseClassID=gibbonTTDayRowClass.gibbonCourseClassID)
+                JOIN gibbonCourse ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID)
+                WHERE gibbonTTDayDate.date=:date
+                AND gibbonTTDayRowClass.gibbonSpaceID=:gibbonSpaceID
+                AND (
+                    (gibbonTTColumnRow.timeStart >= :timeStart AND gibbonTTColumnRow.timeStart <= :timeEnd)
+                    OR (:timeStart >= gibbonTTColumnRow.timeStart AND :timeStart <= gibbonTTColumnRow.timeEnd)
+                )
+                AND (SELECT gibbonTTSpaceChangeID FROM gibbonTTSpaceChange AS roomReleased JOIN gibbonTTDayRowClass AS roomTT ON (roomTT.gibbonTTDayRowClassID=roomReleased.gibbonTTDayRowClassID) WHERE roomReleased.date=:date AND roomReleased.gibbonTTDayRowClassID=gibbonTTDayRowClass.gibbonTTDayRowClassID AND roomTT.gibbonSpaceID=:gibbonSpaceID LIMIT 1) IS NULL
+            )";
+
+        return $this->db()->select($sql, $data);
+    }
 }

--- a/src/Domain/Staff/StaffGateway.php
+++ b/src/Domain/Staff/StaffGateway.php
@@ -104,14 +104,18 @@ class StaffGateway extends QueryableGateway
 
     public function selectStaffByID($gibbonPersonID, $type = null)
     {
-        $data = array('gibbonPersonID' => $gibbonPersonID);
-        $sql = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.title, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.image_240, gibbonStaff.type, gibbonStaff.jobTitle
+        $gibbonPersonIDList = is_array($gibbonPersonID) ? implode(',', $gibbonPersonID) : $gibbonPersonID;
+
+        $data = array('gibbonPersonIDList' => $gibbonPersonIDList);
+        $sql = "SELECT gibbonPerson.gibbonPersonID, gibbonPerson.title, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.image_240, gibbonStaff.type, gibbonStaff.jobTitle, gibbonPerson.username
                 FROM gibbonPerson
                 LEFT JOIN gibbonStaff ON (gibbonPerson.gibbonPersonID=gibbonStaff.gibbonPersonID)
-                WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID
+                WHERE FIND_IN_SET(gibbonPerson.gibbonPersonID, :gibbonPersonIDList)
                 AND gibbonPerson.status='Full'";
 
         if (!empty($type)) $sql .= " AND gibbonStaff.type='Teaching'";
+
+        $sql .= " ORDER BY surname, preferredName";
 
         return $this->db()->select($sql, $data);
     }

--- a/src/Domain/Timetable/CourseEnrolmentGateway.php
+++ b/src/Domain/Timetable/CourseEnrolmentGateway.php
@@ -238,6 +238,22 @@ class CourseEnrolmentGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
+    public function getClassStudentCount($gibbonCourseClassID)
+    {
+        $data =['gibbonCourseClassID' => $gibbonCourseClassID, 'today' => date('Y-m-d')];
+        $sql = "SELECT COUNT(gibbonCourseClassPerson.gibbonCourseClassPersonID)
+            FROM gibbonCourseClassPerson
+            INNER JOIN gibbonPerson ON gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID
+            
+            WHERE gibbonCourseClassPerson.gibbonCourseClassID=:gibbonCourseClassID
+            AND gibbonPerson.status='Full'
+            AND (gibbonPerson.dateStart IS NULL OR gibbonPerson.dateStart<=:today)
+            AND (gibbonPerson.dateEnd IS NULL  OR gibbonPerson.dateEnd>=:today)
+            AND gibbonCourseClassPerson.role='Student'";
+
+        return $this->db()->selectOne($sql, $data);
+    }
+
     public function unenrolAutomaticCourseEnrolments($gibbonFormGroupID, $gibbonStudentEnrolmentID, $date = null)
     {
         $data = array('gibbonFormGroupIDOriginal' => $gibbonFormGroupID, 'gibbonStudentEnrolmentID' => $gibbonStudentEnrolmentID, 'dateUnenrolled' => $date ?? date('Y-m-d'));

--- a/src/Domain/Timetable/TimetableDayDateGateway.php
+++ b/src/Domain/Timetable/TimetableDayDateGateway.php
@@ -45,7 +45,7 @@ class TimetableDayDateGateway extends QueryableGateway
     public function getTimetablePeriodByDayRowClass($gibbonTTDayRowClassID)
     {
         $data = ['gibbonTTDayRowClassID' => $gibbonTTDayRowClassID];
-        $sql = "SELECT gibbonTTColumnRow.name, gibbonTTColumnRow.timeStart, gibbonTTColumnRow.timeEnd 
+        $sql = "SELECT gibbonTTColumnRow.name, gibbonTTColumnRow.timeStart, gibbonTTColumnRow.timeEnd, gibbonTTDayRowClass.gibbonCourseClassID
                 FROM gibbonTTDayRowClass
                 JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID)
                 WHERE gibbonTTDayRowClass.gibbonTTDayRowClassID=:gibbonTTDayRowClassID";

--- a/src/Domain/Timetable/TimetableDayDateGateway.php
+++ b/src/Domain/Timetable/TimetableDayDateGateway.php
@@ -35,10 +35,21 @@ class TimetableDayDateGateway extends QueryableGateway
     private static $primaryKey = 'gibbonTTDayDateID';
 
     public function deleteTTDatesInRange($firstDayOld, $firstDayNew)
-   {
-       $data = array('firstDayOld' => $firstDayOld, 'firstDayNew' => $firstDayNew);
-       $sql = "DELETE FROM gibbonTTDayDate WHERE date >= :firstDayOld AND date < :firstDayNew";
+    {
+        $data = array('firstDayOld' => $firstDayOld, 'firstDayNew' => $firstDayNew);
+        $sql = "DELETE FROM gibbonTTDayDate WHERE date >= :firstDayOld AND date < :firstDayNew";
 
-       return $this->db()->delete($sql, $data);
-   }
+        return $this->db()->delete($sql, $data);
+    }
+    
+    public function getTimetablePeriodByDayRowClass($gibbonTTDayRowClassID)
+    {
+        $data = ['gibbonTTDayRowClassID' => $gibbonTTDayRowClassID];
+        $sql = "SELECT gibbonTTColumnRow.name, gibbonTTColumnRow.timeStart, gibbonTTColumnRow.timeEnd 
+                FROM gibbonTTDayRowClass
+                JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID)
+                WHERE gibbonTTDayRowClass.gibbonTTDayRowClassID=:gibbonTTDayRowClassID";
+
+        return $this->db()->selectOne($sql, $data);
+    }
 }


### PR DESCRIPTION
Currently, the View Available Facilities and View Available Teachers reports have a hover-over with information. However, there is often too much information to see before the hover-over fades, as well as not enough information about the facility/teacher themselves. This PR adds an on-click option to these reports, with a modal window that displays more information about the selected facilities/teachers.

Also, the Add Facility Change option didn't tell users if the facility was in use or not, so you needed to do lots of manual cross-checking to see what's available. This PR adds an ajax check when you have a time slot and facility selected, and lets you know if its Available or In Use.

This is not a full refactor. I've cleaned up some areas of the View Available Facilities/Teachers reports, but there is still lots of html in there, that should be refactored when the timetable is eventually refactored to use templates.

**How Has This Been Tested?**
Locally and in production.

**Screenshots**
Facility modal:
<img width="841" alt="Screenshot 2021-10-06 at 2 15 16 PM" src="https://user-images.githubusercontent.com/897700/136153305-a238e02b-04de-476f-8785-516f1204f799.png">

Add Facility Change:
<img width="936" alt="Screenshot 2021-10-06 at 2 40 31 PM" src="https://user-images.githubusercontent.com/897700/136153298-c7ea57b4-59f2-4788-8dbd-2e814a5af37a.png">

