### PR TITLE
Update Planner Edit

### DIFF
--- a/src/UI/Dashboard/ParentDashboard.php
+++ b/src/UI/Dashboard/ParentDashboard.php
@@ -675,11 +675,9 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                             $activitiesOutput .= '<td>';
                             $activitiesOutput .= $row['name'];
                             $activitiesOutput .= '</td>';
-                            if ($options != '') {
-                                $activitiesOutput .= '<td>';
-                                $activitiesOutput .= trim($row['type']);
-                                $activitiesOutput .= '</td>';
-                            }
+                            $activitiesOutput .= '<td>';
+                            $activitiesOutput .= trim($row['type']);
+                            $activitiesOutput .= '</td>';
                             $activitiesOutput .= '<td>';
                             if ($dateType != 'Date') {
                                 $terms = getTerms($connection2, $this->session->get('gibbonSchoolYearID'), true);


### PR DESCRIPTION
Updates the Planner module with the option to create and link a new Markbook Column when editing an already existing lesson plan.

<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
Added lines to planner_edit and planner_editProcess that allows for the creation and linking of a Markbook Column when submitting a change to an already existing lesson plan.

**Motivation and Context**
This helps when planning lessons ahead of time, and a teacher doesn't know whether or not there will be homework. Now, a lesson can be planned ahead, and edited later with the opportunity to add a linked Markbook Column entry to the system.

**How Has This Been Tested?**
Tested and verified on a personal installation of Gibbon v22.

**Screenshots**
![EditLesson_1](https://user-images.githubusercontent.com/8291025/150211694-2da99777-177e-40f9-98a2-00f84f214be6.png)

