### PR TITLE
System: fix Url class not returning an absolute URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -52,8 +52,8 @@ $settingGateway = $container->get(SettingGateway::class);
  * MODULE BREADCRUMBS
  */
 if ($isLoggedIn && $module = $page->getModule()) {
-    $page->breadcrumbs->setBaseURL('index.php?q=/modules/'.$module->name.'/');
-    $page->breadcrumbs->add($module->type == 'Core' ? __($module->name) : __m($module->name), trim($module->entryURL, '/'));
+    $page->breadcrumbs->setBaseURL(Url::fromModuleRoute($module->name));
+    $page->breadcrumbs->add($module->type == 'Core' ? __($module->name) : __m($module->name), $module->entryURL);
 }
 
 /**

--- a/indexFindRedirect.php
+++ b/indexFindRedirect.php
@@ -12,7 +12,7 @@ if ($session->has('absoluteURL')) {
     if ($type == 'Stu') {
         $URL = Url::fromModuleRoute('Students', 'student_view_details')->withQueryParam('gibbonPersonID', $id);
     } elseif ($type == 'Act') {
-        $URL = Url::fromModuleRoute($id);
+        $URL = Url::fromModuleRoute(strstr($id, '/', true), trim(strstr($id, '/'), '/ '));
     } elseif ($type == 'Sta') {
         $URL = Url::fromModuleRoute('Staff', 'staff_view_details')->withQueryParam('gibbonPersonID', $id);
     } elseif ($type == 'Cla') {

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -122,7 +122,7 @@ else {
                 'title'  => __('Password Reset'),
                 'body'   => nl2br(trim($body, "\n")),
                 'button' => [
-                    'url'  => Url::fromRoute('passwordReset')->withQueryParams([
+                    'url'  => Url::fromAbsoluteRoute('passwordReset')->withQueryParams([
                         'input' => $input,
                         'step' => 2,
                         'gibbonPersonResetID' => $gibbonPersonResetID,

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -128,6 +128,7 @@ else {
                         'gibbonPersonResetID' => $gibbonPersonResetID,
                         'key' => $key,
                     ]),
+                    'external' => true,
                     'text' => __('Click Here'),
                 ],
             ]);

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -122,7 +122,7 @@ else {
                 'title'  => __('Password Reset'),
                 'body'   => nl2br(trim($body, "\n")),
                 'button' => [
-                    'url'  => Url::fromAbsoluteRoute('passwordReset')->withQueryParams([
+                    'url'  => Url::fromRoute('passwordReset')->withAbsoluteUrl()->withQueryParams([
                         'input' => $input,
                         'step' => 2,
                         'gibbonPersonResetID' => $gibbonPersonResetID,

--- a/resources/templates/index.twig.html
+++ b/resources/templates/index.twig.html
@@ -119,9 +119,9 @@ TODO: add template variable details.
                                         {% if loop.last %}
                                             <li aria-current="page" class="list-none inline ml-0 trailEnd">{{ title }}</li>
                                         {% elseif loop.revindex > 5 and loop.index != 1 %}
-                                            <li class="list-none inline ml-0 "><a class="text-blue-700 underline" href="{{ absoluteURL }}/{{ src }}">...</a> > </li>
+                                            <li class="list-none inline ml-0 "><a class="text-blue-700 underline" href="{{ src }}">...</a> > </li>
                                         {% else %}
-                                            <li class="list-none inline ml-0 "><a class="text-blue-700 underline" href="{{ absoluteURL }}/{{ src }}">{{ title }}</a> > </li>
+                                            <li class="list-none inline ml-0 "><a class="text-blue-700 underline" href="{{ src }}">{{ title }}</a> > </li>
                                         {% endif %}
                                     {% endfor %}
                                 </ol>

--- a/resources/templates/mail/email.twig.html
+++ b/resources/templates/mail/email.twig.html
@@ -172,7 +172,7 @@ SOFTWARE.
                                   <tbody>
                                     <tr>
                                       <td style="font-family: {{ fontFamily }}; font-size: 18px; vertical-align: top; background-color: {{ buttonColor }}; border-radius: 5px; text-align: center;"> 
-                                        <a href="{{ button.external ? button.url : absoluteURL ~ '/' ~ button.url }}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{ buttonColor }}; border: solid 1px {{ buttonColor }}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 18px; font-weight: bold; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: {{ buttonColor }};">
+                                        <a href="{{ button.external or 'http' in button.url ? button.url : absoluteURL ~ '/' ~ button.url }}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {{ buttonColor }}; border: solid 1px {{ buttonColor }}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 18px; font-weight: bold; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: {{ buttonColor }};">
                                             {{ button.text }}
                                         </a> </td>
                                     </tr>
@@ -186,7 +186,7 @@ SOFTWARE.
                                     <tbody>
                                         <tr>
                                         <td style="font-family: {{ fontFamily }}; font-size: 18px; vertical-align: top; background-color: {{ buttonColor }}; border-radius: 5px; text-align: center;"> 
-                                            <a href="{{ button2.external ? button2.url : absoluteURL ~ '/' ~ button2.url }}" target="_blank" style="display: inline-block; color: {{ buttonColor }}; background-color: #ffffff; border: solid 1px {{ buttonColor }}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 18px; font-weight: normal; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: {{ buttonColor }};">
+                                            <a href="{{ button2.external or 'http' in button2.url ? button2.url : absoluteURL ~ '/' ~ button2.url }}" target="_blank" style="display: inline-block; color: {{ buttonColor }}; background-color: #ffffff; border: solid 1px {{ buttonColor }}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 18px; font-weight: normal; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: {{ buttonColor }};">
                                                 {{ button2.text }}
                                             </a> </td>
                                         </tr>

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -45,13 +45,6 @@ class Url extends Uri implements UriInterface
     protected static $baseUrl;
 
     /**
-     * The path portion of the baseUrl.
-     *
-     * @var string
-     */
-    protected static $basePath;
-
-    /**
      * The handler of the route.
      *
      * @var string
@@ -85,8 +78,7 @@ class Url extends Uri implements UriInterface
      */
     public static function fromRoute(string $route_path = ''): self
     {
-        return (new static())
-            ->withPath(static::$basePath)
+        return (new static(self::$baseUrl))
             ->withRoutePath($route_path);
     }
 
