### PR TITLE
Refactor: make getEditor function obsoleted

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -23,6 +23,7 @@ use Gibbon\Services\Format;
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Domain\System\LogGateway;
 use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Forms\Input\Editor;
 
 function getIPAddress() {
     $return = false;
@@ -469,6 +470,8 @@ function getWeekNumber($date, $connection2, $guid)
  *
  * @deprecated  Since v25. Will be removed in the future.
  *              Please use \Gibbon\Forms\Input\Editor directly.
+ * @version v25
+ * @since   v12
  *
  * @param string   $guid              Obsoleted parameter.
  * @param boolean  $tinymceInit
@@ -486,16 +489,17 @@ function getWeekNumber($date, $connection2, $guid)
  */
 function getEditor($guid, $tinymceInit = true, $id = '', $value = '', $rows = 10, $showMedia = false, $required = false, $initiallyHidden = false, $allowUpload = true, $initialFilter = '', $resourceAlphaSort = false): string
 {
-    global $page, $session;
-
-    $templateData = compact('tinymceInit', 'id', 'value', 'rows', 'showMedia', 'required', 'initiallyHidden', 'allowUpload', 'initialFilter', 'resourceAlphaSort');
-
-    $templateData['name'] = $templateData['id'];
-    $templateData['id'] = preg_replace('/[^a-zA-Z0-9_-]/', '', $templateData['id']);
-
-    $templateData['absoluteURL'] = $session->get('absoluteURL');
-
-    return $page->fetchFromTemplate('components/editor.twig.html', $templateData);
+    $editor = (new Editor($id))
+        ->tinymceInit($tinymceInit)
+        ->setValue($value)
+        ->setRows($rows)
+        ->showMedia($showMedia)
+        ->setRequired($required)
+        ->initiallyHidden($initiallyHidden)
+        ->allowUpload($allowUpload)
+        ->initialFilter($initialFilter)
+        ->resourceAlphaSort($resourceAlphaSort);
+    return $editor->getOutput();
 }
 
 function getYearGroups($connection2)

--- a/functions.php
+++ b/functions.php
@@ -465,11 +465,26 @@ function getWeekNumber($date, $connection2, $guid)
 }
 
 /**
- * Updated v18 to use a twig template.
+ * Render the editor. Updated v18 to use a twig template.
  *
- * $tinymceInit indicates whether or not tinymce should be initialised, or whether this will be done else where later (this can be used to improve page load.
+ * @deprecated  Since v25. Will be removed in the future.
+ *              Please use \Gibbon\Forms\Input\Editor directly.
+ *
+ * @param string   $guid              Obsoleted parameter.
+ * @param boolean  $tinymceInit
+ * @param string   $id
+ * @param string   $value
+ * @param integer  $rows
+ * @param boolean  $showMedia
+ * @param boolean  $required
+ * @param boolean  $initiallyHidden
+ * @param boolean  $allowUpload
+ * @param string   $initialFilter
+ * @param boolean  $resourceAlphaSort
+ *
+ * @return string
  */
