### PR TITLE
System Admin: fix custom field headings not working for non-english locales

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ v23.0.01
 
     Bug Fixes
         System Admin: fixed password field in user imports in Import From File
+        System Admin: fixed custom field headings not working for non-english locales
 
 
 v23.0.00

--- a/modules/Activities/activities_manage_add.php
+++ b/modules/Activities/activities_manage_add.php
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
@@ -162,7 +162,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
     $payment = $settingGateway->getSettingByScope('Activities', 'payment');
     if ($payment != 'None' && $payment != 'Single') {
-        $form->addRow()->addHeading(__('Cost'));
+        $form->addRow()->addHeading('Cost', __('Cost'));
 
         $row = $form->addRow();
             $row->addLabel('payment', __('Cost'));
@@ -192,7 +192,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
                 ]);
     }
 
-    $form->addRow()->addHeading(__('Time Slots'));
+    $form->addRow()->addHeading('Time Slots', __('Time Slots'));
 
     //Block template
     $sqlWeekdays = "SELECT gibbonDaysOfWeekID as value, name FROM gibbonDaysOfWeek ORDER BY sequenceNumber";
@@ -250,7 +250,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
     $slotBlocks->addPredefinedBlock("Add Time Slot", ['location' => 'Internal']);
 
-    $form->addRow()->addHeading(__('Staff'));
+    $form->addRow()->addHeading('Staff', __('Staff'));
 
     $row = $form->addRow();
         $row->addLabel('staff', __('Staff'));

--- a/modules/Activities/activities_manage_edit.php
+++ b/modules/Activities/activities_manage_edit.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             }
 
 
-            $form->addRow()->addHeading(__('Basic Information'));
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
@@ -157,7 +157,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
             $payment = $settingGateway->getSettingByScope('Activities', 'payment');
             if ($payment != 'None' && $payment != 'Single') {
-                $form->addRow()->addHeading(__('Cost'));
+                $form->addRow()->addHeading('Cost', __('Cost'));
 
                 $row = $form->addRow();
                     $row->addLabel('payment', __('Cost'));
@@ -186,7 +186,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
                         ]);
             }
 
-            $form->addRow()->addHeading(__('Time Slots'));
+            $form->addRow()->addHeading('Time Slots', __('Time Slots'));
 
             //Block template
             $sqlWeekdays = "SELECT gibbonDaysOfWeekID as value, name FROM gibbonDaysOfWeek ORDER BY sequenceNumber";
@@ -251,7 +251,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
                 $slotBlocks->addBlock($slot['gibbonActivitySlotID'], $slot);
             }
 
-            $form->addRow()->addHeading(__('Current Staff'));
+            $form->addRow()->addHeading('Current Staff', __('Current Staff'));
 
             $form->addRow()->addContent('<b>'.__('Warning').'</b>: '.__('If you delete a member of staff, any unsaved changes to this record will be lost!'))->wrap('<i>', '</i>');
 
@@ -278,7 +278,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             $activityStaffGateway = $container->get(ActivityStaffGateway::class);
             $staffTable->withData($activityStaffGateway->selectActivityStaff($gibbonActivityID)->toDataSet());
 
-            $form->addRow()->addHeading(__('New Staff'));
+            $form->addRow()->addHeading('New Staff', __('New Staff'));
 
             $row = $form->addRow();
                 $row->addLabel('staff', __('Staff'));

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -180,7 +180,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
         $form->addHiddenValue('absenceType', $absenceType);
         $form->addHiddenValue('gibbonPersonID', implode(",", $gibbonPersonID));
 
-        $form->addRow()->addHeading(__('Set Future Attendance'));
+        $form->addRow()->addHeading('Set Future Attendance', __('Set Future Attendance'));
 
         if ($absenceType == 'full') {
             $row = $form->addRow();

--- a/modules/Attendance/attendance_take_adHoc.php
+++ b/modules/Attendance/attendance_take_adHoc.php
@@ -177,7 +177,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
     $form->addHiddenValue('currentDate', $currentDate);
     $form->addHiddenValue('count', count($students));
 
-    $form->addRow()->addHeading(__('Take Attendance'));
+    $form->addRow()->addHeading('Take Attendance', __('Take Attendance'));
 
     $grid = $form->addRow()->addGrid('attendance')->setBreakpoints('w-1/2 sm:w-1/4 md:w-1/5 lg:w-1/4');
 

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -212,7 +212,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                 $form->addHiddenValue('address', $session->get('address'));
                 $form->addHiddenValue('currentDate', $currentDate);
 
-                $form->addRow()->addHeading(__('Take Attendance'));
+                $form->addRow()->addHeading('Take Attendance', __('Take Attendance'));
 
                 $row = $form->addRow();
                     $row->addLabel('summary', __('Recent Attendance Summary'));

--- a/modules/Attendance/attendance_take_byPerson_edit.php
+++ b/modules/Attendance/attendance_take_byPerson_edit.php
@@ -70,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
 			$form->addHiddenValue('gibbonPersonID', $gibbonPersonID);
 			$form->addHiddenValue('currentDate', $currentDate);
 
-			$form->addRow()->addHeading(__('Edit Attendance'));
+			$form->addRow()->addHeading('Edit Attendance', __('Edit Attendance'));
 
 			$row = $form->addRow();
 				$row->addLabel('student', __('Student'));

--- a/modules/Behaviour/behaviour_manage_add.php
+++ b/modules/Behaviour/behaviour_manage_add.php
@@ -93,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             }
             
             $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
-            $form->addRow()->addHeading(__('Step 1'));
+            $form->addRow()->addHeading('Step 1', __('Step 1'));
 
             //Student
             $row = $form->addRow();
@@ -142,7 +142,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 	$row->addSelect('level')->fromArray($optionsLevels)->placeholder();
             }
 
-            $form->addRow()->addHeading(__('Details'));
+            $form->addRow()->addHeading('Details', __('Details'));
 
 			//Incident
             $row = $form->addRow();

--- a/modules/Behaviour/behaviour_manage_addMulti.php
+++ b/modules/Behaviour/behaviour_manage_addMulti.php
@@ -51,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
     $form = Form::create('addform', $session->get('absoluteURL').'/modules/Behaviour/behaviour_manage_addMultiProcess.php?gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonFormGroupID='.$_GET['gibbonFormGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->addHiddenValue('address', '/modules/Behaviour/behaviour_manage_addMulti.php');
-    $form->addRow()->addHeading(__('Step 1'));
+    $form->addRow()->addHeading('Step 1', __('Step 1'));
 
     $policyLink = $settingGateway->getSettingByScope('Behaviour', 'policyLink');
     if (!empty($policyLink)) {
@@ -134,7 +134,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 ->placeholder();
     }
 
-    $form->addRow()->addHeading(__('Details'));
+    $form->addRow()->addHeading('Details', __('Details'));
 
     //Incident
     $row = $form->addRow();

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -103,7 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 }
             
                 $form->addHiddenValue('address', "/modules/Behaviour/behaviour_manage_add.php");
-                $form->addRow()->addClass('hidden')->addHeading(__('Step 1'));
+                $form->addRow()->addClass('hidden')->addHeading('Step 1', __('Step 1'));
 
                 //Student
                 $row = $form->addRow();
@@ -151,7 +151,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                     	$row->addSelect('level')->fromArray($optionsLevels)->selected($values['level'])->placeholder();
                 }
 
-                $form->addRow()->addHeading(__('Details'));
+                $form->addRow()->addHeading('Details', __('Details'));
 
                 //Incident
                 $row = $form->addRow();

--- a/modules/Data Updater/data_finance.php
+++ b/modules/Data Updater/data_finance.php
@@ -198,7 +198,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_finance.
                     $form->addHiddenValue('address', $session->get('address'));
 					$form->addHiddenValue('existing', isset($values['gibbonFinanceInvoiceeUpdateID'])? $values['gibbonFinanceInvoiceeUpdateID'] : 'N');
 
-					$form->addRow()->addHeading(__('Invoice To'));
+					$form->addRow()->addHeading('Invoice To', __('Invoice To'));
 
 					$form->addRow()->addContent(__('If you choose family, future invoices will be sent according to your family\'s contact preferences, which can be changed at a later date by contacting the school. For example you may wish both parents to receive the invoice, or only one. Alternatively, if you choose Company, you can choose for all or only some fees to be covered by the specified company.'))->wrap('<p>', '</p>');
 

--- a/modules/Data Updater/data_medical.php
+++ b/modules/Data Updater/data_medical.php
@@ -292,7 +292,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical.
 						}
 
 						// ADD NEW CONDITION
-						$form->addRow()->addHeading(__('Add Medical Condition'));
+						$form->addRow()->addHeading('Add Medical Condition', __('Add Medical Condition'));
 
 						$form->toggleVisibilityByClass('addConditionRow')->onCheckbox('addCondition')->when('Yes');
 

--- a/modules/Data Updater/data_medical_manage_edit.php
+++ b/modules/Data Updater/data_medical_manage_edit.php
@@ -155,7 +155,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
             };
 
             // Basic Medical Form
-            $form->addRow()->addHeading(__('Basic Information'));
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             foreach ($compare as $fieldName => $label) {
                 $comparisonFields($form, $oldValues, $newValues, $fieldName, $label);

--- a/modules/Data Updater/data_personal.php
+++ b/modules/Data Updater/data_personal.php
@@ -309,7 +309,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     $form->addHiddenValue('existing', isset($values['gibbonPersonUpdateID'])? $values['gibbonPersonUpdateID'] : 'N');
 
                     // BASIC INFORMATION
-                    $form->addRow()->addHeading(__('Basic Information'));
+                    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                     $row = $form->addRow()->onlyIf($isVisible('title'));
                         $row->addLabel('title', __('Title'));
@@ -343,7 +343,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     if ($student || $staff) {
                         $form->addRow()
                             ->onlyIf($anyVisible(['emergency1Name', 'emergency1Relationship', 'emergency1Number1', 'emergency1Number2', 'emergency2Name', 'emergency2Relationship', 'emergency2Number1', 'emergency2Number2']))
-                            ->addHeading(__('Emergency Contacts'));
+                            ->addHeading('Emergency Contacts', __('Emergency Contacts'));
 
                         $form->addRow()->addContent(__('These details are used when immediate family members (e.g. parent, spouse) cannot be reached first. Please try to avoid listing immediate family members.'));
 
@@ -381,7 +381,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     }
 
                     // CONTACT INFORMATION
-                    $form->addRow()->addHeading(__('Contact Information'));
+                    $form->addRow()->addHeading('Contact Information', __('Contact Information'));
 
                     $row = $form->addRow()->onlyIf($isVisible('email'));
                         $row->addLabel('email', __('Email'));
@@ -482,7 +482,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     }
 
                     // BACKGROUND INFORMATION
-                    $form->addRow()->addHeading(__('Background Information'));
+                    $form->addRow()->addHeading('Background Information', __('Background Information'));
 
                     $row = $form->addRow()->onlyIf($isVisible('languageFirst'));
                         $row->addLabel('languageFirst', __('First Language'));
@@ -539,7 +539,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     if ($parent) {
                         $form->addRow()
                             ->onlyIf($anyVisible(['profession', 'employer', 'jobTitle']))
-                            ->addHeading(__('Employment'));
+                            ->addHeading('Employment', __('Employment'));
 
                         $row = $form->addRow()->onlyIf($isVisible('profession'));
                             $row->addLabel('profession', __('Profession'));
@@ -557,7 +557,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     // MISCELLANEOUS
                     $form->addRow()
                         ->onlyIf($anyVisible(['vehicleRegistration']))
-                        ->addHeading(__('Miscellaneous'));
+                        ->addHeading('Miscellaneous', __('Miscellaneous'));
 
                     $row = $form->addRow()->onlyIf($isVisible('vehicleRegistration'));
                         $row->addLabel('vehicleRegistration', __('Vehicle Registration'));

--- a/modules/Data Updater/data_staff.php
+++ b/modules/Data Updater/data_staff.php
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_staff.ph
         $form->addHiddenValue('gibbonStaffID', $gibbonStaffID);
         $form->addHiddenValue('gibbonPersonID', $gibbonPersonID);
 
-        $form->addRow()->addHeading(__('Basic Information'));
+        $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
         $row = $form->addRow();
             $row->addLabel('initials', __('Initials'))->description(__('Must be unique if set.'));
@@ -150,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_staff.ph
             $row->addLabel('jobTitle', __('Job Title'));
             $row->addTextField('jobTitle')->maxlength(100);
 
-        $form->addRow()->addHeading(__('First Aid'));
+        $form->addRow()->addHeading('First Aid', __('First Aid'));
 
         $row = $form->addRow();
             $row->addLabel('firstAidQualified', __('First Aid Qualified?'));
@@ -166,7 +166,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_staff.ph
             $row->addLabel('firstAidExpiry', __('First Aid Expiry'));
             $row->addDate('firstAidExpiry');
 
-        $form->addRow()->addHeading(__('Biography'));
+        $form->addRow()->addHeading('Biography', __('Biography'));
 
         $row = $form->addRow();
             $row->addLabel('countryOfOrigin', __('Country Of Origin'));

--- a/modules/Departments/department_course_edit.php
+++ b/modules/Departments/department_course_edit.php
@@ -71,7 +71,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_cou
 
                 $form->addHiddenValue('address', $session->get('address'));
 
-                $form->addRow()->addHeading(__('Overview'));
+                $form->addRow()->addHeading('Overview', __('Overview'));
                 $form->addRow()->addEditor('description', $guid)->setRows(20)->setValue($values['description']);
 
                 $row = $form->addRow();

--- a/modules/Departments/department_edit.php
+++ b/modules/Departments/department_edit.php
@@ -65,10 +65,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_edi
 
 				$form->addHiddenValue('address', $session->get('address'));
 
-				$form->addRow()->addHeading(__('Overview'));
+				$form->addRow()->addHeading('Overview', __('Overview'));
 				$form->addRow()->addEditor('blurb', $guid)->setRows(20)->setValue($values['blurb']);
 
-				$form->addRow()->addHeading(__('Current Resources'));
+				$form->addRow()->addHeading('Current Resources', __('Current Resources'));
 
 				$data = array('gibbonDepartmentID' => $gibbonDepartmentID);
 				$sql = 'SELECT * FROM gibbonDepartmentResource WHERE gibbonDepartmentID=:gibbonDepartmentID ORDER BY name';

--- a/modules/Finance/budgetCycles_manage_add.php
+++ b/modules/Finance/budgetCycles_manage_add.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
     $form->addHiddenValue("address", $session->get('address'));
 
     $row = $form->addRow();
-        $row->addHeading(__("Basic Information"));
+        $row->addHeading("Basic Information", __("Basic Information"));
 
     $row = $form->addRow();
         $row->addLabel("name", __("Name"))->description(__("Must be unique."));
@@ -71,7 +71,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
         $row->addDate("dateEnd")->required();
 
     $row = $form->addRow();
-        $row->addHeading(__("Budget Allocations"));
+        $row->addHeading("Budget Allocations", __("Budget Allocations"));
 
 
         $dataBudget = array();

--- a/modules/Finance/budgetCycles_manage_edit.php
+++ b/modules/Finance/budgetCycles_manage_edit.php
@@ -52,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
             $form->addHiddenValue("address", $session->get('address'));
 
             $row = $form->addRow();
-                $row->addHeading(__("Basic Information"));
+                $row->addHeading("Basic Information", __("Basic Information"));
 
             $row = $form->addRow();
                 $row->addLabel("name", __("Name"))->description(__("Must be unique."));
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
                 $row->addDate("dateEnd")->required();
 
             $row = $form->addRow();
-                $row->addHeading(__("Budget Allocations"));
+                $row->addHeading("Budget Allocations", __("Budget Allocations"));
 
 
                 $dataBudget = array('gibbonFinanceBudgetCycleID' => $gibbonFinanceBudgetCycleID);

--- a/modules/Finance/budgets_manage_add.php
+++ b/modules/Finance/budgets_manage_add.php
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_add
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('General Settings'));
+    $form->addRow()->addHeading('General Settings', __('General Settings'));
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_add
         $row->addLabel('category', __('Category'));
         $row->addSelect('category')->fromString($categories)->placeholder()->required();
 
-    $form->addRow()->addHeading(__('Staff'));
+    $form->addRow()->addHeading('Staff', __('Staff'));
 
     $row = $form->addRow();
         $row->addLabel('staff', __('Staff'));

--- a/modules/Finance/budgets_manage_edit.php
+++ b/modules/Finance/budgets_manage_edit.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('General Settings'));
+            $form->addRow()->addHeading('General Settings', __('General Settings'));
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Must be unique.'));
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
                 $row->addLabel('category', __('Category'));
                 $row->addSelect('category')->fromString($categories)->placeholder()->required();
 
-            $form->addRow()->addHeading(__('Current Staff'));
+            $form->addRow()->addHeading('Current Staff', __('Current Staff'));
 
             $data = array('gibbonFinanceBudgetID' => $gibbonFinanceBudgetID);
             $sql = "SELECT preferredName, surname, gibbonFinanceBudgetPerson.* FROM gibbonFinanceBudgetPerson JOIN gibbonPerson ON (gibbonFinanceBudgetPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonFinanceBudgetID=:gibbonFinanceBudgetID AND gibbonPerson.status='Full' ORDER BY FIELD(access,'Full','Write','Read'), surname, preferredName";
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgets_manage_edi
                 }
             }
 
-            $form->addRow()->addHeading(__('New Staff'));
+            $form->addRow()->addHeading('New Staff', __('New Staff'));
 
             $row = $form->addRow();
                 $row->addLabel('staff', __('Staff'));

--- a/modules/Finance/expenseRequest_manage_reimburse.php
+++ b/modules/Finance/expenseRequest_manage_reimburse.php
@@ -111,7 +111,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                     $form->addHiddenValue('gibbonFinanceBudgetCycleID', $gibbonFinanceBudgetCycleID);
 
-                    $form->addRow()->addHeading(__('Basic Information'));
+                    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                     $cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
                     $row = $form->addRow();
@@ -161,7 +161,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                         $column->addLabel('purchaseDetails', __('Purchase Details'));
                         $column->addContent($values['purchaseDetails'])->setClass('fullWidth');
 
-                    $form->addRow()->addHeading(__('Log'));
+                    $form->addRow()->addHeading('Log', __('Log'));
 
                     $expenseLog = $container->get(ExpenseLog::class)->create($gibbonFinanceExpenseID);
                     $form->addRow()->addContent($expenseLog->getOutput());
@@ -173,7 +173,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                     $form->toggleVisibilityByClass('payment')->onSelect('status')->when('Paid');
 
-                    $form->addRow()->addHeading(__('Payment Information'))->addClass('payment');
+                    $form->addRow()->addHeading('Payment Information', __('Payment Information'))->addClass('payment');
 
                     $row = $form->addRow()->addClass('payment');
                         $row->addLabel('paymentDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));

--- a/modules/Finance/expenseRequest_manage_view.php
+++ b/modules/Finance/expenseRequest_manage_view.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
 
                         $form->addHiddenValue('gibbonFinanceBudgetCycleID', $gibbonFinanceBudgetCycleID);
 
-                        $form->addRow()->addHeading(__('Basic Information'));
+                        $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                         $cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
                         $row = $form->addRow();
@@ -164,7 +164,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                             $column->addLabel('purchaseDetails', __('Purchase Details'));
                             $column->addContent($values['purchaseDetails'])->setClass('fullWidth');
 
-                        $form->addRow()->addHeading(__('Log'));
+                        $form->addRow()->addHeading('Log', __('Log'));
 
                         $expenseLog = $container->get(ExpenseLog::class)->create($gibbonFinanceExpenseID);
                         $form->addRow()->addContent($expenseLog->getOutput());

--- a/modules/Finance/expenses_manage_add.php
+++ b/modules/Finance/expenses_manage_add.php
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
             $form->addHiddenValue('gibbonFinanceBudgetID2', $gibbonFinanceBudgetID2);
 			$form->addHiddenValue('gibbonFinanceBudgetCycleID', $gibbonFinanceBudgetCycleID);
 
-			$form->addRow()->addHeading(__('Basic Information'));
+			$form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
 			$cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
 			$row = $form->addRow();
@@ -132,7 +132,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ad
 
 			$form->toggleVisibilityByClass('paymentInfo')->onSelect('status')->when('Paid');
 
-			$form->addRow()->addHeading(__('Payment Information'))->addClass('paymentInfo');
+			$form->addRow()->addHeading('Payment Information', __('Payment Information'))->addClass('paymentInfo');
 
 			$row = $form->addRow()->addClass('paymentInfo');
 				$row->addLabel('paymentDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));

--- a/modules/Finance/expenses_manage_approve.php
+++ b/modules/Finance/expenses_manage_approve.php
@@ -158,7 +158,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
 							$form->addHiddenValue('gibbonFinanceBudgetID2', $gibbonFinanceBudgetID2);
 							$form->addHiddenValue('gibbonFinanceBudgetCycleID', $gibbonFinanceBudgetCycleID);
 
-							$form->addRow()->addHeading(__('Basic Information'));
+							$form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
 							$cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
 							$row = $form->addRow();
@@ -202,7 +202,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
 								$col->addLabel('purchaseDetails', __('Purchase Details'));
 								$col->addContent($values['purchaseDetails']);
 
-                            $form->addRow()->addHeading(__('Budget Tracking'));
+                            $form->addRow()->addHeading('Budget Tracking', __('Budget Tracking'));
 
                             $row = $form->addRow();
                                 $row->addLabel('costLabel', __('Total Cost'));
@@ -233,12 +233,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
                                         ->addClass( (is_numeric($budgetRemaining) && $budgetRemaining - $values['cost'] > 0)? 'textUnderBudget' : 'textOverBudget' );
                             }
 
-                            $form->addRow()->addHeading(__('Log'));
+                            $form->addRow()->addHeading('Log', __('Log'));
 
                             $expenseLog = $container->get(ExpenseLog::class)->create($gibbonFinanceExpenseID);
                             $form->addRow()->addContent($expenseLog->getOutput());
 
-                            $form->addRow()->addHeading(__('Action'));
+                            $form->addRow()->addHeading('Action', __('Action'));
 
                             $approvalRequired = approvalRequired($guid, $session->get('gibbonPersonID'), $values['gibbonFinanceExpenseID'], $gibbonFinanceBudgetCycleID, $connection2);
                             if ($approvalRequired != true) {

--- a/modules/Finance/expenses_manage_edit.php
+++ b/modules/Finance/expenses_manage_edit.php
@@ -148,7 +148,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 							$form->addHiddenValue('gibbonFinanceBudgetID2', $gibbonFinanceBudgetID2);
 							$form->addHiddenValue('gibbonFinanceBudgetCycleID', $gibbonFinanceBudgetCycleID);
 
-							$form->addRow()->addHeading(__('Basic Information'));
+							$form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
 							$cycleName = getBudgetCycleName($gibbonFinanceBudgetCycleID, $connection2);
 							$row = $form->addRow();
@@ -201,7 +201,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 								$col->addLabel('purchaseDetails', __('Purchase Details'));
 								$col->addContent($values['purchaseDetails']);
 
-                            $form->addRow()->addHeading(__('Budget Tracking'));
+                            $form->addRow()->addHeading('Budget Tracking', __('Budget Tracking'));
 
                             $row = $form->addRow();
                                 $row->addLabel('cost', __('Total Cost'));
@@ -232,7 +232,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
                                     ->setValue($budgetRemainingLabel)
                                     ->addClass( (is_numeric($budgetRemaining) && $budgetRemaining - $values['cost'] > 0)? 'textUnderBudget' : 'textOverBudget' );
 
-                            $form->addRow()->addHeading(__('Log'));
+                            $form->addRow()->addHeading('Log', __('Log'));
 
                             $expenseLog = $container->get(ExpenseLog::class)->create($gibbonFinanceExpenseID);
                             $form->addRow()->addContent($expenseLog->getOutput());
@@ -242,7 +242,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
 								$form->toggleVisibilityByClass('paymentInfo')->onSelect('status')->when('Paid');
 							}
 
-							$form->addRow()->addHeading(__('Payment Information'))->addClass('paymentInfo');
+							$form->addRow()->addHeading('Payment Information', __('Payment Information'))->addClass('paymentInfo');
 
 							$row = $form->addRow()->addClass('paymentInfo');
 								$row->addLabel('paymentDate', __('Date Paid'))->description(__('Date of payment, not entry to system.'));

--- a/modules/Finance/invoicees_manage_edit.php
+++ b/modules/Finance/invoicees_manage_edit.php
@@ -75,7 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoicees_manage_e
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('existing', isset($values['gibbonFinanceInvoiceeUpdateID'])? $values['gibbonFinanceInvoiceeUpdateID'] : 'N');
 
-            $form->addRow()->addHeading(__('Invoice To'));
+            $form->addRow()->addHeading('Invoice To', __('Invoice To'));
 
             $form->addRow()->addContent(__('If you choose family, future invoices will be sent according to your family\'s contact preferences, which can be changed at a later date by contacting the school. For example you may wish both parents to receive the invoice, or only one. Alternatively, if you choose Company, you can choose for all or only some fees to be covered by the specified company.'))->wrap('<p>', '</p>');
 

--- a/modules/Finance/invoices_manage_add.php
+++ b/modules/Finance/invoices_manage_add.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
 
         $form->addHiddenValue('address', $session->get('address'));
 
-        $form->addRow()->addHeading(__('Basic Information'));
+        $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
         $row = $form->addRow();
             $row->addLabel('schoolYear', __('School Year'));
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ad
             $row->addLabel('notes', __('Notes'))->description(__('Notes will be displayed on the final invoice and receipt.'));
             $row->addTextArea('notes')->setRows(5);
 
-        $form->addRow()->addHeading(__('Fees'));
+        $form->addRow()->addHeading('Fees', __('Fees'));
 
         // CUSTOM BLOCKS
 

--- a/modules/Finance/invoices_manage_edit.php
+++ b/modules/Finance/invoices_manage_edit.php
@@ -80,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
             $form->addHiddenValue('gibbonFinanceInvoiceID', $gibbonFinanceInvoiceID);
             $form->addHiddenValue('billingScheduleType', $values['billingScheduleType']);
 
-            $form->addRow()->addHeading(__('Basic Information'));
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             $row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
@@ -159,7 +159,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
                 $row->addTextArea('notes')->setRows(5);
 
             // FEES
-            $form->addRow()->addHeading(__('Fees'));
+            $form->addRow()->addHeading('Fees', __('Fees'));
 
             // Ad Hoc OR Issued (Fixed Fees)
             $dataFees = array('gibbonFinanceInvoiceID' => $values['gibbonFinanceInvoiceID']);
@@ -257,7 +257,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
                 }
             }
 
