### PR TITLE
System: Fix form.twig.html compatibility with elements that are not a layout Element

### DIFF
--- a/resources/templates/components/form.twig.html
+++ b/resources/templates/components/form.twig.html
@@ -19,12 +19,12 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     {% if form.getTitle %}
         <h2>{{ form.getTitle }}</h2>
     {% endif %}
-    
+
     {% if form.getDescription %}
         <p>{{ form.getDescription|raw }}</p>
     {% endif %}
 
-    
+
     {% block header %}
         <header class="relative">
             {% if form.getHeader %}
@@ -50,7 +50,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
             {% set sectionLoop = loop %}
 
             {% for num, row in rows %}
-            
+
                 {% set rowLoop = loop %}
                 {% if true or renderStyle == 'flex' %}
                     {% set rowClass = 'flex flex-col sm:flex-row justify-between sm:items-center content-center p-0' %}
@@ -65,7 +65,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
                 {% for element in row.getElements %}
                     {% set colspan = loop.last and loop.length < totalColumns ? (totalColumns + 1 - loop.length) : 0  %}
-                    
+
                     {% if element.isInstanceOf('Gibbon\\Forms\\Layout\\Heading') %}
                         {% set class = 'flex-grow justify-center' %}
                     {% elseif element.isInstanceOf('Gibbon\\Forms\\Layout\\Label') %}
@@ -89,7 +89,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
                     {% endif %}
 
 
-                    <div class="{{ class }} {{ element.getClass|replace({'standardWidth': ''}) }}" {{ colspan ? 'colspan="%s"'|format(colspan)|raw }}>
+                    <div class="{{ class }} {{ element.instanceOf('Gibbon\\Forms\\Layout\\Element') ? element.getClass|replace({'standardWidth': ''}) : '' }}" {{ colspan ? 'colspan="%s"'|format(colspan)|raw }}>
                         {{ element.getOutput|replace({'standardWidth': renderStyle == 'flex' ? 'w-full' : '' })|raw }}
 
                         {% if element.instanceOf('Gibbon\\Forms\\ValidatableInterface') %}


### PR DESCRIPTION
**Description**
* ~~Fix DataTable's use as form element but without proper getClass method~~.
* Modify the form template to be compatible with form element that are not `Gibbon\Forms\Layout\Element` (i.e. do not provide a `getClass` method.)

**Motivation and Context**
* DataTable is used as Form element in Gibbon (e.g. [here](https://github.com/GibbonEdu/core/blob/d2eae14a420930e4b25fa0c15dc766eea346e626/modules/Activities/activities_manage.php#L116)).
* There are places in the form template (e.g. [here](https://github.com/GibbonEdu/core/blob/d2eae14a420930e4b25fa0c15dc766eea346e626/resources/templates/components/formTable.twig.html#L32) and [here](https://github.com/GibbonEdu/core/blob/d2eae14a420930e4b25fa0c15dc766eea346e626/resources/templates/components/formTable.twig.html#L43)) that expects elements to have a `getClass` method and it returns `string`. Failing to comply would cause cryptic deprecated message in PHP 8.1:
   ```
   Deprecated: strtr(): Passing null to parameter #1 ($string) of type string is deprecated in /home/runner/work/GibbonEduCore/GibbonEduCore/vendor/twig/twig/src/Extension/CoreExtension.php on line 519
   ```
* The deprecated message will become official warning or error in future version of PHP.
* ~~If DataTable is expected to be form element, having the trait actually enhances its feature on that front.~~

**How Has This Been Tested?**
* Locally.
* CI environment with PHP 8.1