@@ -105,8 +97,7 @@ class Url extends Uri implements UriInterface
      */
     public static function fromModuleRoute(string $module, string $route_path = ''): self
     {
-        return (new static())
-            ->withPath(static::$basePath)
+        return (new static(self::$baseUrl))
             ->withModule($module)
             ->withRoutePath($route_path);
     }
@@ -124,8 +115,7 @@ class Url extends Uri implements UriInterface
      */
     public static function fromHandlerRoute(string $handler, string $route_path = ''): self
     {
-        $new = (new static())
-            ->withPath(static::$basePath)
+        $new = (new static(self::$baseUrl))
             ->withRoutePath($route_path);
         $new->routeHandler = $handler;
         return $new;
@@ -150,8 +140,7 @@ class Url extends Uri implements UriInterface
         string $route_path
     ): self
     {
-        $new = (new static())
-            ->withPath(static::$basePath)
+        $new = (new static(self::$baseUrl))
             ->withModule($module)
             ->withRoutePath($route_path);
         $new->routeHandler = $handler;
@@ -185,6 +174,7 @@ class Url extends Uri implements UriInterface
             $new->routePath = null; // reset routePath to prevent infinite recursion
             return $new->__toString();
         }
+
         return parent::__toString();
     }
 
@@ -247,12 +237,12 @@ class Url extends Uri implements UriInterface
     }
 
     /**
-     * Setup the class to use the baseUrl and basePath for all
-     * rendered URL. Should be the "absoluteURL" in session variables.
+     * Setup the class to use the baseUrl for all rendered URLs.
+     * Should be the "absoluteURL" in session variables.
      *
      * Will be used by the fromRoute and fromModuleRoute methods.
      *
-     * Note: The setting is binded to the class in the
+     * Note: The setting is bound to the class in the
      * environment, so you should only do this once per request.
      *
      * @param string $baseUrl
@@ -261,10 +251,8 @@ class Url extends Uri implements UriInterface
      */
     public static function setBaseUrl(string $baseUrl)
     {
-        // make sure the base url do not have trailing slash
+        // Make sure the base url does not have trailing slash
         self::$baseUrl = rtrim($baseUrl, '/');
-        $parsed = parse_url(self::$baseUrl);
-        self::$basePath = $parsed['path'] ?? '';
     }
 
     /**
@@ -307,6 +295,8 @@ class Url extends Uri implements UriInterface
      */
     private function withRoutePath(string $route_path): self
     {
+        $route_path = preg_replace('/\.php$/i', '', $route_path);
+
         if ($this->routePath === $route_path) {
             return $this;
         }

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -45,6 +45,13 @@ class Url extends Uri implements UriInterface
     protected static $baseUrl;
 
     /**
+     * The path portion of the baseUrl.
+     *
+     * @var string
+     */
+    protected static $basePath;
+
+    /**
      * The handler of the route.
      *
      * @var string
@@ -78,7 +85,25 @@ class Url extends Uri implements UriInterface
      */
     public static function fromRoute(string $route_path = ''): self
     {
-        return (new static(self::$baseUrl))
+        return (new static())
+            ->withPath(static::$basePath)
+            ->withRoutePath($route_path);
+    }
+
+    /**
+     * Create Uri instance for the absolute url of the given Gibbon routes.
+     * This can be used for external links, such as those sent in emails.
+     *
+     * @param string $route_path
+     *   The core route path (e.g. "preferences", "privacyPolicy"). If left empty,
+     *   will use the base path (Home).
+     *
+     * @return static
+     *   The URL object.
+     */
+    public static function fromAbsoluteRoute(string $route_path = ''): self
+    {
+        return (new static(static::$baseUrl))
             ->withRoutePath($route_path);
     }
 
@@ -97,7 +122,8 @@ class Url extends Uri implements UriInterface
      */
     public static function fromModuleRoute(string $module, string $route_path = ''): self
     {
-        return (new static(self::$baseUrl))
+        return (new static())
+            ->withPath(static::$basePath)
             ->withModule($module)
             ->withRoutePath($route_path);
     }
@@ -115,7 +141,8 @@ class Url extends Uri implements UriInterface
      */
     public static function fromHandlerRoute(string $handler, string $route_path = ''): self
     {
-        $new = (new static(self::$baseUrl))
+        $new = (new static())
+            ->withPath(static::$basePath)
             ->withRoutePath($route_path);
         $new->routeHandler = $handler;
         return $new;
@@ -140,7 +167,8 @@ class Url extends Uri implements UriInterface
         string $route_path
     ): self
     {
-        $new = (new static(self::$baseUrl))
+        $new = (new static())
+            ->withPath(static::$basePath)
             ->withModule($module)
             ->withRoutePath($route_path);
         $new->routeHandler = $handler;
@@ -174,7 +202,6 @@ class Url extends Uri implements UriInterface
             $new->routePath = null; // reset routePath to prevent infinite recursion
             return $new->__toString();
         }
-
         return parent::__toString();
     }
 
