### PR TITLE
Tests: translation test to skip if needed

### DIFF
--- a/tests/unit/Gibbon/Locale/TranslationTest.php
+++ b/tests/unit/Gibbon/Locale/TranslationTest.php
@@ -64,9 +64,16 @@ class TranslationTest extends TestCase
             ->method('get')
             ->willReturn(null); // always return null
 
+        // Check if the locale has been installed. Skip test if not.
+        $langCode = 'es_ES';
+        if (!is_dir(realpath(__DIR__.'/../../../..') . '/i18n/' . $langCode)) {
+            $this->markTestSkipped("Gibbon i18n files for \"{$langCode}\" are not installed. Unable to proceed.");
+            return;
+        }
+
         // mock locale object
         $locale = new Locale(realpath(__DIR__.'/../../../..'), $mockSession);
-        $locale->setLocale('es_ES');
+        $locale->setLocale($langCode);
         $locale->setSystemTextDomain(realpath(__DIR__.'/../../../..'));
 
         // remember how to restore locale


### PR DESCRIPTION
**Description**
* translation test should be skipped if the translation files are not installed.

**Motivation and Context**
* to remind developer to install i18n files before running some of the tests.

**How Has This Been Tested?**
* Locally.