-            $form->addRow()->addHeading(__('Payment Log'));
+            $form->addRow()->addHeading('Payment Log', __('Payment Log'));
 
             $form->addRow()->addContent(getPaymentLog($connection2, $guid, 'gibbonFinanceInvoice', $gibbonFinanceInvoiceID));
 
@@ -266,7 +266,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_ed
             // EMAIL RECEIPTS
             if ($values['status'] == 'Issued' || $values['status'] == 'Paid - Partial') {
                 $form->toggleVisibilityByClass('emailReceipts')->onSelect('status')->when(array('Paid', 'Paid - Partial', 'Paid - Complete'));
-                $form->addRow()->addHeading(__('Email Receipt'))->addClass('emailReceipts');
+                $form->addRow()->addHeading('Email Receipt', __('Email Receipt'))->addClass('emailReceipts');
 
                 $row = $form->addRow()->addClass('emailReceipts');
                     $row->addYesNoRadio('emailReceipt')->checked('Y');

--- a/modules/Finance/invoices_manage_issue.php
+++ b/modules/Finance/invoices_manage_issue.php
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
 			$form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonFinanceInvoiceID', $gibbonFinanceInvoiceID);
 
-			$form->addRow()->addHeading(__('Basic Information'));
+			$form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
 			$row = $form->addRow();
                 $row->addLabel('schoolYear', __('School Year'));
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
                 $row->addLabel('notes', __('Notes'))->description(__('Notes will be displayed on the final invoice and receipt.'));
 				$row->addTextArea('notes')->setRows(5);
 
-			$form->addRow()->addHeading(__('Fees'));
+			$form->addRow()->addHeading('Fees', __('Fees'));
 
 			$totalFee = getInvoiceTotalFee($pdo, $gibbonFinanceInvoiceID, $values['status']);
 			$row = $form->addRow();
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_is
 				$row->addLabel('invoiceToText', __('Invoice To'));
 				$row->addTextField('invoiceToText')->required()->readonly()->setValue(__($values['invoiceTo']));
 
-			$form->addRow()->addHeading(__('Email Invoice'));
+			$form->addRow()->addHeading('Email Invoice', __('Email Invoice'));
 
 			$email = $container->get(SettingGateway::class)->getSettingByScope('Finance', 'email');
 			$form->addHiddenValue('email', $email);

--- a/modules/Formal Assessment/externalAssessment_manage_details_add.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_add.php
@@ -94,7 +94,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
                 $form->addHiddenValue('search', $search);
                 $form->addHiddenValue('allStudents', $allStudents);
 
-                $form->addRow()->addHeading(__('Assessment Type'));
+                $form->addRow()->addHeading('Assessment Type', __('Assessment Type'));
 
                 $sql = "SELECT gibbonExternalAssessmentID as value, name FROM gibbonExternalAssessment WHERE active='Y' ORDER BY name";
                 $row = $form->addRow();

--- a/modules/Formal Assessment/internalAssessment_manage_add.php
+++ b/modules/Formal Assessment/internalAssessment_manage_add.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
             $form->setFactory(DatabaseFormFactory::create($pdo));
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Basic Information'));
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
             $sql = "SELECT gibbonYearGroup.name as groupBy, gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonYearGroup ON (gibbonCourse.gibbonYearGroupIDList LIKE concat( '%', gibbonYearGroup.gibbonYearGroupID, '%' )) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.reportable='Y' ORDER BY gibbonYearGroup.sequenceNumber, name";
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $row->addLabel('file', __('Attachment'));
                 $row->addFileUpload('file');
 
-            $form->addRow()->addHeading(__('Assessment'));
+            $form->addRow()->addHeading('Assessment', __('Assessment'));
 
             $attainmentLabel = !empty($attainmentAlternativeName)? sprintf(__('Assess %1$s?'), $attainmentAlternativeName) : __('Assess Attainment?');
             $row = $form->addRow();
@@ -126,7 +126,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
                 $row->addYesNoRadio('uploadedResponse')->required();
 
-            $form->addRow()->addHeading(__('Access'));
+            $form->addRow()->addHeading('Access', __('Access'));
 
             $row = $form->addRow();
                 $row->addLabel('viewableStudents', __('Viewable to Students'));

--- a/modules/Formal Assessment/internalAssessment_manage_edit.php
+++ b/modules/Formal Assessment/internalAssessment_manage_edit.php
@@ -80,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     $form->setFactory(DatabaseFormFactory::create($pdo));
                     $form->addHiddenValue('address', $session->get('address'));
 
-                    $form->addRow()->addHeading(__('Basic Information'));
+                    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                     $row = $form->addRow();
                         $row->addLabel('className', __('Class'));
@@ -105,7 +105,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                         $row->addLabel('file', __('Attachment'));
                         $row->addFileUpload('file')->setAttachment('attachment', $session->get('absoluteURL'), $values['attachment']);
 
-                    $form->addRow()->addHeading(__('Assessment'));
+                    $form->addRow()->addHeading('Assessment', __('Assessment'));
 
                     $attainmentLabel = !empty($attainmentAlternativeName)? sprintf(__('Assess %1$s?'), $attainmentAlternativeName) : __('Assess Attainment?');
                     $row = $form->addRow();
@@ -139,7 +139,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                         $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
                         $row->addYesNoRadio('uploadedResponse')->required();
 
-                    $form->addRow()->addHeading(__('Access'));
+                    $form->addRow()->addHeading('Access', __('Access'));
 
                     $row = $form->addRow();
                         $row->addLabel('viewableStudents', __('Viewable to Students'));

--- a/modules/Formal Assessment/internalAssessment_write_data.php
+++ b/modules/Formal Assessment/internalAssessment_write_data.php
@@ -124,7 +124,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     $form->setFactory(DatabaseFormFactory::create($pdo));
                     $form->addHiddenValue('address', $session->get('address'));
 
-                    $form->addRow()->addHeading(__('Assessment Details'));
+                    $form->addRow()->addHeading('Assessment Details', __('Assessment Details'));
 
                     $row = $form->addRow();
                         $row->addLabel('description', __('Description'));
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
 
 
                     if (count($students) == 0) {
-                        $form->addRow()->addHeading(__('Students'));
+                        $form->addRow()->addHeading('Students', __('Students'));
                         $form->addRow()->addAlert(__('There are no records to display.'), 'error');
                     } else {
                         $table = $form->addRow()->addTable()->setClass('smallIntBorder fullWidth colorOddEven noMargin noPadding noBorder');
@@ -225,7 +225,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
 
                     $form->addHiddenValue('count', $count);
 
-                    $form->addRow()->addHeading(__('Assessment Complete?'));
+                    $form->addRow()->addHeading('Assessment Complete?', __('Assessment Complete?'));
 
                     $row = $form->addRow();
                         $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));

--- a/modules/Individual Needs/in_edit.php
+++ b/modules/Individual Needs/in_edit.php
@@ -222,7 +222,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/in_edit.p
 
             $table = $form->addRow()->addTable()->setClass('smallIntBorder fullWidth mt-2');
 
