### PR TITLE
Fix Reports NullContext compliance with the DataContext interface

### DIFF
--- a/modules/Reports/src/Contexts/NullContext.php
+++ b/modules/Reports/src/Contexts/NullContext.php
@@ -24,12 +24,19 @@ use Gibbon\Module\Reports\DataContext;
 
 class NullContext implements DataContext
 {
+
+    /**
+     * {@inheritDoc}
+     */
     public function getFormatter()
     {
         return function () { return ''; };
     }
 
-    public function getIdentifiers(Connection $db, string $gibbonSchoolYearID, string $gibbonReportID, string $gibbonYearGroupID)
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifiers(Connection $pdo, string $gibbonReportID, string $gibbonYearGroupID)
     {
         return [];
     }

--- a/modules/Reports/src/DataContext.php
+++ b/modules/Reports/src/DataContext.php
@@ -23,6 +23,21 @@ use Gibbon\Contracts\Database\Connection;
 
 interface DataContext
 {
+    /**
+     * Get formatter (callable) to format with.
+     *
+     * @return callable
+     */
     public function getFormatter();
+
+    /**
+     * Get the identifiers.
+     *
+     * @param Connection $pdo
+     * @param string     $gibbonReportID
+     * @param string     $gibbonYearGroupID
+     *
+     * @return array
+     */
     public function getIdentifiers(Connection $pdo, string $gibbonReportID, string $gibbonYearGroupID);
 }


### PR DESCRIPTION
**Description**
* Fix the parameter list of NullContext::getIdentifiers().
* Improve documentation to the DataContext interface.

**Motivation and Context**
* NullContext::getIdentifiers() has 1 more parameter than the DataContext::getIdentifiers() and hence failed to implement DataContext. Reading the code and see the parameter list is wrong.

**How Has This Been Tested?**
* Locally
* CI environment.