### PR TITLE
Installer: fix homepage link generation

### DIFF
--- a/installer/install.php
+++ b/installer/install.php
@@ -186,7 +186,7 @@ try {
 
         // Show success message if the installation is a complete success.
         if ($message === null) {
-            $absoluteURL = str_replace('/installer/install.php', '', $_SERVER['PHP_SELF']);
+            $absoluteURL = str_replace('/installer/install.php', '/', $_SERVER['PHP_SELF']);
             $page->addSuccess(sprintf(__('Congratulations, your installation is complete. Feel free to %1$sgo to your Gibbon homepage%2$s and login with the username and password you created.'), "<a href='$absoluteURL'>", '</a>'));
             echo $page->fetchFromTemplate('ui/gettingStarted.twig.html', ['postInstall' => true]);
         }

--- a/installer/install.php
+++ b/installer/install.php
@@ -186,7 +186,7 @@ try {
 
         // Show success message if the installation is a complete success.
         if ($message === null) {
-            $absoluteURL = str_replace('/installer/install.php', '/', $_SERVER['PHP_SELF']);
+            $absoluteURL = $session->get('absoluteURL');
             $page->addSuccess(sprintf(__('Congratulations, your installation is complete. Feel free to %1$sgo to your Gibbon homepage%2$s and login with the username and password you created.'), "<a href='$absoluteURL'>", '</a>'));
             echo $page->fetchFromTemplate('ui/gettingStarted.twig.html', ['postInstall' => true]);
         }

--- a/tests/install/InstallCept.php
+++ b/tests/install/InstallCept.php
@@ -65,7 +65,9 @@ try {
     // Follow the go to homepage link to the front page.
     $I->see('go to your Gibbon homepage', '.success');
     $I->click('go to your Gibbon homepage');
-    $I->canSeeCurrentUrlMatches('/^\/$/');
+
+    // The URL should either be empty or a single slash (root).
+    $I->canSeeCurrentUrlMatches('/^(|\/)$/');
 
 } catch (Exception $e) {
     codecept_debug($I->grabTextFrom('body'));

--- a/tests/install/InstallCept.php
+++ b/tests/install/InstallCept.php
@@ -62,6 +62,11 @@ try {
 
     $I->see('Congratulations, your installation is complete.', '.success');
 
+    // Follow the go to homepage link to the front page.
+    $I->see('go to your Gibbon homepage', '.success');
+    $I->click('go to your Gibbon homepage');
+    $I->canSeeCurrentUrlMatches('/^\/$/');
+
 } catch (Exception $e) {
     codecept_debug($I->grabTextFrom('body'));
     throw $e;


### PR DESCRIPTION
**Description**
* Fix the "go to Gibbon homepage" link in the message on step 4 of installation.
* Update InstallCept to check if the link goes to the home page.

**Motivation and Context**
* See issued reported by [tiekubd](https://ask.gibbonedu.org/profile/tiekubd) on [this Gibbon Support Forum thread](https://ask.gibbonedu.org/discussion/comment/9434)

**How Has This Been Tested?**
* Locally.
* CI environment.