### PR TITLE
System: upgrade twig to version 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "league/container": "^3.3.3",
         "aura/sqlquery": "3.*-dev",
         "tecnickcom/tcpdf": "^6.4",
-        "twig/twig": "^2.0",
+        "twig/twig": "^3.0",
         "slim/slim": "^4.0",
         "phpmailer/phpmailer": "^6.5.0",
         "matthewbdaly/sms-client": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b755a6ac41a6f0c932cae9d53b7bffe9",
+    "content-hash": "21be0fba858c21589ee2007add148755",
     "packages": [
         {
             "name": "aura/sqlquery",
@@ -3624,37 +3624,34 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.12.5",
+            "version": "v3.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "18772e0190734944277ee97a02a9a6c6555fcd94"
+                "reference": "a27fa056df8a6384316288ca8b0fa3a35fdeb569"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/18772e0190734944277ee97a02a9a6c6555fcd94",
-                "reference": "18772e0190734944277ee97a02a9a6c6555fcd94",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a27fa056df8a6384316288ca8b0fa3a35fdeb569",
+                "reference": "a27fa056df8a6384316288ca8b0fa3a35fdeb569",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4|^5.0"
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.12-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -3685,7 +3682,21 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2020-02-11T15:31:23+00:00"
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-17T08:44:23+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
**Description**
* Change composer.json of twig version from 2.x to 3.x.
* The actual library version will be locked to 3.3.3.

**Motivation and Context**
* According to [official blog](https://symfony.com/blog/preparing-your-applications-for-twig-3), the only change from Twig 2.x to 3.x is to remove the old [PSR-0](https://www.php-fig.org/psr/psr-0/) class names in favour of [PSR-4](https://www.php-fig.org/psr/psr-4/) namespace-based class names. I checked Gibbon's source code and the PSR-0 style class names were never used.
* Version 3.3.3 has merged some php 8.1 support feature to fix its issue.

**How Has This Been Tested?**
* Locally.
* CI environment.