### PR TITLE
Test: disable jit compilation in CI environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: gettext, gd, zip, pdo-mysql
           tools: composer:v2
-          ini-values: date.timezone="Etc/UTC", xdebug.max_nesting_level = -1
+          ini-values: date.timezone="Etc/UTC", xdebug.max_nesting_level=-1, opcache.jit="off"
 
       - name: Checkout source code
         uses: actions/checkout@v2


### PR DESCRIPTION
**Description**
* Disable JIT compilation in CI environment.

**Motivation and Context**
* xdebug is not compatible with JIT compilation in PHP 8.0+ and
  opcache. This cause warning message in the CI environment.
  ![2021-10-22 14-08-25 的螢幕擷圖](https://user-images.githubusercontent.com/91274/138401879-09b103da-8984-40d1-b978-20ffadee245e.png)


**How Has This Been Tested?**
* CI environment.

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
