### PR TITLE
System: fix SessionHandler implementations

### DIFF
--- a/src/Session/DatabaseSessionHandler.php
+++ b/src/Session/DatabaseSessionHandler.php
@@ -68,6 +68,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface
      * @param string $name
      * @return bool true for success or false for failure
      */
+    #[\ReturnTypeWillChange]
     public function open($path, $name)
     {
         return true;
@@ -78,6 +79,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface
      *
      * @return bool true for success or false for failure
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -89,6 +91,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface
      * @param string $id
      * @return bool true for success or false for failure
      */
+    #[\ReturnTypeWillChange]
     public function destroy($id)
     {
         $data = ['gibbonSessionID' => $id];
@@ -103,13 +106,14 @@ class DatabaseSessionHandler implements SessionHandlerInterface
      * @param string $id
      * @return string the session data or an empty string
      */
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         $data = ['gibbonSessionID' => $id];
         $sql = "SELECT sessionData FROM gibbonSession WHERE gibbonSessionID=:gibbonSessionID";
 
         $sessionData = (string)$this->db->selectOne($sql, $data);
-        
+
         if ($this->encrypted) {
             $sessionData = $this->decrypt($sessionData, $this->key);
         }
@@ -124,6 +128,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface
      * @param string $data
      * @return bool true for success or false for failure
      */
+    #[\ReturnTypeWillChange]
     public function write($id, $sessionData)
     {
         if ($this->encrypted) {
@@ -144,6 +149,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface
      * @param int $max_lifetime
      * @return bool true for success or false for failure
      */
+    #[\ReturnTypeWillChange]
     public function gc($max_lifetime)
     {
         $data = ['maxLifetime' => $max_lifetime];

--- a/src/Session/NativeSessionHandler.php
+++ b/src/Session/NativeSessionHandler.php
@@ -31,7 +31,7 @@ use SessionHandlerInterface;
 class NativeSessionHandler extends SessionHandler implements SessionHandlerInterface
 {
     use SessionEncryption;
-    
+
     /**
      * @var string
      */
@@ -43,7 +43,7 @@ class NativeSessionHandler extends SessionHandler implements SessionHandlerInter
     private $encrypted;
 
     /**
-     * Create a session handler that extends the built-in PHP session handler and 
+     * Create a session handler that extends the built-in PHP session handler and
      * adds optional encryption if an encryption key is provided.
      *
      * @param string|null $key
@@ -55,12 +55,13 @@ class NativeSessionHandler extends SessionHandler implements SessionHandlerInter
     }
 
     /**
-     * Overrides the SessionHandler read method, with the additional option to handle 
+     * Overrides the SessionHandler read method, with the additional option to handle
      * session data encryption.
      *
      * @param string $id
      * @return string the session data or an empty string
      */
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         $data = parent::read($id);
@@ -68,18 +69,19 @@ class NativeSessionHandler extends SessionHandler implements SessionHandlerInter
         if ($this->encrypted) {
             return $this->decrypt($data, $this->key);
         }
-        
+
         return $data;
     }
 
     /**
-     * Overrides the SessionHandler write method, with the additional option to handle 
+     * Overrides the SessionHandler write method, with the additional option to handle
      * session data encryption.
      *
      * @param string $id
      * @param string $data
      * @return bool true for success or false for failure
      */
+    #[\ReturnTypeWillChange]
     public function write($id, $data)
     {
         if ($this->encrypted) {


### PR DESCRIPTION
**Description**
* Added `#[\ReturnTypeWillChange]` to suppress PHP 8.1 deprecated message about [SessionHandler](https://www.php.net/manual/en/class.sessionhandler.php) implementation issue of typehint signature.

**Motivation and Context**
* The SessionHandler signature has change since php 8.0 and specifies the return type of its methods with union typehint.
  But union typehint is only valid for php 8.0+, thus there is no way to do the proper typehint for php 8.0+ while keeping
  backward compatibility.

* PHP 8.1 will show deprecated message for the failed typehint. The only way to suppress the message is to add the [attribute](https://www.php.net/manual/en/language.attributes.overview.php) `#[\ReturnTypeWillChange]` to the methods with issue.

* Similar issue can be seen here: https://www.drupal.org/project/drupal/issues/3224523

**How Has This Been Tested?**
* CI environment with PHP 8.1.