### PR TITLE
Locale: improved handling for unsupported locale

### DIFF
--- a/index.php
+++ b/index.php
@@ -278,11 +278,19 @@ if (!empty($_GET['i18n']) && $gibbon->locale->getLocale() != $_GET['i18n']) {
     $sql = "SELECT * FROM gibboni18n WHERE code=:code LIMIT 1";
 
     if ($result = $pdo->selectOne($sql, $data)) {
-        setLanguageSession($guid, $result, false);
-        $gibbon->locale->setLocale($_GET['i18n']);
-        $gibbon->locale->setTextDomain($pdo);
-        $localeCode = str_replace('_', '-', $gibbon->locale->getLocale());
-        $cacheLoad = true;
+        try {
+            $gibbon->locale->setLocale($_GET['i18n']);
+
+            // Only do the below if the setLocale is success.
+            setLanguageSession($guid, $result, false);
+            $gibbon->locale->setLocale($_GET['i18n']);
+            $gibbon->locale->setTextDomain($pdo);
+            $localeCode = str_replace('_', '-', $_GET['i18n']);
+            $cacheLoad = true;
+        } catch (\Exception $e) {
+            error_log('Warning: ' . $e->getMessage());
+            $page->addWarning($e->getMessage());
+        }
     }
 }
 

--- a/installer/install.php
+++ b/installer/install.php
@@ -89,7 +89,12 @@ $locale_code = $_POST['code'] ?? 'en_GB';
 
 //Set language pre-install
 if (function_exists('gettext')) {
-    $gibbon->locale->setLocale($locale_code);
+    try {
+        $gibbon->locale->setLocale($locale_code);
+    } catch (\Exception $e) {
+        // Do nothing.
+    }
+
     bindtextdomain('gibbon', '../i18n');
     textdomain('gibbon');
 }

--- a/installer/install.php
+++ b/installer/install.php
@@ -36,7 +36,11 @@ $_POST = $validator->sanitize($_POST);
 
 // Fix missing locale causing failed page load
 if (empty($gibbon->locale->getLocale())) {
-    $gibbon->locale->setLocale('en_GB');
+    try {
+        $gibbon->locale->setLocale('en_GB');
+    } catch (\Exception $e) {
+        // Do nothing.
+    }
 }
 
 // Page object for rendering

--- a/src/Gibbon/Core.php
+++ b/src/Gibbon/Core.php
@@ -65,7 +65,7 @@ class Core
     public function __construct($directory)
     {
         $this->basePath = realpath($directory);
-        
+
         // Load the configuration, if installed
         $this->loadConfigFromFile($this->basePath . '/config.php');
 
@@ -84,7 +84,7 @@ class Core
 
         $db = $container->get('db');
         $this->session = $container->get('session');
-        
+
         Format::setupFromSession($this->session);
 
         if (empty($this->session->get('systemSettingsSet'))) {
@@ -96,7 +96,11 @@ class Core
             ini_set('display_errors', 0);
         }
 
-        $this->locale->setLocale($this->session->get(array('i18n', 'code')));
+        try {
+            $this->locale->setLocale($this->session->get(array('i18n', 'code')));
+        } catch (\Exception $e) {
+            error_log('Core Warning: ' . $e->getMessage());
+        }
         $this->locale->setTimezone($this->session->get('timezone', 'UTC'));
         $this->locale->setTextDomain($db);
         $this->locale->setStringReplacementList($this->session, $db);
@@ -147,7 +151,7 @@ class Core
     /**
      * Get a config value by name, otherwise return the config array.
      * @param string|null $name
-     * 
+     *
      * @return mixed|array
      */
     public function getConfig($name = null)
@@ -197,7 +201,7 @@ class Core
     {
         // Load the config values (from an array if possible)
         if (!$this->isInstalled()) return;
-        
+
         $this->config = include $configFilePath;
 
         if (!isset($databasePort)) $databasePort = '';

--- a/tests/unit/Gibbon/Locale/TranslateNTest.php
+++ b/tests/unit/Gibbon/Locale/TranslateNTest.php
@@ -48,7 +48,12 @@ class TranslateNTest extends TestCase
         // mocked locale object
         $i18ncode = 'es_ES';
         $locale = new Locale(__DIR__ . '/mock', $mockSession);
-        $locale->setLocale($i18ncode);
+        try {
+            $locale->setLocale($i18ncode);
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Unable to proceed with the test: ' . $e->getMessage());
+            return;
+        }
         $locale->setSystemTextDomain(__DIR__ . '/mock');
         $this->locale = $locale;
     }

--- a/tests/unit/Gibbon/Locale/TranslateTest.php
+++ b/tests/unit/Gibbon/Locale/TranslateTest.php
@@ -51,7 +51,12 @@ class TranslateTest extends TestCase
         // mocked locale object
         $i18ncode = 'zh_TW';
         $locale = new Locale(__DIR__ . '/mock', $mockSession);
-        $locale->setLocale($i18ncode);
+        try {
+            $locale->setLocale($i18ncode);
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Unable to proceed with the test: ' . $e->getMessage());
+            return;
+        }
         $locale->setSystemTextDomain(__DIR__ . '/mock');
 
         $this->locale = $locale;

--- a/tests/unit/Gibbon/Locale/TranslationTest.php
+++ b/tests/unit/Gibbon/Locale/TranslationTest.php
@@ -11,6 +11,7 @@ namespace Gibbon;
 
 use PHPUnit\Framework\TestCase;
 use Gibbon\Contracts\Services\Session;
+use PHPUnit\Framework\SkippedTestError;
 
 // Require the system-wide functions.
 require_once __DIR__.'/../../../../functions.php';
@@ -66,7 +67,12 @@ class TranslationTest extends TestCase
 
         // mock locale object
         $locale = new Locale(realpath(__DIR__.'/../../../..'), $mockSession);
-        $locale->setLocale('es_ES');
+        try {
+            $locale->setLocale('es_ES');
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Unable to proceed with the test: ' . $e->getMessage());
+            return;
+        }
         $locale->setSystemTextDomain(realpath(__DIR__.'/../../../..'));
 
         // remember how to restore locale


### PR DESCRIPTION
**Description**
* setlocale might fail for some system lacking the locale to set.
* Gibbon should gracefully handle these case and tell administrator / user about it.

**Motivation and Context**
* Some tests are unable to run locally because my system do not have Spanish locale.
* PHPUnit should gracefully skip those test instead of complaining of incorrect translation.
* Further investigation found issue with core logic in handling potential issue(s) with system update and missing locale.

**How Has This Been Tested?**
* Locally.
* CI Environment.

**Screenshots**
![Screenshot from 2022-09-29 00-26-46](https://user-images.githubusercontent.com/91274/192834459-2d513cb8-c218-497c-9743-83b03ec636a5.png)