@@ -237,12 +264,12 @@ class Url extends Uri implements UriInterface
     }
 
     /**
-     * Setup the class to use the baseUrl for all rendered URLs.
-     * Should be the "absoluteURL" in session variables.
+     * Setup the class to use the baseUrl and basePath for all
+     * rendered URL. Should be the "absoluteURL" in session variables.
      *
      * Will be used by the fromRoute and fromModuleRoute methods.
      *
-     * Note: The setting is bound to the class in the
+     * Note: The setting is binded to the class in the
      * environment, so you should only do this once per request.
      *
      * @param string $baseUrl
@@ -251,8 +278,10 @@ class Url extends Uri implements UriInterface
      */
     public static function setBaseUrl(string $baseUrl)
     {
-        // Make sure the base url does not have trailing slash
+        // make sure the base url do not have trailing slash
         self::$baseUrl = rtrim($baseUrl, '/');
+        $parsed = parse_url(self::$baseUrl);
+        self::$basePath = $parsed['path'] ?? '';
     }
 
     /**

--- a/src/UI/Dashboard/StaffDashboard.php
+++ b/src/UI/Dashboard/StaffDashboard.php
@@ -234,7 +234,7 @@ class StaffDashboard implements OutputableInterface
         //GET TIMETABLE
         $timetable = false;
         if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') and $this->session->get('username') != '' and getRoleCategory($this->session->get('gibbonRoleIDCurrent'), $connection2) == 'Staff') {
-            $apiEndpoint = $this->session->get('absoluteURL').'/index_tt_ajax.php';
+            $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php');
             $jsonQuery = [
                 'gibbonTTID' => $_GET['gibbonTTID'] ?? '',
                 'ttDate' => $_POST['ttDate'] ?? '',

--- a/src/UI/Dashboard/StudentDashboard.php
+++ b/src/UI/Dashboard/StudentDashboard.php
@@ -206,7 +206,7 @@ class StudentDashboard implements OutputableInterface
         //GET TIMETABLE
         $timetable = false;
         if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') and $this->session->get('username') != '' and getRoleCategory($this->session->get('gibbonRoleIDCurrent'), $connection2) == 'Student') {
-            $apiEndpoint = $this->session->get('absoluteURL').'/index_tt_ajax.php';
+            $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php');
             $jsonQuery = [
                 'gibbonTTID' => $_GET['gibbonTTID'] ?? '',
                 'ttDate' => $_POST['ttDate'] ?? '',

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -49,7 +49,7 @@ class Breadcrumbs
      */
     public function setBaseURL(string $baseURL)
     {
-        $this->baseURL = trim(urldecode($baseURL), '/ ').'/';
+        $this->baseURL = rtrim(urldecode($baseURL), '/ ').'/';
         return $this;
     }
 

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -49,7 +49,7 @@ class Breadcrumbs
      */
     public function setBaseURL(string $baseURL)
     {
-        $this->baseURL = trim($baseURL, '/ ').'/';
+        $this->baseURL = trim(urldecode($baseURL), '/ ').'/';
         return $this;
     }
 