-function getEditor($guid, $tinymceInit = true, $id = '', $value = '', $rows = 10, $showMedia = false, $required = false, $initiallyHidden = false, $allowUpload = true, $initialFilter = '', $resourceAlphaSort = false)
+function getEditor($guid, $tinymceInit = true, $id = '', $value = '', $rows = 10, $showMedia = false, $required = false, $initiallyHidden = false, $allowUpload = true, $initialFilter = '', $resourceAlphaSort = false): string
 {
     global $page, $session;
 

--- a/modules/Planner/moduleFunctions.php
+++ b/modules/Planner/moduleFunctions.php
@@ -23,6 +23,7 @@ use Gibbon\Services\Format;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\Timetable\CourseGateway;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
+use Gibbon\Forms\Input\Editor;
 
 //Make the display for a block, according to the input provided, where $i is a unique number appended to the block's field ids.
 //Mode can be masterAdd, masterEdit, workingDeploy, workingEdit, plannerEdit, embed
@@ -155,7 +156,15 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
     				echo "<div style='text-align: left; font-weight: bold; margin-top: 15px'>".__('Block Contents').'</div>';
                     //Block Contents
                     if ($mode != 'embed') {
-                        echo getEditor($guid, false, "contents$i", $contents, 20, true, false, false, true);
+                        $editor = (new Editor("contents$i"))
+                            ->tinymceInit(false)
+                            ->setValue($contents)
+                            ->setRows(20)
+                            ->showMedia(true)
+                            ->setRequired(false)
+                            ->initiallyHidden(false)
+                            ->allowUpload(true);
+                        echo $editor->getOutput();
                     } else {
                         echo "<div style='max-width: 595px; margin-right: 0!important; padding: 5px!important'><p>$contents</p></div>";
                     }
@@ -163,7 +172,15 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
                     //Teacher's Notes
                     if ($mode != 'embed') {
                         echo "<div style='text-align: left; font-weight: bold; margin-top: 15px'>".__('Teacher\'s Notes').'</div>';
-                        echo getEditor($guid, false, "teachersNotes$i", $teachersNotes, 20, true, false, false, true);
+                        $editor = (new Editor("teachersNotes$i"))
+                            ->tinymceInit(false)
+                            ->setValue($teachersNotes)
+                            ->setRows(20)
+                            ->showMedia(true)
+                            ->setRequired(false)
+                            ->initiallyHidden(false)
+                            ->allowUpload(true);
+                        echo $editor->getOutput();
                     } elseif ($teachersNotes != '') {
                         echo "<div style='text-align: left; font-weight: bold; margin-top: 15px'>".__('Teacher\'s Notes').'</div>';
                         echo "<div style='max-width: 595px; margin-right: 0!important; padding: 5px!important; background-color: #F6CECB'><p>$teachersNotes</p></div>";
@@ -504,7 +521,15 @@ function makeBlockOutcome($guid,  $i, $type = '', $gibbonOutcomeID = '', $title 
 					<td colspan=2 style='vertical-align: top'>
 						<?php
                             if ($allowOutcomeEditing == 'Y') {
-                                echo getEditor($guid, false, $type.'contents'.$i, $contents, 20, false, false, false, true);
+                                $editor = (new Editor($type.'contents'.$i))
+                                    ->tinymceInit(false)
+                                    ->setValue($contents)
+                                    ->setRows(20)
+                                    ->showMedia(false)
+                                    ->setRequired(false)
+                                    ->initiallyHidden(false)
+                                    ->allowUpload(true);
+                                echo $editor->getOutput();
                             } else {
                                 echo "<div style='padding: 5px'>$contents</div>";
                                 echo "<input type='hidden' name='".$type.'contents'.$i."' value='".htmlPrep($contents)."'/>";

--- a/modules/Planner/planner_editorAjax.php
+++ b/modules/Planner/planner_editorAjax.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Forms\Input\Editor;
+
 include '../../gibbon.php';
 include './moduleFunctions.php';
 
@@ -27,4 +29,13 @@ $value = $_POST['value'] ?? '';
 $showMedia = $_POST['showMedia'] ?? false;
 $rows = !empty($_POST['rows']) ? $_POST['rows'] : 15;
 
-echo getEditor($guid, false, $id, $value, $rows, $showMedia, false, false, $showMedia, '', false);
+$editor = (new Editor($id))
+    ->tinymceInit(false)
+    ->setValue($value)
+    ->setRows($rows)
+    ->showMedia($showMedia)
+    ->setRequired(false)
+    ->initiallyHidden(false)
+    ->allowUpload($showMedia)
+    ->resourceAlphaSort(false);
+echo $editor->getOutput();

--- a/src/Forms/FormFactory.php
+++ b/src/Forms/FormFactory.php
@@ -162,9 +162,9 @@ class FormFactory implements FormFactoryInterface
         return new Input\Finder($name);
     }
 
-    public function createEditor($name, $guid)
+    public function createEditor(string $name)
     {
-        return new Input\Editor($name, $guid);
+        return new Input\Editor($name);
     }
 
     public function createCodeEditor($name)

--- a/src/Forms/Input/Editor.php
+++ b/src/Forms/Input/Editor.php
@@ -47,7 +47,7 @@ class Editor extends Input
     /**
      * Set the textarea rows attribute to control the height of the editor box.
      * @param  int  $count
-     * @return self
+     * @return $this
      */
     public function setRows($count)
     {
@@ -59,7 +59,7 @@ class Editor extends Input
      * Set whether tinyMCE uploader should be enabled.
      *
      * @param   bool  $value
-     * @return  self
+     * @return  $this
      */
     public function tinymceInit(bool $value)
     {
@@ -70,7 +70,7 @@ class Editor extends Input
     /**
      * Set whether the media bar for upload and quick inser is available.
      * @param   bool    $value
-     * @return  self
+     * @return  $this
      */
     public function showMedia($value = true)
     {
@@ -81,7 +81,7 @@ class Editor extends Input
     /**
      * Set whether the editor input is initially hidden.
      * @param   bool    $value
-     * @return  self
+     * @return  $this
      */
     public function initiallyHidden($value = true)
     {
@@ -92,7 +92,7 @@ class Editor extends Input
     /**
      * Allow resources to be uploaded through the editor window.
      * @param   bool    $value
-     * @return  self
+     * @return  $this
      */
     public function allowUpload($value = true)
     {
@@ -103,7 +103,7 @@ class Editor extends Input
     /**
      * Sets the sort order for resource upload.
      * @param   bool    $value
-     * @return  self
+     * @return  $this
      */
     public function resourceAlphaSort($value = true)
     {
@@ -114,7 +114,7 @@ class Editor extends Input
     /**
      * Sets a filter for resource upload.
      * @param   string    $value
-     * @return  self
+     * @return  $this
      */
     public function initialFilter($value = '')
     {

--- a/src/Forms/Traits/InputAttributesTrait.php
+++ b/src/Forms/Traits/InputAttributesTrait.php
@@ -32,7 +32,7 @@ trait InputAttributesTrait
     /**
      * Set the input's name attribute.
      * @param  string  $name
-     * @return self
+     * @return $this
      */
     public function setName($name = '')
     {
@@ -52,7 +52,7 @@ trait InputAttributesTrait
     /**
      * Set the input's value.
      * @param  string  $value
-     * @return self
+     * @return $this
      */
     public function setValue($value = '')
     {
@@ -76,7 +76,7 @@ trait InputAttributesTrait
     public function loadFrom(&$data)
     {
         $name = str_replace('[]', '', $this->getName());
-        
+
         if (isset($data[$name])) {
             $value = $data[$name];
 
@@ -110,7 +110,7 @@ trait InputAttributesTrait
     /**
      * Set the input's size attribute.
      * @param  string|int  $size
-     * @return self
+     * @return $this
      */
     public function setSize($size = '')
     {
@@ -149,7 +149,7 @@ trait InputAttributesTrait
     /**
      * Set the input's disabled attribute.
      * @param  bool  $disabled
-     * @return self
+     * @return $this
      */
     public function setDisabled($disabled)
     {
@@ -177,7 +177,7 @@ trait InputAttributesTrait
     /**
      * Set the input to required.
      * @param   bool    $value
-     * @return  self
+     * @return $this
      */
     public function required($required = true)
     {
@@ -187,7 +187,7 @@ trait InputAttributesTrait
     /**
      * Set if the input is required.
      * @param  bool  $required
-     * @return self
+     * @return $this
      */
     public function setRequired($required)
     {
@@ -207,7 +207,7 @@ trait InputAttributesTrait
     /**
      * Set the input to readonly.
      * @param   bool    $value
-     * @return  self
+     * @return  $this
      */
     public function readonly($value = true)
     {
@@ -217,7 +217,7 @@ trait InputAttributesTrait
     /**
      * Set the input's readonly attribute.
      * @param  string  $value
-     * @return self
+     * @return $this
      */
     public function setReadonly($value)
     {
@@ -238,7 +238,7 @@ trait InputAttributesTrait
     /**
      * Set the input's tabindex attribute.
      * @param  string  $value
-     * @return self
+     * @return $this
      */
     public function setTabIndex($value)
     {
@@ -246,7 +246,7 @@ trait InputAttributesTrait
 
         return $this;
     }
-    
+
     /**
      * Gets the input's tabindex attribute.
      * @return  int
@@ -260,7 +260,7 @@ trait InputAttributesTrait
      * Set the input's aria property and value.
      * @param  string      $property
      * @param  string|int  $value
-     * @return self
+     * @return $this
      */
     public function setAria($property, $value)
     {


### PR DESCRIPTION
**Description**
* Editor::getElement() is refactored to handle its own rendering instead of relying on getEditor.
* All getEditor calls can then be rewrite to use Editor directly.
* The getEditor() function is marked obsoleted. It is kept for module developers to adapt the change.

**Motivation and Context**
The function getEditor can be, and should be, completely replaced by the Editor class itself.

**How Has This Been Tested?**
* CI Environment

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
