### PR TITLE
Remove legacy class namespace compatibility

### DIFF
--- a/gibbon.php
+++ b/gibbon.php
@@ -131,8 +131,5 @@ if ($gibbon->isInstalled() && $session->has('absoluteURL')) {
 if (!empty($session->get('module'))) {
     $moduleNamespace = preg_replace('/[^a-zA-Z0-9]/', '', $session->get('module'));
     $autoloader->addPsr4('Gibbon\\Module\\'.$moduleNamespace.'\\', realpath(__DIR__).'/modules/'.$session->get('module').'/src');
-
-    // Temporary backwards-compatibility for external modules (Query Builder)
-    $autoloader->addPsr4('Gibbon\\'.$moduleNamespace.'\\', realpath(__DIR__).'/modules/'.$session->get('module'));
     $autoloader->register(true);
 }


### PR DESCRIPTION
**Description**
* Remove autoloading support to autoload class like: "Gibbon\SomeModule\MyClass" -> "modules/Some Module/MyClass.php"

**Motivation and Context**
* The backward compatibility was introduced in f4fde610be (Nov 2018).
* As the comment stated, it was "Temporary backwards-compatibility for external modules (Query Builder)".
* I've checked the latest version of [Query Builder](https://github.com/GibbonEdu/module-queryBuilder/tree/806de79f3f19564637fae038fb87833b852486a2). The legacy class namespace style doesn't seem to exists anymore.

**How Has This Been Tested?**
* Locally