### PR TITLE
Identifying internal urls

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -113,7 +113,7 @@ class Url extends Uri implements UriInterface
     public static function fromModuleRoute(string $module, string $route_path = ''): self
     {
         return (new static())
-            ->withPath(static::$basePath)
+            ->withPath('./')
             ->withModule($module)
             ->withRoutePath($route_path);
     }


### PR DESCRIPTION
**Description**
Changed the initial url path to use "'./" instead of $basePath, this way the internal links don't open a new window.

**Motivation and Context**
All urls are identified as external links

**How Has This Been Tested?**
Local and Travis