--- a/tests/unit/Gibbon/UrlTest.php
+++ b/tests/unit/Gibbon/UrlTest.php
@@ -33,10 +33,10 @@ class UrlTest extends TestCase
     public function testFromRoute()
     {
         $url = Url::fromRoute('some_action');
-        $this->assertEquals('/some/path/index.php?q=some_action.php', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php', (string) $url);
 
         $url = Url::fromRoute()->withQuery('hello=world');
-        $this->assertEquals('/some/path/index.php?hello=world', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/index.php?hello=world', (string) $url);
     }
 
     /**
@@ -88,12 +88,12 @@ class UrlTest extends TestCase
     public function testFromModuleRoute()
     {
         $url = Url::fromModuleRoute('My Module', 'some_action');
-        $this->assertEquals('/some/path/index.php?' . http_build_query([
+        $this->assertEquals('http://foobar.com/some/path/index.php?' . http_build_query([
             'q' => '/modules/My Module/some_action.php',
         ]), (string) $url);
 
         $url = Url::fromModuleRoute('My Module');
-        $this->assertEquals('/some/path/index.php?' . http_build_query([
+        $this->assertEquals('http://foobar.com/some/path/index.php?' . http_build_query([
             'q' => '/modules/My Module/',
         ]), (string) $url);
     }
@@ -147,10 +147,10 @@ class UrlTest extends TestCase
     public function testFromHandlerPath()
     {
         $url = Url::fromHandlerRoute('fullscreen.php');
-        $this->assertEquals('/some/path/fullscreen.php', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/fullscreen.php', (string) $url);
 
         $url = Url::fromHandlerRoute('fullscreen.php', 'some_action');
-        $this->assertEquals('/some/path/fullscreen.php?q=some_action.php', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/fullscreen.php?q=some_action.php', (string) $url);
     }
 
     /**
@@ -172,10 +172,10 @@ class UrlTest extends TestCase
     public function testWithQueryParam()
     {
         $url = Url::fromRoute('some_action')->withQueryParam('foo', 'bar');
-        $this->assertEquals('/some/path/index.php?q=some_action.php&foo=bar', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php&foo=bar', (string) $url);
 
         $url = Url::fromRoute()->withQueryParam('foo', 'world');
-        $this->assertEquals('/some/path/index.php?foo=world', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/index.php?foo=world', (string) $url);
     }
 
     /**
@@ -184,10 +184,10 @@ class UrlTest extends TestCase
     public function testWithReturn()
     {
         $url = Url::fromRoute('some_action')->withReturn('successx');
-        $this->assertEquals('/some/path/index.php?q=some_action.php&return=successx', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php&return=successx', (string) $url);
 
         $url = Url::fromRoute()->withReturn('successx');
-        $this->assertEquals('/some/path/index.php?return=successx', (string) $url);
+        $this->assertEquals('http://foobar.com/some/path/index.php?return=successx', (string) $url);
     }
 
     /**

--- a/tests/unit/Gibbon/UrlTest.php
+++ b/tests/unit/Gibbon/UrlTest.php
@@ -44,10 +44,10 @@ class UrlTest extends TestCase
      */
     public function testFromAbsoluteRoute()
     {
-        $url = Url::fromAbsoluteRoute('some_action');
+        $url = Url::fromRoute('some_action')->withAbsoluteUrl();
         $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php', (string) $url);
 
-        $url = Url::fromAbsoluteRoute()->withQuery('hello=world');
+        $url = Url::fromRoute()->withAbsoluteUrl()->withQuery('hello=world');
         $this->assertEquals('http://foobar.com/some/path/index.php?hello=world', (string) $url);
     }
 
@@ -112,6 +112,22 @@ class UrlTest extends TestCase
 
     /**
      * @covers \Gibbon\Http\Url::fromModuleRoute()
+     */
+    public function testFromAbsoluteModuleRoute()
+    {
+        $url = Url::fromModuleRoute('My Module', 'some_action')->withAbsoluteUrl();
+        $this->assertEquals('http://foobar.com/some/path/index.php?' . http_build_query([
+            'q' => '/modules/My Module/some_action.php',
+        ]), (string) $url);
+
+        $url = Url::fromModuleRoute('My Module')->withAbsoluteUrl();
+        $this->assertEquals('http://foobar.com/some/path/index.php?' . http_build_query([
+            'q' => '/modules/My Module/',
+        ]), (string) $url);
+    }
+
+    /**
+     * @covers \Gibbon\Http\Url::fromModuleRoute()
      * @covers \Gibbon\Http\Url::withQueryParams()
      */
     public function testFromModuleRouteWithQueryParams()
@@ -163,6 +179,18 @@ class UrlTest extends TestCase
 
         $url = Url::fromHandlerRoute('fullscreen.php', 'some_action');
         $this->assertEquals('/some/path/fullscreen.php?q=some_action.php', (string) $url);
+    }
+
+    /**
+     * @covers \Gibbon\Http\Url::fromHandlerPath()
+     */
+    public function testFromAbsoluteHandlerPath()
+    {
+        $url = Url::fromHandlerRoute('fullscreen.php')->withAbsoluteUrl();
+        $this->assertEquals('http://foobar.com/some/path/fullscreen.php', (string) $url);
+
+        $url = Url::fromHandlerRoute('fullscreen.php', 'some_action')->withAbsoluteUrl();
+        $this->assertEquals('http://foobar.com/some/path/fullscreen.php?q=some_action.php', (string) $url);
     }
 
     /**

--- a/tests/unit/Gibbon/UrlTest.php
+++ b/tests/unit/Gibbon/UrlTest.php
@@ -33,10 +33,10 @@ class UrlTest extends TestCase
     public function testFromRoute()
     {
         $url = Url::fromRoute('some_action');
-        $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php', (string) $url);
+        $this->assertEquals('/some/path/index.php?q=some_action.php', (string) $url);
 
         $url = Url::fromRoute()->withQuery('hello=world');
-        $this->assertEquals('http://foobar.com/some/path/index.php?hello=world', (string) $url);
+        $this->assertEquals('/some/path/index.php?hello=world', (string) $url);
     }
 
     /**
@@ -88,12 +88,12 @@ class UrlTest extends TestCase
     public function testFromModuleRoute()
     {
         $url = Url::fromModuleRoute('My Module', 'some_action');
-        $this->assertEquals('http://foobar.com/some/path/index.php?' . http_build_query([
+        $this->assertEquals('/some/path/index.php?' . http_build_query([
             'q' => '/modules/My Module/some_action.php',
         ]), (string) $url);
 
         $url = Url::fromModuleRoute('My Module');
-        $this->assertEquals('http://foobar.com/some/path/index.php?' . http_build_query([
+        $this->assertEquals('/some/path/index.php?' . http_build_query([
             'q' => '/modules/My Module/',
         ]), (string) $url);
     }
@@ -147,10 +147,10 @@ class UrlTest extends TestCase
     public function testFromHandlerPath()
     {
         $url = Url::fromHandlerRoute('fullscreen.php');
-        $this->assertEquals('http://foobar.com/some/path/fullscreen.php', (string) $url);
+        $this->assertEquals('/some/path/fullscreen.php', (string) $url);
 
         $url = Url::fromHandlerRoute('fullscreen.php', 'some_action');
-        $this->assertEquals('http://foobar.com/some/path/fullscreen.php?q=some_action.php', (string) $url);
+        $this->assertEquals('/some/path/fullscreen.php?q=some_action.php', (string) $url);
     }
 
     /**
@@ -172,10 +172,10 @@ class UrlTest extends TestCase
     public function testWithQueryParam()
     {
         $url = Url::fromRoute('some_action')->withQueryParam('foo', 'bar');
-        $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php&foo=bar', (string) $url);
+        $this->assertEquals('/some/path/index.php?q=some_action.php&foo=bar', (string) $url);
 
         $url = Url::fromRoute()->withQueryParam('foo', 'world');
-        $this->assertEquals('http://foobar.com/some/path/index.php?foo=world', (string) $url);
+        $this->assertEquals('/some/path/index.php?foo=world', (string) $url);
     }
 
     /**
@@ -184,10 +184,10 @@ class UrlTest extends TestCase
     public function testWithReturn()
     {
         $url = Url::fromRoute('some_action')->withReturn('successx');
-        $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php&return=successx', (string) $url);
+        $this->assertEquals('/some/path/index.php?q=some_action.php&return=successx', (string) $url);
 
         $url = Url::fromRoute()->withReturn('successx');
-        $this->assertEquals('http://foobar.com/some/path/index.php?return=successx', (string) $url);
+        $this->assertEquals('/some/path/index.php?return=successx', (string) $url);
     }
 
     /**

--- a/tests/unit/Gibbon/UrlTest.php
+++ b/tests/unit/Gibbon/UrlTest.php
@@ -40,6 +40,18 @@ class UrlTest extends TestCase
     }
 
     /**
+     * @covers \Gibbon\Http\Url::fromAbsoluteRoute()
+     */
+    public function testFromAbsoluteRoute()
+    {
+        $url = Url::fromAbsoluteRoute('some_action');
+        $this->assertEquals('http://foobar.com/some/path/index.php?q=some_action.php', (string) $url);
+
+        $url = Url::fromAbsoluteRoute()->withQuery('hello=world');
+        $this->assertEquals('http://foobar.com/some/path/index.php?hello=world', (string) $url);
+    }
+
+    /**
      * @covers \Gibbon\Http\Url::fromRoute()
      * @covers \Gibbon\Http\Url::withQueryParams()
      */


### PR DESCRIPTION
We were running into bugs related to the fact that Gibbon relies on using absoluteURL in many areas, but the new Url class was returning a relative URL. These affected the breadcrumbs, fast finder, timetable, password reset, etc. 

For example:

- Breadcrumbs with an absoluteURL of `http://localhost:8888/gibbon/` were ending up as `http://localhost:8888/gibbon/gibbon/index.php?q=/modules/System Admin/systemOverview.php` because the url was relative, so browsers were prepending the current url, but the path has also been parsed and added to the url route path.
- The timetable was not working because the ajax load script was expecting an absolute path and was receiving a relative one.
- Preferences links in notification emails were not working because the NotificationSender was putting a relative link in the href attribute.

This PR updates the Url class to return a fully resolved absolute URL. It appears the base Uri class is designed to parse a url into it's component parts when passed into the constructor, so the Url class no longer needs to parse the url when the setBaseUrl method is called. Instead, it stores the baseUrl and passes it into the constructor when using the withRoute, withModuleRoute, etc. methods.

**Motivation and Context**
Fixes bugs that have occurred after #1383

**How Has This Been Tested?**
Locally