### PR TITLE
Added translation support in attendance types and fixed the End date field

### DIFF
--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -189,7 +189,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
 
             $row = $form->addRow();
                 $row->addLabel('dateEnd', __('End Date'));
-                $row->addDate('dateEnd');
+                $row->addDate('dateEnd')->minimum(date('Y-m-d', strtotime('today +2 day')));;
         } else {
             $form->addHiddenValue('dateStart', $date);
             $form->addHiddenValue('dateEnd', $date);
@@ -212,7 +212,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
 
         // Filter only attendance types with future = 'Y'
         $attendanceTypes = array_reduce($attendance->getAttendanceTypes(), function ($group, $item) {
-            if ($item['future'] == 'Y') $group[] = $item['name'];
+            if ($item['future'] == 'Y') $group[$item['name']] = __($item['name']);
             return $group;
         }, array());
 


### PR DESCRIPTION
**Description**
- Added a rule: the "Date End" field has a minimum value of 2 days more than the current day
- Translation support to Type field

**Motivation and Context**
If you choose Absence type = full day, the system allows the value of the "End date" previous to current day.

**How Has This Been Tested?**
Local and Travis

**Screenshots**
![Screenshot_20220107_180528](https://user-images.githubusercontent.com/1969911/148610956-fa227ea7-392f-4975-b66d-014bcf9279cb.png)

