### PR TITLE
Test: migrate phpunit.xml file format

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,10 +1,10 @@
+<?xml version="1.0"?>
 <phpunit
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="bootstrap.php"
-         cacheTokens="false"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
@@ -19,12 +19,13 @@
          timeoutForMediumTests="10"
          timeoutForLargeTests="60"
          verbose="true">
+    <coverage/>
     <testsuites>
         <testsuite name="Tests">
             <directory suffix=".php">unit</directory>
         </testsuite>
     </testsuites>
     <logging>
-        <log type="testdox-text" target="log/testdox.txt"/>
+        <testdoxText outputFile="log/testdox.txt"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
**Description**
* Do the phpunit suggested fix to the configuration file format (running `phpunit --migrate-configuration`).

**Motivation and Context**
* phpunit was suggesting the change.

**How Has This Been Tested?**
* CI environment
* Locally

**Screenshots**
![Screenshot from 2022-09-27 09-21-25](https://user-images.githubusercontent.com/91274/192409680-df9c1bab-588d-4d05-812e-e3b53bc3528b.png)
