### PR TITLE
Test: check server_log for deprecated message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: test
+name: CI Tests
 
 on:
   pull_request:
@@ -88,6 +88,29 @@ jobs:
           DB_NAME: gibbon_test
           DB_USERNAME: root
           DB_PASSWORD: ""
+
+      - name: Check PHP warning and deprecated messages in server_log
+        run: |
+          # Check number of warning messages.
+          export NUM_WARNING=$(grep 'PHP Warning: ' ./tests/log/server_log | wc -l)
+          if [ "$NUM_WARNING" -eq 0 ]; then
+            echo -e '\e[32mNo warning message.\e[0m'
+          else
+            echo -e "\e[1m\e[33mGot $NUM_WARNING warning messages:\e[0m"
+            grep --line-number --color=always 'PHP Warning: ' ./tests/log/server_log || echo -e '\e[32mNo warning or deprecated message found in log.\e[0m'
+            echo
+          fi
+
+          # Check number of deprecated messages. Cause error if found.
+          export NUM_DEPRECATED=$(grep 'Deprecated: ' ./tests/log/server_log | wc -l)
+          if [ "$NUM_DEPRECATED" -eq 0 ]; then
+            echo -e '\e[32mNo deprecated message.\e[0m'
+          else
+            echo -e "\e[1m\e[31mGot $NUM_DEPRECATED deprecated messages:\e[0m"
+            grep --line-number --color=always 'Deprecated: ' ./tests/log/server_log || echo -e '\e[32mNo warning or deprecated message found in log.\e[0m'
+            (exit 1)
+          fi
+        continue-on-error: ${{ matrix.experimental }}
 
       - name: Save Test Artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
**Description**
* Add an additional CI step to print any warning or deprecated message generated. Will trigger failure if there is any deprecated message.
* Warning messages are show in the CI logs but will not cause test error.
* Any deprecated message will cause the CI test to fail, thus hint committer to fix the issue when it is introduced.

**Motivation and Context**
* Warning and deprecated message(s) in server log of CI test was not visible to developers in CI test. But they are good indicator to any potential problem we might have.
* Including this in our CI test can raise awareness in these potential issue(s).

**How Has This Been Tested?**
* CI Environment.

**Screenshots**
![2021-10-15 13-39-59 的螢幕擷圖](https://user-images.githubusercontent.com/91274/137440204-d39c0ee3-ec1a-49c8-b7d4-e0d88cffbb4f.png)
![2021-10-15 13-39-47 的螢幕擷圖](https://user-images.githubusercontent.com/91274/137440201-cd32a727-71ea-4188-bc92-a11e02708e78.png)
![2021-10-15 13-39-27 的螢幕擷圖](https://user-images.githubusercontent.com/91274/137440198-53815d0f-b695-42b4-944b-3865a2968dc4.png)
