### PR TITLE
PHP 8.2 Compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
         php-version: ["7.3", "7.4", "8.0", "8.1"]
         experimental: [false]
         name: ["CI Test"]
+        include:
+          - php-version: "8.2"
+            experimental: true
+            name: "CI Test, Experimental"
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ["7.3", "7.4", "8.0", "8.1"]
+        php-version: ["7.3", "7.4", "8.0", "8.1", "8.2"]
         experimental: [false]
         name: ["CI Test"]
-        include:
-          - php-version: "8.2"
-            experimental: true
-            name: "CI Test, Experimental"
     services:
       mysql:
         image: mysql:5.7

--- a/modules/Markbook/src/MarkbookView.php
+++ b/modules/Markbook/src/MarkbookView.php
@@ -97,9 +97,15 @@ class MarkbookView
 
     /**
      * The database ID of the gibbonCourseClass
-     * @var [type]
+     * @var int
      */
     public $gibbonCourseClassID;
+
+    /**
+     * The database ID of the gibbonSchoolYear
+     * @var int
+     */
+    public $gibbonSchoolYearID;
 
     /**
      * @var SettingGateway
@@ -323,10 +329,10 @@ class MarkbookView
         foreach ($dataSet as $i => $columnData) {
             if ($column = new MarkbookColumn($columnData, $this->settings['enableEffort'], $this->settings['enableRubrics'])) {
                 $this->columns[$i] = $column;
-				
+
 				// Grab the minimum sequenceNumber for the current page set, to pass to markbook_viewAjax.php
 				$this->minSequenceNumber = min($this->minSequenceNumber, $columnData['sequenceNumber']);
-                
+
 				// Attach planner info to help determine if theres homework submissions for this column
                 if (!empty($columnData['gibbonPlannerEntry'])) {
                     $column->setSubmissionDetails($columnData['gibbonPlannerEntry']);

--- a/src/Data/Validator.php
+++ b/src/Data/Validator.php
@@ -57,7 +57,7 @@ class Validator
 
         // Default allowable tags
         $allowableTags['*CustomEditor'] = 'HTML';
-        
+
         // Match wildcard * in allowable tags and add these fields to the list
         foreach ($allowableTags as $field => $value) {
             if (stripos($field, '*') === false) continue;
@@ -110,7 +110,7 @@ class Validator
                     $value = trim($value);
                 }
 
-                
+
             }
 
             $output[$field] = $value;
@@ -201,7 +201,7 @@ class Validator
         $dom->validateOnParse=false;
         libxml_use_internal_errors(true);
 
-        $value = '<?xml encoding="utf-8" ?>' . mb_convert_encoding($value, 'HTML-ENTITIES', 'UTF-8');
+        $value = '<?xml encoding="utf-8" ?>' . mb_encode_numericentity($value, [0x80, 0xfffffff, 0, 0xfffffff], 'UTF-8');
 
         if ($dom->loadHTML('<body>'.$value.'</body>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD)) {
             // Iterate over the DOM and remove attributes not in the whitelist

--- a/src/Database/Migrations/2021-08-01-GoogleSettings.php
+++ b/src/Database/Migrations/2021-08-01-GoogleSettings.php
@@ -26,13 +26,25 @@ use Gibbon\Database\Migrations\Migration;
  */
 class GoogleSettings extends Migration
 {
+    /**
+     * Database connection
+     *
+     * @var Connection
+     */
     protected $db;
+
+    /**
+     * Setting Gateway
+     *
+     * @var SettingGateway
+     */
+    protected $settingGateway;
 
     public function __construct(Connection $db, SettingGateway $settingGateway)
     {
         $this->db = $db;
         $this->settingGateway = $settingGateway;
-    }   
+    }
 
     public function migrate()
     {
@@ -42,7 +54,7 @@ class GoogleSettings extends Migration
         if ($googleOAuth == 'Migrated') {
             return true;
         }
-        
+
         $data = [
             'enabled'      => $googleOAuth,
             'clientName'   => $this->settingGateway->getSettingByScope('System', 'googleClientName'),


### PR DESCRIPTION
**Description**
* Add PHP 8.2 as a test target of Gibbon.
* Fix all issues that causes deprecation warning in the unit test.

**Motivation and Context**
* [PHP 8.2RC1](https://www.php.net/archive/2022.php#2022-09-01-4) has been released. It's perhaps time to include the version for testing.

**How Has This Been Tested?**
* CI environment.