### PR TITLE
Forms: add sticky submit button for long forms

### DIFF
--- a/resources/assets/js/setup.js
+++ b/resources/assets/js/setup.js
@@ -103,4 +103,16 @@ $(document).ready(function(){
             "#ffffff", "White", 
         ],
     });
+
+    // Sticky Observer
+    const el = document.querySelector(".submitRow.sticky");
+    const observer = new IntersectionObserver( 
+        function([e]) { 
+            e.target.classList.toggle("shadow-top", e.intersectionRatio < 1);
+            e.target.classList.toggle("bg-gray-300", e.intersectionRatio < 1);
+        },
+        { threshold: [1] }
+    );
+
+    observer.observe(el);
 });

--- a/resources/templates/components/form.twig.html
+++ b/resources/templates/components/form.twig.html
@@ -52,7 +52,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     {% set renderStyle = "standardForm" in form.getClass or "noIntBorder" in form.getClass and "blank" not in form.getClass ? 'flex' : 'table' %}
 
     {% if form.getRows|length > 0 %}
-        <div class="{{ form.getClass }} font-sans text-xs text-gray-700 relative overflow-hidden {{ "blank" not in form.getClass ? 'bg-gray-100 rounded border mt-3' }}" style="{{ "noIntBorder" in form.getClass ? 'background:#edf7ff' }}" cellspacing="0">
+        <div class="{{ form.getClass }} font-sans text-xs text-gray-700 relative {{ "blank" not in form.getClass ? 'bg-gray-100 rounded border mt-3' }}" style="{{ "noIntBorder" in form.getClass ? 'background:#edf7ff' }}" cellspacing="0">
 
         {% for section, rows in form.getRowsByHeading %}
             {% set sectionLoop = loop %}

--- a/resources/templates/index.twig.html
+++ b/resources/templates/index.twig.html
@@ -107,7 +107,7 @@ TODO: add template variable details.
                         {{ include('navigation.twig.html') }}
                     {% endif %}
 
-                    <div id="content" class="{{ contentClass ? contentClass : 'max-w-full' }} w-full shadow bg-white sm:rounded lg:flex-1 px-8 {{ page.breadcrumbs ? 'py-6' : 'pb-6' }} {{ not preventOverflow ? 'overflow-x-scroll lg:overflow-x-auto' : 'overflow-x-auto xl:overflow-x-unset' }} ">
+                    <div id="content" class="{{ contentClass ? contentClass : 'max-w-full' }} w-full shadow bg-white sm:rounded lg:flex-1 px-8 {{ page.breadcrumbs ? 'py-6' : 'pb-6' }} ">
 
                         {% block page %}
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -244,7 +244,12 @@ class Form implements OutputableInterface
 
     public function getRowsByHeading()
     {
-        return array_reduce($this->rows, function ($group, $row) {
+        $rowCount = count($this->rows);
+        return array_reduce($this->rows, function ($group, $row) use (&$rowCount) {
+            
+            if ($row->getHeading() == 'submit' && $rowCount > 10) {
+                $row->addClass('submitRow sticky -bottom-px bg-gray-100 border-t -mt-px mb-px z-50');
+            }
             $group[$row->getHeading()][] = $row;
             return $group;
         }, []);

--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -1344,3 +1344,11 @@ table.smallIntBorder td.noPadding {
 .standardForm:not(.blank) .formRow:not(:last-child)  {
     border-bottom-width: 1px;
 }
+
+.\-bottom-px {
+    bottom: -1px;
+}
+
+.shadow-top {
+    box-shadow: 0 -1px 3px 0 rgba(0, 0, 0, 0.1), 0 -2px 2px -1px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
Updates forms so that long forms, those with more than 10 fields, have a floating submit button. The submit-button-row changes colour when floating, to differentiate it from other fields and make it clearer that it's not the bottom of the form.

**Motivation and Context**
Makes it easier for users to save changes when working with long forms, especially users and planners.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="942" alt="Screenshot 2022-08-03 at 5 52 59 PM" src="https://user-images.githubusercontent.com/897700/183829497-f481852e-fc2d-4f1c-af93-dcb3f0cbe2b7.png">

