### PR TITLE
Make phpstan a part of standard tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
           DB_USERNAME: root
           DB_PASSWORD: ""
 
+      - name: Run composer test:phpstan (experimental)
+        run: composer test:phpstan
+        continue-on-error: true
+
       - name: Check PHP warning and deprecated messages in server_log
         run: |
           # Check number of warning messages.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
             "cd tests && ../vendor/bin/phpunit --verbose --colors=always --configuration phpunit.xml"
         ],
         "test:phpstan": [
-            "vendor/bin/phpstan analyse --ansi --no-progress --no-interaction -c phpstan.neon"
+            "vendor/bin/phpstan analyse --ansi --no-progress --memory-limit=-1 --no-interaction -c phpstan.neon"
         ],
         "test:codesniffer": [
           "vendor/bin/phpcs --standard=PSR2 modules/Library/"
@@ -74,7 +74,7 @@
         "codeception/module-db": "^1.1",
         "codeception/module-filesystem": "^1.0",
         "codeception/module-asserts": "^1.3",
-        "phpstan/phpstan": "^0.12.98"
+        "phpstan/phpstan": "^1.8"
     },
     "replace": {
         "pimple/pimple": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96dad05287a68246961945853c2ca177",
+    "content-hash": "a665d3747e36597ed8393c5124e6107a",
     "packages": [
         {
             "name": "aura/auth",
@@ -5550,20 +5550,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.99",
+            "version": "1.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c386ab2741e64cc9e21729f891b28b2b10fe6618",
+                "reference": "c386ab2741e64cc9e21729f891b28b2b10fe6618",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.2|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -5573,11 +5573,6 @@
                 "phpstan.phar"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.12-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "bootstrap.php"
@@ -5588,9 +5583,13 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.6"
             },
             "funding": [
                 {
@@ -5602,15 +5601,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-12T20:09:55+00:00"
+            "time": "2022-09-23T09:54:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
**Description**
* Upgrade phpstan to the latest version to be compatible with the latest php.
* Make phpstan a part of CI test but allow it to fail.

**Motivation and Context**
* The static analysis provided by the tool catches many potential issues in the code base.
* It would be good if the test is run against any changes made to the code base before merging in the future.
* After this is merged, will gradually add fixes to the codebase until all phpstan tests are passed.

**How Has This Been Tested?**
* Locally.
* CI environment.