### PR TITLE
Messenger: add the abiliy to send confidential messages

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -675,5 +675,7 @@ DELETE FROM `gibbonPermission` WHERE gibbonActionID=(SELECT gibbonActionID FROM 
 ++$count;
 $sql[$count][0] = '25.0.00';
 $sql[$count][1] = "
-
+ALTER TABLE `gibbonMessenger` ADD `confidential` ENUM('N','Y') NOT NULL DEFAULT 'N' AFTER `smsReport`;end
+INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, `description`, `URLList`, `entryURL`, `entrySidebar`, `menuShow`, `defaultPermissionAdmin`, `defaultPermissionTeacher`, `defaultPermissionStudent`, `defaultPermissionParent`, `defaultPermissionSupport`, `categoryPermissionStaff`, `categoryPermissionStudent`, `categoryPermissionParent`, `categoryPermissionOther`) VALUES((SELECT gibbonModuleID FROM gibbonModule WHERE name='Messenger'), 'New Message_confidential', 0, 'Manage Messages', 'Enable users to send confidential messages which are not listed in Manage Messages for any other user.', 'messenger_post.php', 'messenger_post.php', 'Y', 'N', 'Y', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N');end
+INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001', (SELECT gibbonActionID FROM gibbonAction JOIN gibbonModule ON (gibbonAction.gibbonModuleID=gibbonModule.gibbonModuleID) WHERE gibbonModule.name='Messenger' AND gibbonAction.name='New Message_confidential'));end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ v25.0.00
     Changes With Important Notices
 
     Tweaks & Additions
+        Messenger: added the ability to send confidential messages which are not viewable by other users
 
     Bug Fixes
         System: improved exception handling for transactions in Connection class

--- a/modules/Messenger/messenger_manage.php
+++ b/modules/Messenger/messenger_manage.php
@@ -41,6 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_manage
     $messengerGateway = $container->get(MessengerGateway::class);
     $criteria = $messengerGateway->newQueryCriteria(true)
         ->searchBy($messengerGateway->getSearchableColumns(), $search)
+        ->filterBy('confidential', $session->get('gibbonPersonID'))
         ->sortBy(['timestamp'], 'DESC')
         ->fromPOST();
 
@@ -87,7 +88,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_manage
     $table->addColumn('subject', __('Subject'))
         ->context('primary')
         ->format(function ($values) {
-            return '<b>'.$values['subject'].'</b>';
+            $tag = $values['confidential'] == 'Y' ? Format::tag(__('Confidential'), 'dull ml-2') : '';
+            return Format::bold($values['subject']).$tag;
         });
 
     $table->addColumn('timestamp', __('Date Sent'))

--- a/modules/Messenger/messenger_manage_edit.php
+++ b/modules/Messenger/messenger_manage_edit.php
@@ -23,20 +23,20 @@ use Gibbon\Services\Format;
 use Gibbon\Domain\User\RoleGateway;
 
 if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_manage_edit.php")==FALSE) {
-	//Acess denied
-	print "<div class='error'>" ;
-		print __("You do not have access to this action.") ;
-	print "</div>" ;
+    //Acess denied
+    print "<div class='error'>" ;
+        print __("You do not have access to this action.") ;
+    print "</div>" ;
 }
 else {
-	//Get action with highest precendence
-	$highestAction=getHighestGroupedAction($guid, $_GET["q"], $connection2) ;
-	if ($highestAction==FALSE) {
-		print "<div class='error'>" ;
-		print __("The highest grouped action cannot be determined.") ;
-		print "</div>" ;
-	}
-	else {
+    //Get action with highest precendence
+    $highestAction=getHighestGroupedAction($guid, $_GET["q"], $connection2) ;
+    if ($highestAction==FALSE) {
+        print "<div class='error'>" ;
+        print __("The highest grouped action cannot be determined.") ;
+        print "</div>" ;
+    }
+    else {
         $search = $_GET['search'] ?? null;
         $updateReturn = $_GET["updateReturn"] ?? '';
 
@@ -44,233 +44,245 @@ else {
             ->add(__('Manage Messages'), 'messenger_manage.php', ['search' => $search])
             ->add(__('Edit Message'));
 
-		$updateReturnMessage="" ;
-		$class="error" ;
-		if (!($updateReturn=="")) {
-			if ($updateReturn=="fail0") {
-				$updateReturnMessage=__("Your request failed because you do not have access to this action.") ;
-			}
-			else if ($updateReturn=="fail1") {
-				$updateReturnMessage=__("Your request failed because your inputs were invalid.") ;
-			}
-			else if ($updateReturn=="fail2") {
-				$updateReturnMessage=__("Your request failed due to a database error.") ;
-			}
-			else if ($updateReturn=="fail3") {
-				$updateReturnMessage=__("Your request failed because your inputs were invalid.") ;
-			}
-			else if ($updateReturn=="fail4") {
-				$updateReturnMessage=__("Your request failed because your inputs were invalid.") ;
-			}
-			else if ($updateReturn=="success0") {
-				$updateReturnMessage=__("Your request was completed successfully.") ;
-				$class="success" ;
-			}
-			print "<div class='$class'>" ;
-				print $updateReturnMessage;
-			print "</div>" ;
-		}
+        $updateReturnMessage="" ;
+        $class="error" ;
+        if (!($updateReturn=="")) {
+            if ($updateReturn=="fail0") {
+                $updateReturnMessage=__("Your request failed because you do not have access to this action.") ;
+            }
+            else if ($updateReturn=="fail1") {
+                $updateReturnMessage=__("Your request failed because your inputs were invalid.") ;
+            }
+            else if ($updateReturn=="fail2") {
+                $updateReturnMessage=__("Your request failed due to a database error.") ;
+            }
+            else if ($updateReturn=="fail3") {
+                $updateReturnMessage=__("Your request failed because your inputs were invalid.") ;
+            }
+            else if ($updateReturn=="fail4") {
+                $updateReturnMessage=__("Your request failed because your inputs were invalid.") ;
+            }
+            else if ($updateReturn=="success0") {
+                $updateReturnMessage=__("Your request was completed successfully.") ;
+                $class="success" ;
+            }
+            print "<div class='$class'>" ;
+                print $updateReturnMessage;
+            print "</div>" ;
+        }
 
-		//Check if gibbonMessengerID specified
-		$gibbonMessengerID=$_GET["gibbonMessengerID"] ;
-		if ($gibbonMessengerID=="") {
-			print "<div class='error'>" ;
-				print __("You have not specified one or more required parameters.") ;
-			print "</div>" ;
-		}
-		else {
-			try {
-				if ($highestAction=="Manage Messages_all") {
-					$data=array("gibbonMessengerID"=>$gibbonMessengerID);
-					$sql="SELECT gibbonMessenger.*, title, surname, preferredName FROM gibbonMessenger JOIN gibbonPerson ON (gibbonMessenger.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonMessengerID=:gibbonMessengerID" ;
-				}
-				else {
-					$data=array("gibbonMessengerID"=>$gibbonMessengerID, "gibbonPersonID"=>$session->get('gibbonPersonID'));
-					$sql="SELECT gibbonMessenger.*, title, surname, preferredName FROM gibbonMessenger JOIN gibbonPerson ON (gibbonMessenger.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonMessengerID=:gibbonMessengerID AND gibbonMessenger.gibbonPersonID=:gibbonPersonID" ;
-				}
-				$result=$connection2->prepare($sql);
-				$result->execute($data);
-			}
-			catch(PDOException $e) {
-				print "<div class='error'>" . $e->getMessage() . "</div>" ;
-			}
+        //Check if gibbonMessengerID specified
+        $gibbonMessengerID=$_GET["gibbonMessengerID"] ;
+        if ($gibbonMessengerID=="") {
+            print "<div class='error'>" ;
+                print __("You have not specified one or more required parameters.") ;
+            print "</div>" ;
+        }
+        else {
+            try {
+                if ($highestAction=="Manage Messages_all") {
+                    $data=array("gibbonMessengerID"=>$gibbonMessengerID);
+                    $sql="SELECT gibbonMessenger.*, title, surname, preferredName FROM gibbonMessenger LEFT JOIN gibbonPerson ON (gibbonMessenger.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonMessengerID=:gibbonMessengerID" ;
+                }
+                else {
+                    $data=array("gibbonMessengerID"=>$gibbonMessengerID, "gibbonPersonID"=>$session->get('gibbonPersonID'));
+                    $sql="SELECT gibbonMessenger.*, title, surname, preferredName FROM gibbonMessenger LEFT JOIN gibbonPerson ON (gibbonMessenger.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonMessengerID=:gibbonMessengerID AND gibbonMessenger.gibbonPersonID=:gibbonPersonID" ;
+                }
+                $result=$connection2->prepare($sql);
+                $result->execute($data);
+            }
+            catch(PDOException $e) {
+                print "<div class='error'>" . $e->getMessage() . "</div>" ;
+            }
 
 
-			if ($result->rowCount()!=1) {
-				print "<div class='error'>" ;
-					print __("The specified record cannot be found.") ;
-				print "</div>" ;
-			}
-			else {
-				//Let's go!
-				$values=$result->fetch() ;
-				echo '<div class="warning">';
-					echo '<b><u>'.__('Note').'</u></b>: '.__('Changes made here do not apply to emails and SMS messages (which have already been sent), but only to message wall messages.');
-				echo '</div>';
+            if ($result->rowCount()!=1) {
+                print "<div class='error'>" ;
+                    print __("The specified record cannot be found.") ;
+                print "</div>" ;
+            }
+            else {
+                //Let's go!
+                $values=$result->fetch() ;
 
-				$form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/messenger_manage_editProcess.php');
+                // Confidential Check
+                if ($values['confidential'] == 'Y' && $session->get('gibbonPersonID') != $values['gibbonPersonID']) {
+                    $page->addError(__('You do not have access to this action.'));
+                    return;
+                }
 
-				$form->addHiddenValue('address', $session->get('address'));
-				$form->addHiddenValue('gibbonMessengerID', $values['gibbonMessengerID']);
+                $page->addWarning('<b><u>'.__('Note').'</u></b>: '.__('Changes made here do not apply to emails and SMS messages (which have already been sent), but only to message wall messages.'));
+                
+                $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/messenger_manage_editProcess.php');
 
-				$form->addRow()->addHeading('Delivery Mode', __('Delivery Mode'));
-				//Delivery by email
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byEmail")) {
-					$row = $form->addRow();
-						$row->addLabel('email', __('Email'))->description(__('Deliver this message to user\'s primary email account?'));
-						if ($values["email"]=="Y") {
-							$row->addContent("<img title='" . __('Sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconTick.png'/>")->addClass('right');
-						}
-						else {
-							$row->addContent("<img title='" . __('Not sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconCross.png'/>")->addClass('right') ;
-						}
-				}
+                $form->addHiddenValue('address', $session->get('address'));
+                $form->addHiddenValue('gibbonMessengerID', $values['gibbonMessengerID']);
 
-				//Delivery by message wall
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byMessageWall")) {
-					$row = $form->addRow();
-						$row->addLabel('messageWall', __('Message Wall'))->description(__('Place this message on user\'s message wall?'));
-						$row->addYesNoRadio('messageWall')->checked('N')->required();
+                $form->addRow()->addHeading('Delivery Mode', __('Delivery Mode'));
+                //Delivery by email
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byEmail")) {
+                    $row = $form->addRow();
+                        $row->addLabel('email', __('Email'))->description(__('Deliver this message to user\'s primary email account?'));
+                        if ($values["email"]=="Y") {
+                            $row->addContent("<img title='" . __('Sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconTick.png'/>")->addClass('right');
+                        }
+                        else {
+                            $row->addContent("<img title='" . __('Not sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconCross.png'/>")->addClass('right') ;
+                        }
+                }
 
-					$form->toggleVisibilityByClass('messageWall')->onRadio('messageWall')->when('Y');
+                //Delivery by message wall
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_byMessageWall")) {
+                    $row = $form->addRow();
+                        $row->addLabel('messageWall', __('Message Wall'))->description(__('Place this message on user\'s message wall?'));
+                        $row->addYesNoRadio('messageWall')->checked('N')->required();
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_manage.php", "Manage Messages_all")) {
-						$row = $form->addRow()->addClass('messageWall');
-							$row->addLabel('messageWallPin', __('Pin To Top?'));
-							$row->addYesNo('messageWallPin')->selected($values['messageWallPin'])->required();
-					}
+                    $form->toggleVisibilityByClass('messageWall')->onRadio('messageWall')->when('Y');
 
-					$row = $form->addRow()->addClass('messageWall');
-				        $row->addLabel('date1', __('Publication Dates'))->description(__('Select up to three individual dates.'));
-						$col = $row->addColumn('date1')->addClass('stacked');
-						$col->addDate('date1')->setValue(Format::date($values['messageWall_date1']))->required();
-						$col->addDate('date2')->setValue(Format::date($values['messageWall_date2']));
-						$col->addDate('date3')->setValue(Format::date($values['messageWall_date3']));
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_manage.php", "Manage Messages_all")) {
+                        $row = $form->addRow()->addClass('messageWall');
+                            $row->addLabel('messageWallPin', __('Pin To Top?'));
+                            $row->addYesNo('messageWallPin')->selected($values['messageWallPin'])->required();
+                    }
 
-				//Delivery by SMS
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_bySMS")) {
+                    $row = $form->addRow()->addClass('messageWall');
+                        $row->addLabel('date1', __('Publication Dates'))->description(__('Select up to three individual dates.'));
+                        $col = $row->addColumn('date1')->addClass('stacked');
+                        $col->addDate('date1')->setValue(Format::date($values['messageWall_date1']))->required();
+                        $col->addDate('date2')->setValue(Format::date($values['messageWall_date2']));
+                        $col->addDate('date3')->setValue(Format::date($values['messageWall_date3']));
+                }
+
+                //Delivery by SMS
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_bySMS")) {
                     $settingGateway = $container->get(SettingGateway::class);
-					$smsUsername = $settingGateway->getSettingByScope("Messenger", "smsUsername" ) ;
-					$smsPassword = $settingGateway->getSettingByScope("Messenger", "smsPassword" ) ;
-					$smsURL = $settingGateway->getSettingByScope("Messenger", "smsURL" ) ;
-					$smsURLCredit = $settingGateway->getSettingByScope("Messenger", "smsURLCredit" ) ;
-					if ($smsUsername == "" OR $smsPassword == "" OR $smsURL == "") {
-						$row = $form->addRow()->addClass('sms');
-							$row->addLabel('sms', __('SMS'))->description(__('Deliver this message to user\'s mobile phone?'));
-							$row->addAlert(sprintf(__('SMS NOT CONFIGURED. Please contact %1$s for help.'), "<a href='mailto:" . $session->get('organisationAdministratorEmail') . "'>" . $session->get('organisationAdministratorName') . "</a>"), 'message');
-					}
-					else {
-						$row = $form->addRow();
-							$row->addLabel('sms', __('SMS'))->description(__('Deliver this message to user\'s mobile phone?'));
-							if ($values["sms"]=="Y") {
-								$row->addContent("<img title='" . __('Sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconTick.png'/>")->addClass('right');
-							}
-							else {
-								$row->addContent("<img title='" . __('Not sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconCross.png'/>")->addClass('right') ;
-							}
-					}
-				}
+                    $smsUsername = $settingGateway->getSettingByScope("Messenger", "smsUsername" ) ;
+                    $smsPassword = $settingGateway->getSettingByScope("Messenger", "smsPassword" ) ;
+                    $smsURL = $settingGateway->getSettingByScope("Messenger", "smsURL" ) ;
+                    $smsURLCredit = $settingGateway->getSettingByScope("Messenger", "smsURLCredit" ) ;
+                    if ($smsUsername == "" OR $smsPassword == "" OR $smsURL == "") {
+                        $row = $form->addRow()->addClass('sms');
+                            $row->addLabel('sms', __('SMS'))->description(__('Deliver this message to user\'s mobile phone?'));
+                            $row->addAlert(sprintf(__('SMS NOT CONFIGURED. Please contact %1$s for help.'), "<a href='mailto:" . $session->get('organisationAdministratorEmail') . "'>" . $session->get('organisationAdministratorName') . "</a>"), 'message');
+                    }
+                    else {
+                        $row = $form->addRow();
+                            $row->addLabel('sms', __('SMS'))->description(__('Deliver this message to user\'s mobile phone?'));
+                            if ($values["sms"]=="Y") {
+                                $row->addContent("<img title='" . __('Sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconTick.png'/>")->addClass('right');
+                            }
+                            else {
+                                $row->addContent("<img title='" . __('Not sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconCross.png'/>")->addClass('right') ;
+                            }
+                    }
+                }
 
-				//MESSAGE DETAILS
-				$form->addRow()->addHeading('Message Details', __('Message Details'));
+                // Confidential Message Option
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_confidential")) {
+                    $row = $form->addRow();
+                        $row->addLabel('confidential', __('Confidential'))->description(__('Other users will not be able to see this message in Manage Messages.'));
+                        $row->addYesNoRadio('confidential')->checked($values['confidential'] ?? 'N')->required();
+                }
 
-				$row = $form->addRow();
-					$row->addLabel('subject', __('Subject'));
-					$row->addTextField('subject')->maxLength(60)->required();
+                //MESSAGE DETAILS
+                $form->addRow()->addHeading('Message Details', __('Message Details'));
 
-				$row = $form->addRow();
-			        $col = $row->addColumn('body');
-			        $col->addLabel('body', __('Body'));
-			        $col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true);
+                $row = $form->addRow();
+                    $row->addLabel('subject', __('Subject'));
+                    $row->addTextField('subject')->maxLength(60)->required();
 
-				//READ RECEIPTS
-				if (!isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_readReceipts")) {
-					$form->addHiddenValue('emailReceipt', 'N');
-				}
-				else {
-					$form->addRow()->addHeading('Email Read Receipts', __('Email Read Receipts'));
+                $row = $form->addRow();
+                    $col = $row->addColumn('body');
+                    $col->addLabel('body', __('Body'));
+                    $col->addEditor('body', $guid)->required()->setRows(20)->showMedia(true);
 
-					$row = $form->addRow();
-						$row->addLabel('emailReceipt', __('Enable Read Receipts'))->description(__('Each email recipient will receive a personalised confirmation link.'));
-						if ($values["emailReceipt"]=="Y") {
-							$row->addContent("<img title='" . __('Sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconTick.png'/>")->addClass('right');
-						}
-						else {
-							$row->addContent("<img title='" . __('Not sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconCross.png'/>")->addClass('right') ;
-						}
+                //READ RECEIPTS
+                if (!isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_readReceipts")) {
+                    $form->addHiddenValue('emailReceipt', 'N');
+                }
+                else {
+                    $form->addRow()->addHeading('Email Read Receipts', __('Email Read Receipts'));
 
-					$row = $form->addRow()->addClass('emailReceipt');
-						$row->addLabel('emailReceiptText', __('Link Text'))->description(__('Confirmation link text to display to recipient.'));
-						$row->addTextArea('emailReceiptText')->setRows(3)->required()->setValue(__('By clicking on this link I confirm that I have read, and agree to, the text contained within this email, and give consent for my child to participate.'))->readonly();
-				}
+                    $row = $form->addRow();
+                        $row->addLabel('emailReceipt', __('Enable Read Receipts'))->description(__('Each email recipient will receive a personalised confirmation link.'));
+                        if ($values["emailReceipt"]=="Y") {
+                            $row->addContent("<img title='" . __('Sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconTick.png'/>")->addClass('right');
+                        }
+                        else {
+                            $row->addContent("<img title='" . __('Not sent by email.') . "' src='./themes/" . $session->get('gibbonThemeName') . "/img/iconCross.png'/>")->addClass('right') ;
+                        }
 
-				//TARGETS
-				$form->addRow()->addHeading('Targets', __('Targets'));
-				$roleCategory = getRoleCategory($session->get('gibbonRoleIDCurrent'), $connection2);
+                    $row = $form->addRow()->addClass('emailReceipt');
+                        $row->addLabel('emailReceiptText', __('Link Text'))->description(__('Confirmation link text to display to recipient.'));
+                        $row->addTextArea('emailReceiptText')->setRows(3)->required()->setValue(__('By clicking on this link I confirm that I have read, and agree to, the text contained within this email, and give consent for my child to participate.'))->readonly();
+                }
 
-				//Get existing TARGETS
-				try {
-					$dataTarget=array("gibbonMessengerID"=>$gibbonMessengerID);
-					$sqlTarget="SELECT * FROM gibbonMessengerTarget WHERE gibbonMessengerID=:gibbonMessengerID ORDER BY type" ;
-					$resultTarget=$connection2->prepare($sqlTarget);
-					$resultTarget->execute($dataTarget);
-				}
-				catch(PDOException $e) {
-					echo "<div class='error'>" . $e->getMessage() . "</div>" ;
-				}
+                //TARGETS
+                $form->addRow()->addHeading('Targets', __('Targets'));
+                $roleCategory = getRoleCategory($session->get('gibbonRoleIDCurrent'), $connection2);
 
-				$targets = $resultTarget->fetchAll();
+                //Get existing TARGETS
+                try {
+                    $dataTarget=array("gibbonMessengerID"=>$gibbonMessengerID);
+                    $sqlTarget="SELECT * FROM gibbonMessengerTarget WHERE gibbonMessengerID=:gibbonMessengerID ORDER BY type" ;
+                    $resultTarget=$connection2->prepare($sqlTarget);
+                    $resultTarget->execute($dataTarget);
+                }
+                catch(PDOException $e) {
+                    echo "<div class='error'>" . $e->getMessage() . "</div>" ;
+                }
 
-				//Role
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_role")) {
-					$selected = array_reduce($targets, function($group, $item) {
-						if ($item['type'] == 'Role') $group[] = $item['id'];
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('role', __('Role'))->description(__('Users of a certain type.'));
-						$row->addYesNoRadio('role')->checked($checked)->required();
+                $targets = $resultTarget->fetchAll();
 
-					$form->toggleVisibilityByClass('role')->onRadio('role')->when('Y');
+                //Role
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_role")) {
+                    $selected = array_reduce($targets, function($group, $item) {
+                        if ($item['type'] == 'Role') $group[] = $item['id'];
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('role', __('Role'))->description(__('Users of a certain type.'));
+                        $row->addYesNoRadio('role')->checked($checked)->required();
 
-					$roleGateway = $container->get(RoleGateway::class);
-					// CRITERIA
-					$criteria = $roleGateway->newQueryCriteria()
-						->sortBy(['gibbonRole.name']);
+                    $form->toggleVisibilityByClass('role')->onRadio('role')->when('Y');
 
-					$arrRoles = array();
-					$roles = $roleGateway->queryRoles($criteria);
+                    $roleGateway = $container->get(RoleGateway::class);
+                    // CRITERIA
+                    $criteria = $roleGateway->newQueryCriteria()
+                        ->sortBy(['gibbonRole.name']);
 
-					foreach ($roles AS $role) {
-						$arrRoles[$role['gibbonRoleID']] = __($role['name'])." (".__($role['category']).")";
-					}
-					$row = $form->addRow()->addClass('role hiddenReveal');
-						$row->addLabel('roles[]', __('Select Roles'));
-						$row->addSelect('roles[]')->fromArray($arrRoles)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
+                    $arrRoles = array();
+                    $roles = $roleGateway->queryRoles($criteria);
 
-					//Role Category
-					$selected = array_reduce($targets, function($group, $item) {
-						if ($item['type'] == 'Role Category') $group[] = $item['id'];
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('roleCategory', __('Role Category'))->description(__('Users of a certain type.'));
-						$row->addYesNoRadio('roleCategory')->checked($checked)->required();
+                    foreach ($roles AS $role) {
+                        $arrRoles[$role['gibbonRoleID']] = __($role['name'])." (".__($role['category']).")";
+                    }
+                    $row = $form->addRow()->addClass('role hiddenReveal');
+                        $row->addLabel('roles[]', __('Select Roles'));
+                        $row->addSelect('roles[]')->fromArray($arrRoles)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
 
-					$form->toggleVisibilityByClass('roleCategory')->onRadio('roleCategory')->when('Y');
+                    //Role Category
+                    $selected = array_reduce($targets, function($group, $item) {
+                        if ($item['type'] == 'Role Category') $group[] = $item['id'];
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('roleCategory', __('Role Category'))->description(__('Users of a certain type.'));
+                        $row->addYesNoRadio('roleCategory')->checked($checked)->required();
 
-					$data = array();
-					$sql = 'SELECT DISTINCT category AS value, category AS name FROM gibbonRole ORDER BY category';
-					$row = $form->addRow()->addClass('roleCategory hiddenReveal');
-						$row->addLabel('roleCategories[]', __('Select Role Categories'));
-						$row->addSelect('roleCategories[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(4)->required()->placeholder()->selected($selected);
-				} else if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_postQuickWall.php")) {
+                    $form->toggleVisibilityByClass('roleCategory')->onRadio('roleCategory')->when('Y');
+
+                    $data = array();
+                    $sql = 'SELECT DISTINCT category AS value, category AS name FROM gibbonRole ORDER BY category';
+                    $row = $form->addRow()->addClass('roleCategory hiddenReveal');
+                        $row->addLabel('roleCategories[]', __('Select Role Categories'));
+                        $row->addSelect('roleCategories[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(4)->required()->placeholder()->selected($selected);
+                } else if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_postQuickWall.php")) {
                     // Handle the edge case where a user can post a Quick Wall message but doesn't have access to the Role target
                     $row = $form->addRow();
-						$row->addLabel('roleCategoryLabel', __('Role Category'))->description(__('Users of a certain type.'));
+                        $row->addLabel('roleCategoryLabel', __('Role Category'))->description(__('Users of a certain type.'));
                         $row->addYesNoRadio('roleCategoryLabel')->checked('Y')->readonly()->disabled();
 
                     $form->addHiddenValue('role', 'N');
@@ -282,461 +294,461 @@ else {
                     }
                 }
 
-				//Year group
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_yearGroups_any")) {
-					$selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Year Group') {
-							$group[] = $item['id'];
-							$selectedByRole['staff'] = $item['staff'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('yearGroup', __('Year Group'))->description(__('Students in year; staff by tutors and courses taught.'));
-						$row->addYesNoRadio('yearGroup')->checked($checked)->required();
+                //Year group
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_yearGroups_any")) {
+                    $selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Year Group') {
+                            $group[] = $item['id'];
+                            $selectedByRole['staff'] = $item['staff'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('yearGroup', __('Year Group'))->description(__('Students in year; staff by tutors and courses taught.'));
+                        $row->addYesNoRadio('yearGroup')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('yearGroup')->onRadio('yearGroup')->when('Y');
+                    $form->toggleVisibilityByClass('yearGroup')->onRadio('yearGroup')->when('Y');
 
-					$data = array();
-					$sql = 'SELECT gibbonYearGroupID AS value, name FROM gibbonYearGroup ORDER BY sequenceNumber';
-					$row = $form->addRow()->addClass('yearGroup hiddenReveal');
-						$row->addLabel('yearGroups[]', __('Select Year Groups'));
-						$row->addSelect('yearGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
+                    $data = array();
+                    $sql = 'SELECT gibbonYearGroupID AS value, name FROM gibbonYearGroup ORDER BY sequenceNumber';
+                    $row = $form->addRow()->addClass('yearGroup hiddenReveal');
+                        $row->addLabel('yearGroups[]', __('Select Year Groups'));
+                        $row->addSelect('yearGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
 
-					$row = $form->addRow()->addClass('yearGroup hiddenReveal');
-						$row->addLabel('yearGroupsStaff', __('Include Staff?'));
-						$row->addYesNo('yearGroupsStaff')->selected($selectedByRole['staff']);
+                    $row = $form->addRow()->addClass('yearGroup hiddenReveal');
+                        $row->addLabel('yearGroupsStaff', __('Include Staff?'));
+                        $row->addYesNo('yearGroupsStaff')->selected($selectedByRole['staff']);
 
-					$row = $form->addRow()->addClass('yearGroup hiddenReveal');
-						$row->addLabel('yearGroupsStudents', __('Include Students?'));
-							$row->addYesNo('yearGroupsStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('yearGroup hiddenReveal');
+                        $row->addLabel('yearGroupsStudents', __('Include Students?'));
+                            $row->addYesNo('yearGroupsStudents')->selected($selectedByRole['students']);
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_yearGroups_parents")) {
-						$row = $form->addRow()->addClass('yearGroup hiddenReveal');
-							$row->addLabel('yearGroupsParents', __('Include Parents?'));
-							$row->addYesNo('yearGroupsParents')->selected($selectedByRole['parents']);
-					}
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_yearGroups_parents")) {
+                        $row = $form->addRow()->addClass('yearGroup hiddenReveal');
+                            $row->addLabel('yearGroupsParents', __('Include Parents?'));
+                            $row->addYesNo('yearGroupsParents')->selected($selectedByRole['parents']);
+                    }
+                }
 
-				//Form group
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_any")) {
-					$selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Form Group') {
-							$group[] = $item['id'];
-							$selectedByRole['staff'] = $item['staff'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('formGroup', __('Form Group'))->description(__('Tutees and tutors.'));
-						$row->addYesNoRadio('formGroup')->checked($checked)->required();
+                //Form group
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_any")) {
+                    $selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Form Group') {
+                            $group[] = $item['id'];
+                            $selectedByRole['staff'] = $item['staff'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('formGroup', __('Form Group'))->description(__('Tutees and tutors.'));
+                        $row->addYesNoRadio('formGroup')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('formGroup')->onRadio('formGroup')->when('Y');
+                    $form->toggleVisibilityByClass('formGroup')->onRadio('formGroup')->when('Y');
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_any")) {
-						$data=array("gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'));
-						$sql="SELECT gibbonFormGroupID AS value, name FROM gibbonFormGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name" ;
-					}
-					else {
-						if ($roleCategory == "Staff") {
-							$data=array("gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'), "gibbonPersonID1"=>$session->get('gibbonPersonID'), "gibbonPersonID2"=>$session->get('gibbonPersonID'), "gibbonPersonID3"=>$session->get('gibbonPersonID'), "gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'));
-							$sql="SELECT gibbonFormGroupID AS value, name FROM gibbonFormGroup WHERE (gibbonPersonIDTutor=:gibbonPersonID1 OR gibbonPersonIDTutor2=:gibbonPersonID2 OR gibbonPersonIDTutor3=:gibbonPersonID3) AND gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name" ;
-						}
-						else if ($roleCategory == "Student") {
-							$data=array("gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'), "gibbonPersonID"=>$session->get('gibbonPersonID'), );
-							$sql="SELECT gibbonFormGroupID AS value, name FROM gibbonFormGroup JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonFormGroup.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name" ;
-						}
-					}
-					$row = $form->addRow()->addClass('formGroup hiddenReveal');
-						$row->addLabel('formGroups[]', __('Select Form Groups'));
-						$row->addSelect('formGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_any")) {
+                        $data=array("gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'));
+                        $sql="SELECT gibbonFormGroupID AS value, name FROM gibbonFormGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name" ;
+                    }
+                    else {
+                        if ($roleCategory == "Staff") {
+                            $data=array("gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'), "gibbonPersonID1"=>$session->get('gibbonPersonID'), "gibbonPersonID2"=>$session->get('gibbonPersonID'), "gibbonPersonID3"=>$session->get('gibbonPersonID'), "gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'));
+                            $sql="SELECT gibbonFormGroupID AS value, name FROM gibbonFormGroup WHERE (gibbonPersonIDTutor=:gibbonPersonID1 OR gibbonPersonIDTutor2=:gibbonPersonID2 OR gibbonPersonIDTutor3=:gibbonPersonID3) AND gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name" ;
+                        }
+                        else if ($roleCategory == "Student") {
+                            $data=array("gibbonSchoolYearID"=>$session->get('gibbonSchoolYearID'), "gibbonPersonID"=>$session->get('gibbonPersonID'), );
+                            $sql="SELECT gibbonFormGroupID AS value, name FROM gibbonFormGroup JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonFormGroup.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name" ;
+                        }
+                    }
+                    $row = $form->addRow()->addClass('formGroup hiddenReveal');
+                        $row->addLabel('formGroups[]', __('Select Form Groups'));
+                        $row->addSelect('formGroups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->placeholder()->selected($selected);
 
-					$row = $form->addRow()->addClass('formGroup hiddenReveal');
-						$row->addLabel('formGroupsStaff', __('Include Staff?'));
-						$row->addYesNo('formGroupsStaff')->selected($selectedByRole['staff']);
+                    $row = $form->addRow()->addClass('formGroup hiddenReveal');
+                        $row->addLabel('formGroupsStaff', __('Include Staff?'));
+                        $row->addYesNo('formGroupsStaff')->selected($selectedByRole['staff']);
 
-					$row = $form->addRow()->addClass('formGroup hiddenReveal');
-						$row->addLabel('formGroupsStudents', __('Include Students?'));
-						$row->addYesNo('formGroupsStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('formGroup hiddenReveal');
+                        $row->addLabel('formGroupsStudents', __('Include Students?'));
+                        $row->addYesNo('formGroupsStudents')->selected($selectedByRole['students']);
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_parents")) {
-						$row = $form->addRow()->addClass('formGroup hiddenReveal');
-							$row->addLabel('formGroupsParents', __('Include Parents?'));
-							$row->addYesNo('formGroupsParents')->selected($selectedByRole['parents']);
-					}
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_formGroups_parents")) {
+                        $row = $form->addRow()->addClass('formGroup hiddenReveal');
+                            $row->addLabel('formGroupsParents', __('Include Parents?'));
+                            $row->addYesNo('formGroupsParents')->selected($selectedByRole['parents']);
+                    }
+                }
 
-				// Course
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_any")) {
-					$selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Course') {
-							$group[] = $item['id'];
-							$selectedByRole['staff'] = $item['staff'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('course', __('Course'))->description(__('Members of a course of study.'));
-						$row->addYesNoRadio('course')->checked($checked)->required();
+                // Course
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_any")) {
+                    $selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Course') {
+                            $group[] = $item['id'];
+                            $selectedByRole['staff'] = $item['staff'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('course', __('Course'))->description(__('Members of a course of study.'));
+                        $row->addYesNoRadio('course')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('course')->onRadio('course')->when('Y');
+                    $form->toggleVisibilityByClass('course')->onRadio('course')->when('Y');
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_any")) {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
-						$sql = "SELECT gibbonCourseID as value, nameShort as name FROM gibbonCourse WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
-					} else {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'));
-						$sql = "SELECT gibbonCourse.gibbonCourseID as value, gibbonCourse.nameShort as name
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_any")) {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
+                        $sql = "SELECT gibbonCourseID as value, nameShort as name FROM gibbonCourse WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
+                    } else {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'));
+                        $sql = "SELECT gibbonCourse.gibbonCourseID as value, gibbonCourse.nameShort as name
                                 FROM gibbonCourse
                                 JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID)
                                 JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
                                 WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND NOT role LIKE '%- Left' GROUP BY gibbonCourse.gibbonCourseID ORDER BY name";
-					}
+                    }
 
-					$row = $form->addRow()->addClass('course hiddenReveal');
-						$row->addLabel('courses[]', __('Select Courses'));
-						$row->addSelect('courses[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
+                    $row = $form->addRow()->addClass('course hiddenReveal');
+                        $row->addLabel('courses[]', __('Select Courses'));
+                        $row->addSelect('courses[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
 
-					$row = $form->addRow()->addClass('course hiddenReveal');
-						$row->addLabel('coursesStaff', __('Include Staff?'));
-						$row->addYesNo('coursesStaff')->selected($selectedByRole['staff']);
+                    $row = $form->addRow()->addClass('course hiddenReveal');
+                        $row->addLabel('coursesStaff', __('Include Staff?'));
+                        $row->addYesNo('coursesStaff')->selected($selectedByRole['staff']);
 
-					$row = $form->addRow()->addClass('course hiddenReveal');
-						$row->addLabel('coursesStudents', __('Include Students?'));
-						$row->addYesNo('coursesStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('course hiddenReveal');
+                        $row->addLabel('coursesStudents', __('Include Students?'));
+                        $row->addYesNo('coursesStudents')->selected($selectedByRole['students']);
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_parents")) {
-						$row = $form->addRow()->addClass('course hiddenReveal');
-							$row->addLabel('coursesParents', __('Include Parents?'));
-							$row->addYesNo('coursesParents')->selected($selectedByRole['parents']);
-					}
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_courses_parents")) {
+                        $row = $form->addRow()->addClass('course hiddenReveal');
+                            $row->addLabel('coursesParents', __('Include Parents?'));
+                            $row->addYesNo('coursesParents')->selected($selectedByRole['parents']);
+                    }
+                }
 
-				// Class
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_any")) {
-					$selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Class') {
-							$group[] = $item['id'];
-							$selectedByRole['staff'] = $item['staff'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('class', __('Class'))->description(__('Members of a class within a course.'));
-						$row->addYesNoRadio('class')->checked($checked)->required();
+                // Class
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_any")) {
+                    $selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Class') {
+                            $group[] = $item['id'];
+                            $selectedByRole['staff'] = $item['staff'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('class', __('Class'))->description(__('Members of a class within a course.'));
+                        $row->addYesNoRadio('class')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('class')->onRadio('class')->when('Y');
+                    $form->toggleVisibilityByClass('class')->onRadio('class')->when('Y');
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_any")) {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
-						$sql = "SELECT gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
-					} else {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'));
-						$sql = "SELECT gibbonCourseClass.gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_any")) {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
+                        $sql = "SELECT gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
+                    } else {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'));
+                        $sql = "SELECT gibbonCourseClass.gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name
                             FROM gibbonCourse
                             JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID)
                             JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
                             WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND NOT role LIKE '%- Left' ORDER BY gibbonCourseClass.name";
-					}
+                    }
 
-					$row = $form->addRow()->addClass('class hiddenReveal');
-						$row->addLabel('classes[]', __('Select Classes'));
-						$row->addSelect('classes[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
+                    $row = $form->addRow()->addClass('class hiddenReveal');
+                        $row->addLabel('classes[]', __('Select Classes'));
+                        $row->addSelect('classes[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
 
-					$row = $form->addRow()->addClass('class hiddenReveal');
-						$row->addLabel('classesStaff', __('Include Staff?'));
-						$row->addYesNo('classesStaff')->selected($selectedByRole['staff']);
+                    $row = $form->addRow()->addClass('class hiddenReveal');
+                        $row->addLabel('classesStaff', __('Include Staff?'));
+                        $row->addYesNo('classesStaff')->selected($selectedByRole['staff']);
 
-					$row = $form->addRow()->addClass('class hiddenReveal');
-						$row->addLabel('classesStudents', __('Include Students?'));
-						$row->addYesNo('classesStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('class hiddenReveal');
+                        $row->addLabel('classesStudents', __('Include Students?'));
+                        $row->addYesNo('classesStudents')->selected($selectedByRole['students']);
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_parents")) {
-						$row = $form->addRow()->addClass('class hiddenReveal');
-							$row->addLabel('classesParents', __('Include Parents?'));
-							$row->addYesNo('classesParents')->selected($selectedByRole['parents']);
-					}
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_classes_parents")) {
+                        $row = $form->addRow()->addClass('class hiddenReveal');
+                            $row->addLabel('classesParents', __('Include Parents?'));
+                            $row->addYesNo('classesParents')->selected($selectedByRole['parents']);
+                    }
+                }
 
-				//Activities
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_any")) {
-					$selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Activity') {
-							$group[] = $item['id'];
-							$selectedByRole['staff'] = $item['staff'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('activity', __('Activity'))->description(__('Members of an activity.'));
-						$row->addYesNoRadio('activity')->checked($checked)->required();
+                //Activities
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_any")) {
+                    $selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Activity') {
+                            $group[] = $item['id'];
+                            $selectedByRole['staff'] = $item['staff'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('activity', __('Activity'))->description(__('Members of an activity.'));
+                        $row->addYesNoRadio('activity')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('activity')->onRadio('activity')->when('Y');
+                    $form->toggleVisibilityByClass('activity')->onRadio('activity')->when('Y');
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_any")) {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
-						$sql = "SELECT gibbonActivityID as value, name FROM gibbonActivity WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name";
-					} else {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'));
-						if ($roleCategory == "Staff") {
-							$sql = "SELECT gibbonActivity.gibbonActivityID as value, name FROM gibbonActivity JOIN gibbonActivityStaff ON (gibbonActivityStaff.gibbonActivityID=gibbonActivity.gibbonActivityID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name";
-						} else if ($roleCategory == "Student") {
-							$sql = "SELECT gibbonActivity.gibbonActivityID as value, name FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivityStudent.gibbonActivityID=gibbonActivity.gibbonActivityID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND status='Accepted' AND active='Y' ORDER BY name";
-						}
-					}
-					$row = $form->addRow()->addClass('activity hiddenReveal');
-						$row->addLabel('activities[]', __('Select Activities'));
-						$row->addSelect('activities[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_any")) {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
+                        $sql = "SELECT gibbonActivityID as value, name FROM gibbonActivity WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name";
+                    } else {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'));
+                        if ($roleCategory == "Staff") {
+                            $sql = "SELECT gibbonActivity.gibbonActivityID as value, name FROM gibbonActivity JOIN gibbonActivityStaff ON (gibbonActivityStaff.gibbonActivityID=gibbonActivity.gibbonActivityID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name";
+                        } else if ($roleCategory == "Student") {
+                            $sql = "SELECT gibbonActivity.gibbonActivityID as value, name FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivityStudent.gibbonActivityID=gibbonActivity.gibbonActivityID) WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND status='Accepted' AND active='Y' ORDER BY name";
+                        }
+                    }
+                    $row = $form->addRow()->addClass('activity hiddenReveal');
+                        $row->addLabel('activities[]', __('Select Activities'));
+                        $row->addSelect('activities[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
 
-					$row = $form->addRow()->addClass('activity hiddenReveal');
-						$row->addLabel('activitiesStaff', __('Include Staff?'));
-						$row->addYesNo('activitiesStaff')->selected($selectedByRole['staff']);
+                    $row = $form->addRow()->addClass('activity hiddenReveal');
+                        $row->addLabel('activitiesStaff', __('Include Staff?'));
+                        $row->addYesNo('activitiesStaff')->selected($selectedByRole['staff']);
 
-					$row = $form->addRow()->addClass('activity hiddenReveal');
-						$row->addLabel('activitiesStudents', __('Include Students?'));
-						$row->addYesNo('activitiesStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('activity hiddenReveal');
+                        $row->addLabel('activitiesStudents', __('Include Students?'));
+                        $row->addYesNo('activitiesStudents')->selected($selectedByRole['students']);
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_parents")) {
-						$row = $form->addRow()->addClass('activity hiddenReveal');
-							$row->addLabel('activitiesParents', __('Include Parents?'));
-							$row->addYesNo('activitiesParents')->selected($selectedByRole['parents']);
-					}
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_activities_parents")) {
+                        $row = $form->addRow()->addClass('activity hiddenReveal');
+                            $row->addLabel('activitiesParents', __('Include Parents?'));
+                            $row->addYesNo('activitiesParents')->selected($selectedByRole['parents']);
+                    }
+                }
 
-				// Applicants
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_applicants")) {
-					$selected = array_reduce($targets, function($group, $item) {
-						if ($item['type'] == 'Applicants') $group[] = $item['id'];
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('applicants', __('Applicants'))->description(__('Applicants from a given year.'))->description(__('Does not apply to the message wall.'));
-						$row->addYesNoRadio('applicants')->checked($checked)->required();
+                // Applicants
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_applicants")) {
+                    $selected = array_reduce($targets, function($group, $item) {
+                        if ($item['type'] == 'Applicants') $group[] = $item['id'];
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('applicants', __('Applicants'))->description(__('Applicants from a given year.'))->description(__('Does not apply to the message wall.'));
+                        $row->addYesNoRadio('applicants')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('applicants')->onRadio('applicants')->when('Y');
+                    $form->toggleVisibilityByClass('applicants')->onRadio('applicants')->when('Y');
 
-					$sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear ORDER BY sequenceNumber DESC";
-					$row = $form->addRow()->addClass('applicants hiddenReveal');
-						$row->addLabel('applicantList[]', __('Select Years'));
-						$row->addSelect('applicantList[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required()->selected($selected);
-				}
+                    $sql = "SELECT gibbonSchoolYearID as value, name FROM gibbonSchoolYear ORDER BY sequenceNumber DESC";
+                    $row = $form->addRow()->addClass('applicants hiddenReveal');
+                        $row->addLabel('applicantList[]', __('Select Years'));
+                        $row->addSelect('applicantList[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required()->selected($selected);
+                }
 
-				// Houses
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_all") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_my")) {
-					$selected = array_reduce($targets, function($group, $item) {
-						if ($item['type'] == 'Houses') $group[] = $item['id'];
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('houses', __('Houses'))->description(__('Houses for competitions, etc.'));
-						$row->addYesNoRadio('houses')->checked($checked)->required();
+                // Houses
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_all") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_my")) {
+                    $selected = array_reduce($targets, function($group, $item) {
+                        if ($item['type'] == 'Houses') $group[] = $item['id'];
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('houses', __('Houses'))->description(__('Houses for competitions, etc.'));
+                        $row->addYesNoRadio('houses')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('houses')->onRadio('houses')->when('Y');
+                    $form->toggleVisibilityByClass('houses')->onRadio('houses')->when('Y');
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_all")) {
-						$data = array();
-						$sql = "SELECT gibbonHouseID as value, name FROM gibbonHouse ORDER BY name";
-					} else if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_my")) {
-						$dataSelect = array('gibbonPersonID'=>$session->get('gibbonPersonID'));
-						$sql = "SELECT gibbonHouse.gibbonHouseID as value, name FROM gibbonHouse JOIN gibbonPerson ON (gibbonHouse.gibbonHouseID=gibbonPerson.gibbonHouseID) WHERE gibbonPersonID=:gibbonPersonID ORDER BY name";
-					}
-					$row = $form->addRow()->addClass('houses hiddenReveal');
-						$row->addLabel('houseList[]', __('Select Houses'));
-						$row->addSelect('houseList[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_all")) {
+                        $data = array();
+                        $sql = "SELECT gibbonHouseID as value, name FROM gibbonHouse ORDER BY name";
+                    } else if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_houses_my")) {
+                        $dataSelect = array('gibbonPersonID'=>$session->get('gibbonPersonID'));
+                        $sql = "SELECT gibbonHouse.gibbonHouseID as value, name FROM gibbonHouse JOIN gibbonPerson ON (gibbonHouse.gibbonHouseID=gibbonPerson.gibbonHouseID) WHERE gibbonPersonID=:gibbonPersonID ORDER BY name";
+                    }
+                    $row = $form->addRow()->addClass('houses hiddenReveal');
+                        $row->addLabel('houseList[]', __('Select Houses'));
+                        $row->addSelect('houseList[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);
+                }
 
-				// Transport
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_transport_any")) {
-					$selectedByRole = array('staff' => 'Y', 'students' => 'Y', 'parents' => 'N');
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Transport') {
-							$group[] = $item['id'];
-							$selectedByRole['staff'] = $item['staff'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('transport', __('Transport'))->description(__('Applies to all staff and students who have transport set.'));
-						$row->addYesNoRadio('transport')->checked($checked)->required();
+                // Transport
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_transport_any")) {
+                    $selectedByRole = array('staff' => 'Y', 'students' => 'Y', 'parents' => 'N');
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Transport') {
+                            $group[] = $item['id'];
+                            $selectedByRole['staff'] = $item['staff'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('transport', __('Transport'))->description(__('Applies to all staff and students who have transport set.'));
+                        $row->addYesNoRadio('transport')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('transport')->onRadio('transport')->when('Y');
+                    $form->toggleVisibilityByClass('transport')->onRadio('transport')->when('Y');
 
-					$sql = "SELECT DISTINCT transport as value, transport as name FROM gibbonPerson WHERE status='Full' AND NOT transport='' ORDER BY transport";
-					$row = $form->addRow()->addClass('transport hiddenReveal');
-						$row->addLabel('transports[]', __('Select Transport'));
-						$row->addSelect('transports[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required()->selected($selected);
+                    $sql = "SELECT DISTINCT transport as value, transport as name FROM gibbonPerson WHERE status='Full' AND NOT transport='' ORDER BY transport";
+                    $row = $form->addRow()->addClass('transport hiddenReveal');
+                        $row->addLabel('transports[]', __('Select Transport'));
+                        $row->addSelect('transports[]')->fromQuery($pdo, $sql)->selectMultiple()->setSize(6)->required()->selected($selected);
 
-					$row = $form->addRow()->addClass('transport hiddenReveal');
-						$row->addLabel('transportStaff', __('Include Staff?'));
-						$row->addYesNo('transportStaff')->selected($selectedByRole['staff']);
+                    $row = $form->addRow()->addClass('transport hiddenReveal');
+                        $row->addLabel('transportStaff', __('Include Staff?'));
+                        $row->addYesNo('transportStaff')->selected($selectedByRole['staff']);
 
-					$row = $form->addRow()->addClass('transport hiddenReveal');
-						$row->addLabel('transportStudents', __('Include Students?'));
-						$row->addYesNo('transportStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('transport hiddenReveal');
+                        $row->addLabel('transportStudents', __('Include Students?'));
+                        $row->addYesNo('transportStudents')->selected($selectedByRole['students']);
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_transport_parents")) {
-						$row = $form->addRow()->addClass('transport hiddenReveal');
-							$row->addLabel('transportParents', __('Include Parents?'));
-							$row->addYesNo('transportParents')->selected($selectedByRole['parents']);
-					}
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_transport_parents")) {
+                        $row = $form->addRow()->addClass('transport hiddenReveal');
+                            $row->addLabel('transportParents', __('Include Parents?'));
+                            $row->addYesNo('transportParents')->selected($selectedByRole['parents']);
+                    }
+                }
 
-				// Attendance Status / Absentees
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_attendance")) {
-					$selectedByRole = array('students' => 'N', 'parents' => 'N',);
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Attendance') {
-							$group[] = $item['id'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';$row = $form->addRow();
-						$row->addLabel('attendance', __('Attendance Status'))->description(__('Students matching the given attendance status.'));
-						$row->addYesNoRadio('attendance')->checked($checked)->required();
+                // Attendance Status / Absentees
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_attendance")) {
+                    $selectedByRole = array('students' => 'N', 'parents' => 'N',);
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Attendance') {
+                            $group[] = $item['id'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';$row = $form->addRow();
+                        $row->addLabel('attendance', __('Attendance Status'))->description(__('Students matching the given attendance status.'));
+                        $row->addYesNoRadio('attendance')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('attendance')->onRadio('attendance')->when('Y');
+                    $form->toggleVisibilityByClass('attendance')->onRadio('attendance')->when('Y');
 
-					$sql = "SELECT name, gibbonRoleIDAll FROM gibbonAttendanceCode WHERE active = 'Y' ORDER BY direction DESC, sequenceNumber ASC, name";
-					$result = $pdo->executeQuery(array(), $sql);
+                    $sql = "SELECT name, gibbonRoleIDAll FROM gibbonAttendanceCode WHERE active = 'Y' ORDER BY direction DESC, sequenceNumber ASC, name";
+                    $result = $pdo->executeQuery(array(), $sql);
 
-					// Filter the attendance codes by allowed roles (if any)
-					$currentRole = $session->get('gibbonRoleIDCurrent');
-					$attendanceCodes = ($result->rowCount() > 0)? $result->fetchAll() : array();
-					$attendanceCodes = array_filter($attendanceCodes, function($item) use ($currentRole) {
-						if (!empty($item['gibbonRoleIDAll'])) {
-							$rolesAllowed = array_map('trim', explode(',', $item['gibbonRoleIDAll']));
-							return in_array($currentRole, $rolesAllowed);
-						} else {
-							return true;
-						}
-					});
-					$attendanceCodes = array_column($attendanceCodes, 'name');
+                    // Filter the attendance codes by allowed roles (if any)
+                    $currentRole = $session->get('gibbonRoleIDCurrent');
+                    $attendanceCodes = ($result->rowCount() > 0)? $result->fetchAll() : array();
+                    $attendanceCodes = array_filter($attendanceCodes, function($item) use ($currentRole) {
+                        if (!empty($item['gibbonRoleIDAll'])) {
+                            $rolesAllowed = array_map('trim', explode(',', $item['gibbonRoleIDAll']));
+                            return in_array($currentRole, $rolesAllowed);
+                        } else {
+                            return true;
+                        }
+                    });
+                    $attendanceCodes = array_column($attendanceCodes, 'name');
 
-					$row = $form->addRow()->addClass('attendance hiddenReveal');
-						$row->addLabel('attendanceStatus[]', __('Select Attendance Status'));
-						$row->addSelect('attendanceStatus[]')->fromArray($attendanceCodes)->selectMultiple()->setSize(6)->required()->selected($selected);
+                    $row = $form->addRow()->addClass('attendance hiddenReveal');
+                        $row->addLabel('attendanceStatus[]', __('Select Attendance Status'));
+                        $row->addSelect('attendanceStatus[]')->fromArray($attendanceCodes)->selectMultiple()->setSize(6)->required()->selected($selected);
 
-					$row = $form->addRow()->addClass('attendance hiddenReveal');
-						$row->addLabel('attendanceStudents', __('Include Students?'));
-						$row->addYesNo('attendanceStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('attendance hiddenReveal');
+                        $row->addLabel('attendanceStudents', __('Include Students?'));
+                        $row->addYesNo('attendanceStudents')->selected($selectedByRole['students']);
 
-					$row = $form->addRow()->addClass('attendance hiddenReveal');
-						$row->addLabel('attendanceParents', __('Include Parents?'));
-						$row->addYesNo('attendanceParents')->selected($selectedByRole['parents']);
-				}
+                    $row = $form->addRow()->addClass('attendance hiddenReveal');
+                        $row->addLabel('attendanceParents', __('Include Parents?'));
+                        $row->addYesNo('attendanceParents')->selected($selectedByRole['parents']);
+                }
 
-				// Group
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_any")) {
-					$selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
-					$selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
-						if ($item['type'] == 'Group') {
-							$group[] = $item['id'];
-							$selectedByRole['staff'] = $item['staff'];
-							$selectedByRole['students'] = $item['students'];
-							$selectedByRole['parents'] = $item['parents'];
-						}
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';
-					$row = $form->addRow();
-						$row->addLabel('group', __('Group'))->description(__('Members of a Messenger module group.'));
-						$row->addYesNoRadio('group')->checked($checked)->required();
+                // Group
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_my") OR isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_any")) {
+                    $selectedByRole = array('staff' => 'N', 'students' => 'N', 'parents' => 'N',);
+                    $selected = array_reduce($targets, function($group, $item) use (&$selectedByRole) {
+                        if ($item['type'] == 'Group') {
+                            $group[] = $item['id'];
+                            $selectedByRole['staff'] = $item['staff'];
+                            $selectedByRole['students'] = $item['students'];
+                            $selectedByRole['parents'] = $item['parents'];
+                        }
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';
+                    $row = $form->addRow();
+                        $row->addLabel('group', __('Group'))->description(__('Members of a Messenger module group.'));
+                        $row->addYesNoRadio('group')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('messageGroup')->onRadio('group')->when('Y');
+                    $form->toggleVisibilityByClass('messageGroup')->onRadio('group')->when('Y');
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_any")) {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
-						$sql = "SELECT gibbonGroup.gibbonGroupID as value, gibbonGroup.name FROM gibbonGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
-					} else {
-						$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'), 'gibbonSchoolYearID2' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID2' => $session->get('gibbonPersonID'));
-						$sql = "(SELECT gibbonGroup.gibbonGroupID as value, gibbonGroup.name FROM gibbonGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonIDOwner=:gibbonPersonID ORDER BY name)
-							UNION
-							(SELECT gibbonGroup.gibbonGroupID as value, gibbonGroup.name FROM gibbonGroup JOIN gibbonGroupPerson ON (gibbonGroupPerson.gibbonGroupID=gibbonGroup.gibbonGroupID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID2 AND gibbonPersonID=:gibbonPersonID2)
-							ORDER BY name
-							";
-					}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_any")) {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
+                        $sql = "SELECT gibbonGroup.gibbonGroupID as value, gibbonGroup.name FROM gibbonGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
+                    } else {
+                        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $session->get('gibbonPersonID'), 'gibbonSchoolYearID2' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID2' => $session->get('gibbonPersonID'));
+                        $sql = "(SELECT gibbonGroup.gibbonGroupID as value, gibbonGroup.name FROM gibbonGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonPersonIDOwner=:gibbonPersonID ORDER BY name)
+                            UNION
+                            (SELECT gibbonGroup.gibbonGroupID as value, gibbonGroup.name FROM gibbonGroup JOIN gibbonGroupPerson ON (gibbonGroupPerson.gibbonGroupID=gibbonGroup.gibbonGroupID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID2 AND gibbonPersonID=:gibbonPersonID2)
+                            ORDER BY name
+                            ";
+                    }
 
-					$row = $form->addRow()->addClass('messageGroup hiddenReveal');
-						$row->addLabel('groups[]', __('Select Groups'));
-						$row->addSelect('groups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);;
+                    $row = $form->addRow()->addClass('messageGroup hiddenReveal');
+                        $row->addLabel('groups[]', __('Select Groups'));
+                        $row->addSelect('groups[]')->fromQuery($pdo, $sql, $data)->selectMultiple()->setSize(6)->required()->selected($selected);;
 
-					$row = $form->addRow()->addClass('messageGroup hiddenReveal');
-						$row->addLabel('groupsStaff', __('Include Staff?'));
-						$row->addYesNo('groupsStaff')->selected($selectedByRole['staff']);
+                    $row = $form->addRow()->addClass('messageGroup hiddenReveal');
+                        $row->addLabel('groupsStaff', __('Include Staff?'));
+                        $row->addYesNo('groupsStaff')->selected($selectedByRole['staff']);
 
-					$row = $form->addRow()->addClass('messageGroup hiddenReveal');
-						$row->addLabel('groupsStudents', __('Include Students?'));
-						$row->addYesNo('groupsStudents')->selected($selectedByRole['students']);
+                    $row = $form->addRow()->addClass('messageGroup hiddenReveal');
+                        $row->addLabel('groupsStudents', __('Include Students?'));
+                        $row->addYesNo('groupsStudents')->selected($selectedByRole['students']);
 
-					if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_parents")) {
-						$row = $form->addRow()->addClass('messageGroup hiddenReveal');
-							$row->addLabel('groupsParents', __('Include Parents?'))->description('Parents who are members, and parents of student members.');
-							$row->addYesNo('groupsParents')->selected($selectedByRole['parents']);
-					}
-				}
+                    if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_groups_parents")) {
+                        $row = $form->addRow()->addClass('messageGroup hiddenReveal');
+                            $row->addLabel('groupsParents', __('Include Parents?'))->description('Parents who are members, and parents of student members.');
+                            $row->addYesNo('groupsParents')->selected($selectedByRole['parents']);
+                    }
+                }
 
-				// Individuals
-				if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_individuals")) {
-					$selected = array_reduce($targets, function($group, $item) {
-						if ($item['type'] == 'Individuals') $group[] = $item['id'];
-						return $group;
-					}, array());
-					$checked = !empty($selected)? 'Y' : 'N';$row = $form->addRow();
-						$row->addLabel('individuals', __('Individuals'))->description(__('Individuals from the whole school.'));
-						$row->addYesNoRadio('individuals')->checked($checked)->required();
+                // Individuals
+                if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_individuals")) {
+                    $selected = array_reduce($targets, function($group, $item) {
+                        if ($item['type'] == 'Individuals') $group[] = $item['id'];
+                        return $group;
+                    }, array());
+                    $checked = !empty($selected)? 'Y' : 'N';$row = $form->addRow();
+                        $row->addLabel('individuals', __('Individuals'))->description(__('Individuals from the whole school.'));
+                        $row->addYesNoRadio('individuals')->checked($checked)->required();
 
-					$form->toggleVisibilityByClass('individuals')->onRadio('individuals')->when('Y');
+                    $form->toggleVisibilityByClass('individuals')->onRadio('individuals')->when('Y');
 
-					$sql = "SELECT gibbonRole.category, gibbonPersonID, preferredName, surname, username FROM gibbonPerson JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary) WHERE status='Full' ORDER BY surname, preferredName";
-					$result = $pdo->executeQuery(array(), $sql);
+                    $sql = "SELECT gibbonRole.category, gibbonPersonID, preferredName, surname, username FROM gibbonPerson JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary) WHERE status='Full' ORDER BY surname, preferredName";
+                    $result = $pdo->executeQuery(array(), $sql);
 
-					// Build a set of individuals by ID => formatted name
-					$individuals = ($result->rowCount() > 0)? $result->fetchAll() : array();
-					$individuals = array_reduce($individuals, function($group, $item){
-						$group[$item['gibbonPersonID']] = Format::name("", $item['preferredName'], $item['surname'], 'Student', true) . ' ('.$item['username'].', '.__($item['category']).')';
-						return $group;
-					}, array());
+                    // Build a set of individuals by ID => formatted name
+                    $individuals = ($result->rowCount() > 0)? $result->fetchAll() : array();
+                    $individuals = array_reduce($individuals, function($group, $item){
+                        $group[$item['gibbonPersonID']] = Format::name("", $item['preferredName'], $item['surname'], 'Student', true) . ' ('.$item['username'].', '.__($item['category']).')';
+                        return $group;
+                    }, array());
 
-					$row = $form->addRow()->addClass('individuals hiddenReveal');
-						$row->addLabel('individualList[]', __('Select Individuals'));
-						$row->addSelect('individualList[]')->fromArray($individuals)->selectMultiple()->setSize(6)->required()->selected($selected);
-				}
+                    $row = $form->addRow()->addClass('individuals hiddenReveal');
+                        $row->addLabel('individualList[]', __('Select Individuals'));
+                        $row->addSelect('individualList[]')->fromArray($individuals)->selectMultiple()->setSize(6)->required()->selected($selected);
+                }
 
-				$form->loadAllValuesFrom($values);
+                $form->loadAllValuesFrom($values);
 
-				$row = $form->addRow();
-					$row->addFooter();
-					$row->addSubmit();
+                $row = $form->addRow();
+                    $row->addFooter();
+                    $row->addSubmit();
 
-				echo $form->getOutput();
-			}
-		}
-	}
+                echo $form->getOutput();
+            }
+        }
+    }
 }

--- a/modules/Messenger/messenger_manage_editProcess.php
+++ b/modules/Messenger/messenger_manage_editProcess.php
@@ -71,6 +71,7 @@ else {
                     $date3=Format::dateConvert($_POST["date3"]) ;
                 }
             }
+            $confidential = $_POST['confidential'] ?? '';
             $subject = $_POST['subject'] ?? '';
             $body = $_POST['body'] ?? '';
 
@@ -82,8 +83,8 @@ else {
             else {
                 //Write to database
                 try {
-                    $dataUpdate=array("messageWall"=>$messageWall, "messageWallPin" => $messageWallPin, "messageWall_date1"=>$date1, "messageWall_date2"=>$date2, "messageWall_date3"=>$date3, "subject"=>$subject, "body"=>$body, "timestamp"=>date("Y-m-d H:i:s"), "gibbonMessengerID"=>$gibbonMessengerID);
-                    $sqlUpdate="UPDATE gibbonMessenger SET messageWall=:messageWall, messageWallPin=:messageWallPin, messageWall_date1=:messageWall_date1, messageWall_date2=:messageWall_date2, messageWall_date3=:messageWall_date3, subject=:subject, body=:body, timestamp=:timestamp WHERE gibbonMessengerID=:gibbonMessengerID" ;
+                    $dataUpdate=array("messageWall"=>$messageWall, "messageWallPin" => $messageWallPin, "messageWall_date1"=>$date1, "messageWall_date2"=>$date2, "messageWall_date3"=>$date3, "subject"=>$subject, "body"=>$body, 'confidential' => $confidential, "timestamp"=>date("Y-m-d H:i:s"), "gibbonMessengerID"=>$gibbonMessengerID);
+                    $sqlUpdate="UPDATE gibbonMessenger SET messageWall=:messageWall, messageWallPin=:messageWallPin, messageWall_date1=:messageWall_date1, messageWall_date2=:messageWall_date2, messageWall_date3=:messageWall_date3, subject=:subject, body=:body, confidential=:confidential, timestamp=:timestamp WHERE gibbonMessengerID=:gibbonMessengerID" ;
                     $resultUpdate=$connection2->prepare($sqlUpdate);
                     $resultUpdate->execute($dataUpdate);
                 }

--- a/modules/Messenger/messenger_post.php
+++ b/modules/Messenger/messenger_post.php
@@ -163,10 +163,16 @@ else {
                     $form->addHiddenValue('smsCreditBalance', $smsCredits);
                 }
 
-                $form->addRow()->addAlert($smsAlert, 'error')->addClass('sms');
+                $form->addRow()->addClass('sms')->addAlert($smsAlert, 'error');
             }
         }
 
+        // Confidential Message Option
+        if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.php", "New Message_confidential")) {
+            $row = $form->addRow();
+                $row->addLabel('confidential', __('Confidential'))->description(__('Other users will not be able to see this message in Manage Messages.'));
+                $row->addYesNoRadio('confidential')->checked('N')->required();
+        }
 
         //MESSAGE DETAILS
         $form->addRow()->addHeading('Message Details', __('Message Details'));

--- a/modules/Messenger/messenger_postPreProcess.php
+++ b/modules/Messenger/messenger_postPreProcess.php
@@ -50,6 +50,7 @@ if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.p
         'body'              => $_POST['body'] ?? '',
         'emailReceipt'      => $_POST['emailReceipt'] ?? 'N',
         'emailReceiptText'  => $_POST['emailReceiptText'] ?? '',
+        'confidential'      => $_POST['confidential'] ?? 'N',
         'gibbonPersonID'    => $session->get('gibbonPersonID'),
         'timestamp'         => date('Y-m-d H:i:s'),
     ];

--- a/modules/Messenger/messenger_postProcess.php
+++ b/modules/Messenger/messenger_postProcess.php
@@ -106,7 +106,8 @@ else {
 		if (isset($_POST["emailReceiptText"])) {
 			$emailReceiptText = $_POST["emailReceiptText"] ;
 		}
-		$individualNaming = $_POST["individualNaming"] ;
+		$individualNaming = $_POST["individualNaming"] ?? 'N';
+        $confidential = $_POST['confidential'] ?? 'N';
 
 		if ($subject == "" OR $body == "" OR ($email == "Y" AND $from == "") OR $emailReceipt == '' OR ($emailReceipt == "Y" AND $emailReceiptText == "") OR $individualNaming == "") {
             //Fail 3
@@ -2110,7 +2111,7 @@ else {
                     return $recipient != $from && !in_array($recipient, $recipientList);
                 });
 
-                if (!empty($messageBccList) && !empty($report)) {
+                if (!empty($messageBccList) && !empty($report) && $confidential == 'N') {
                     $mail->ClearAddresses();
                     foreach ($messageBccList as $recipient) {
                         $mail->AddBCC($recipient, '');

--- a/src/Database/Migrations/2021-03-03-MedicalFields.php
+++ b/src/Database/Migrations/2021-03-03-MedicalFields.php
@@ -46,7 +46,7 @@ class MedicalFields extends Migration
         $partialFail = false;
 
         // Prevent running this migration if the field has already been removed
-        $fieldPresent = $this->db->select("SHOW COLUMNS FROM `gibbonPersonMedical` LIKE 'bloodType'");
+        $fieldPresent = $this->db->select("SHOW COLUMNS FROM `gibbonPersonMedical` LIKE 'bloodType'")->fetchAll();
         if (empty($fieldPresent)) return true;
 
         // Create the Blood Type and Tetanus custom fields

--- a/src/Domain/Messenger/MessengerGateway.php
+++ b/src/Domain/Messenger/MessengerGateway.php
@@ -49,7 +49,7 @@ class MessengerGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonMessenger.gibbonMessengerID', 'gibbonMessenger.subject', 'gibbonMessenger.timestamp', 'gibbonMessenger.email', 'gibbonMessenger.messageWall', 'gibbonMessenger.sms', 'gibbonMessenger.messageWall_date1', 'gibbonMessenger.messageWall_date2', 'gibbonMessenger.messageWall_date3', 'gibbonMessenger.emailReceipt', 'gibbonPerson.title', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonRole.category', 
+                'gibbonMessenger.gibbonMessengerID', 'gibbonMessenger.subject', 'gibbonMessenger.timestamp', 'gibbonMessenger.email', 'gibbonMessenger.messageWall', 'gibbonMessenger.sms', 'gibbonMessenger.messageWall_date1', 'gibbonMessenger.messageWall_date2', 'gibbonMessenger.messageWall_date3', 'gibbonMessenger.emailReceipt', 'gibbonMessenger.confidential', 'gibbonPerson.title', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonRole.category', 
             ])
             ->innerJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonMessenger.gibbonPersonID')
             ->innerJoin('gibbonRole', 'gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary')
@@ -60,6 +60,14 @@ class MessengerGateway extends QueryableGateway
             $query->where('gibbonMessenger.gibbonPersonID=:gibbonPersonID')
                 ->bindValue('gibbonPersonID', $gibbonPersonID);
         }
+
+        $criteria->addFilterRules([
+            'confidential' => function ($query, $gibbonPersonIDCreatedBy) {
+                return $query
+                    ->where('(gibbonMessenger.confidential="N" OR (gibbonMessenger.confidential="Y" AND gibbonMessenger.gibbonPersonID=:gibbonPersonIDCreatedBy))')
+                    ->bindValue('gibbonPersonIDCreatedBy', $gibbonPersonIDCreatedBy);
+            },
+        ]);
 
         return $this->runQuery($query, $criteria);
     }


### PR DESCRIPTION
Generally messages are only viewable by the person who sent them, as the default permission is "Manage Messages_my." However, any admin or other user with "Manage Messages_all" permission can see all messages sent by all users. This PR adds the option to give select users the "New Message_confidential" permission, which enables them to send messages which do not show up for any other user regardless of their permissions.

- Adds a `confidential` field to the gibbonMessenger table.
- Adds a permission `New Message_confidential`, enabled for admin only by default.
- Checks permissions and confidential flag on Manage Messages and Edit Message pages.
- Checks confidential flag when using the BCC messages option.
- Adds a visual `Confidential` tag to messages in Manage Messages.

**Motivation and Context**
This enables school admin and leadership to send sensitive messages when needed without them being viewable by other users.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
<img width="1176" alt="Screenshot 2022-06-24 at 2 17 26 PM" src="https://user-images.githubusercontent.com/897700/175475707-32fbb4a9-8bf6-402c-afe7-35b017435c1f.png">
<img width="821" alt="Screenshot 2022-06-24 at 2 17 44 PM" src="https://user-images.githubusercontent.com/897700/175475716-a66a8a44-d14c-4f78-ab12-4d0780fb7aba.png">
