### PR TITLE
System: improve documentation for DatabaseFormFactory

### DIFF
--- a/src/Forms/DatabaseFormFactory.php
+++ b/src/Forms/DatabaseFormFactory.php
@@ -34,13 +34,23 @@ use Gibbon\Services\Format;
  */
 class DatabaseFormFactory extends FormFactory
 {
+    /**
+     * Database connection.
+     *
+     * @var Connection
+     */
     protected $pdo;
 
+    /**
+     * Cached queries
+     *
+     * @var array
+     */
     protected $cachedQueries = array();
 
     /**
      * Create a factory with access to the provided a database connection.
-     * @param  Gibbon\Contracts\Database\Connection  $pdo
+     * @param  Connection  $pdo
      */
     public function __construct(Connection $pdo)
     {


### PR DESCRIPTION
**Description**
Fix phpdocs namespace usage.

**Motivation and Context**
* Types in phpdocs should either be short name (refers to type specified in use statement) or starts from root.

**How Has This Been Tested?**
* Locally with VSCode and [Intelephence](https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client).