### PR TITLE
System: gracefully handle empty HTTP_HOST

### DIFF
--- a/gibbon.php
+++ b/gibbon.php
@@ -120,7 +120,7 @@ if ($gibbon->isInstalled() && $session->has('absoluteURL')) {
         $urlBasePath = substr($baseDir, $prefixLength);
 
         // Construct the full URL to the base URL path.
-        $host = $_SERVER['HTTP_HOST'];
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
         $protocol = !empty($_SERVER['HTTPS']) ? 'https' : 'http';
         return "{$protocol}://{$host}{$urlBasePath}";
     })();


### PR DESCRIPTION
**Description**
* $_SERVER['HTTP_HOST'] would be unset for CLI access (e.g. unit test) and thus should be used with fallback value coercion.

**Motivation and Context**
* To suppress warning message in test envrionment.

**How Has This Been Tested?**
* Locally with phpunit.