### PR TITLE
System: add Url support to Breadcrumbs

### DIFF
--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -19,10 +19,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\View\Components;
 
+use Psr\Http\Message\UriInterface;
+
 /**
  * Breadcrumb trail.
  *
- * @version v17
+ * @version v23
  * @since   v17
  */
 class Breadcrumbs
@@ -48,25 +50,42 @@ class Breadcrumbs
     public function setBaseURL(string $baseURL)
     {
         $this->baseURL = trim($baseURL, '/ ').'/';
-        
         return $this;
     }
 
     /**
      * Add a named route to the trail.
      *
-     * @param string $title   Name to display on this route's link
-     * @param string $route   URL relative to the trail's BaseURL
-     * @param array  $params  Additional URL params to append to the route
+     * @version v23
+     * @since   v17
+     *
+     * @param string              $title   Name to display on this route's link
+     * @param string|UriInterface $route   String URL relative to the trail's BaseURL, or
+     *                                     UriInterface.
+     * @param array               $params  Additional URL params to append to the route.
+     *                                     Only has effect if $route is a string.
      * @return self
      */
-    public function add(string $title, string $route = '', array $params = [])
+    public function add(string $title, $route = '', array $params = [])
     {
-        $route = !empty($params)
-            ? trim($route, '/ ').'&'.http_build_query($params)
-            : trim($route, '/ ');
+        if (!is_string($route) && !$route instanceof UriInterface) {
+            throw new \InvalidArgumentException(sprintf(
+                'Route should be either a string or an implementation of UriInterface. Got %s',
+                var_export($route, true)
+            ));
+        }
 
-        $this->items[$title] = !empty($route)? $this->baseURL . $route : '';
+        // backward compatible
+        if (is_string($route)) {
+            $route = !empty($params)
+                ? trim($route, '/ ').'&'.http_build_query($params)
+                : trim($route, '/ ');
+            $this->items[$title] = !empty($route)? $this->baseURL . $route : '';
+        } else {
+            // Do not support the query parameter at all because
+            // UriInterface should have that covered.
+            $this->items[$title] = $route;
+        }
 
         return $this;
     }


### PR DESCRIPTION
**Description**
* Breadcrumbs class now accepts both string route (for backward
  compatibility) and UriInterface, which Gibbon\Http\Url implements.

**Motivation and Context**
* For promoting the use of the new Url class in breadcrumb.

**How Has This Been Tested?**
* Locally with PHPUnit.
* CI Environment.