-            $table->addRow()->addHeading(__('Individual Education Plan'))->setClass('mt-4 mb-2');
+            $table->addRow()->addHeading('Individual Education Plan', __('Individual Education Plan'))->setClass('mt-4 mb-2');
 
             if (!empty($gibbonINArchiveID)) {
                 // ARCHIVED IEP

--- a/modules/Individual Needs/investigations_manage_add.php
+++ b/modules/Individual Needs/investigations_manage_add.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
         $form = Form::create('addform', $session->get('absoluteURL')."/modules/Individual Needs/investigations_manage_addProcess.php?gibbonPersonID=$gibbonPersonID&gibbonFormGroupID=$gibbonFormGroupID&gibbonYearGroupID=$gibbonYearGroupID");
         $form->setFactory(DatabaseFormFactory::create($pdo));
         $form->addHiddenValue('address', "/modules/Individual Needs/investigations_manage_add.php");
-        $form->addRow()->addHeading(__('Basic Information'));
+        $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
         //Student
         $row = $form->addRow();

--- a/modules/Individual Needs/investigations_manage_edit.php
+++ b/modules/Individual Needs/investigations_manage_edit.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
                     $form->setFactory(DatabaseFormFactory::create($pdo));
                     $form->addHiddenValue('address', "/modules/Individual Needs/investigations_manage_edit.php");
                     $form->addHiddenValue('gibbonINInvestigationID', $gibbonINInvestigationID);
-                    $form->addRow()->addHeading(__('Basic Information'));
+                    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                     //Student
                     $row = $form->addRow();
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
 
                     //Form Tutor Resolution
                     if ($investigation['status'] == 'Resolved' || ($investigation['status'] == 'Referral' && $isTutor)) {
-                        $form->addRow()->addHeading(__('Form Tutor Resolution'));
+                        $form->addRow()->addHeading('Form Tutor Resolution', __('Form Tutor Resolution'));
                         if ($isTutor && $investigation['status'] == 'Referral') {
                             $row = $form->addRow();
                                 $row->addLabel('resolvable', __('Resolvable?'))->description(__('Is form tutor able to resolve without further input? If no, further investigation will be launched.'));
@@ -187,7 +187,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
                     }
 
                     if ($investigation['status'] == 'Investigation' || $investigation['status'] == 'Investigation Complete') {
-                        $form->addRow()->addHeading(__('Investigation Details'));
+                        $form->addRow()->addHeading('Investigation Details', __('Investigation Details'));
 
                         $contributionsGateway = $container->get(INInvestigationContributionGateway::class);
                         $criteria2 = $contributionsGateway->newQueryCriteria()

--- a/modules/Individual Needs/investigations_submit_detail.php
+++ b/modules/Individual Needs/investigations_submit_detail.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
             $form->addHiddenValue('address', "/modules/Individual Needs/investigations_manage_edit.php");
             $form->addHiddenValue('gibbonINInvestigationID', $gibbonINInvestigationID);
             $form->addHiddenValue('gibbonINInvestigationContributionID', $gibbonINInvestigationContributionID);
-            $form->addRow()->addHeading(__('Basic Information'));
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             //Student
             $row = $form->addRow();
@@ -103,7 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
                 $column->addLabel('parentsResponseNo', __('Reason'))->description(__('Reasons why parents are not aware of the situation.'));
                 $column->addTextArea('parentsResponseNo')->setName('parentsResponse')->setRows(5)->setClass('fullWidth')->readonly()->required();
 
-            $form->addRow()->addHeading(__('Contributor Input'));
+            $form->addRow()->addHeading('Contributor Input', __('Contributor Input'));
 
             //Type
             $row = $form->addRow();

--- a/modules/Library/library_lending_item_edit.php
+++ b/modules/Library/library_lending_item_edit.php
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Item Details'));
+            $form->addRow()->addHeading('Item Details', __('Item Details'));
 
             $row = $form->addRow();
                 $row->addLabel('id', __('ID'));
@@ -79,7 +79,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 $row->addLabel('statusCurrent', __('Current Status'));
                 $row->addTextField('statusCurrent')->setValue(__($values['status']))->readonly()->required();
 
-            $form->addRow()->addHeading(__('This Event'));
+            $form->addRow()->addHeading('This Event', __('This Event'));
 
             $statuses = array(
                 'On Loan' => __('On Loan'),
@@ -102,7 +102,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 $row->addDate('returnExpected')->setValue(Format::date($values['returnExpected']))->required();
 
 
-            $row = $form->addRow()->addHeading(__('On Return'));
+            $row = $form->addRow()->addHeading('On Return', __('On Return'));
 
             $actions = array(
                 'Reserve' => __('Reserve'),

--- a/modules/Library/library_lending_item_renew.php
+++ b/modules/Library/library_lending_item_renew.php
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Item Details'));
+            $form->addRow()->addHeading('Item Details', __('Item Details'));
 
             $row = $form->addRow();
                 $row->addLabel('id', __('ID'));
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 $row->addLabel('statusCurrent', __('Current Status'));
                 $row->addTextField('statusCurrent')->setValue(__($values['status']))->readonly()->required();
 
-            $row = $form->addRow()->addHeading(__('On Return'));
+            $row = $form->addRow()->addHeading('On Return', __('On Return'));
                 $row->append(__('The new status will be set to "Returned" unless the fields below are completed:'));
 
             $form->addHiddenValue('gibbonPersonIDStatusResponsible', $values['gibbonPersonIDStatusResponsible']);

--- a/modules/Library/library_lending_item_return.php
+++ b/modules/Library/library_lending_item_return.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Item Details'));
+            $form->addRow()->addHeading('Item Details', __('Item Details'));
 
             $row = $form->addRow();
                 $row->addLabel('id', __('ID'));
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 $row->addLabel('statusCurrent', __('Current Status'));
                 $row->addTextField('statusCurrent')->setValue(__($values['status']))->readonly()->required();
 
-            $row = $form->addRow()->addHeading(__('On Return'));
+            $row = $form->addRow()->addHeading('On Return', __('On Return'));
                 $row->append(__('The new status will be set to "Returned" unless the fields below are completed:'));
 
             $actions = array(

--- a/modules/Library/library_lending_item_signout.php
+++ b/modules/Library/library_lending_item_signout.php
@@ -94,7 +94,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
             $form->addHiddenValue('gibbonLibraryItemID', $gibbonLibraryItemID);
             $form->addHiddenValue('statusCurrent', $values['status']);
 
-            $form->addRow()->addHeading(__('Item Details'));
+            $form->addRow()->addHeading('Item Details', __('Item Details'));
 
             $row = $form->addRow();
                 $row->addLabel('idLabel', __('ID'));
@@ -108,7 +108,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 $row->addLabel('statusCurrentText', __('Current Status'));
                 $row->addTextField('statusCurrentText')->setValue(__($values['status']))->readonly()->required();
 
-            $form->addRow()->addHeading(__('This Event'));
+            $form->addRow()->addHeading('This Event', __('This Event'));
 
             $statuses = array(
                 'On Loan' => __('On Loan'),
@@ -163,7 +163,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 $row->addLabel('returnExpected', __('Expected Return Date'))->description(sprintf(__('Default renew length is today plus %1$s day(s)'), $loanLength));
                 $row->addDate('returnExpected')->setValue(date($session->get('i18n')['dateFormatPHP'], time() + ($loanLength * 60 * 60 * 24)))->required();
 
-            $row = $form->addRow()->addHeading(__('On Return'));
+            $row = $form->addRow()->addHeading('On Return', __('On Return'));
 
             $actions = array(
                 'Reserve' => __('Reserve'),

--- a/modules/Library/library_manage_catalog_add.php
+++ b/modules/Library/library_manage_catalog_add.php
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Catalog Type'));
+    $form->addRow()->addHeading('Catalog Type', __('Catalog Type'));
 
     $sql = "SELECT gibbonLibraryTypeID AS value, name FROM gibbonLibraryType WHERE active='Y' ORDER BY name";
     $row = $form->addRow();
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 
     $form->toggleVisibilityByClass('general')->onSelect('gibbonLibraryTypeID')->whenNot('Please select...');
 
-    $form->addRow()->addClass('general')->addHeading(__('General Details'))->addClass('general');
+    $form->addRow()->addClass('general')->addHeading('General Details', __('General Details'))->addClass('general');
 
     $row = $form->addRow()->addClass('general');
         $row->addLabel('name', __('Name'))->description(__('Volume or product name.'));
@@ -198,7 +198,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
         $row->addLabel('comment', __('Comments/Notes'));
         $row->addTextArea('comment')->setRows(10);
 
-    $form->addRow()->addClass('general')->addHeading(__('Type-Specific Details'))->addClass('general');
+    $form->addRow()->addClass('general')->addHeading('Type-Specific Details', __('Type-Specific Details'))->addClass('general');
 
     // Type-specific form fields loaded via ajax
     $row = $form->addRow('detailsRow')->addClass('general')->addContent('')->addClass('general');

--- a/modules/Library/library_manage_catalog_duplicate.php
+++ b/modules/Library/library_manage_catalog_duplicate.php
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
 
                 $form->addHiddenValue('address', $session->get('address'));
 
-                $form->addRow()->addHeading(__('Step 1 - Quantity'));
+                $form->addRow()->addHeading('Step 1 - Quantity', __('Step 1 - Quantity'));
 
                 $form->addHiddenValue('gibbonLibraryTypeID', $values['gibbonLibraryTypeID']);
                 $row = $form->addRow();
@@ -121,7 +121,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
                 $form->addHiddenValue('gibbonLibraryTypeID', $_POST['gibbonLibraryTypeID']);
                 $form->addHiddenValue('gibbonLibraryItemID', $values['gibbonLibraryItemID']);
 
-                $form->addRow()->addHeading(__('Step 2 - Details'));
+                $form->addRow()->addHeading('Step 2 - Details', __('Step 2 - Details'));
 
                 for ($i = 1; $i <= $number; ++$i) {
                     $row = $form->addRow();

--- a/modules/Library/library_manage_catalog_edit.php
+++ b/modules/Library/library_manage_catalog_edit.php
@@ -70,13 +70,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
             $form->addHiddenValue('type', $values['type']);
             $form->addHiddenValue('statusBorrowable', 'Available');
 
-            $form->addRow()->addHeading(__('Catalog Type'));
+            $form->addRow()->addHeading('Catalog Type', __('Catalog Type'));
 
             $row = $form->addRow();
                 $row->addLabel('typeText', __('Type'));
                 $row->addTextField('typeText')->required()->readOnly()->setValue(__($values['type']));
 
-            $form->addRow()->addHeading(__('General Details'));
+            $form->addRow()->addHeading('General Details', __('General Details'));
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'))->description(__('Volume or product name.'));
@@ -216,7 +216,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_manage_cat
                 $row->addLabel('comment', __('Comments/Notes'));
                 $row->addTextArea('comment')->setRows(10);
 
-            $form->addRow()->addHeading(__('Type-Specific Details'));
+            $form->addRow()->addHeading('Type-Specific Details', __('Type-Specific Details'));
 
             // Type-specific form fields loaded via ajax
             $row = $form->addRow('detailsRow')->addContent('');

--- a/modules/Markbook/markbook_edit_add.php
+++ b/modules/Markbook/markbook_edit_add.php
@@ -117,7 +117,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                 $form->setFactory(DatabaseFormFactory::create($pdo));
                 $form->addHiddenValue('address', $session->get('address'));
 
-                $form->addRow()->addHeading(__('Basic Information'));
+                $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                 $row = $form->addRow();
                     $row->addLabel('courseName', __('Class'));
@@ -173,7 +173,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                     $result = $pdo->executeQuery($data, $sql);
                     $currentTerm = ($result->rowCount() > 0)? $result->fetchColumn(0) : '';
 
-                    $form->addRow()->addHeading(__('Term Date'));
+                    $form->addRow()->addHeading('Term Date', __('Term Date'));
 
                     $row = $form->addRow();
                         $row->addLabel('gibbonSchoolYearTermID', __('Term'));
@@ -186,7 +186,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                     $form->addHiddenValue('date', Format::date($date));
                 }
 
-                $form->addRow()->addHeading(__('Assessment'));
+                $form->addRow()->addHeading('Assessment', __('Assessment'));
 
                 // ATTAINMENT
                 $attainmentLabel = !empty($attainmentAltName)? sprintf(__('Assess %1$s?'), $attainmentAltName) : __('Assess Attainment?');
@@ -254,7 +254,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                     $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
                     $row->addYesNoRadio('uploadedResponse')->required();
 
-                $form->addRow()->addHeading(__('Access'));
+                $form->addRow()->addHeading('Access', __('Access'));
 
                 $row = $form->addRow();
                     $row->addLabel('viewableStudents', __('Viewable to Students'));

--- a/modules/Markbook/markbook_edit_addMulti.php
+++ b/modules/Markbook/markbook_edit_addMulti.php
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                 $form->setFactory(DatabaseFormFactory::create($pdo));
                 $form->addHiddenValue('address', $session->get('address'));
 
-                $form->addRow()->addHeading(__('Basic Information'));
+                $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                 if ($highestAction == 'Edit Markbook_multipleClassesAcrossSchool' or $highestAction == 'Edit Markbook_everything') {
                     $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
@@ -157,7 +157,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                     $result = $pdo->executeQuery($data, $sql);
                     $currentTerm = ($result->rowCount() > 0)? $result->fetchColumn(0) : '';
 
-                    $form->addRow()->addHeading(__('Term Date'));
+                    $form->addRow()->addHeading('Term Date', __('Term Date'));
 
                     $row = $form->addRow();
                         $row->addLabel('gibbonSchoolYearTermID', __('Term'));
@@ -170,7 +170,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                     $form->addHiddenValue('date', Format::date($date));
                 }
 
-                $form->addRow()->addHeading(__('Assessment'));
+                $form->addRow()->addHeading('Assessment', __('Assessment'));
 
                 // ATTAINMENT
                 $attainmentLabel = !empty($attainmentAltName)? sprintf(__('Assess %1$s?'), $attainmentAltName) : __('Assess Attainment?');
@@ -238,7 +238,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                     $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
                     $row->addYesNoRadio('uploadedResponse')->required();
 
-                $form->addRow()->addHeading(__('Access'));
+                $form->addRow()->addHeading('Access', __('Access'));
 
                 $row = $form->addRow();
                     $row->addLabel('viewableStudents', __('Viewable to Students'));

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -308,7 +308,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
                     $form->addHiddenValue('address', $session->get('address'));
 
                     if (count($students) == 0) {
-                        $form->addRow()->addHeading(__('Students'));
+                        $form->addRow()->addHeading('Students', __('Students'));
                         $form->addRow()->addAlert(__('There are no records to display.'), 'error');
                     } else {
                         $attainmentScale = '';
@@ -487,7 +487,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
 
                     $form->addHiddenValue('count', $count);
 
-                    $form->addRow()->addHeading(__('Assessment Complete?'));
+                    $form->addRow()->addHeading('Assessment Complete?', __('Assessment Complete?'));
 
                     $row = $form->addRow();
                         $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));

--- a/modules/Markbook/markbook_edit_edit.php
+++ b/modules/Markbook/markbook_edit_edit.php
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
                         $form->setFactory(DatabaseFormFactory::create($pdo));
                         $form->addHiddenValue('address', $session->get('address'));
 
-                        $form->addRow()->addHeading(__('Basic Information'));
+                        $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                         $row = $form->addRow();
                             $row->addLabel('courseName', __('Class'));
@@ -187,7 +187,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
 
                         // DATE
                         if ($enableGroupByTerm == 'Y') {
-                            $form->addRow()->addHeading(__('Term Date'));
+                            $form->addRow()->addHeading('Term Date', __('Term Date'));
 
                             $row = $form->addRow();
                                 $row->addLabel('gibbonSchoolYearTermID', __('Term'));
@@ -201,7 +201,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
                             $form->addHiddenValue('date', Format::date($values['date']));
                         }
 
-                        $form->addRow()->addHeading(__('Assessment'));
+                        $form->addRow()->addHeading('Assessment', __('Assessment'));
 
                         // ATTAINMENT
                         $attainmentLabel = !empty($attainmentAltName)? sprintf(__('Assess %1$s?'), $attainmentAltName) : __('Assess Attainment?');
@@ -269,7 +269,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
                             $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
                             $row->addYesNoRadio('uploadedResponse')->required();
 
-                        $form->addRow()->addHeading(__('Access'));
+                        $form->addRow()->addHeading('Access', __('Access'));
 
                         $row = $form->addRow();
                             $row->addLabel('viewableStudents', __('Viewable to Students'));

--- a/modules/Markbook/weighting_manage_add.php
+++ b/modules/Markbook/weighting_manage_add.php
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
 
                 $form->addHiddenValue('address', $session->get('address'));
 
-                $form->addRow()->addHeading(__('Add Markbook Weighting'));
+                $form->addRow()->addHeading('Add Markbook Weighting', __('Add Markbook Weighting'));
 
                 $types = $settingGateway->getSettingByScope('Markbook', 'markbookType');
                 $types = !empty($types)? explode(',', $types) : array();

--- a/modules/Markbook/weighting_manage_edit.php
+++ b/modules/Markbook/weighting_manage_edit.php
@@ -114,7 +114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
                     $form->addHiddenValue('address', $session->get('address'));
                     $form->addHiddenValue('type', $values['type']);
 
-                    $form->addRow()->addHeading(__('Add Markbook Weighting'));
+                    $form->addRow()->addHeading('Add Markbook Weighting', __('Add Markbook Weighting'));
 
                     $row = $form->addRow();
                         $row->addLabel('type', __('Type'));

--- a/modules/Messenger/messenger_manage_edit.php
+++ b/modules/Messenger/messenger_manage_edit.php
@@ -113,7 +113,7 @@ else {
 				$form->addHiddenValue('address', $session->get('address'));
 				$form->addHiddenValue('gibbonMessengerID', $values['gibbonMessengerID']);
 
-				$form->addRow()->addHeading(__('Delivery Mode'));
+				$form->addRow()->addHeading('Delivery Mode', __('Delivery Mode'));
 				//Delivery by email
 				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byEmail")) {
 					$row = $form->addRow();
@@ -173,7 +173,7 @@ else {
 				}
 
 				//MESSAGE DETAILS
-				$form->addRow()->addHeading(__('Message Details'));
+				$form->addRow()->addHeading('Message Details', __('Message Details'));
 
 				$row = $form->addRow();
 					$row->addLabel('subject', __('Subject'));
@@ -189,7 +189,7 @@ else {
 					$form->addHiddenValue('emailReceipt', 'N');
 				}
 				else {
-					$form->addRow()->addHeading(__('Email Read Receipts'));
+					$form->addRow()->addHeading('Email Read Receipts', __('Email Read Receipts'));
 
 					$row = $form->addRow();
 						$row->addLabel('emailReceipt', __('Enable Read Receipts'))->description(__('Each email recipient will receive a personalised confirmation link.'));
@@ -206,7 +206,7 @@ else {
 				}
 
 				//TARGETS
-				$form->addRow()->addHeading(__('Targets'));
+				$form->addRow()->addHeading('Targets', __('Targets'));
 				$roleCategory = getRoleCategory($session->get('gibbonRoleIDCurrent'), $connection2);
 
 				//Get existing TARGETS

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -76,7 +76,7 @@ else {
         $form->addHiddenValue('address', $session->get('address'));
 
         //DELIVERY MODE
-        $form->addRow()->addHeading(__('Delivery Mode'));
+        $form->addRow()->addHeading('Delivery Mode', __('Delivery Mode'));
 
         $deliverByEmail = isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byEmail");
         $deliverByWall = isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byMessageWall");
@@ -169,7 +169,7 @@ else {
 
 
         //MESSAGE DETAILS
-        $form->addRow()->addHeading(__('Message Details'));
+        $form->addRow()->addHeading('Message Details', __('Message Details'));
 
         $signature = getSignature($guid, $connection2, $session->get('gibbonPersonID')) ;
 
@@ -241,7 +241,7 @@ else {
         if (!isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_readReceipts")) {
             $form->addHiddenValue('emailReceipt', 'N');
         } else {
-            $form->addRow()->addHeading(__('Customisation'));
+            $form->addRow()->addHeading('Customisation', __('Customisation'));
 
             $row = $form->addRow();
                 $row->addLabel('emailReceipt', __('Enable Read Receipts'))->description(__('Each email recipient will receive a personalised confirmation link.'));
@@ -269,7 +269,7 @@ else {
         }
 
         //TARGETS
-        $form->addRow()->addHeading(__('Targets'));
+        $form->addRow()->addHeading('Targets', __('Targets'));
 
         $defaultSendStaff = ($roleCategory == 'Staff' || $roleCategory == 'Student')? 'Y' : 'N';
         $defaultSendStudents = ($roleCategory == 'Staff' || $roleCategory == 'Student')? 'Y' : 'N';

--- a/modules/Messenger/messenger_postQuickWall.php
+++ b/modules/Messenger/messenger_postQuickWall.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_postQu
 		$form->addHiddenValue("roleCategories[$key]", $category);
 	}
 
-	$form->addRow()->addHeading(__('Delivery Mode'));
+	$form->addRow()->addHeading('Delivery Mode', __('Delivery Mode'));
 
 	$row = $form->addRow();
 		$row->addLabel('messageWallLabel', __('Message Wall'))->description(__('Place this message on user\'s message wall?'));
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_postQu
 		$col->addDate('date2');
 		$col->addDate('date3');
 
-	$form->addRow()->addHeading(__('Message Details'));
+	$form->addRow()->addHeading('Message Details', __('Message Details'));
 
     $row = $form->addRow();
         $row->addLabel('subject', __('Subject'));

--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
             $form->addHiddenValue('address', $session->get('address'));
 
             //BASIC INFORMATION
-            $form->addRow()->addHeading(__('Basic Information'));
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             if ($viewBy == 'class') {
                 $form->addHiddenValue('gibbonCourseClassID', $values['gibbonCourseClassID']);
@@ -267,7 +267,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
                 $row->addLabel('timeEnd', __('End Time'))->description(__("Format: hh:mm (24hr)"));
                 $row->addTime('timeEnd')->setValue($nextTimeEnd)->required();
 
-            $form->addRow()->addHeading(__('Lesson Content'));
+            $form->addRow()->addHeading('Lesson Content', __('Lesson Content'));
 
             $description = $settingGateway->getSettingByScope('Planner', 'lessonDetailsTemplate') ;
             $row = $form->addRow();
@@ -282,7 +282,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
                 $column->addEditor('teachersNotes', $guid)->setRows(25)->showMedia()->setValue($teachersNotes);
 
             //HOMEWORK
-            $form->addRow()->addHeading(__($homeworkNameSingular));
+            $form->addRow()->addHeading($homeworkNameSingular, __($homeworkNameSingular));
 
             $form->toggleVisibilityByClass('homework')->onRadio('homework')->when('Y');
             $row = $form->addRow();
@@ -345,7 +345,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
             }
 
             //MARKBOOK
-            $form->addRow()->addHeading(__('Markbook'));
+            $form->addRow()->addHeading('Markbook', __('Markbook'));
 
             $form->toggleVisibilityByClass('homework')->onRadio('homework')->when('Y');
             $row = $form->addRow();
@@ -353,7 +353,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
                 $row->addRadio('markbook')->fromArray(array('Y' => __('Yes'), 'N' => __('No')))->required()->checked('N')->inline(true);
 
             //ADVANCED
-            $form->addRow()->addHeading(__('Advanced Options'));
+            $form->addRow()->addHeading('Advanced Options', __('Advanced Options'));
 
             $form->toggleVisibilityByClass('advanced')->onCheckbox('advanced')->when('Y');
             $row = $form->addRow();
@@ -361,10 +361,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
 
             // OUTCOMES
             if ($viewBy == 'date') {
-                $form->addRow()->addHeading(__('Outcomes'))->addClass('advanced');
+                $form->addRow()->addHeading('Outcomes', __('Outcomes'))->addClass('advanced');
                 $form->addRow()->addAlert(__('Outcomes cannot be set when viewing the Planner by date. Use the "Choose A Class" dropdown in the sidebar to switch to a class. Make sure to save your changes first.'), 'warning')->addClass('advanced');
             } else {
-                $form->addRow()->addHeading(__('Outcomes'))->addClass('advanced');
+                $form->addRow()->addHeading('Outcomes', __('Outcomes'))->addClass('advanced');
                 $form->addRow()->addContent(__('Link this lesson to outcomes (defined in the Manage Outcomes section of the Planner), and track which outcomes are being met in which lessons.'))->addClass('advanced');
 
                 $allowOutcomeEditing = $settingGateway->getSettingByScope('Planner', 'allowOutcomeEditing');
@@ -374,7 +374,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
             }
 
             //Access
-            $form->addRow()->addHeading(__('Access'))->addClass('advanced');
+            $form->addRow()->addHeading('Access', __('Access'))->addClass('advanced');
 
             $sharingDefaultStudents = $settingGateway->getSettingByScope('Planner', 'sharingDefaultStudents');
             $row = $form->addRow()->addClass('advanced');
@@ -387,7 +387,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
                 $row->addYesNo('viewableParents')->required()->selected($sharingDefaultParents);
 
             //Guests
-            $form->addRow()->addHeading(__('Guests'))->addClass('advanced');
+            $form->addRow()->addHeading('Guests', __('Guests'))->addClass('advanced');
 
             $row = $form->addRow()->addClass('advanced');
                 $row->addLabel('guests', __('Guest List'));

--- a/modules/Planner/planner_duplicate.php
+++ b/modules/Planner/planner_duplicate.php
@@ -298,7 +298,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.
                             $row->addTime('timeEnd')->setValue(substr($next['end'], 0, 5))->required();
 
                         if ($values['homework'] == 'Y') {
-                            $form->addRow()->addHeading(__($homeworkNamePlural));
+                            $form->addRow()->addHeading($homeworkNamePlural, __($homeworkNamePlural));
 
                             $row = $form->addRow();
                                 $row->addLabel('homeworkDueDate', __('{homeworkName} Due Date', ['homeworkName' => __($homeworkNameSingular)]));

--- a/modules/Planner/planner_edit.php
+++ b/modules/Planner/planner_edit.php
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                 $form->addHiddenValue('address', $session->get('address'));
 
                 //BASIC INFORMATION
-                $form->addRow()->addHeading(__('Basic Information'));
+                $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                 if ($highestAction == 'Lesson Planner_viewEditAllClasses') {
                     $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
@@ -216,7 +216,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
 
 
                 //LESSON
-                $form->addRow()->addHeading(__('Lesson Content'));
+                $form->addRow()->addHeading('Lesson Content', __('Lesson Content'));
 
                 $description = $settingGateway->getSettingByScope('Planner', 'lessonDetailsTemplate') ;
                 $row = $form->addRow();
@@ -232,7 +232,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
 
                 //SMART BLOCKS
                 if (!empty($values['gibbonUnitID'])) {
-                    $form->addRow()->addHeading(__('Smart Blocks'));
+                    $form->addRow()->addHeading('Smart Blocks', __('Smart Blocks'));
 
                     $form->addRow()->addContent("<div class='float-right'><a href='".$session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module')."/units_edit_working.php&gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=".$values['gibbonCourseID'].'&gibbonUnitID='.$values['gibbonUnitID'].'&gibbonSchoolYearID='.$session->get('gibbonSchoolYearID')."&gibbonUnitClassID=$gibbonUnitClassID'>".__('Edit Unit').'</a></div>');
 
@@ -257,7 +257,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                 }
 
                 //HOMEWORK
-                $form->addRow()->addHeading(__($homeworkNameSingular));
+                $form->addRow()->addHeading($homeworkNameSingular, __($homeworkNameSingular));
 
                 $form->toggleVisibilityByClass('homework')->onRadio('homework')->when('Y');
                 $row = $form->addRow();
@@ -325,10 +325,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
 
                 // OUTCOMES
                 if ($viewBy == 'date') {
-                    $form->addRow()->addHeading(__('Outcomes'));
+                    $form->addRow()->addHeading('Outcomes', __('Outcomes'));
                     $form->addRow()->addAlert(__('Outcomes cannot be set when viewing the Planner by date. Use the "Choose A Class" dropdown in the sidebar to switch to a class. Make sure to save your changes first.'), 'warning');
                 } else {
-                    $form->addRow()->addHeading(__('Outcomes'));
+                    $form->addRow()->addHeading('Outcomes', __('Outcomes'));
                     $form->addRow()->addContent(__('Link this lesson to outcomes (defined in the Manage Outcomes section of the Planner), and track which outcomes are being met in which lessons.'));
 
                     $allowOutcomeEditing = $settingGateway->getSettingByScope('Planner', 'allowOutcomeEditing');
@@ -352,7 +352,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                 }
 
                 //Access
-                $form->addRow()->addHeading(__('Access'));
+                $form->addRow()->addHeading('Access', __('Access'));
 
                 $row = $form->addRow();
                     $row->addLabel('viewableStudents', __('Viewable to Students'));
@@ -363,7 +363,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                     $row->addYesNo('viewableParents')->required();
 
                 //Guests
-                $form->addRow()->addHeading(__('Current Guests'));
+                $form->addRow()->addHeading('Current Guests', __('Current Guests'));
 
                 $data = array('gibbonPlannerEntryID' => $gibbonPlannerEntryID);
                 $sql = "SELECT title, preferredName, surname, category, gibbonPlannerEntryGuest.* FROM gibbonPlannerEntryGuest JOIN gibbonPerson ON (gibbonPlannerEntryGuest.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID ORDER BY surname, preferredName";
@@ -390,7 +390,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                     }
                 }
 
-                $form->addRow()->addHeading(__('New Guests'));
+                $form->addRow()->addHeading('New Guests', __('New Guests'));
 
                 $row = $form->addRow();
                     $row->addLabel('guests', __('Guest List'));

--- a/modules/Planner/resources_manage_add.php
+++ b/modules/Planner/resources_manage_add.php
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_a
         $form->setFactory(DatabaseFormFactory::create($pdo));
         $form->addHiddenValue('address', $session->get('address'));
 
-        $form->addRow()->addHeading(__('Resource Contents'));
+        $form->addRow()->addHeading('Resource Contents', __('Resource Contents'));
 
         $types = array('File' => __('File'), 'HTML' => __('HTML'), 'Link' => __('Link'));
         $row = $form->addRow();
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_a
             $row->addLabel('link', __('Link'));
             $row->addURL('link')->maxLength(255)->required();
 
-        $form->addRow()->addHeading(__('Resource Details'));
+        $form->addRow()->addHeading('Resource Details', __('Resource Details'));
 
         $row = $form->addRow();
             $row->addLabel('name', __('Name'));

--- a/modules/Planner/resources_manage_edit.php
+++ b/modules/Planner/resources_manage_edit.php
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_e
                 $form->addHiddenValue('address', $session->get('address'));
                 $form->addHiddenValue('type', $values['type']);
 
-                $form->addRow()->addHeading(__('Resource Contents'));
+                $form->addRow()->addHeading('Resource Contents', __('Resource Contents'));
 
                 if ($values['type'] == 'File') {
                     // File
@@ -105,7 +105,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_e
                         $row->addURL('link')->maxLength(255)->required()->setValue($values['content']);
                 }
 
-                $form->addRow()->addHeading(__('Resource Details'));
+                $form->addRow()->addHeading('Resource Details', __('Resource Details'));
 
                 $row = $form->addRow();
                     $row->addLabel('name', __('Name'));

--- a/modules/Planner/units_add.php
+++ b/modules/Planner/units_add.php
@@ -95,7 +95,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_add.php') ==
                         $form->addHiddenValue('address', $session->get('address'));
 
                         //OVERVIEW
-                        $form->addRow()->addHeading(__('Overview'));
+                        $form->addRow()->addHeading('Overview', __('Overview'));
 
                         $row = $form->addRow();
                             $row->addLabel('yearName', __('School Year'));
@@ -141,7 +141,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_add.php') ==
                                 ->setParameter('allowFreeTagging', true);
 
                         //CLASSES
-                        $form->addRow()->addHeading(__('Classes'))->append(__('Select classes which will have access to this unit.'));
+                        $form->addRow()->addHeading('Classes', __('Classes'))->append(__('Select classes which will have access to this unit.'));
 
 
                             $dataClass = array();
@@ -172,7 +172,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_add.php') ==
                         $form->addHiddenValue('classCount', $classCount);
 
                         //UNIT OUTLINE
-                        $form->addRow()->addHeading(__('Unit Outline'));
+                        $form->addRow()->addHeading('Unit Outline', __('Unit Outline'));
 
                         $settingGateway = $container->get(SettingGateway::class);
                         $unitOutline = $settingGateway->getSettingByScope('Planner', 'unitOutlineTemplate');
@@ -203,20 +203,20 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_add.php') ==
                                 ->accepts(substr($ext, 0, -2));
 
                         //ADVANCED
-                        $form->addRow()->addHeading(__('Advanced Options'));
+                        $form->addRow()->addHeading('Advanced Options', __('Advanced Options'));
 
                         $form->toggleVisibilityByClass('advanced')->onCheckbox('advanced')->when('Y');
                         $row = $form->addRow();
                             $row->addCheckbox('advanced')->setValue('Y')->description(__('Show Advanced Options'));
 
                         //OUTCOMES
-                        $form->addRow()->addHeading(__('Outcomes'))->append(__('Link this unit to outcomes (defined in the Manage Outcomes section of the Planner), and track which outcomes are being met in which units, classes and courses.'))->addClass('advanced');
+                        $form->addRow()->addHeading('Outcomes', __('Outcomes'))->append(__('Link this unit to outcomes (defined in the Manage Outcomes section of the Planner), and track which outcomes are being met in which units, classes and courses.'))->addClass('advanced');
                         $allowOutcomeEditing = $settingGateway->getSettingByScope('Planner', 'allowOutcomeEditing');
                         $row = $form->addRow()->addClass('advanced');
                             $row->addPlannerOutcomeBlocks('outcome', $gibbon->session, $gibbonYearGroupIDList, $gibbonDepartmentID, $allowOutcomeEditing);
 
                         //SMART BLOCKS
-                        $form->addRow()->addHeading(__('Smart Blocks'))->append(__('Smart Blocks aid unit planning by giving teachers help in creating and maintaining new units, splitting material into smaller units which can be deployed to lesson plans. As well as predefined fields to fill, Smart Units provide a visual view of the content blocks that make up a unit. Blocks may be any kind of content, such as discussion, assessments, group work, outcome etc.'))->addClass('advanced');
+                        $form->addRow()->addHeading('Smart Blocks', __('Smart Blocks'))->append(__('Smart Blocks aid unit planning by giving teachers help in creating and maintaining new units, splitting material into smaller units which can be deployed to lesson plans. As well as predefined fields to fill, Smart Units provide a visual view of the content blocks that make up a unit. Blocks may be any kind of content, such as discussion, assessments, group work, outcome etc.'))->addClass('advanced');
                         $blockCreator = $form->getFactory()
                             ->createButton('addNewFee')
                             ->setValue(__('Click to create a new block'))
@@ -233,7 +233,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_add.php') ==
                         $form->addHiddenValue('blockCount', "5");
 
                         //MISCELLANEOUS SETTINGS
-                        $form->addRow()->addHeading(__('Miscellaneous Settings'))->addClass('advanced');
+                        $form->addRow()->addHeading('Miscellaneous Settings', __('Miscellaneous Settings'))->addClass('advanced');
 
                         $licences = array(
                             "Copyright" => __("Copyright"),

--- a/modules/Planner/units_duplicate.php
+++ b/modules/Planner/units_duplicate.php
@@ -115,7 +115,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_duplicate.ph
 
                                 $form->addHiddenValue('address', $session->get('address'));
 
-                                $form->addRow()->addHeading(__('Source'));
+                                $form->addRow()->addHeading('Source', __('Source'));
 
                                 $row = $form->addRow();
                                     $row->addLabel('yearName', __('School Year'));
@@ -129,7 +129,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_duplicate.ph
                                     $row->addLabel('unitName', __('Unit'));
                                     $row->addTextField('unitName')->readonly()->setValue($values['name']);
 
-                                $form->addRow()->addHeading(__('Target'));
+                                $form->addRow()->addHeading('Target', __('Target'));
 
                                 $row = $form->addRow();
                                     $row->addLabel('gibbonSchoolYearIDCopyTo', __('School Year'));
@@ -193,7 +193,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_duplicate.ph
 
                                     $form->toggleVisibilityByClass('targetClass')->onRadio('copyLessons')->when('Y');
 
-                                    $form->addRow()->addHeading(__('Source'));
+                                    $form->addRow()->addHeading('Source', __('Source'));
 
                                     $row = $form->addRow();
                                         $row->addLabel('yearName', __('School Year'));
@@ -214,7 +214,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_duplicate.ph
                                         $row->addLabel('gibbonCourseClassIDSource', __('Source Class'));
                                         $row->addSelect('gibbonCourseClassIDSource')->fromQuery($pdo, $sqlSelectClassSource, $dataSelectClassSource)->required()->placeholder();
 
-                                    $form->addRow()->addHeading(__('Target'));
+                                    $form->addRow()->addHeading('Target', __('Target'));
 
                                     $row = $form->addRow();
                                         $row->addLabel('year', __('School Year'));

--- a/modules/Planner/units_edit.php
+++ b/modules/Planner/units_edit.php
@@ -108,7 +108,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                         $form->addHiddenValue('address', $session->get('address'));
 
                         //OVERVIEW
-                        $form->addRow()->addHeading(__('Overview'));
+                        $form->addRow()->addHeading('Overview', __('Overview'));
 
                         $row = $form->addRow();
                             $row->addLabel('yearName', __('School Year'));
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                                 ->setParameter('allowFreeTagging', true);
 
                         //CLASSES
-                        $form->addRow()->addHeading(__('Classes'))->append(__('Select classes which will have access to this unit.'));
+                        $form->addRow()->addHeading('Classes', __('Classes'))->append(__('Select classes which will have access to this unit.'));
 
                         if ($session->get('gibbonSchoolYearIDCurrent') == $gibbonSchoolYearID && $session->get('gibbonSchoolYearIDCurrent') == $session->get('gibbonSchoolYearID')) {
 
@@ -250,7 +250,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                         $form->addHiddenValue('classCount', $classCount ?? 0);
 
                         //UNIT OUTLINE
-                        $form->addRow()->addHeading(__('Unit Outline'));
+                        $form->addRow()->addHeading('Unit Outline', __('Unit Outline'));
 
                         $settingGateway = $container->get(SettingGateway::class);
 
@@ -283,7 +283,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                                 ->setAttachment('attachment', $session->get('absoluteURL'), $values['attachment']);
 
                         //OUTCOMES
-                        $form->addRow()->addHeading(__('Outcomes'))->append(__('Link this unit to outcomes (defined in the Manage Outcomes section of the Planner), and track which outcomes are being met in which units, classes and courses.'));
+                        $form->addRow()->addHeading('Outcomes', __('Outcomes'))->append(__('Link this unit to outcomes (defined in the Manage Outcomes section of the Planner), and track which outcomes are being met in which units, classes and courses.'));
                         $allowOutcomeEditing = $settingGateway->getSettingByScope('Planner', 'allowOutcomeEditing');
                         $row = $form->addRow();
                             $customBlocks = $row->addPlannerOutcomeBlocks('outcome', $gibbon->session, $gibbonYearGroupIDList, $gibbonDepartmentID, $allowOutcomeEditing);
@@ -303,7 +303,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                         }
 
                         //SMART BLOCKS
-                        $form->addRow()->addHeading(__('Smart Blocks'))->append(__('Smart Blocks aid unit planning by giving teachers help in creating and maintaining new units, splitting material into smaller units which can be deployed to lesson plans. As well as predefined fields to fill, Smart Units provide a visual view of the content blocks that make up a unit. Blocks may be any kind of content, such as discussion, assessments, group work, outcome etc.'));
+                        $form->addRow()->addHeading('Smart Blocks', __('Smart Blocks'))->append(__('Smart Blocks aid unit planning by giving teachers help in creating and maintaining new units, splitting material into smaller units which can be deployed to lesson plans. As well as predefined fields to fill, Smart Units provide a visual view of the content blocks that make up a unit. Blocks may be any kind of content, such as discussion, assessments, group work, outcome etc.'));
                         $blockCreator = $form->getFactory()
                             ->createButton('addNewFee')
                             ->setValue(__('Click to create a new block'))
@@ -330,7 +330,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                         }
 
                         //MISCELLANEOUS SETTINGS
-                        $form->addRow()->addHeading(__('Miscellaneous Settings'));
+                        $form->addRow()->addHeading('Miscellaneous Settings', __('Miscellaneous Settings'));
 
                         $licences = array(
                             "Copyright" => __("Copyright"),

--- a/modules/Planner/units_edit_copyForward.php
+++ b/modules/Planner/units_edit_copyForward.php
@@ -112,7 +112,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_copyFor
                         $form->addHiddenValue('gibbonUnitID', $gibbonUnitID);
                         $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 
-                        $form->addRow()->addHeading(__('Source'));
+                        $form->addRow()->addHeading('Source', __('Source'));
                             $row = $form->addRow();
                             $row->addLabel('yearName', __('School Year'));
                             $row->addTextField('yearName')->readonly()->setValue($year)->required();
@@ -127,7 +127,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_copyFor
 
                             $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
                             $sql = "SELECT gibbonSchoolYearID as value,name FROM gibbonSchoolYear WHERE (status='Upcoming' OR status='Current') ORDER BY sequenceNumber";
-                            $form->addRow()->addHeading(__('Target'));
+                            $form->addRow()->addHeading('Target', __('Target'));
                             $row = $form->addRow();
                                 $row->addLabel('gibbonSchoolYearIDCopyTo', __('Year'));
                                 $row->addSelect('gibbonSchoolYearIDCopyTo')->fromQuery($pdo, $sql)->placeholder()->isRequired();

--- a/modules/Planner/units_edit_deploy.php
+++ b/modules/Planner/units_edit_deploy.php
@@ -265,7 +265,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
             $col->addContent('<div class="sortableArea py-2 mt-16">'.$content.'</div>');
         }
 
-        $form->addRow()->addHeading(__('Access'));
+        $form->addRow()->addHeading('Access', __('Access'));
 
         $row = $form->addRow();
             $row->addLabel('viewableStudents', __('Viewable to Students'));

--- a/modules/Reports/archive_manage_upload.php
+++ b/modules/Reports/archive_manage_upload.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
     
     $form->addHiddenValue('address', $gibbon->session->get('address'));
 
-    $form->addRow()->addHeading(__('File Import'));
+    $form->addRow()->addHeading('File Import', __('File Import'));
 
     $row = $form->addRow();
         $row->addLabel('file', __('ZIP File'));
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
         $row->addLabel('fileSection', __('Section Number'))->description(__('Once split, which section contains the username? Counting from 1.'));
         $row->addNumber('fileSection')->required()->maxLength(1);
 
-    $form->addRow()->addHeading(__('Report Info'));
+    $form->addRow()->addHeading('Report Info', __('Report Info'));
 
     $archives = $container->get(ReportArchiveGateway::class)->selectWriteableArchives()->fetchKeyPair();
     $row = $form->addRow();

--- a/modules/Reports/archive_manage_uploadPreview.php
+++ b/modules/Reports/archive_manage_uploadPreview.php
@@ -124,7 +124,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
     $form->addHiddenValue('fileSection', $fileSection);
     $form->addHiddenValue('file', $file);
 
-    $form->addRow()->addHeading(__('Report Info'));
+    $form->addRow()->addHeading('Report Info', __('Report Info'));
 
     $row = $form->addRow();
         $row->addLabel('archiveName', __('Archive'));

--- a/modules/Reports/notification_send.php
+++ b/modules/Reports/notification_send.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/notification_send.
         $form->addHiddenValue('address', $gibbon->session->get('address'));
         $form->addHiddenValue('step', 2);
 
-        $form->addRow()->addHeading(__('Step 1'));
+        $form->addRow()->addHeading('Step 1', __('Step 1'));
         $types = [
             __('Staff') => [
                 'proofReadingEdits' => __('Proof Reading Edits'),
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/notification_send.
         $form->addHiddenValue('type', $type);
         $form->addHiddenValue('gibbonReportingCycleIDList', implode(',', $gibbonReportingCycleIDList));
 
-        $form->addRow()->addHeading(__('Step 2'));
+        $form->addRow()->addHeading('Step 2', __('Step 2'));
 
         $form->addRow()->addAlert(__('This action will send the following notification to {count} users.', ['count' => '<b>'.$notificationCount.'</b>']).$notificationList, 'message');
 

--- a/modules/Reports/reporting_cycles_manage_add.php
+++ b/modules/Reports/reporting_cycles_manage_add.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_cycles_m
         $column->addTextArea('notes')->setRows(5)->setClass('w-full');
 
     // MILESTONES
-    $form->addRow()->addHeading(__('Milestones'));
+    $form->addRow()->addHeading('Milestones', __('Milestones'));
 
     // Custom Block Template
     $addBlockButton = $form->getFactory()->createButton(__('Add Milestone'))->addClass('addBlock');

--- a/modules/Reports/reporting_cycles_manage_edit.php
+++ b/modules/Reports/reporting_cycles_manage_edit.php
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_cycles_m
         $column->addTextArea('notes')->setRows(5)->setClass('w-full');
 
     // MILESTONES
-    $form->addRow()->addHeading(__('Milestones'));
+    $form->addRow()->addHeading('Milestones', __('Milestones'));
 
     // Custom Block Template
     $addBlockButton = $form->getFactory()->createButton(__('Add Milestone'))->addClass('addBlock');

--- a/modules/Reports/reports_manage_add.php
+++ b/modules/Reports/reports_manage_add.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage_add
     $form->addHiddenValue('address', $gibbon->session->get('address'));
     $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 
-    $form->addRow()->addHeading(__('Report Details'));
+    $form->addRow()->addHeading('Report Details', __('Report Details'));
 
     $schoolYear = $container->get(SchoolYearGateway::class)->getSchoolYearByID($gibbonSchoolYearID);
     $row = $form->addRow();
@@ -84,7 +84,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage_add
         $row->addLabel('gibbonYearGroupIDList', __('Year Groups'));
         $row->addCheckboxYearGroup('gibbonYearGroupIDList')->addCheckAllNone()->loadFromCSV($values);
     
-    $form->addRow()->addHeading(__('Access'));
+    $form->addRow()->addHeading('Access', __('Access'));
 
     $archives = $container->get(ReportArchiveGateway::class)->selectWriteableArchives()->fetchKeyPair();
     $row = $form->addRow();

--- a/modules/Reports/reports_manage_edit.php
+++ b/modules/Reports/reports_manage_edit.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage_edi
     $form->addHiddenValue('gibbonReportID', $gibbonReportID);
     $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 
-    $form->addRow()->addHeading(__('Report Details'));
+    $form->addRow()->addHeading('Report Details', __('Report Details'));
 
     $schoolYear = $container->get(SchoolYearGateway::class)->getSchoolYearByID($values['gibbonSchoolYearID']);
     $row = $form->addRow();
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage_edi
         $row->addLabel('gibbonYearGroupIDList', __('Year Groups'));
         $row->addCheckboxYearGroup('gibbonYearGroupIDList')->addCheckAllNone()->loadFromCSV($values);
 
-    $form->addRow()->addHeading(__('Access'));
+    $form->addRow()->addHeading('Access', __('Access'));
 
     $archives = $container->get(ReportArchiveGateway::class)->selectWriteableArchives()->fetchKeyPair();
     $row = $form->addRow();

--- a/modules/Reports/settings.php
+++ b/modules/Reports/settings.php
@@ -35,14 +35,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/settings.php') == 
 
     $form->addHiddenValue('address', $gibbon->session->get('address'));
 
-    $form->addRow()->addHeading(__('General Options'));
+    $form->addRow()->addHeading('General Options', __('General Options'));
 
     $setting = $settingGateway->getSettingByScope('Reports', 'archiveInformation', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $form->addRow()->addHeading(__('System Settings'));
+    $form->addRow()->addHeading('System Settings', __('System Settings'));
 
     $setting = $settingGateway->getSettingByScope('Reports', 'customAssetPath', true);
     $row = $form->addRow();

--- a/modules/Reports/templates_manage_add.php
+++ b/modules/Reports/templates_manage_add.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_a
 
     $form->addHiddenValue('address', $gibbon->session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique'));
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_a
         $row->addLabel('flags', __('Renderer'));
         $row->addSelect('flags')->fromArray($flags)->required();
 
-    $form->addRow()->addHeading(__('Document Setup'));
+    $form->addRow()->addHeading('Document Setup', __('Document Setup'));
 
     $orientations = ['P' => __('Portrait'), 'L' => __('Landscape')];
     $row = $form->addRow();

--- a/modules/Reports/templates_manage_edit.php
+++ b/modules/Reports/templates_manage_edit.php
@@ -62,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
     $form->addHiddenValue('address', $gibbon->session->get('address'));
     $form->addHiddenValue('gibbonReportTemplateID', $gibbonReportTemplateID);
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('name', __('Name'))->description(__('Must be unique'));
@@ -91,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_e
         $row->addLabel('flags', __('Renderer'));
         $row->addSelect('flags')->fromArray($flags)->required();
 
-    $form->addRow()->addHeading(__('Document Setup'));
+    $form->addRow()->addHeading('Document Setup', __('Document Setup'));
 
     $orientations = ['P' => __('Portrait'), 'L' => __('Landscape')];
     $row = $form->addRow();

--- a/modules/Reports/templates_manage_section_edit.php
+++ b/modules/Reports/templates_manage_section_edit.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_s
     $form->addHiddenValue('gibbonReportTemplateID', $gibbonReportTemplateID);
     $form->addHiddenValue('gibbonReportTemplateSectionID', $gibbonReportTemplateSectionID);
 
-    $form->addRow()->addHeading(__('Basic Details'));
+    $form->addRow()->addHeading('Basic Details', __('Basic Details'));
     $row = $form->addRow();
         $row->addLabel('name', __('Name'));
         $row->addTextField('name')->maxLength(90)->required();
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_s
 
     // CONFIGURE
     if ($config = json_decode($prototype['config'] ?? '', true)) {
-        $form->addRow()->addHeading(__('Configure'));
+        $form->addRow()->addHeading('Configure', __('Configure'));
         $configValues = json_decode($values['config'] ?? '', true);
 
         foreach ($config as $configName => $configOptions) {
@@ -123,7 +123,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_manage_s
     }
     
     // TEMPLATE
-    $form->addRow()->addHeading(__('Template'));
+    $form->addRow()->addHeading('Template', __('Template'));
     $params = json_decode($values['templateParams'] ?? '', true);
 
     $row = $form->addRow();

--- a/modules/Rubrics/rubrics_add.php
+++ b/modules/Rubrics/rubrics_add.php
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_add.php') 
 
             $form->addHiddenValue('address', $session->get('address'));
             
-            $form->addRow()->addHeading(__('Rubric Basics'));
+            $form->addRow()->addHeading('Rubric Basics', __('Rubric Basics'));
 
             $row = $form->addRow();
                 $row->addLabel('scope', 'Scope');
@@ -126,7 +126,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_add.php') 
                 $row->addLabel('gibbonScaleID', __('Grade Scale'))->description(__('Link columns to grades on a scale?'));
                 $row->addSelect('gibbonScaleID')->fromQuery($pdo, $sql)->placeholder();
 
-            $form->addRow()->addHeading(__('Rubric Design'));
+            $form->addRow()->addHeading('Rubric Design', __('Rubric Design'));
 
             $row = $form->addRow();
                 $row->addLabel('rows', __('Initial Rows'))->description(__('Rows store assessment strands.'));

--- a/modules/Rubrics/rubrics_duplicate.php
+++ b/modules/Rubrics/rubrics_duplicate.php
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_duplicate.
 
 					$form->addHiddenValue('address', $session->get('address'));
 
-					$form->addRow()->addHeading(__('Rubric Basics'));
+					$form->addRow()->addHeading('Rubric Basics', __('Rubric Basics'));
 
 					$row = $form->addRow();
                         $row->addLabel('scope', 'Scope');

--- a/modules/Rubrics/rubrics_edit.php
+++ b/modules/Rubrics/rubrics_edit.php
@@ -183,7 +183,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit.php')
 
                     $form->addHiddenValue('address', $session->get('address'));
 
-                    $form->addRow()->addHeading(__('Rubric Basics'));
+                    $form->addRow()->addHeading('Rubric Basics', __('Rubric Basics'));
 
                     $row = $form->addRow();
                         $row->addLabel('scope', 'Scope');

--- a/modules/Rubrics/rubrics_edit_editRowsColumns.php
+++ b/modules/Rubrics/rubrics_edit_editRowsColumns.php
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
 
                     $form->addHiddenValue('address', $session->get('address'));
                     
-                    $form->addRow()->addHeading(__('Rubric Basics'));
+                    $form->addRow()->addHeading('Rubric Basics', __('Rubric Basics'));
 
                     $row = $form->addRow();
                         $row->addLabel('scope', 'Scope');
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
                         $row->addLabel('name', __('Name'));
 						$row->addTextField('name')->maxLength(50)->required()->readOnly();
 						
-					$form->addRow()->addHeading(__('Rows'));
+					$form->addRow()->addHeading('Rows', __('Rows'));
 
 					// Get outcomes by year group
 					$data = array('gibbonYearGroupIDList' => $values['gibbonYearGroupIDList']);
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_edit_editR
 					}
 
                     $row = $form->addRow();
-                        $row->addHeading(__('Columns'));
+                        $row->addHeading('Columns', __('Columns'));
                         $row->addContent(__('Visualise?'))->setClass('font-bold text-center');
                         $row->addContent()->setClass('w-full sm:max-w-sm');
 

--- a/modules/School Admin/alertLevelSettings.php
+++ b/modules/School Admin/alertLevelSettings.php
@@ -38,7 +38,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/daysOfWeek_ma
 
     $count = 0;
     while ($rowSQL = $result->fetch()) {
-        $row = $form->addRow()->addHeading(__($rowSQL['name']));
+        $row = $form->addRow()->addHeading($rowSQL['name'], __($rowSQL['name']));
 
         $form->addHiddenValue('gibbonAlertLevelID'.$count, $rowSQL['gibbonAlertLevelID']);
 

--- a/modules/School Admin/attendanceSettings.php
+++ b/modules/School Admin/attendanceSettings.php
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('Reasons'));
+    $row = $form->addRow()->addHeading('Reasons', __('Reasons'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Context & Defaults'));
+    $row = $form->addRow()->addHeading('Context & Defaults', __('Context & Defaults'));
 
     $setting = $settingGateway->getSettingByScope('Attendance', 'countClassAsSchool', true);
     $row = $form->addRow();
@@ -133,7 +133,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
             ->required();
 
 
-    $row = $form->addRow()->addHeading(__('Student Self Registration'));
+    $row = $form->addRow()->addHeading('Student Self Registration', __('Student Self Registration'));
 
     $setting = $settingGateway->getSettingByScope('Attendance', 'studentSelfRegistrationIPAddresses', true);
     $row = $form->addRow();
@@ -161,7 +161,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/attendanceSet
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
 
-    $row = $form->addRow()->addHeading(__('Attendance CLI'));
+    $row = $form->addRow()->addHeading('Attendance CLI', __('Attendance CLI'));
 
     $setting = $settingGateway->getSettingByScope('Attendance', 'attendanceCLINotifyByFormGroup', true);
     $row = $form->addRow();

--- a/modules/School Admin/behaviourSettings.php
+++ b/modules/School Admin/behaviourSettings.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/behaviourSett
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('Descriptors'));
+    $row = $form->addRow()->addHeading('Descriptors', __('Descriptors'));
 
     $setting = $settingGateway->getSettingByScope('Behaviour', 'enableDescriptors', true);
     $row = $form->addRow();
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/behaviourSett
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Levels'));
+    $row = $form->addRow()->addHeading('Levels', __('Levels'));
 
     $setting = $settingGateway->getSettingByScope('Behaviour', 'enableLevels', true);
     $row = $form->addRow();
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/behaviourSett
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Notifications'));
+    $row = $form->addRow()->addHeading('Notifications', __('Notifications'));
 
     $setting = $settingGateway->getSettingByScope('Behaviour', 'notifyTutors', true);
     $row = $form->addRow();
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/behaviourSett
         $row->addYesNo($setting['name'])->selected($setting['value']);
 
     
-    $row = $form->addRow()->addHeading(__('Behaviour Letters'))->append(__('By using a {linkCLIScript}, {systemName} can be configured to automatically generate and email behaviour letters to parents and tutors, once certain behaviour threshold levels have been reached. Visit the {linkEmailTemplates} page to customise the templates for each behaviour letter email.', ['systemName' => $session->get('systemName'), 'linkCLIScript' => Format::link('https://gibbonedu.org/support/administrators/command-line-tools/', __('CLI script')),'linkEmailTemplates' => Format::link('./index.php?q=/modules/System Admin/emailTemplates_manage.php', __('Email Templates'))]));
+    $row = $form->addRow()->addHeading('Behaviour Letters', __('Behaviour Letters'))->append(__('By using a {linkCLIScript}, {systemName} can be configured to automatically generate and email behaviour letters to parents and tutors, once certain behaviour threshold levels have been reached. Visit the {linkEmailTemplates} page to customise the templates for each behaviour letter email.', ['systemName' => $session->get('systemName'), 'linkCLIScript' => Format::link('https://gibbonedu.org/support/administrators/command-line-tools/', __('CLI script')),'linkEmailTemplates' => Format::link('./index.php?q=/modules/System Admin/emailTemplates_manage.php', __('Email Templates'))]));
 
     $setting = $settingGateway->getSettingByScope('Behaviour', 'enableNegativeBehaviourLetters', true);
     $row = $form->addRow();
@@ -115,7 +115,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/behaviourSett
             $row->addSelect($setting['name'])->fromArray(range(1,20))->selected($setting['value'])->required();
     }
 
-    $row = $form->addRow()->addHeading(__('Miscellaneous'));
+    $row = $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
     $setting = $settingGateway->getSettingByScope('Behaviour', 'policyLink', true);
     $row = $form->addRow();

--- a/modules/School Admin/dashboardSettings.php
+++ b/modules/School Admin/dashboardSettings.php
@@ -34,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/dashboardSett
     $form->addHiddenValue('address', $session->get('address'));
 
     // Staff dashboard
-    $form->addRow()->addHeading(__('Staff Dashboard'));
+    $form->addRow()->addHeading('Staff Dashboard', __('Staff Dashboard'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/dashboardSett
 
 
     // Student dashboard
-    $form->addRow()->addHeading(__('Student Dashboard'));
+    $form->addRow()->addHeading('Student Dashboard', __('Student Dashboard'));
 
     $setting = $settingGateway->getSettingByScope('School Admin', 'studentDashboardEnable', true);
     $row = $form->addRow();
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/dashboardSett
             ->selected($setting['value']);
 
     // Parent dashboard
-    $form->addRow()->addHeading(__('Parent Dashboard'));
+    $form->addRow()->addHeading('Parent Dashboard', __('Parent Dashboard'));
     $setting = $settingGateway->getSettingByScope('School Admin', 'parentDashboardEnable', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));

--- a/modules/School Admin/department_manage_edit.php
+++ b/modules/School Admin/department_manage_edit.php
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
                     ->accepts('.jpg,.jpeg,.gif,.png')
                     ->setAttachment('logo', $session->get('absoluteURL'), $values['logo']);
 
-            $form->addRow()->addHeading(__('Current Staff'));
+            $form->addRow()->addHeading('Current Staff', __('Current Staff'));
 
             $data = array('gibbonDepartmentID' => $gibbonDepartmentID);
             $sql = "SELECT preferredName, surname, gibbonDepartmentStaff.* FROM gibbonDepartmentStaff JOIN gibbonPerson ON (gibbonDepartmentStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonDepartmentID=:gibbonDepartmentID AND gibbonPerson.status='Full' ORDER BY surname, preferredName";
@@ -131,7 +131,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/department_ma
                 }
             }
 
-            $form->addRow()->addHeading(__('New Staff'));
+            $form->addRow()->addHeading('New Staff', __('New Staff'));
 
             $row = $form->addRow();
                 $row->addLabel('staff', __('Staff'));

--- a/modules/School Admin/emailSummarySettings.php
+++ b/modules/School Admin/emailSummarySettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/emailSummaryS
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Weekly Summary'));
+    $form->addRow()->addHeading('Weekly Summary', __('Weekly Summary'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/emailSummaryS
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->required()->selected($setting['value']);
 
-    $form->addRow()->addHeading(__('Daily Summary'));
+    $form->addRow()->addHeading('Daily Summary', __('Daily Summary'));
 
     $setting = $settingGateway->getSettingByScope('School Admin', 'parentDailyEmailSummaryIntroduction', true);
     $row = $form->addRow();

--- a/modules/School Admin/financeSettings.php
+++ b/modules/School Admin/financeSettings.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('General Settings'));
+    $row = $form->addRow()->addHeading('General Settings', __('General Settings'));
 
     $settingGateway = $container->get(SettingGateway::class);
     $setting = $settingGateway->getSettingByScope('Finance', 'email', true);
@@ -57,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
             ->setValue($setting['value'])
             ->decimalPlaces(2);
 
-    $row = $form->addRow()->addHeading(__('Invoices'));
+    $row = $form->addRow()->addHeading('Invoices', __('Invoices'));
 
     $setting = $settingGateway->getSettingByScope('Finance', 'invoiceText', true);
     $row = $form->addRow();
@@ -93,7 +93,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Receipts'));
+    $row = $form->addRow()->addHeading('Receipts', __('Receipts'));
 
     $setting = $settingGateway->getSettingByScope('Finance', 'receiptText', true);
     $row = $form->addRow();
@@ -110,7 +110,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Reminders'));
+    $row = $form->addRow()->addHeading('Reminders', __('Reminders'));
 
     $setting = $settingGateway->getSettingByScope('Finance', 'reminder1Text', true);
     $row = $form->addRow();
@@ -127,7 +127,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/financeSettin
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Expenses'));
+    $row = $form->addRow()->addHeading('Expenses', __('Expenses'));
 
     $setting = $settingGateway->getSettingByScope('Finance', 'budgetCategories', true);
     $row = $form->addRow();

--- a/modules/School Admin/formalAssessmentSettings.php
+++ b/modules/School Admin/formalAssessmentSettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/formalAssessm
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Internal Assessment Settings'));
+    $form->addRow()->addHeading('Internal Assessment Settings', __('Internal Assessment Settings'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/formalAssessm
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value'])->required();
 
-    $form->addRow()->addHeading(__('Primary External Assessement'))->append(__('These settings allow a particular type of external assessment to be associated with each year group. The selected assessment will be used as the primary assessment to be used as a baseline for comparison (for example, within the Markbook). You are required to select a particular field category from which to draw data (if no category is chosen, the data will not be saved).'));
+    $form->addRow()->addHeading('Primary External Assessement', __('Primary External Assessement'))->append(__('These settings allow a particular type of external assessment to be associated with each year group. The selected assessment will be used as the primary assessment to be used as a baseline for comparison (for example, within the Markbook). You are required to select a particular field category from which to draw data (if no category is chosen, the data will not be saved).'));
 
     $row = $form->addRow()->setClass('break');
         $row->addContent(__('Year Group'));

--- a/modules/School Admin/librarySettings.php
+++ b/modules/School Admin/librarySettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/activitySetti
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('Descriptors'));
+    $row = $form->addRow()->addHeading('Descriptors', __('Descriptors'));
 
     $settingGateway = $container->get(SettingGateway::class);
 

--- a/modules/School Admin/markbookSettings.php
+++ b/modules/School Admin/markbookSettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/markbookSetti
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('Features'));
+    $row = $form->addRow()->addHeading('Features', __('Features'));
 
     $settingGateway = $container->get(SettingGateway::class);
     $setting = $settingGateway->getSettingByScope('Markbook', 'enableEffort', true);
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/markbookSetti
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
     	$row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Interface'));
+    $row = $form->addRow()->addHeading('Interface', __('Interface'));
 
     $setting = $settingGateway->getSettingByScope('Markbook', 'markbookType', true);
     $row = $form->addRow();
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/markbookSetti
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Warnings'));
+    $row = $form->addRow()->addHeading('Warnings', __('Warnings'));
 
     $setting = $settingGateway->getSettingByScope('Markbook', 'showStudentAttainmentWarning', true);
     $row = $form->addRow();

--- a/modules/School Admin/messengerSettings.php
+++ b/modules/School Admin/messengerSettings.php
@@ -32,11 +32,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/messengerSett
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('SMS Settings'));
+    $row = $form->addRow()->addHeading('SMS Settings', __('SMS Settings'));
 
     $row = $form->addRow()->addAlert(__('Gibbon can use a number of different gateways to send out SMS messages. These are paid services, not affiliated with Gibbon, and you must create your own account with them before being able to send out SMSs using the Messenger module.').' '.sprintf(__('%1$sClick here%2$s to configure SMS settings.'), "<a href='".$session->get('absoluteURL')."/index.php?q=/modules/System Admin/thirdPartySettings.php'>", "</a>"));
 
-	$row = $form->addRow()->addHeading(__('Message Wall Settings'));
+	$row = $form->addRow()->addHeading('Message Wall Settings', __('Message Wall Settings'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -45,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/messengerSett
     	$row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Miscellaneous'));
+    $row = $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
 	$setting = $settingGateway->getSettingByScope('Messenger', 'messageBcc', true);
 	$row = $form->addRow();

--- a/modules/School Admin/plannerSettings.php
+++ b/modules/School Admin/plannerSettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/plannerSettin
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Planner Templates'));
+    $form->addRow()->addHeading('Planner Templates', __('Planner Templates'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/plannerSettin
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setRows(10)->setValue($setting['value']);
 
-    $form->addRow()->addHeading(__('Interface'));
+    $form->addRow()->addHeading('Interface', __('Interface'));
     
     $setting = $settingGateway->getSettingByScope('Planner', 'homeworkNameSingular', true);
     $row = $form->addRow();
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/plannerSettin
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->required()->setValue($setting['value']);
 
-    $form->addRow()->addHeading(__('Access Settings'));
+    $form->addRow()->addHeading('Access Settings', __('Access Settings'));
 
     $setting = $settingGateway->getSettingByScope('Planner', 'makeUnitsPublic', true);
     $row = $form->addRow();

--- a/modules/Staff/absences_add.php
+++ b/modules/Staff/absences_add.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_add.php') =
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     if ($highestAction == 'New Absence_any') {
         $gibbonPersonID = $_GET['gibbonPersonID'] ?? $session->get('gibbonPersonID');
@@ -155,7 +155,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_add.php') =
         // Pre-fill the last approver from the one most recently used
         $gibbonPersonIDApproval = $staffAbsenceGateway->getMostRecentApproverByPerson($gibbonPersonID);
 
-        $form->addRow()->addHeading(__('Requires Approval'))->addClass('approvalRequired');
+        $form->addRow()->addHeading('Requires Approval', __('Requires Approval'))->addClass('approvalRequired');
 
         $row = $form->addRow()->addClass('approvalRequired');
         $row->addLabel('gibbonPersonIDApproval', __('Approver'));
@@ -170,7 +170,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_add.php') =
     }
 
     // NOTIFICATIONS
-    $form->addRow()->addHeading(__('Notifications'));
+    $form->addRow()->addHeading('Notifications', __('Notifications'));
 
     $row = $form->addRow()->addClass('approvalRequired hidden');
         $row->addAlert(__('The following people will only be notified if this absence is approved.'), 'message');
@@ -214,7 +214,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_add.php') =
 
     // COVERAGE
     if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_request.php')) {
-        $form->addRow()->addHeading(__('Coverage'))->addClass('approvalNotRequired');
+        $form->addRow()->addHeading('Coverage', __('Coverage'))->addClass('approvalNotRequired');
 
         $row = $form->addRow()->addClass('approvalNotRequired');
             $row->addLabel('coverageRequired', __('Substitute Required'));

--- a/modules/Staff/absences_manage_edit.php
+++ b/modules/Staff/absences_manage_edit.php
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_manage_edit
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffAbsenceID', $gibbonStaffAbsenceID);
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Person'));
@@ -147,7 +147,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_manage_edit
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffAbsenceID', $gibbonStaffAbsenceID);
 
-    $form->addRow()->addHeading(__('Add'));
+    $form->addRow()->addHeading('Add', __('Add'));
 
     $row = $form->addRow();
         $row->addLabel('allDay', __('All Day'));

--- a/modules/Staff/applicationForm.php
+++ b/modules/Staff/applicationForm.php
@@ -113,7 +113,7 @@ if ($proceed == false) {
             ->setURL('/modules/Staff/applicationForm_jobOpenings_view.php')
             ->displayLabel();
 
-        $form->addRow()->addHeading(__('Job Related Information'));
+        $form->addRow()->addHeading('Job Related Information', __('Job Related Information'));
 
         $jobOpeningsProcessed = array();
         foreach ($jobOpenings as $jobOpening) {
@@ -131,7 +131,7 @@ if ($proceed == false) {
                 $column->addEditor('questions', $guid)->setRows(10)->setValue($staffApplicationFormQuestions)->required();
         }
 
-        $form->addRow()->addHeading(__('Personal Data'));
+        $form->addRow()->addHeading('Personal Data', __('Personal Data'));
 
         if ($gibbonPersonID != null) { //Logged in
             $form->addHiddenValue('gibbonPersonID', $gibbonPersonID);
@@ -172,7 +172,7 @@ if ($proceed == false) {
                 $row->addLabel('dob', __('Date of Birth'));
                 $row->addDate('dob')->required();
 
-            $form->addRow()->addHeading(__('Background Data'));
+            $form->addRow()->addHeading('Background Data', __('Background Data'));
 
             $row = $form->addRow();
                 $row->addLabel('languageFirst', __('First Language'))->description(__('Student\'s native/first/mother language.'));
@@ -197,7 +197,7 @@ if ($proceed == false) {
             $params = ['staff' => true, 'applicationForm' => true];
             $container->get(PersonalDocumentHandler::class)->addPersonalDocumentsToForm($form, null, null, $params);
 
-            $form->addRow()->addHeading(__('Contacts'));
+            $form->addRow()->addHeading('Contacts', __('Contacts'));
 
             $row = $form->addRow();
                 $row->addLabel('email', __('Email'));
@@ -231,7 +231,7 @@ if ($proceed == false) {
             $staffApplicationFormRequiredDocumentsText = $settingGateway->getSettingByScope('Staff', 'staffApplicationFormRequiredDocumentsText');
             $staffApplicationFormRequiredDocumentsCompulsory = $settingGateway->getSettingByScope('Staff', 'staffApplicationFormRequiredDocumentsCompulsory');
 
-            $heading = $form->addRow()->addHeading(__('Supporting Documents'));
+            $heading = $form->addRow()->addHeading('Supporting Documents', __('Supporting Documents'));
 
             if (!empty($staffApplicationFormRequiredDocumentsText)) {
                 $heading->append($staffApplicationFormRequiredDocumentsText);
@@ -266,7 +266,7 @@ if ($proceed == false) {
         //REFERENCES
         $applicationFormRefereeLink = $settingGateway->getSettingByScope('Staff', 'applicationFormRefereeLink');
         if ($applicationFormRefereeLink != '') {
-            $heading = $form->addRow()->addHeading(__('References'));
+            $heading = $form->addRow()->addHeading('References', __('References'));
                 $heading->append(__('Your nominated referees will be emailed a confidential form to complete on your behalf.'));
 
             $row = $form->addRow();
@@ -285,7 +285,7 @@ if ($proceed == false) {
         //AGREEMENT
         $agreement = $settingGateway->getSettingByScope('Staff', 'staffApplicationFormAgreement');
         if (!empty($agreement)) {
-            $form->addRow()->addHeading(__('Agreement'))->append($agreement)->wrap('<p>', '</p>');
+            $form->addRow()->addHeading('Agreement', __('Agreement'))->append($agreement)->wrap('<p>', '</p>');
 
             $row = $form->addRow();
                 $row->addLabel('agreement', '<b>'.__('Do you agree to the above?').'</b>');

--- a/modules/Staff/applicationForm_manage_edit.php
+++ b/modules/Staff/applicationForm_manage_edit.php
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 ->directLink()
                 ->displayLabel();
 
-            $form->addRow()->addHeading(__('For Office Use'));
+            $form->addRow()->addHeading('For Office Use', __('For Office Use'));
 
             $row = $form->addRow();
                 $row->addLabel('gibbonStaffApplicationFormID', __('Application ID'));
@@ -137,7 +137,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 $column->addLabel('notes', __('Notes'));
                 $column->addTextArea('notes')->setRows(5)->setClass('fullWidth');
 
-            $form->addRow()->addHeading(__('Job Related Information'));
+            $form->addRow()->addHeading('Job Related Information', __('Job Related Information'));
             
             $form->addHiddenValue('type', $values['type']);
 
@@ -158,7 +158,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                     $column->addContent($values['questions']);
             }
 
-            $form->addRow()->addHeading(__('Personal Data'));
+            $form->addRow()->addHeading('Personal Data', __('Personal Data'));
 
             if ($values['gibbonPersonID'] != null) { //Logged in
                 $form->addHiddenValue('gibbonPersonID', $values['gibbonPersonID']);
@@ -209,7 +209,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                     $row->addLabel('dob', __('Date of Birth'));
                     $row->addDate('dob')->required();
 
-                $form->addRow()->addHeading(__('Background Data'));
+                $form->addRow()->addHeading('Background Data', __('Background Data'));
 
                 $row = $form->addRow();
                     $row->addLabel('languageFirst', __('First Language'))->description(__('Student\'s native/first/mother language.'));
@@ -234,7 +234,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 $params = ['staff' => true, 'applicationForm' => true];
                 $container->get(PersonalDocumentHandler::class)->addPersonalDocumentsToForm($form, 'gibbonStaffApplicationForm', $gibbonStaffApplicationFormID, $params);
 
-                $form->addRow()->addHeading(__('Contacts'));
+                $form->addRow()->addHeading('Contacts', __('Contacts'));
 
                 $row = $form->addRow();
                     $row->addLabel('email', __('Email'));
@@ -273,7 +273,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 $staffApplicationFormRequiredDocumentsText = $settingGateway->getSettingByScope('Staff', 'staffApplicationFormRequiredDocumentsText');
                 $staffApplicationFormRequiredDocumentsCompulsory = $settingGateway->getSettingByScope('Staff', 'staffApplicationFormRequiredDocumentsCompulsory');
 
-                $heading = $form->addRow()->addHeading(__('Supporting Documents'));
+                $heading = $form->addRow()->addHeading('Supporting Documents', __('Supporting Documents'));
 
                 $fileUploader = new Gibbon\FileUploader($pdo, $gibbon->session);
 
@@ -311,7 +311,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
             //REFERENCES
             $applicationFormRefereeLink = $settingGateway->getSettingByScope('Staff', 'applicationFormRefereeLink');
             if ($applicationFormRefereeLink != '') {
-                $heading = $form->addRow()->addHeading(__('References'));
+                $heading = $form->addRow()->addHeading('References', __('References'));
 
                 $row = $form->addRow();
                     $row->addLabel('referenceEmail1', __('Referee 1'))->description(__('An email address for a referee at the applicant\'s current school.'));

--- a/modules/Staff/coverage_availability.php
+++ b/modules/Staff/coverage_availability.php
@@ -141,7 +141,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_availabilit
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonPersonID', $gibbonPersonID);
 
-    $form->addRow()->addHeading(__('Add'));
+    $form->addRow()->addHeading('Add', __('Add'));
 
     $row = $form->addRow();
     $row->addLabel('allDay', __('All Day'));

--- a/modules/Staff/coverage_manage_add.php
+++ b/modules/Staff/coverage_manage_add.php
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_add.
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Add Coverage'));
+    $form->addRow()->addHeading('Add Coverage', __('Add Coverage'));
 
     $row = $form->addRow();
         $row->addAlert(__("This option lets you add general coverage for a substitute that is not associated with a staff absence. This can be useful if they are covering an activity or event rather than a particular absence."), 'message');

--- a/modules/Staff/coverage_manage_edit.php
+++ b/modules/Staff/coverage_manage_edit.php
@@ -63,7 +63,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_edit
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffCoverageID', $gibbonStaffCoverageID);
 
-    $form->addRow()->addHeading(__('Coverage Request'));
+    $form->addRow()->addHeading('Coverage Request', __('Coverage Request'));
 
     if (!empty($coverage['gibbonPersonID'])) {
         $staffCard = $container->get(StaffCard::class);
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_edit
         $row->addTextArea('notesStatus')->setRows(3)->setValue($coverage['notesStatus']);
     
     
-    $form->addRow()->addHeading(__('Substitute'));
+    $form->addRow()->addHeading('Substitute', __('Substitute'));
 
     if ($coverage['requestType'] == 'Individual') {
         $row = $form->addRow();

--- a/modules/Staff/coverage_request.php
+++ b/modules/Staff/coverage_request.php
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_request.php
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffAbsenceID', $gibbonStaffAbsenceID);
 
-    $form->addRow()->addHeading(__('Coverage Request'));
+    $form->addRow()->addHeading('Coverage Request', __('Coverage Request'));
 
     $requestTypes = ['Broadcast'  => __('Any available substitute')];
 

--- a/modules/Staff/coverage_view_accept.php
+++ b/modules/Staff/coverage_view_accept.php
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_view_accept
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffCoverageID', $gibbonStaffCoverageID);
 
-    $form->addRow()->addHeading(__('Accept Coverage Request'));
+    $form->addRow()->addHeading('Accept Coverage Request', __('Accept Coverage Request'));
 
     $row = $form->addRow()->addContent($table->getOutput());
 

--- a/modules/Staff/coverage_view_cancel.php
+++ b/modules/Staff/coverage_view_cancel.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_view_cancel
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffCoverageID', $gibbonStaffCoverageID);
 
-    $form->addRow()->addHeading(__('Cancel Coverage Request'));
+    $form->addRow()->addHeading('Cancel Coverage Request', __('Cancel Coverage Request'));
 
     if ($coverage['requestType'] == 'Individual') {
         $row = $form->addRow();

--- a/modules/Staff/coverage_view_decline.php
+++ b/modules/Staff/coverage_view_decline.php
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_view_declin
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffCoverageID', $gibbonStaffCoverageID);
 
-    $form->addRow()->addHeading(__('Decline Coverage Request'));
+    $form->addRow()->addHeading('Decline Coverage Request', __('Decline Coverage Request'));
     
     // Staff Card
     $staffCard = $container->get(StaffCard::class);

--- a/modules/Staff/coverage_view_edit.php
+++ b/modules/Staff/coverage_view_edit.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_view_edit.p
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonStaffCoverageID', $gibbonStaffCoverageID);
 
-    $form->addRow()->addHeading(__('Attachment'));
+    $form->addRow()->addHeading('Attachment', __('Attachment'));
     
     $types = array('File' => __('File'),  'Link' => __('Link'), 'Text' => __('Text'));
     $row = $form->addRow();
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_view_edit.p
             ->required()
             ->setValue($coverage['attachmentContent'] ?? '');
 
-    $form->addRow()->addHeading(__('Details'));
+    $form->addRow()->addHeading('Details', __('Details'));
 
     $row = $form->addRow();
         $row->addLabel('notesStatus', __('Comment'))->description(__('This message is shared with substitutes, and is also visible to users who manage staff coverage.'));

--- a/modules/Staff/staff_manage_add.php
+++ b/modules/Staff/staff_manage_add.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_add.php
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Person'))->description(__('Must be unique.'));
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_add.php
         $row->addLabel('jobTitle', __('Job Title'));
         $row->addTextField('jobTitle')->maxlength(100);
 
-    $form->addRow()->addHeading(__('First Aid'));
+    $form->addRow()->addHeading('First Aid', __('First Aid'));
 
     $row = $form->addRow();
         $row->addLabel('firstAidQualified', __('First Aid Qualified?'));
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_add.php
         $row->addLabel('firstAidExpiry', __('First Aid Expiry'));
         $row->addDate('firstAidExpiry');
 
-    $form->addRow()->addHeading(__('Biography'));
+    $form->addRow()->addHeading('Biography', __('Biography'));
 
     $row = $form->addRow();
         $row->addLabel('countryOfOrigin', __('Country Of Origin'));

--- a/modules/Staff/staff_manage_edit.php
+++ b/modules/Staff/staff_manage_edit.php
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
                     ->addParam('allStaff', $allStaff)
                     ->displayLabel();
 
-                $form->addRow()->addHeading(__('Basic Information'));
+                $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
                 $row = $form->addRow();
                     $row->addLabel('gibbonPersonName', __('Person'))->description(__('Must be unique.'));
@@ -119,7 +119,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
                     $row->addLabel('dateEnd', __('End Date'))->description(__("Users's last day at school."));
                     $row->addDate('dateEnd');
 
-                $form->addRow()->addHeading(__('First Aid'));
+                $form->addRow()->addHeading('First Aid', __('First Aid'));
 
                 $row = $form->addRow();
                     $row->addLabel('firstAidQualified', __('First Aid Qualified?'));
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_manage_edit.ph
                     $row->addLabel('firstAidExpiry', __('First Aid Expiry'));
                     $row->addDate('firstAidExpiry');
 
-                $form->addRow()->addHeading(__('Biography'));
+                $form->addRow()->addHeading('Biography', __('Biography'));
 
                 $row = $form->addRow();
                     $row->addLabel('countryOfOrigin', __('Country Of Origin'));

--- a/modules/Staff/substitutes_manage_add.php
+++ b/modules/Staff/substitutes_manage_add.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/substitutes_manage_a
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Person'))->description(__('Must be unique.'));

--- a/modules/Staff/substitutes_manage_edit.php
+++ b/modules/Staff/substitutes_manage_edit.php
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/substitutes_manage_e
             ->addParam('search', $search);
     }
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Person'));
@@ -111,7 +111,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/substitutes_manage_e
         $row->addLabel('details', __('Details'))->description(__('Additional information such as year group preference, language preference, etc.'));
         $row->addTextArea('details')->setRows(2)->maxlength(255);
 
-    $form->addRow()->addHeading(__('Contact Information'));
+    $form->addRow()->addHeading('Contact Information', __('Contact Information'));
 
     $row = $form->addRow();
         $row->addLabel('phone1Label', __('Phone').' 1');

--- a/modules/Students/applicationForm.php
+++ b/modules/Students/applicationForm.php
@@ -208,7 +208,7 @@ if ($proceed == false) {
     }
 
     // STUDENT PERSONAL DATA
-    $form->addRow()->addHeading(__('Student'));
+    $form->addRow()->addHeading('Student', __('Student'));
     $form->addRow()->addSubheading(__('Student Personal Data'));
 
     $row = $form->addRow();
@@ -425,7 +425,7 @@ if ($proceed == false) {
             $form->addHiddenValue('homeAddressCountry', isset($application['homeAddressCountry'])? $application['homeAddressCountry'] : '');
         } else {
             // HOME ADDRESS
-            $form->addRow()->addHeading(__('Home Address'))->append(__('This address will be used for all members of the family. If an individual within the family needs a different address, this can be set through Data Updater after admission.'));
+            $form->addRow()->addHeading('Home Address', __('Home Address'))->append(__('This address will be used for all members of the family. If an individual within the family needs a different address, this can be set through Data Updater after admission.'));
 
             $row = $form->addRow();
                 $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
@@ -600,7 +600,7 @@ if ($proceed == false) {
         $form->addHiddenValue('gibbonFamily', 'TRUE');
 
         $row = $form->addRow();
-            $row->addHeading(__('Family'))->append(__('Choose the family you wish to associate this application with.'));
+            $row->addHeading('Family', __('Family'))->append(__('Choose the family you wish to associate this application with.'));
 
         $table = $form->addRow()->addTable()->addClass('colorOddEven');
 
@@ -647,7 +647,7 @@ if ($proceed == false) {
     }
 
     // SIBLINGS
-    $form->addRow()->addHeading(__('Siblings'))->append(__('Please give information on the applicants\'s siblings.'));
+    $form->addRow()->addHeading('Siblings', __('Siblings'))->append(__('Please give information on the applicants\'s siblings.'));
 
     $table = $form->addRow()->addTable()->addClass('colorOddEven');
 
@@ -702,7 +702,7 @@ if ($proceed == false) {
 
     if ($languageOptionsActive == 'Y' && ($languageOptionsBlurb != '' OR $languageOptionsLanguageList != '')) {
 
-        $heading = $form->addRow()->addHeading(__('Language Selection'));
+        $heading = $form->addRow()->addHeading('Language Selection', __('Language Selection'));
 
         if (!empty($languageOptionsBlurb)) {
             $heading->append($languageOptionsBlurb);
@@ -726,7 +726,7 @@ if ($proceed == false) {
     $scholarshipOptionsActive = $settingGateway->getSettingByScope('Application Form', 'scholarshipOptionsActive');
 
     if ($scholarshipOptionsActive == 'Y') {
-        $heading = $form->addRow()->addHeading(__('Scholarships'));
+        $heading = $form->addRow()->addHeading('Scholarships', __('Scholarships'));
 
         $scholarship = $settingGateway->getSettingByScope('Application Form', 'scholarships');
         if (!empty($scholarship)) {
@@ -747,7 +747,7 @@ if ($proceed == false) {
     $paymentOptionsActive = $settingGateway->getSettingByScope('Application Form', 'paymentOptionsActive');
 
     if ($paymentOptionsActive == 'Y') {
-        $form->addRow()->addHeading(__('Payment'));
+        $form->addRow()->addHeading('Payment', __('Payment'));
 
         $form->addRow()->addContent(__('If you choose family, future invoices will be sent according to your family\'s contact preferences, which can be changed at a later date by contacting the school. For example you may wish both parents to receive the invoice, or only one. Alternatively, if you choose Company, you can choose for all or only some fees to be covered by the specified company.'))->wrap('<p>','</p>');
 
@@ -820,7 +820,7 @@ if ($proceed == false) {
         $requiredDocumentsText = $settingGateway->getSettingByScope('Application Form', 'requiredDocumentsText');
         $requiredDocumentsCompulsory = $settingGateway->getSettingByScope('Application Form', 'requiredDocumentsCompulsory');
 
-        $heading = $form->addRow()->addHeading(__('Supporting Documents'));
+        $heading = $form->addRow()->addHeading('Supporting Documents', __('Supporting Documents'));
 
         if (!empty($requiredDocumentsText)) {
             $heading->append($requiredDocumentsText);
@@ -853,7 +853,7 @@ if ($proceed == false) {
 
 
     // MISCELLANEOUS
-    $form->addRow()->addHeading(__('Miscellaneous'));
+    $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
     $howDidYouHear = $settingGateway->getSettingByScope('Application Form', 'howDidYouHear');
     $howDidYouHearList = explode(',', $howDidYouHear);
@@ -892,7 +892,7 @@ if ($proceed == false) {
     // AGREEMENT
     $agreement = $settingGateway->getSettingByScope('Application Form', 'agreement');
     if (!empty($agreement)) {
-        $form->addRow()->addHeading(__('Agreement'))->append($agreement);
+        $form->addRow()->addHeading('Agreement', __('Agreement'))->append($agreement);
 
         $row = $form->addRow();
             $row->addLabel('agreement', '<b>'.__('Do you agree to the above?').'</b>');
@@ -901,7 +901,7 @@ if ($proceed == false) {
 
     // OFFICE ONLY
     if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_manage.php')) {
-        $form->addRow()->addHeading(__('For Office Use'));
+        $form->addRow()->addHeading('For Office Use', __('For Office Use'));
 
         $row = $form->addRow();
             $row->addLabel('skipEmailNotification', __('Skip sending a notification email to parents?'));

--- a/modules/Students/applicationForm_manage_edit.php
+++ b/modules/Students/applicationForm_manage_edit.php
@@ -101,7 +101,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     $form->addHiddenValue('gibbonApplicationFormID', $application['gibbonApplicationFormID']);
 
     $row = $form->addRow();
-        $row->addHeading(__('For Office Use'));
+        $row->addHeading('For Office Use', __('For Office Use'));
         $row->addContent(__('Fix Block Caps'))->wrap('<small class="emphasis small" style="float:right;margin-top:16px;"><a id="fixCaps">', '</a></small>');
 
     $row = $form->addRow();
@@ -322,7 +322,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     }
 
     // STUDENT PERSONAL DATA
-    $form->addRow()->addHeading(__('Student'));
+    $form->addRow()->addHeading('Student', __('Student'));
     $form->addRow()->addSubheading(__('Student Personal Data'));
 
     $row = $form->addRow();
@@ -480,7 +480,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $form->addHiddenValue('gibbonFamily', 'FALSE');
 
         // HOME ADDRESS
-        $form->addRow()->addHeading(__('Home Address'))->append(__('This address will be used for all members of the family. If an individual within the family needs a different address, this can be set through Data Updater after admission.'));
+        $form->addRow()->addHeading('Home Address', __('Home Address'))->append(__('This address will be used for all members of the family. If an individual within the family needs a different address, this can be set through Data Updater after admission.'));
 
         $row = $form->addRow();
             $row->addLabel('homeAddress', __('Home Address'))->description(__('Unit, Building, Street'));
@@ -634,7 +634,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $form->addHiddenValue('gibbonFamilyID', $application['gibbonFamilyID']);
 
         $row = $form->addRow();
-            $row->addHeading(__('Family'))->append(sprintf(__('The applying family is already a member of %1$s.'), $session->get('organisationName')));
+            $row->addHeading('Family', __('Family'))->append(sprintf(__('The applying family is already a member of %1$s.'), $session->get('organisationName')));
 
         $dataFamily = array('gibbonFamilyID' => $application['gibbonFamilyID']);
         $sqlFamily = 'SELECT * FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
@@ -670,7 +670,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     }
 
     // SIBLINGS
-    $form->addRow()->addHeading(__('Siblings'))->append(__('Please give information on the applicants\'s siblings.'));
+    $form->addRow()->addHeading('Siblings', __('Siblings'))->append(__('Please give information on the applicants\'s siblings.'));
 
     $table = $form->addRow()->addTable()->addClass('colorOddEven');
 
@@ -696,7 +696,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
     if ($languageOptionsActive == 'Y' && ($languageOptionsBlurb != '' OR $languageOptionsLanguageList != '')) {
 
-        $heading = $form->addRow()->addHeading(__('Language Selection'));
+        $heading = $form->addRow()->addHeading('Language Selection', __('Language Selection'));
 
         if (!empty($languageOptionsBlurb)) {
             $heading->append($languageOptionsBlurb)->wrap('<p>','</p>');
@@ -722,7 +722,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     $scholarshipOptionsActive = $settingGateway->getSettingByScope('Application Form', 'scholarshipOptionsActive');
 
     if ($scholarshipOptionsActive == 'Y') {
-        $heading = $form->addRow()->addHeading(__('Scholarships'));
+        $heading = $form->addRow()->addHeading('Scholarships', __('Scholarships'));
 
         $scholarship = $settingGateway->getSettingByScope('Application Form', 'scholarships');
         if (!empty($scholarship)) {
@@ -743,7 +743,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     $paymentOptionsActive = $settingGateway->getSettingByScope('Application Form', 'paymentOptionsActive');
 
     if ($paymentOptionsActive == 'Y') {
-        $form->addRow()->addHeading(__('Payment'));
+        $form->addRow()->addHeading('Payment', __('Payment'));
 
         $form->addRow()->addContent(__('If you choose family, future invoices will be sent according to your family\'s contact preferences, which can be changed at a later date by contacting the school. For example you may wish both parents to receive the invoice, or only one. Alternatively, if you choose Company, you can choose for all or only some fees to be covered by the specified company.'))->wrap('<p>','</p>');
 
@@ -820,7 +820,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
         $requiredDocumentsText = $settingGateway->getSettingByScope('Application Form', 'requiredDocumentsText');
         $requiredDocumentsCompulsory = $settingGateway->getSettingByScope('Application Form', 'requiredDocumentsCompulsory');
 
-        $heading = $form->addRow()->addHeading(__('Supporting Documents'));
+        $heading = $form->addRow()->addHeading('Supporting Documents', __('Supporting Documents'));
 
         if (!empty($requiredDocumentsText)) {
             $heading->append($requiredDocumentsText);
@@ -862,7 +862,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
 
     // MISCELLANEOUS
-    $form->addRow()->addHeading(__('Miscellaneous'));
+    $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
     $howDidYouHear = $settingGateway->getSettingByScope('Application Form', 'howDidYouHear');
     $howDidYouHearList = explode(',', $howDidYouHear);

--- a/modules/Students/applicationForm_payFee.php
+++ b/modules/Students/applicationForm_payFee.php
@@ -68,7 +68,7 @@ $form->addHiddenValue('address', $session->get('address'));
 $form->addHiddenValue('key', $gibbonApplicationFormHash);
 $form->addHiddenValue('gibbonApplicationFormID', $application['gibbonApplicationFormID']);
 
-$form->addRow()->addHeading(__('Application Fee'));
+$form->addRow()->addHeading('Application Fee', __('Application Fee'));
 
 $row = $form->addRow()->addContent(sprintf(__('Payment can be made by credit card, using our secure {gateway} payment gateway. When you press Pay Online Now, you will be directed to {gateway} in order to make payment. During this process we do not see or store your credit card details. Once the transaction is complete you will be returned to %1$s.', ['gateway' => $paymentGateway]), $session->get('systemName')))->wrap('<p class="my-2">', '</p>');
 

--- a/modules/Students/firstAidRecord_add.php
+++ b/modules/Students/firstAidRecord_add.php
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ad
 
         $form->addHiddenValue('address', $session->get('address'));
 
-        $row = $form->addRow()->addHeading(__('Basic Information'));
+        $row = $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
         $row = $form->addRow();
             $row->addLabel('gibbonPersonID', __('Patient'));
@@ -88,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ad
             $column->addLabel('actionTaken', __('Action Taken'));
             $column->addTextArea('actionTaken')->setRows(8)->setClass('fullWidth');
 
-        $row = $form->addRow()->addHeading(__('Follow Up'));
+        $row = $form->addRow()->addHeading('Follow Up', __('Follow Up'));
         
         $row = $form->addRow();
             $column = $row->addColumn();

--- a/modules/Students/firstAidRecord_edit.php
+++ b/modules/Students/firstAidRecord_edit.php
@@ -70,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonPersonID', $values['gibbonPersonIDPatient']);
 
-            $row = $form->addRow()->addHeading(__('Basic Information'));
+            $row = $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             $row = $form->addRow();
                 $row->addLabel('patient', __('Patient'));
@@ -102,7 +102,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
                 $column->addLabel('actionTaken', __('Action Taken'));
                 $column->addTextArea('actionTaken')->setValue($values['actionTaken'])->setRows(8)->setClass('fullWidth')->readonly();
 
-            $row = $form->addRow()->addHeading(__('Follow Up'));
+            $row = $form->addRow()->addHeading('Follow Up', __('Follow Up'));
 
             //Print old-style followup as first log entry
             if (!empty($values['followUp'])) {

--- a/modules/Students/medicalForm_manage_add.php
+++ b/modules/Students/medicalForm_manage_add.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('General Information'));
+    $form->addRow()->addHeading('General Information', __('General Information'));
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Student'));

--- a/modules/Students/medicalForm_manage_condition_add.php
+++ b/modules/Students/medicalForm_manage_condition_add.php
@@ -75,7 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonPersonMedicalID', $gibbonPersonMedicalID);
 
-            $form->addRow()->addHeading(__('General Information'));
+            $form->addRow()->addHeading('General Information', __('General Information'));
 
             $row = $form->addRow();
                 $row->addLabel('personName', __('Student'));

--- a/modules/Students/medicalForm_manage_condition_edit.php
+++ b/modules/Students/medicalForm_manage_condition_edit.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonPersonMedicalID', $gibbonPersonMedicalID);
 
-            $form->addRow()->addHeading(__('General Information'));
+            $form->addRow()->addHeading('General Information', __('General Information'));
 
             $row = $form->addRow();
                 $row->addLabel('personName', __('Student'));

--- a/modules/Students/medicalForm_manage_edit.php
+++ b/modules/Students/medicalForm_manage_edit.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('General Information'));
+            $form->addRow()->addHeading('General Information', __('General Information'));
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Student'));

--- a/modules/Students/student_withdraw.php
+++ b/modules/Students/student_withdraw.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_withdraw.
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('gibbonPersonID', __('Student'));
@@ -62,14 +62,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_withdraw.
         $row->addTextField('nextSchool')->maxLength(100)->autocomplete($schools);
 
     // NOTES
-    $form->addRow()->addHeading(__('Notes'));
+    $form->addRow()->addHeading('Notes', __('Notes'));
 
     $col = $form->addRow()->addColumn();
         $col->addLabel('withdrawNote', __('Withdraw Note'))->description(__('If provided, these will be saved in student notes, as well as shared with notification recipients.'));
         $col->addTextArea('withdrawNote');
 
     // NOTIFICATIONS
-    $form->addRow()->addHeading(__('Notifications'));
+    $form->addRow()->addHeading('Notifications', __('Notifications'));
 
     $row = $form->addRow();
         $row->addLabel('notify', __('Automatically Notify'));

--- a/modules/System Admin/activeSessions.php
+++ b/modules/System Admin/activeSessions.php
@@ -39,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/activeSession
     if (!empty($primaryRole['name']) && $primaryRole['name'] == 'Administrator') {
         $form = Form::create('sessionSettings', $session->get('absoluteURL').'/modules/System Admin/activeSessions_settingsProcess.php');
 
-        $form->addRow()->addHeading(__('Settings'));
+        $form->addRow()->addHeading('Settings', __('Settings'));
 
         $setting = $settingGateway->getSettingByScope('System Admin', 'maintenanceMode', true);
         $row = $form->addRow();

--- a/modules/System Admin/cacheManager.php
+++ b/modules/System Admin/cacheManager.php
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/cacheManager.
     // FORM
     $form = Form::create('cacheSettings', $session->get('absoluteURL').'/modules/'.$session->get('module').'/cacheManager_settingsProcess.php');
 
-    $form->addRow()->addHeading(__('Settings'));
+    $form->addRow()->addHeading('Settings', __('Settings'));
 
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/cacheManager.
     $form = Form::create('clearCache', $session->get('absoluteURL').'/modules/'.$session->get('module').'/cacheManager_clearCacheProcess.php');
     $form->addClass('mt-10');
 
-    $form->addRow()->addHeading(__('System Data'));
+    $form->addRow()->addHeading('System Data', __('System Data'));
 
     $row = $form->addRow();
         $row->addLabel('templateCache', __('Template Cache'));

--- a/modules/System Admin/customFields.php
+++ b/modules/System Admin/customFields.php
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields.
         $table->addColumn('name', __('Name'))
             ->description(__('Heading'))
             ->format(function($values) {
-                return $values['name'].'<br/>'.Format::small($values['heading']);
+                return $values['name'].'<br/>'.Format::small(__($values['heading']));
             });
 
         $table->addColumn('type', __('Type'))

--- a/modules/System Admin/customFields_add.php
+++ b/modules/System Admin/customFields_add.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $contextChained = array_reduce(array_keys($headings), function($group, $context) use (&$headings, &$contextHeadings, &$contextCustom) {
         foreach ($headings[$context] as $key => $value) {
             $contextHeadings[$key.'_'.$context] = $value;
-            $group[$value.'_'.$context] = $context;
+            $group[$key.'_'.$context] = $context;
         }
         $contextHeadings['Custom_'.$context] = '['.__('Custom').']';
         $contextCustom[] = 'Custom_'.$context;

--- a/modules/System Admin/customFields_add.php
+++ b/modules/System Admin/customFields_add.php
@@ -42,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
     $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/customFields_addProcess.php');
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Details'));
+    $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
     $row = $form->addRow();
         $row->addLabel('context', __('Context'));
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $row->addLabel('active', __('Active'));
         $row->addYesNo('active')->required();
 
-    $form->addRow()->addHeading(__('Configure'));
+    $form->addRow()->addHeading('Configure', __('Configure'));
 
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
@@ -123,7 +123,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $row->addLabel('hidden', __('Hidden'))->description(__('Is this field hidden from profiles and user-facing pages?'));
         $row->addYesNo('hidden')->required()->selected('N');
 
-    $form->addRow()->addClass('contextPerson')->addHeading(__('Visibility'));
+    $form->addRow()->addClass('contextPerson')->addHeading('Visibility', __('Visibility'));
 
     $form->toggleVisibilityByClass('contextPerson')->onSelect('context')->when('User');
     $form->toggleVisibilityByClass('contextDataUpdate')->onSelect('context')->when(['User', 'Medical Form', 'Staff']);

--- a/modules/System Admin/customFields_edit.php
+++ b/modules/System Admin/customFields_edit.php
@@ -51,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Details'));
+    $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
     $row = $form->addRow();
         $row->addLabel('context', __('Context'));
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $row->addLabel('active', __('Active'));
         $row->addYesNo('active')->required();
 
-    $form->addRow()->addHeading(__('Configure'));
+    $form->addRow()->addHeading('Configure', __('Configure'));
 
     $types = $customFieldHandler->getTypes();
     $row = $form->addRow();
@@ -129,7 +129,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
         $row->addYesNo('hidden')->required();
 
     if ($values['context'] == 'User') {
-        $form->addRow()->addHeading(__('Visibility'));
+        $form->addRow()->addHeading('Visibility', __('Visibility'));
 
         $activePersonOptions = array(
             'activePersonStudent' => __('Student'),

--- a/modules/System Admin/customFields_edit.php
+++ b/modules/System Admin/customFields_edit.php
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/customFields_
 
     $headings = $customFieldHandler->getHeadings();
     $headings = $headings[$values['context']] ?? [];
-    $isHeadingCustom = !empty($values['heading']) && !in_array($values['heading'], $headings);
+    $isHeadingCustom = !empty($values['heading']) && !array_key_exists($values['heading'], $headings);
     $row = $form->addRow();
         $row->addLabel('heading', __('Heading'))->description(__('Optionally list this field under a heading.'));
         $row->addSelect('heading')

--- a/modules/System Admin/emailTemplates_manage_duplicate.php
+++ b/modules/System Admin/emailTemplates_manage_duplicate.php
@@ -52,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/emailTemplate
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonEmailTemplateID', $gibbonEmailTemplateID);
 
-    $form->addRow()->addHeading(__('Basic Details'));
+    $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
     $row = $form->addRow();
         $row->addLabel('moduleName', __('Module'));

--- a/modules/System Admin/emailTemplates_manage_edit.php
+++ b/modules/System Admin/emailTemplates_manage_edit.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/emailTemplate
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonEmailTemplateID', $gibbonEmailTemplateID);
 
-    $form->addRow()->addHeading(__('Basic Details'));
+    $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
     $row = $form->addRow();
         $row->addLabel('moduleName', __('Module'));
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/emailTemplate
         $row->addLabel('templateName', __('Name'));
         $row->addTextField('templateName')->maxLength(120);
 
-    $form->addRow()->addHeading(__('Template'))
+    $form->addRow()->addHeading('Template', __('Template'))
         ->prepend(Format::link('https://twig.symfony.com/doc/2.x/', '<img class="float-right w-5 h-5" title="'.__('Twig Documentation').'"  src="./themes/Default/img/help.png" >'));
 
     $variables = json_decode($values['variables'] ?? '', true);

--- a/modules/System Admin/privacySettings.php
+++ b/modules/System Admin/privacySettings.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/privacySettin
     $form->addHiddenValue('address', $session->get('address'));
 
     // SECURITY SETTINGS
-    $form->addRow()->addHeading(__('Security Settings'));
+    $form->addRow()->addHeading('Security Settings', __('Security Settings'));
     $form->addRow()->addSubheading(__('Password Policy'));
 
     $settingGateway = $container->get(SettingGateway::class);
@@ -75,7 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/privacySettin
         $row->addTextField($setting['name'])->maxLength(60)->setValue($setting['value']);
 
     // PRIVACY
-    $form->addRow()->addHeading(__('Privacy Settings'));
+    $form->addRow()->addHeading('Privacy Settings', __('Privacy Settings'));
 
     $setting = $settingGateway->getSettingByScope('System Admin', 'cookieConsentEnabled', true);
     $row = $form->addRow();

--- a/modules/System Admin/serverInfo.php
+++ b/modules/System Admin/serverInfo.php
@@ -36,7 +36,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/serverInfo.ph
     $form->setTitle(__('Server Info'));
     $form->setDescription(__("This page outputs a large amount of information about the your server's configuration. This is useful for troubleshooting and debugging."));
 
-    $form->addRow()->addHeading(__('System Logs'));
+    $form->addRow()->addHeading('System Logs', __('System Logs'));
 
     // Display the log information at the top for easy reference
     $row = $form->addRow();

--- a/modules/System Admin/services_manage.php
+++ b/modules/System Admin/services_manage.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/services_mana
     $form->addHiddenValue('address', $session->get('address'));
 
     // VALUE ADDED
-    $form->addRow()->addHeading(__('gibbonedu.com Services'));
+    $form->addRow()->addHeading('gibbonedu.com Services', __('gibbonedu.com Services'));
 
     $settingGateway = $container->get(SettingGateway::class);
 

--- a/modules/System Admin/systemCheck.php
+++ b/modules/System Admin/systemCheck.php
@@ -76,7 +76,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.p
 
     $form = Form::createTable('systemCheck', "")->setClass('smallIntBorder w-full');
 
-    $form->addRow()->addHeading(__('System Requirements'));
+    $form->addRow()->addHeading('System Requirements', __('System Requirements'));
 
     $row = $form->addRow();
         $row->addLabel('phpVersionLabel', sprintf($versionTitle, 'PHP'))->description(sprintf($versionMessage, __('Gibbon').' v'.$version, 'PHP', $phpRequirement));
@@ -105,7 +105,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.p
 
     // APACHE MODULES
     if ($apacheVersion !== false) {
-        $form->addRow()->addHeading(__('Apache Modules'));
+        $form->addRow()->addHeading('Apache Modules', __('Apache Modules'));
 
         $apacheModules = @apache_get_modules();
         foreach ($apacheRequirement as $moduleName) {
@@ -120,7 +120,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.p
     // PHP EXTENSIONS
     if (!empty($extensions) && is_array($extensions)) {
         $form->addRow()
-            ->addHeading(__('PHP Extensions'))
+            ->addHeading('PHP Extensions', __('PHP Extensions'))
             ->append(__('Gibbon requires you to enable the PHP extensions in the following list. The process to do so depends on your server setup.'));
 
         foreach ($extensions as $extension) {
@@ -135,7 +135,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.p
     // PHP SETTINGS
     if (!empty($settings) && is_array($settings)) {
         $form->addRow()
-            ->addHeading(__('PHP Settings'))
+            ->addHeading('PHP Settings', __('PHP Settings'))
             ->append(sprintf(__('Configuration values can be set in your system %s file. On shared host, use %s to set php settings.'), '<code>php.ini</code>', '.htaccess'));
 
         foreach ($settings as $settingDetails) {
@@ -159,7 +159,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemCheck.p
     }
 
     // FILE PERMS
-    $form->addRow()->addHeading(__('File Permissions'));
+    $form->addRow()->addHeading('File Permissions', __('File Permissions'));
 
     $row = $form->addRow();
         $row->addLabel('systemWriteLabel', __('System not publicly writeable'));

--- a/modules/System Admin/systemSettings.php
+++ b/modules/System Admin/systemSettings.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
     $form->addHiddenValue('address', $session->get('address'));
 
     // SYSTEM SETTINGS
-    $form->addRow()->addHeading(__('System Settings'));
+    $form->addRow()->addHeading('System Settings', __('System Settings'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -91,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
     // ORGANISATION
-    $form->addRow()->addHeading(__('Organisation Settings'));
+    $form->addRow()->addHeading('Organisation Settings', __('Organisation Settings'));
 
     $setting = $settingGateway->getSettingByScope('System', 'organisationName', true);
     $row = $form->addRow();
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
         $row->addSelectStaff($setting['name'])->selected($setting['value'])->placeholder()->required();
 
     // LOCALISATION
-    $form->addRow()->addHeading(__('Localisation'));
+    $form->addRow()->addHeading('Localisation', __('Localisation'));
 
     $setting = $settingGateway->getSettingByScope('System', 'country', true);
     $row = $form->addRow();
@@ -169,7 +169,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/systemSetting
         $row->addSelectCurrency($setting['name'])->selected($setting['value'])->required();
 
     // MISCELLANEOUS
-    $form->addRow()->addHeading(__('Miscellaneous'));
+    $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
     $setting = $settingGateway->getSettingByScope('System', 'emailLink', true);
     $row = $form->addRow();

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $form->addHiddenValue('address', $session->get('address'));
 
     // SINGLE SIGN-ON
-    $form->addRow()->addHeading(__('Single Sign-On Integration'))->append(__('If your school uses a service that offers OAuth2 authorization, you can enable single sign on integration with Gibbon. This process makes use of industry-standard OAuth2 protocols, and allows a user to access Gibbon without a username and password, provided that their listed email address is part of the chosen service and is unique in Gibbon.'));
+    $form->addRow()->addHeading('Single Sign-On Integration', __('Single Sign-On Integration'))->append(__('If your school uses a service that offers OAuth2 authorization, you can enable single sign on integration with Gibbon. This process makes use of industry-standard OAuth2 protocols, and allows a user to access Gibbon without a username and password, provided that their listed email address is part of the chosen service and is unique in Gibbon.'));
 
     $settingGateway = $container->get(SettingGateway::class);
     $ssoGoogle = json_decode($settingGateway->getSettingByScope('System Admin', 'ssoGoogle'), true);
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $form->addRow()->addContent($table->render($ssoList));
 
     // PAYMENTS
-    $form->addRow()->addHeading(__('Payment Gateway'))->append(__('Gibbon can handle payments using a payment gateway API. These are external services, not affiliated with Gibbon, and you must create your own account with them before being able to accept payments. Gibbon does not store or process any credit card details.'));
+    $form->addRow()->addHeading('Payment Gateway', __('Payment Gateway'))->append(__('Gibbon can handle payments using a payment gateway API. These are external services, not affiliated with Gibbon, and you must create your own account with them before being able to accept payments. Gibbon does not store or process any credit card details.'));
 
     $setting = $settingGateway->getSettingByScope('System', 'enablePayments', true);
     $row = $form->addRow();
@@ -169,7 +169,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     }
 
     // SMS
-    $form->addRow()->addHeading(__('SMS Settings'))->append(__('Gibbon can use a number of different gateways to send out SMS messages. These are paid services, not affiliated with Gibbon, and you must create your own account with them before being able to send out SMSs using the Messenger module.'));
+    $form->addRow()->addHeading('SMS Settings', __('SMS Settings'))->append(__('Gibbon can use a number of different gateways to send out SMS messages. These are paid services, not affiliated with Gibbon, and you must create your own account with them before being able to send out SMSs using the Messenger module.'));
 
     // SMS Gateway Options - these are not translated, as they represent company names
     $smsGateways = ['OneWaySMS', 'Twilio', 'Nexmo', 'Clockwork', 'TextLocal', 'Mail to SMS'];
@@ -238,7 +238,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     }
 
     // SMTP MAIL
-    $form->addRow()->addHeading(__('SMTP Mail'));
+    $form->addRow()->addHeading('SMTP Mail', __('SMTP Mail'));
 
     $setting = $settingGateway->getSettingByScope('System', 'enableMailerSMTP', true);
     $row = $form->addRow();

--- a/modules/System Admin/thirdPartySettings_ssoEdit.php
+++ b/modules/System Admin/thirdPartySettings_ssoEdit.php
@@ -54,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
 
     if ($sso == 'Google') {
         // GOOGLE
-        $form->addRow()->addHeading(__('Google Integration'))->append(sprintf(__('If your school uses Google Apps, you can enable single sign on and calendar integration with Gibbon. This process makes use of Google\'s APIs, and allows a user to access Gibbon without a username and password, provided that their listed email address is a Google account to which they have access. For configuration instructions, %1$sclick here%2$s.'), "<a href='https://gibbonedu.org/support/administrators/installing-gibbon/authenticating-with-google-oauth/' target='_blank'>", '</a>'));
+        $form->addRow()->addHeading('Google Integration', __('Google Integration'))->append(sprintf(__('If your school uses Google Apps, you can enable single sign on and calendar integration with Gibbon. This process makes use of Google\'s APIs, and allows a user to access Gibbon without a username and password, provided that their listed email address is a Google account to which they have access. For configuration instructions, %1$sclick here%2$s.'), "<a href='https://gibbonedu.org/support/administrators/installing-gibbon/authenticating-with-google-oauth/' target='_blank'>", '</a>'));
 
         $row = $form->addRow();
             $row->addLabel('enabled', __('API Enabled'))->description(__('Enable Gibbon-wide integration with the Google APIs?'));
@@ -90,14 +90,14 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
 
     } else if ($sso == 'Microsoft') {
         // MICROSOFT
-        $form->addRow()->addHeading(__('Microsoft Integration'))->append(sprintf(__('If your school uses Microsoft Azure or Office 365, you can enable single sign on and calendar integration with Gibbon. This process makes use of Microsoft\'s APIs, and allows a user to access Gibbon without a username and password, provided that their listed email address is a Microsoft account to which they have access. For configuration instructions, %1$sclick here%2$s.'), "<a href='https://gibbonedu.org/support/administrators/installing-gibbon/authenticating-with-microsoft-oauth/' target='_blank'>", '</a>'));
+        $form->addRow()->addHeading('Microsoft Integration', __('Microsoft Integration'))->append(sprintf(__('If your school uses Microsoft Azure or Office 365, you can enable single sign on and calendar integration with Gibbon. This process makes use of Microsoft\'s APIs, and allows a user to access Gibbon without a username and password, provided that their listed email address is a Microsoft account to which they have access. For configuration instructions, %1$sclick here%2$s.'), "<a href='https://gibbonedu.org/support/administrators/installing-gibbon/authenticating-with-microsoft-oauth/' target='_blank'>", '</a>'));
 
         $row = $form->addRow();
             $row->addLabel('enabled', __('API Enabled'))->description(__('Enable Gibbon-wide integration with the Microsoft APIs?'));
             $row->addYesNo('enabled')->required();
 
     } else if ($sso == 'Other') {
-        $form->addRow()->addHeading(__('Generic OAuth2 Provider'))->append(__('This setting offers a generic implementation of industry-standard OAuth2 protocols. It uses standard Client ID and Client Secret parameters to connect to an OAuth2 API server. You will need to specify the API endpoints of your chosen service, which can often be found in that service\'s documentation. If your OAuth2 service requires specific API parameters, this feature is unlikely to work.'));
+        $form->addRow()->addHeading('Generic OAuth2 Provider', __('Generic OAuth2 Provider'))->append(__('This setting offers a generic implementation of industry-standard OAuth2 protocols. It uses standard Client ID and Client Secret parameters to connect to an OAuth2 API server. You will need to specify the API endpoints of your chosen service, which can often be found in that service\'s documentation. If your OAuth2 service requires specific API parameters, this feature is unlikely to work.'));
 
         $row = $form->addRow();
             $row->addLabel('enabled', __('API Enabled'));

--- a/modules/Timetable Admin/course_manage_add.php
+++ b/modules/Timetable Admin/course_manage_add.php
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			$form->addHiddenValue('address', $session->get('address'));
 			$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 			
-            $row = $form->addRow()->addHeading(__('Basic Details'));
+            $row = $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addLabel('orderBy', __('Order'))->description(__('May be used to adjust arrangement of courses in reports.'));
 				$row->addNumber('orderBy')->maxLength(3);
 			
-            $row = $form->addRow()->addHeading(__('Display Information'));
+            $row = $form->addRow()->addHeading('Display Information', __('Display Information'));
 
 			$row = $form->addRow();
 				$column = $row->addColumn('blurb');
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addLabel('map', __('Include In Curriculum Map'));
 				$row->addYesNo('map')->required();
 			
-            $row = $form->addRow()->addHeading(__('Configure'));
+            $row = $form->addRow()->addHeading('Configure', __('Configure'));
 
 			$row = $form->addRow();
 				$row->addLabel('gibbonYearGroupIDList', __('Year Groups'))->description(__('Enrolable year groups.'));

--- a/modules/Timetable Admin/course_manage_class_add.php
+++ b/modules/Timetable Admin/course_manage_class_add.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 			$form->addHiddenValue('gibbonCourseID', $gibbonCourseID);
 			
-            $row = $form->addRow()->addHeading(__('Basic Details'));
+            $row = $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));

--- a/modules/Timetable Admin/course_manage_class_edit.php
+++ b/modules/Timetable Admin/course_manage_class_edit.php
@@ -56,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			$form->addHiddenValue('gibbonCourseClassID', $gibbonCourseClassID);
 			$form->addHiddenValue('gibbonCourseID', $gibbonCourseID);
 			
-            $row = $form->addRow()->addHeading(__('Basic Details'));
+            $row = $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));

--- a/modules/Timetable Admin/course_manage_edit.php
+++ b/modules/Timetable Admin/course_manage_edit.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			$form->addHiddenValue('address', $session->get('address'));
 			$form->addHiddenValue('gibbonSchoolYearID', $values['gibbonSchoolYearID']);
 
-            $row = $form->addRow()->addHeading(__('Basic Details'));
+            $row = $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
@@ -97,7 +97,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addLabel('nameShort', __('Short Name'));
 				$row->addTextField('nameShort')->required()->maxLength(12);
 
-            $row = $form->addRow()->addHeading(__('Display Information'));
+            $row = $form->addRow()->addHeading('Display Information', __('Display Information'));
 
 			$row = $form->addRow();
 				$row->addLabel('orderBy', __('Order'))->description(__('May be used to adjust arrangement of courses in reports.'));
@@ -112,7 +112,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 				$row->addLabel('map', __('Include In Curriculum Map'));
                 $row->addYesNo('map')->required();
 
-            $row = $form->addRow()->addHeading(__('Configure'));
+            $row = $form->addRow()->addHeading('Configure', __('Configure'));
 
 			$row = $form->addRow();
 				$row->addLabel('gibbonYearGroupIDList', __('Year Groups'))->description(__('Enrolable year groups.'));

--- a/modules/Timetable Admin/ttDates.php
+++ b/modules/Timetable Admin/ttDates.php
@@ -163,7 +163,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
                 }
             }
 
-            $form->addRow()->addHeading(__('Multi Add'));
+            $form->addRow()->addHeading('Multi Add', __('Multi Add'));
 
             $data= array('gibbonSchoolYearID' => $gibbonSchoolYearID);
             $sql = "SELECT gibbonTTDay.gibbonTTDayID as value, CONCAT(gibbonTT.name, ': ', gibbonTTDay.nameShort) as name

--- a/modules/User Admin/applicationFormSettings.php
+++ b/modules/User Admin/applicationFormSettings.php
@@ -33,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('General Options'));
+    $row = $form->addRow()->addHeading('General Options', __('General Options'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
             $years->selectAll();
         }
 
-    $row = $form->addRow()->addHeading(__('Application Fee'));
+    $row = $form->addRow()->addHeading('Application Fee', __('Application Fee'));
 
     $setting = $settingGateway->getSettingByScope('Application Form', 'applicationFee', true);
     $row = $form->addRow();
@@ -110,7 +110,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('References'));
+    $row = $form->addRow()->addHeading('References', __('References'));
 
     $setting = $settingGateway->getSettingByScope('Students', 'applicationFormRefereeRequired', true);
     $row = $form->addRow();
@@ -124,7 +124,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addURL($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Required Documents Options'));
+    $row = $form->addRow()->addHeading('Required Documents Options', __('Required Documents Options'));
 
     $setting = $settingGateway->getSettingByScope('Application Form', 'requiredDocuments', true);
     $row = $form->addRow();
@@ -146,7 +146,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Language Learning Options'))->append(__('Set values for applicants to specify which language they wish to learn.'));
+    $row = $form->addRow()->addHeading('Language Learning Options', __('Language Learning Options'))->append(__('Set values for applicants to specify which language they wish to learn.'));
 
     $setting = $settingGateway->getSettingByScope('Application Form', 'languageOptionsActive', true);
     $row = $form->addRow();
@@ -165,7 +165,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Sections'));
+    $row = $form->addRow()->addHeading('Sections', __('Sections'));
 
     $setting = $settingGateway->getSettingByScope('Application Form', 'senOptionsActive', true);
     $row = $form->addRow();
@@ -196,7 +196,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/applicationForm
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Acceptance Options'));
+    $row = $form->addRow()->addHeading('Acceptance Options', __('Acceptance Options'));
 
     $setting = $settingGateway->getSettingByScope('Application Form', 'usernameFormat', true);
 	$row = $form->addRow();

--- a/modules/User Admin/dataUpdaterSettings.php
+++ b/modules/User Admin/dataUpdaterSettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/dataUpdaterSett
     $form = Form::create('dataUpdaterSettings', $session->get('absoluteURL').'/modules/'.$session->get('module').'/dataUpdaterSettingsProcess.php');
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('Settings'));
+    $row = $form->addRow()->addHeading('Settings', __('Settings'));
 
     $settingGateway = $container->get(SettingGateway::class);
     $setting = $settingGateway->getSettingByScope('Data Updater', 'requiredUpdates', true);

--- a/modules/User Admin/family_manage_add.php
+++ b/modules/User Admin/family_manage_add.php
@@ -46,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_a
     
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('General Information'));
+    $form->addRow()->addHeading('General Information', __('General Information'));
 
     $row = $form->addRow();
         $row->addLabel('name', __('Family Name'));

--- a/modules/User Admin/family_manage_edit.php
+++ b/modules/User Admin/family_manage_edit.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('General Information'));
+            $form->addRow()->addHeading('General Information', __('General Information'));
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Family Name'));
@@ -248,7 +248,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Add Child'));
+            $form->addRow()->addHeading('Add Child', __('Add Child'));
 
             $row = $form->addRow();
                 $row->addLabel('gibbonPersonID', __('Child\'s Name'));
@@ -341,7 +341,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Add Adult'));
+            $form->addRow()->addHeading('Add Adult', __('Add Adult'));
 
             $adults = array();
 

--- a/modules/User Admin/family_manage_edit_editAdult.php
+++ b/modules/User Admin/family_manage_edit_editAdult.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Edit Adult'));
+            $form->addRow()->addHeading('Edit Adult', __('Edit Adult'));
 
             $row = $form->addRow();
                 $row->addLabel('adult', __('Adult\'s Name'));

--- a/modules/User Admin/family_manage_edit_editChild.php
+++ b/modules/User Admin/family_manage_edit_editChild.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/family_manage_e
 
             $form->addHiddenValue('address', $session->get('address'));
 
-            $form->addRow()->addHeading(__('Edit Child'));
+            $form->addRow()->addHeading('Edit Child', __('Edit Child'));
 
             $row = $form->addRow();
                 $row->addLabel('child', __('Childs\'s Name'));

--- a/modules/User Admin/permission_manage.php
+++ b/modules/User Admin/permission_manage.php
@@ -109,7 +109,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/permission_mana
         $form->addHiddenValue('gibbonRoleID', $gibbonRoleID);
 
         while ($rowModules = $resultModules->fetch()) {
-            $form->addRow()->addHeading(__($rowModules['name']));
+            $form->addRow()->addHeading($rowModules['name'], __($rowModules['name']));
             $table = $form->addRow()->addTable()->setClass('mini rowHighlight columnHighlight fullWidth');
 
             

--- a/modules/User Admin/personalDocumentSettings_manage_add.php
+++ b/modules/User Admin/personalDocumentSettings_manage_add.php
@@ -43,7 +43,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/personalDocumen
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Basic Details'));
+    $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
     $row = $form->addRow();
         $row->addLabel('name', __('Document Name'))->description(__('Must be unique.'));
@@ -65,7 +65,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/personalDocumen
         $row->addLabel('sequenceNumber', __('Sequence Number'));
         $row->addSequenceNumber('sequenceNumber', 'gibbonPersonalDocumentType')->maxLength(3);
 
-    $form->addRow()->addHeading(__('Configure'));
+    $form->addRow()->addHeading('Configure', __('Configure'));
 
     $row = $form->addRow();
         $row->addLabel('document', __('Type'));
@@ -75,7 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/personalDocumen
         $row->addLabel('fields', __('Fields'));
         $row->addCheckbox('fields')->fromArray($personalDocumentHandler->getFields());
 
-    $form->addRow()->addHeading(__('Visibility'));
+    $form->addRow()->addHeading('Visibility', __('Visibility'));
 
     $activePersonOptions = array(
         'activePersonStudent' => __('Student'),

--- a/modules/User Admin/personalDocumentSettings_manage_edit.php
+++ b/modules/User Admin/personalDocumentSettings_manage_edit.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/personalDocumen
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonPersonalDocumentTypeID', $gibbonPersonalDocumentTypeID);
 
-    $form->addRow()->addHeading(__('Basic Details'));
+    $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
     $row = $form->addRow();
         $row->addLabel('name', __('Document Name'))->description(__('Must be unique.'));
@@ -67,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/personalDocumen
         $row->addLabel('required', __('Required'));
         $row->addYesNo('required')->required();
 
-    $form->addRow()->addHeading(__('Configure'));
+    $form->addRow()->addHeading('Configure', __('Configure'));
 
     $row = $form->addRow();
         $row->addLabel('document', __('Type'));
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/personalDocumen
         $row->addLabel('fields', __('Fields'));
         $row->addCheckbox('fields')->fromArray($fieldOptions)->checked(array_keys($checked));
 
-    $form->addRow()->addHeading(__('Visibility'));
+    $form->addRow()->addHeading('Visibility', __('Visibility'));
 
     $activePersonOptions = array(
         'activePersonStudent' => __('Student'),

--- a/modules/User Admin/publicRegistrationSettings.php
+++ b/modules/User Admin/publicRegistrationSettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/publicRegistrat
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('General Settings'));
+    $row = $form->addRow()->addHeading('General Settings', __('General Settings'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/publicRegistrat
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextField($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Interface Options'));
+    $row = $form->addRow()->addHeading('Interface Options', __('Interface Options'));
 
     $setting = $settingGateway->getSettingByScope('User Admin', 'publicRegistrationIntro', true);
     $row = $form->addRow();

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -179,7 +179,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                 }
 
                 //SET EXPECTED USERS TO FULL
-                $form->addRow()->addHeading(__('Set Expected Users To Full'));
+                $form->addRow()->addHeading('Set Expected Users To Full', __('Set Expected Users To Full'));
                 $form->addRow()->addContent(__('This step primes newcomers who have status set to "Expected" to be enrolled as students or added as staff (below).'));
 
                 try {
@@ -351,7 +351,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                 }
 
                 //RE-ENROL OTHER STUDENTS
-                $form->addRow()->addHeading(__('Re-Enrol Other Students'));
+                $form->addRow()->addHeading('Re-Enrol Other Students', __('Re-Enrol Other Students'));
                 $form->addRow()->addContent(__('Any students who are not re-enrolled will have their status set to "Left".').' '.__('Students who are already enrolled will have their enrolment updated.'));
 
                 $lastYearGroup = getLastYearGroupID($connection2);
@@ -424,7 +424,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                 }
 
                 //SET FINAL YEAR USERS TO LEFT
-                $form->addRow()->addHeading(__('Set Final Year Students To Left'));
+                $form->addRow()->addHeading('Set Final Year Students To Left', __('Set Final Year Students To Left'));
                 $form->addRow()->addContent(__('This step finds students in the last year of school and sets their status.'));
 
                 try {
@@ -460,7 +460,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                 }
 
                 //REGISTER NEW STAFF
-                $form->addRow()->addHeading(__('Register New Staff'));
+                $form->addRow()->addHeading('Register New Staff', __('Register New Staff'));
                 $form->addRow()->addContent(__('Any staff who are not registered will have their status set to "Left".'));
 
                 try {

--- a/modules/User Admin/staffApplicationFormSettings.php
+++ b/modules/User Admin/staffApplicationFormSettings.php
@@ -31,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffApplicatio
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('General Options'));
+    $row = $form->addRow()->addHeading('General Options', __('General Options'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -66,7 +66,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffApplicatio
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
     $setting = $settingGateway->getSettingByScope('Staff', 'applicationFormRefereeLink', true);
-    $row = $form->addRow()->addHeading(__($setting['nameDisplay']))->append(__($setting['description']));
+    $row = $form->addRow()->addHeading($setting['nameDisplay'], __($setting['nameDisplay']))->append(__($setting['description']));
 
     $applicationFormRefereeLink = unserialize($setting['value']);
 
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffApplicatio
         $typeCount++;
     }
 
-    $row = $form->addRow()->addHeading(__('Required Documents Options'));
+    $row = $form->addRow()->addHeading('Required Documents Options', __('Required Documents Options'));
 
     $setting = $settingGateway->getSettingByScope('Staff', 'staffApplicationFormRequiredDocuments', true);
     $row = $form->addRow();
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffApplicatio
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value'])->required();
 
-    $row = $form->addRow()->addHeading(__('Acceptance Options'));
+    $row = $form->addRow()->addHeading('Acceptance Options', __('Acceptance Options'));
 
     $setting = $settingGateway->getSettingByScope('Staff', 'staffApplicationFormUsernameFormat', true);
     $row = $form->addRow();

--- a/modules/User Admin/staffSettings.php
+++ b/modules/User Admin/staffSettings.php
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Staff Absence'));
+    $form->addRow()->addHeading('Staff Absence', __('Staff Absence'));
 
     $setting = $settingGateway->getSettingByScope('Staff', 'absenceApprovers', true);
 
@@ -121,7 +121,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $form->addRow()->addHeading(__('Staff Coverage'));
+    $form->addRow()->addHeading('Staff Coverage', __('Staff Coverage'));
 
     $setting = $settingGateway->getSettingByScope('Staff', 'substituteInfo', true);
     $row = $form->addRow();
@@ -138,7 +138,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addNumber($setting['name'])->required()->onlyInteger(false)->setValue($setting['value']);
 
-    $form->addRow()->addHeading(__('Notifications'));
+    $form->addRow()->addHeading('Notifications', __('Notifications'));
 
     $setting = $settingGateway->getSettingByScope('Staff', 'absenceNotificationGroups', true);
     $notificationList = $container->get(GroupGateway::class)->selectGroupsByIDList($setting['value'])->fetchKeyPair();
@@ -169,7 +169,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
             $row->addSelect($setting['name'])->fromArray($thresholds)->required()->selected($setting['value']);
     }
 
-    $row = $form->addRow()->addHeading(__('Field Values'));
+    $row = $form->addRow()->addHeading('Field Values', __('Field Values'));
 
     $setting = $settingGateway->getSettingByScope('Staff', 'salaryScalePositions', true);
     $row = $form->addRow();
@@ -191,7 +191,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/staffSettings.p
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Name Formats'))->append(__('How should staff names be formatted?').' '.__('Choose from [title], [preferredName], [surname].').' '.__('Use a colon to limit the number of letters, for example [preferredName:1] will use the first initial.'));
+    $row = $form->addRow()->addHeading('Name Formats', __('Name Formats'))->append(__('How should staff names be formatted?').' '.__('Choose from [title], [preferredName], [surname].').' '.__('Use a colon to limit the number of letters, for example [preferredName:1] will use the first initial.'));
 
     $data = array('gibbonPersonID' => $session->get('gibbonPersonID'));
     $sql = "SELECT title, preferredName, surname FROM gibbonPerson WHERE gibbonPersonID=:gibbonPersonID";

--- a/modules/User Admin/studentsSettings.php
+++ b/modules/User Admin/studentsSettings.php
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Student Notes'));
+    $form->addRow()->addHeading('Student Notes', __('Student Notes'));
 
     $settingGateway = $container->get(SettingGateway::class);
     $setting = $settingGateway->getSettingByScope('Students', 'enableStudentNotes', true);
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addSelect($setting['name'])->fromArray($noteCreationNotificationRoles)->selected($setting['value'])->required();
 
-    $form->addRow()->addHeading(__('Alerts'));
+    $form->addRow()->addHeading('Alerts', __('Alerts'));
 
     $setting = $settingGateway->getSettingByScope('Students', 'academicAlertLowThreshold', true);
     $row = $form->addRow();
@@ -168,7 +168,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
                 ->maximum(50)
                 ->required();
 
-    $row = $form->addRow()->addHeading(__('Day-Type Options'));
+    $row = $form->addRow()->addHeading('Day-Type Options', __('Day-Type Options'));
 
     $setting = $settingGateway->getSettingByScope('User Admin', 'dayTypeOptions', true);
     $row = $form->addRow();
@@ -180,7 +180,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/studentsSetting
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
         
-    $form->addRow()->addHeading(__('Miscellaneous'));
+    $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
     $setting = $settingGateway->getSettingByScope('School Admin', 'studentAgreementOptions', true);
     $row = $form->addRow();

--- a/modules/User Admin/userSettings.php
+++ b/modules/User Admin/userSettings.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $row = $form->addRow()->addHeading(__('Field Values'));
+    $row = $form->addRow()->addHeading('Field Values', __('Field Values'));
 
     $settingGateway = $container->get(SettingGateway::class);
 
@@ -96,7 +96,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('Privacy Options'));
+    $row = $form->addRow()->addHeading('Privacy Options', __('Privacy Options'));
 
     $setting = $settingGateway->getSettingByScope('User Admin', 'privacy', true);
     $row = $form->addRow();
@@ -115,14 +115,14 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/userSettings.ph
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addTextArea($setting['name'])->setValue($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('User Data Options'));
+    $row = $form->addRow()->addHeading('User Data Options', __('User Data Options'));
 
     $setting = $settingGateway->getSettingByScope('User Admin', 'uniqueEmailAddress', true);
     $row = $form->addRow();
         $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
         $row->addYesNo($setting['name'])->selected($setting['value']);
 
-    $row = $form->addRow()->addHeading(__('User Interface Options'));
+    $row = $form->addRow()->addHeading('User Interface Options', __('User Interface Options'));
 
     $setting = $settingGateway->getSettingByScope('User Admin', 'personalBackground', true);
     $row = $form->addRow();

--- a/modules/User Admin/user_manage_add.php
+++ b/modules/User Admin/user_manage_add.php
@@ -59,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
     $form->addHiddenValue('address', $session->get('address'));
 
     // BASIC INFORMATION
-    $form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
     $row = $form->addRow();
         $row->addLabel('title', __('Title'));
@@ -103,7 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
             ->setMaxUpload(false);
 
     // SYSTEM ACCESS
-    $form->addRow()->addHeading(__('System Access'));
+    $form->addRow()->addHeading('System Access', __('System Access'));
 
     // Put together an array of this user's current roles
     $currentUserRoles = (is_array($session->get('gibbonRoleIDAll'))) ? array_column($session->get('gibbonRoleIDAll'), 0) : array();
@@ -175,7 +175,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addYesNo('passwordForceReset')->required();
 
     // CONTACT INFORMATION
-    $form->addRow()->addHeading(__('Contact Information'));
+    $form->addRow()->addHeading('Contact Information', __('Contact Information'));
 
     $row = $form->addRow();
         $emailLabel = $row->addLabel('email', __('Email'));
@@ -241,7 +241,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addURL('website');
 
     // SCHOOL INFORMATION
-    $form->addRow()->addHeading(__('School Information'));
+    $form->addRow()->addHeading('School Information', __('School Information'));
 
     $dayTypeOptions = $settingGateway->getSettingByScope('User Admin', 'dayTypeOptions');
     if (!empty($dayTypeOptions)) {
@@ -268,7 +268,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addSelectSchoolYear('gibbonSchoolYearIDClassOf');
 
     // BACKGROUND INFORMATION
-    $form->addRow()->addHeading(__('Background Information'));
+    $form->addRow()->addHeading('Background Information', __('Background Information'));
 
     $row = $form->addRow();
         $row->addLabel('languageFirst', __('First Language'));
@@ -308,7 +308,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
     $residencyStatusList = $settingGateway->getSettingByScope('User Admin', 'residencyStatus');
 
     // EMPLOYMENT
-    $form->addRow()->addHeading(__('Employment'));
+    $form->addRow()->addHeading('Employment', __('Employment'));
 
     $row = $form->addRow();
         $row->addLabel('profession', __('Profession'));
@@ -323,7 +323,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addTextField('jobTitle')->maxLength(90);
 
     // EMERGENCY CONTACTS
-    $form->addRow()->addHeading(__('Emergency Contacts'));
+    $form->addRow()->addHeading('Emergency Contacts', __('Emergency Contacts'));
 
     $form->addRow()->addContent(__('These details are used when immediate family members (e.g. parent, spouse) cannot be reached first. Please try to avoid listing immediate family members.'));
 
@@ -360,7 +360,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
         $row->addTextField('emergency2Number2')->maxLength(30);
 
     // MISCELLANEOUS
-    $form->addRow()->addHeading(__('Miscellaneous'));
+    $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
     $sql = "SELECT gibbonHouseID as value, name FROM gibbonHouse ORDER BY name";
     $row = $form->addRow();
@@ -419,7 +419,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
     // STAFF
     $form->toggleVisibilityByClass('staffDetails')->onSelect('gibbonRoleIDPrimary')->when($staffRoles);
     $form->toggleVisibilityByClass('staffRecord')->onCheckbox('staffRecord')->when('Y');
-    $form->addRow()->addClass('staffDetails')->addHeading(__('Staff'))->addClass('staffDetails');
+    $form->addRow()->addClass('staffDetails')->addHeading('Staff', __('Staff'))->addClass('staffDetails');
 
     $row = $form->addRow()->addClass('staffDetails');
         $row->addLabel('staffRecord', __('Add Staff'));
@@ -437,7 +437,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_add
     // STUDENT
     $form->toggleVisibilityByClass('studentDetails')->onSelect('gibbonRoleIDPrimary')->when($studentRoles);
     $form->toggleVisibilityByClass('studentRecord')->onCheckbox('studentRecord')->when('Y');
-    $form->addRow()->addClass('studentDetails')->addHeading(__('Student'))->addClass('studentDetails');
+    $form->addRow()->addClass('studentDetails')->addHeading('Student', __('Student'))->addClass('studentDetails');
 
     $row = $form->addRow()->addClass('studentDetails');
         $row->addLabel('studentRecord', __('Add Student Enrolment'));

--- a/modules/User Admin/user_manage_edit.php
+++ b/modules/User Admin/user_manage_edit.php
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
             $form->addHiddenValue('address', $session->get('address'));
 
             // BASIC INFORMATION
-            $form->addRow()->addHeading(__('Basic Information'));
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
 
             $row = $form->addRow();
                 $row->addLabel('title', __('Title'));
@@ -137,7 +137,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
                     ->setMaxUpload(false);
 
             // SYSTEM ACCESS
-            $form->addRow()->addHeading(__('System Access'));
+            $form->addRow()->addHeading('System Access', __('System Access'));
 
             $data = array();
             $sql = "SELECT gibbonRoleID, gibbonRoleID, name, restriction FROM gibbonRole ORDER BY name";
@@ -229,7 +229,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
                 $row->addYesNo('passwordForceReset')->required();
 
             // CONTACT INFORMATION
-            $form->addRow()->addHeading(__('Contact Information'));
+            $form->addRow()->addHeading('Contact Information', __('Contact Information'));
 
             $row = $form->addRow();
                 $emailLabel = $row->addLabel('email', __('Email'));
@@ -325,7 +325,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
                 $row->addURL('website');
 
             // SCHOOL INFORMATION
-            $form->addRow()->addHeading(__('School Information'));
+            $form->addRow()->addHeading('School Information', __('School Information'));
 
             if ($student) {
                 $dayTypeOptions = $settingGateway->getSettingByScope('User Admin', 'dayTypeOptions');
@@ -380,7 +380,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
             }
 
             // BACKGROUND INFORMATION
-            $form->addRow()->addHeading(__('Background Information'));
+            $form->addRow()->addHeading('Background Information', __('Background Information'));
 
             $row = $form->addRow();
                 $row->addLabel('languageFirst', __('First Language'));
@@ -430,7 +430,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
             // EMPLOYMENT
             if ($parent) {
-                $form->addRow()->addHeading(__('Employment'));
+                $form->addRow()->addHeading('Employment', __('Employment'));
 
                 $row = $form->addRow();
                     $row->addLabel('profession', __('Profession'));
@@ -447,7 +447,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
 
             // EMERGENCY CONTACTS
             if ($student || $staff) {
-                $form->addRow()->addHeading(__('Emergency Contacts'));
+                $form->addRow()->addHeading('Emergency Contacts', __('Emergency Contacts'));
 
                 $form->addRow()->addContent(__('These details are used when immediate family members (e.g. parent, spouse) cannot be reached first. Please try to avoid listing immediate family members.'));
 
@@ -485,7 +485,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_edi
             }
 
             // MISCELLANEOUS
-            $form->addRow()->addHeading(__('Miscellaneous'));
+            $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
             $sql = "SELECT gibbonHouseID as value, name FROM gibbonHouse ORDER BY name";
             $row = $form->addRow();

--- a/passwordReset.php
+++ b/passwordReset.php
@@ -90,7 +90,7 @@ else {
         $form->setClass('smallIntBorder fullWidth');
         $form->addHiddenValue('address', $session->get('address'));
 
-        $form->addRow()->addHeading(__('Reset Password'));
+        $form->addRow()->addHeading('Reset Password', __('Reset Password'));
 
         $policy = getPasswordPolicy($guid, $connection2);
         if ($policy != false) {

--- a/preferences.php
+++ b/preferences.php
@@ -53,7 +53,7 @@ if (!$session->exists("username")) {
 
     $form = Form::create('resetPassword', $session->get('absoluteURL').'/preferencesPasswordProcess.php');
 
-    $form->addRow()->addHeading(__('Reset Password'));
+    $form->addRow()->addHeading('Reset Password', __('Reset Password'));
 
     $policy = getPasswordPolicy($guid, $connection2);
     if ($policy != false) {
@@ -97,7 +97,7 @@ if (!$session->exists("username")) {
         $form = Form::create('preferences', $session->get('absoluteURL').'/preferencesProcess.php');
         $form->setFactory(DatabaseFormFactory::create($pdo));
 
-        $form->addRow()->addHeading(__('Settings'));
+        $form->addRow()->addHeading('Settings', __('Settings'));
 
         $row = $form->addRow();
             $row->addLabel('calendarFeedPersonal', __('Personal Google Calendar ID'))->description(__('Google Calendar ID for your personal calendar.').'<br/>'.__('Only enables timetable integration when logging in via Google.'));

--- a/publicRegistration.php
+++ b/publicRegistration.php
@@ -70,7 +70,7 @@ if ($proceed == false) {
 
     $form->addHiddenValue('address', $session->get('address'));
 
-    $form->addRow()->addHeading(__('Account Details'));
+    $form->addRow()->addHeading('Account Details', __('Account Details'));
 
     $row = $form->addRow();
         $row->addLabel('surname', __('Surname'));
@@ -141,13 +141,13 @@ if ($proceed == false) {
 
     $privacyStatement = $settingGateway->getSettingByScope('User Admin', 'publicRegistrationPrivacyStatement');
     if ($privacyStatement != '') {
-        $form->addRow()->addHeading(__('Privacy Statement'));
+        $form->addRow()->addHeading('Privacy Statement', __('Privacy Statement'));
         $form->addRow()->addContent($privacyStatement);
     }
 
     $agreement = $settingGateway->getSettingByScope('User Admin', 'publicRegistrationAgreement');
     if ($agreement != '') {
-        $form->addRow()->addHeading(__('Agreement'));
+        $form->addRow()->addHeading('Agreement', __('Agreement'));
         $form->addRow()->addContent($agreement);
 
         $row = $form->addRow();

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -105,14 +105,16 @@ class FormFactory implements FormFactoryInterface
         return new Layout\Label($for, $label);
     }
 
-    public function createHeading($content = '', $tag = null)
+    public function createHeading($id = '', $content = null, $tag = null)
     {
-        return new Layout\Heading($content, $tag);
+        $content = is_null($content) || $content == 'h3' ? $id : $content;
+        return new Layout\Heading($id, $content, $tag);
     }
 
-    public function createSubheading($content, $tag = 'h4')
+    public function createSubheading($id = '', $content = null, $tag = 'h4')
     {
-        return new Layout\Heading($content, $tag = 'h4');
+        $content = is_null($content) || $content == 'h4' ? $id : $content;
+        return new Layout\Heading($id, $content, $tag = 'h4');
     }
 
     /**

--- a/src/Forms/Layout/Heading.php
+++ b/src/Forms/Layout/Heading.php
@@ -32,13 +32,15 @@ class Heading extends Element implements OutputableInterface, RowDependancyInter
 {
     protected $row;
     protected $tag = 'h3';
+    protected $id;
 
     /**
      * Add a generic heading element.
      * @param  string  $content
      */
-    public function __construct($content, $tag = null)
+    public function __construct($id, $content, $tag = null)
     {
+        $this->id = $id;
         $this->content = $content;
         $this->tag = !empty($tag) ? $tag : 'h3';
     }
@@ -53,10 +55,10 @@ class Heading extends Element implements OutputableInterface, RowDependancyInter
 
         $this->row->addClass($this->tag == 'h3' ? 'break top-0 z-10' : 'm-0 p-0');
 
-        $headingID = preg_replace('/[^a-zA-Z0-9]/', '', substr(strip_tags($this->content), 0, 60)); 
+        $headingID = preg_replace('/[^a-zA-Z0-9]/', '', substr($this->id, 0, 60)); 
         $this->row->setID($headingID);
 
-        $this->row->setHeading(preg_replace('/[^a-zA-Z0-9 -_]/', '', strip_tags($this->content)));
+        $this->row->setHeading(preg_replace('/[^a-zA-Z0-9 -_]/', '', strip_tags($this->id)));
     }
 
     public function getTag()

--- a/src/Install/Http/InstallController.php
+++ b/src/Install/Http/InstallController.php
@@ -226,7 +226,7 @@ class InstallController
         $form->setMultiPartForm(static::getSteps(), 1);
 
         $form->addHiddenValue('nonce', $nonce);
-        $form->addRow()->addHeading(__('System Requirements'));
+        $form->addRow()->addHeading('System Requirements', __('System Requirements'));
 
         $readyToInstall = $readyToInstall && version_compare($phpVersion, $phpRequirement, '>=');
         $row = $form->addRow();
@@ -287,7 +287,7 @@ class InstallController
             $form->setDescription(Format::alert(__('Not ready to install.'), 'error'));
         }
 
-        $form->addRow()->addHeading(__('Language Settings'));
+        $form->addRow()->addHeading('Language Settings', __('Language Settings'));
 
         // Use default language, or language submitted by previous attempt.
         $row = $form->addRow();
@@ -360,7 +360,7 @@ class InstallController
 
         $form->addHiddenValue('nonce', $nonce);
 
-        $form->addRow()->addHeading(__('Database Settings'));
+        $form->addRow()->addHeading('Database Settings', __('Database Settings'));
 
         $row = $form->addRow();
             $row->addLabel('type', __('Database Type'));
@@ -485,7 +485,7 @@ class InstallController
         $form->addHiddenValue('nonce', $nonce);
         $form->addHiddenValue('cuttingEdgeCodeHidden', 'N');
 
-        $form->addRow()->addHeading(__('User Account'));
+        $form->addRow()->addHeading('User Account', __('User Account'));
 
         $row = $form->addRow();
             $row->addLabel('title', __('Title'));
@@ -553,7 +553,7 @@ class InstallController
                 ->maxLength(30)
                 ->addValidation('Validate.Confirmation', "match: 'passwordNew'");
 
-        $form->addRow()->addHeading(__('System Settings'));
+        $form->addRow()->addHeading('System Settings', __('System Settings'));
 
         $pageURL = (@$_SERVER['HTTPS'] == 'on') ? 'https://' : 'http://';
         $port = '';
@@ -620,7 +620,7 @@ class InstallController
             $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
             $row->addYesNo($setting['name'])->selected(($data[$setting['name']] ?? 'N') == 'Y')->required();
 
-        $form->addRow()->addHeading(__('Organisation Settings'));
+        $form->addRow()->addHeading('Organisation Settings', __('Organisation Settings'));
 
         $setting = $installer->getSetting('organisationName', 'System', true);
         $row = $form->addRow();
@@ -632,7 +632,7 @@ class InstallController
             $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
             $row->addTextField($setting['name'])->setValue($data[$setting['name']] ?? '')->maxLength(50)->required();
 
-        $form->addRow()->addHeading(__('gibbonedu.com Value Added Services'));
+        $form->addRow()->addHeading('gibbonedu.com Value Added Services', __('gibbonedu.com Value Added Services'));
 
         $setting = $installer->getSetting('gibboneduComOrganisationName', 'System', true);
         $row = $form->addRow();
@@ -644,7 +644,7 @@ class InstallController
             $row->addLabel($setting['name'], __($setting['nameDisplay']))->description(__($setting['description']));
             $row->addTextField($setting['name'])->setValue($data[$setting['name']] ?? '');
 
-        $form->addRow()->addHeading(__('Miscellaneous'));
+        $form->addRow()->addHeading('Miscellaneous', __('Miscellaneous'));
 
         $setting = $installer->getSetting('country', 'System', true);
         $row = $form->addRow();


### PR DESCRIPTION
Manuel [on the forums](https://ask.gibbonedu.org/discussion/3524/custom-fields-not-working-in-spanish#latest) has kindly helped us identify an issue with custom field headings, where the value of the heading were inconsistently stored and compared as translated and untranslated strings. This caused the built-in headings to always appear as custom headings, and fields to not display in the correct location.

This PR includes some small fixes on the whole, however to apply the fixes the addHeading() method needed updated in all instances in the core. The change includes passing both the untranslated and translated heading content to the addHeading() method. This change to the method is backwards compatible, so it doesn't break any additional modules.

- Fixes the dropdown keys in Add Custom Field and Edit Custom Field
- Fixes the translation of headings in the Custom Field table
- Changes the addHeading method signature, and Heading class constructor, to use an $id + $content field. 
- Applies the addHeading changes to all instances in the core using that method.

**How Has This Been Tested?**
Locally.
