### PR TITLE
Improve warning detection in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,24 @@ jobs:
       - name: Check PHP warning and deprecated messages in server_log
         run: |
           # Check number of warning messages.
-          export NUM_WARNING=$(grep 'PHP Warning: ' ./tests/log/server_log | wc -l)
+          export NUM_WARNING=$(grep --perl-regexp '(?<!PHP )Warning: ' ./tests/log/server_log | wc -l)
           if [ "$NUM_WARNING" -eq 0 ]; then
             echo -e '\e[32mNo warning message.\e[0m'
+            echo
           else
             echo -e "\e[1m\e[33mGot $NUM_WARNING warning messages:\e[0m"
-            grep --line-number --color=always 'PHP Warning: ' ./tests/log/server_log || echo -e '\e[32mNo warning or deprecated message found in log.\e[0m'
+            grep --line-number --color=always --perl-regexp '(?<!PHP )Warning: ' ./tests/log/server_log || echo -e '\e[32mNo Warning message found in log.\e[0m'
+            echo
+          fi
+
+          # Check number of PHP warning messages.
+          export NUM_PHP_WARNING=$(grep 'PHP Warning: ' ./tests/log/server_log | wc -l)
+          if [ "$NUM_PHP_WARNING" -eq 0 ]; then
+            echo -e '\e[32mNo warning message.\e[0m'
+            echo
+          else
+            echo -e "\e[1m\e[33mGot $NUM_PHP_WARNING PHP warning messages:\e[0m"
+            grep --line-number --color=always 'PHP Warning: ' ./tests/log/server_log || echo -e '\e[32mNo PHP Warning message found in log.\e[0m'
             echo
           fi
 
@@ -103,7 +115,7 @@ jobs:
             echo -e '\e[32mNo deprecated message.\e[0m'
           else
             echo -e "\e[1m\e[31mGot $NUM_DEPRECATED deprecated messages:\e[0m"
-            grep --line-number --color=always 'Deprecated: ' ./tests/log/server_log || echo -e '\e[32mNo warning or deprecated message found in log.\e[0m'
+            grep --line-number --color=always 'Deprecated: ' ./tests/log/server_log || echo -e '\e[32mNo Deprecated message found in log.\e[0m'
             (exit 1)
           fi
         continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
             echo -e "\e[1m\e[33mGot $NUM_WARNING warning messages:\e[0m"
             grep --line-number --color=always --perl-regexp '(?<!PHP )Warning: ' ./tests/log/server_log || echo -e '\e[32mNo Warning message found in log.\e[0m'
             echo
+            (exit 1)
           fi
 
           # Check number of PHP warning messages.
@@ -104,9 +105,10 @@ jobs:
             echo -e '\e[32mNo warning message.\e[0m'
             echo
           else
-            echo -e "\e[1m\e[33mGot $NUM_PHP_WARNING PHP warning messages:\e[0m"
+            echo -e "\e[1m\e[31mGot $NUM_PHP_WARNING PHP warning messages:\e[0m"
             grep --line-number --color=always 'PHP Warning: ' ./tests/log/server_log || echo -e '\e[32mNo PHP Warning message found in log.\e[0m'
             echo
+            (exit 1)
           fi
 
           # Check number of deprecated messages. Cause error if found.
@@ -116,6 +118,7 @@ jobs:
           else
             echo -e "\e[1m\e[31mGot $NUM_DEPRECATED deprecated messages:\e[0m"
             grep --line-number --color=always 'Deprecated: ' ./tests/log/server_log || echo -e '\e[32mNo Deprecated message found in log.\e[0m'
+            echo
             (exit 1)
           fi
         continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
**Description**
* Modify CI test to treat "Warning: " or "PHP Warning: " in server_log as test failure.

**Motivation and Context**
* Detects php issues when they are committed for submit. Much easier to identify the code relevant to the warning message.
* Just cleared all the issues that creates those kind of message. It is a good point in time to do so.

**How Has This Been Tested?**
* CI environment.