### PR TITLE
System: fix contract of BasicAttributesTrait::getClass

### DIFF
--- a/src/Forms/Traits/BasicAttributesTrait.php
+++ b/src/Forms/Traits/BasicAttributesTrait.php
@@ -108,7 +108,7 @@ trait BasicAttributesTrait
      */
     public function getClass()
     {
-        return $this->getAttribute('class');
+        return $this->getAttribute('class') ?? '';
     }
 
     /**


### PR DESCRIPTION
**Description**
* Made sure BassicAttributesTrait::getClass return string, not null.

**Motivation and Context**
* The method is supposed to return string. But internally, it calls getAttribute, which returns `null` if value is not set.

* The use of `element.getClass | replace` in [form.twig.html](https://github.com/GibbonEdu/core/blob/d2eae14a420930e4b25fa0c15dc766eea346e626/resources/templates/components/form.twig.html) will result in passing getClass result to strtr first argument, which only accept string. This will cause deprecated warning in PHP 8.1 and even error in versions after that.

**How Has This Been Tested?**
* Locally.
* CI platform (with PHP 8.1 deprecated messages in server_log)