### PR TITLE
Test: promote php 8.1 from experimental

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ["7.3", "7.4", "8.0"]
+        php-version: ["7.3", "7.4", "8.0", "8.1"]
         experimental: [false]
         name: ["CI Test"]
-        include:
-          - php-version: "8.1"
-            experimental: true
-            name: "CI Test, Experimental"
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
**Description**
* Remove the "experimental" status of php 8.1.
* Any test failure in PHP 8.1, from now on, will cause CI test to fail.


**Motivation and Context**
* Gibbon has passed all CI test on PHP 8.1 for a while now.
* PHP 8.1 is set to release on November 25, 2021. It's simply around the corner (RC4 right now). I don't think it will introduce any new breaking change for us.

**How Has This Been Tested?**
* CI Environment.