### PR TITLE
Markbook: added Term filter to student view, when Group Columns by Term enabled

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ v25.0.00
         Messenger: added the ability to send confidential messages which are not viewable by other users
         Messenger: updated the Transport target to be able to handle comma-separated transport values
         Messenger: improved the success message for confirmed read receipts
+        Markbook: added Term filter to student view, when Group Columns by Term enabled
         Planner: improved the error message when unable to access classes in Unit Planner
         Planner: update Add Lesson Plan to suggest dates based on existing lesson sequence
         Reports: improved the UTF8 character set for DroidSansFallback to include wider CJK support
@@ -80,7 +81,7 @@ v25.0.00
         Reports: fixed batch report bulk-action missing the two-sided option
         Reports: fixed HTML being removed from Rich Text template sections
         School Admin: fixed error in Add Attendance Code when no roles specified
-        School Admin: fixed possible duplicate values using Copy All To Next Year in Manage Form Groups 
+        School Admin: fixed possible duplicate values using Copy All To Next Year in Manage Form Groups
         Staff: fixed staff absences not showing up if outside school year dates
         System Admin: fixed Form Builder submission error when subheading is the first item on a page
         Timetable Admin: adjusted column uniqueness interface string

--- a/modules/Markbook/markbook_view_myMarks.php
+++ b/modules/Markbook/markbook_view_myMarks.php
@@ -18,16 +18,17 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
+use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Domain\School\SchoolYearTermGateway;
 
 $page->breadcrumbs->add(__('View Markbook'));
 
 // Lock the file so other scripts cannot call it
 if (MARKBOOK_VIEW_LOCK !== sha1( $highestAction . $session->get('gibbonPersonID') ) . date('zWy') ) return;
 
-    //Get settings
+    // Get settings
     $settingGateway = $container->get(SettingGateway::class);
     $enableEffort = $settingGateway->getSettingByScope('Markbook', 'enableEffort');
     $enableRubrics = $settingGateway->getSettingByScope('Markbook', 'enableRubrics');
@@ -46,22 +47,34 @@ if (MARKBOOK_VIEW_LOCK !== sha1( $highestAction . $session->get('gibbonPersonID'
     $dataList = array();
     $dataEntry = array();
 
-    $filter = isset($_REQUEST['filter'])? $_REQUEST['filter'] : $session->get('gibbonSchoolYearID');
-    if ($filter != '*') {
-        $dataList['filter'] = $filter;
-        $and .= ' AND gibbonSchoolYearID=:filter';
+    $gibbonDepartmentID = isset($_REQUEST['gibbonDepartmentID']) ? $_REQUEST['gibbonDepartmentID'] : '*';
+    if ($gibbonDepartmentID != '*') {
+        $dataList['gibbonDepartmentID'] = $gibbonDepartmentID;
+        $and .= ' AND gibbonDepartmentID=:gibbonDepartmentID';
     }
 
-    $filter2 = isset($_REQUEST['filter2'])? $_REQUEST['filter2'] : '*';
-    if ($filter2 != '*') {
-        $dataList['filter2'] = $filter2;
-        $and .= ' AND gibbonDepartmentID=:filter2';
+    $gibbonSchoolYearID = isset($_REQUEST['gibbonSchoolYearID'])? $_REQUEST['gibbonSchoolYearID'] : $session->get('gibbonSchoolYearID');
+    if ($gibbonSchoolYearID != '*') {
+        $dataList['gibbonSchoolYearID'] = $gibbonSchoolYearID;
+        $and .= ' AND gibbonSchoolYearID=:gibbonSchoolYearID';
     }
 
-    $filter3 = isset($_REQUEST['filter3'])? $_REQUEST['filter3'] : '';
-    if ($filter3 != '') {
-        $dataEntry['filter3'] = $filter3;
-        $and2 .= ' AND type=:filter3';
+    $termDefault = '';
+    $schoolYearTermGateway = $container->get(SchoolYearTermGateway::class);
+    $termCurrent = $schoolYearTermGateway->getCurrentTermByDate(date('Y-m-d'));
+    $termDefault = (is_array($termCurrent) && $termCurrent['gibbonSchoolYearID'] == $gibbonSchoolYearID) ? $termCurrent['gibbonSchoolYearTermID'] : '' ;
+    $gibbonSchoolYearTermID = isset($_REQUEST['gibbonSchoolYearTermID']) ? $_REQUEST['gibbonSchoolYearTermID'] : $termDefault;
+    if (!empty($gibbonSchoolYearTermID)) {
+        $term = $schoolYearTermGateway->getByID($gibbonSchoolYearTermID);
+        $dataEntry['firstDay'] = $term['firstDay'];
+        $dataEntry['lastDay'] = $term['lastDay'];
+        $and2 .= ' AND completeDate>=:firstDay AND completeDate<=:lastDay';
+    }
+
+    $type = isset($_REQUEST['type'])? $_REQUEST['type'] : '';
+    if ($type != '') {
+        $dataEntry['type'] = $type;
+        $and2 .= ' AND type=:type';
     }
 
     $form = Form::create('filter', $session->get('absoluteURL').'/index.php','get');
@@ -71,28 +84,40 @@ if (MARKBOOK_VIEW_LOCK !== sha1( $highestAction . $session->get('gibbonPersonID'
 
     $sqlSelect = "SELECT gibbonDepartmentID as value, name FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
     $rowFilter = $form->addRow();
-        $rowFilter->addLabel('filter2', __('Learning Areas'));
-        $rowFilter->addSelect('filter2')
+        $rowFilter->addLabel('gibbonDepartmentID', __('Learning Areas'));
+        $rowFilter->addSelect('gibbonDepartmentID')
             ->fromArray(array('*' => __('All Learning Areas')))
             ->fromQuery($pdo, $sqlSelect)
-            ->selected($filter2);
+            ->selected($gibbonDepartmentID);
 
     $dataSelect = array('gibbonPersonID' => $session->get('gibbonPersonID'));
     $sqlSelect = "SELECT gibbonSchoolYear.gibbonSchoolYearID as value, CONCAT(gibbonSchoolYear.name, ' (', gibbonYearGroup.name, ')') AS name FROM gibbonStudentEnrolment JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID) WHERE gibbonPersonID=:gibbonPersonID ORDER BY gibbonSchoolYear.sequenceNumber";
     $rowFilter = $form->addRow();
-        $rowFilter->addLabel('filter', __('School Years'));
-        $rowFilter->addSelect('filter')
+        $rowFilter->addLabel('gibbonSchoolYearID', __('School Years'));
+        $rowFilter->addSelect('gibbonSchoolYearID')
             ->fromArray(array('*' => __('All Years')))
             ->fromQuery($pdo, $sqlSelect, $dataSelect)
-            ->selected($filter);
+            ->selected($gibbonSchoolYearID);
+
+    $enableGroupByTerm = $settingGateway->getSettingByScope('Markbook', 'enableGroupByTerm');
+    if ($enableGroupByTerm == "Y") {
+        $dataSelect = [];
+        $sqlSelect = "SELECT gibbonSchoolYear.gibbonSchoolYearID as chainedTo, gibbonSchoolYearTerm.gibbonSchoolYearTermID as value, gibbonSchoolYearTerm.name FROM gibbonSchoolYearTerm JOIN gibbonSchoolYear ON (gibbonSchoolYearTerm.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) ORDER BY gibbonSchoolYearTerm.sequenceNumber";
+        $rowFilter = $form->addRow();
+            $rowFilter->addLabel('gibbonSchoolYearTermID', __('Term'));
+            $rowFilter->addSelect('gibbonSchoolYearTermID')
+                ->fromQueryChained($pdo, $sqlSelect, $dataSelect, 'gibbonSchoolYearID')
+                ->placeholder()
+                ->selected($gibbonSchoolYearTermID);
+    }
 
     $types = $settingGateway->getSettingByScope('Markbook', 'markbookType');
     if (!empty($types)) {
         $rowFilter = $form->addRow();
-        $rowFilter->addLabel('filter3', __('Type'));
-        $rowFilter->addSelect('filter3')
+        $rowFilter->addLabel('type', __('Type'));
+        $rowFilter->addSelect('type')
             ->fromString($types)
-            ->selected($filter3)
+            ->selected($type)
             ->placeholder();
     }
 
@@ -124,35 +149,33 @@ if (MARKBOOK_VIEW_LOCK !== sha1( $highestAction . $session->get('gibbonPersonID'
     </script>
     <?php
 
-    //Get class list
-
-        $dataList['gibbonPersonID'] = $session->get('gibbonPersonID');
-        $dataList['gibbonPersonID2'] = $session->get('gibbonPersonID');
-        $sqlList = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourse.name, gibbonCourseClass.gibbonCourseClassID, gibbonScaleGrade.value AS target, gibbonPerson.dateStart
-        FROM gibbonCourse
-        JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID)
-        JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
-        JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID)
-        LEFT JOIN gibbonMarkbookTarget ON (gibbonMarkbookTarget.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonMarkbookTarget.gibbonPersonIDStudent=:gibbonPersonID2) LEFT JOIN gibbonScaleGrade ON (gibbonMarkbookTarget.gibbonScaleGradeID=gibbonScaleGrade.gibbonScaleGradeID)
-        WHERE gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID $and ORDER BY course, class";
-        $resultList = $connection2->prepare($sqlList);
-        $resultList->execute($dataList);
+    // Get class list
+    $dataList['gibbonPersonID'] = $session->get('gibbonPersonID');
+    $dataList['gibbonPersonID2'] = $session->get('gibbonPersonID');
+    $sqlList = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourse.name, gibbonCourseClass.gibbonCourseClassID, gibbonScaleGrade.value AS target, gibbonPerson.dateStart
+    FROM gibbonCourse
+    JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID)
+    JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID)
+    JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID)
+    LEFT JOIN gibbonMarkbookTarget ON (gibbonMarkbookTarget.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonMarkbookTarget.gibbonPersonIDStudent=:gibbonPersonID2) LEFT JOIN gibbonScaleGrade ON (gibbonMarkbookTarget.gibbonScaleGradeID=gibbonScaleGrade.gibbonScaleGradeID)
+    WHERE gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID $and ORDER BY course, class";
+    $resultList = $connection2->prepare($sqlList);
+    $resultList->execute($dataList);
     if ($resultList->rowCount() > 0) {
         while ($rowList = $resultList->fetch()) {
 
-                $dataEntry['gibbonPersonIDStudent'] = $session->get('gibbonPersonID');
-                $dataEntry['gibbonCourseClassID'] = $rowList['gibbonCourseClassID'];
-                $sqlEntry = "SELECT *, gibbonMarkbookColumn.comment AS commentOn, gibbonMarkbookColumn.uploadedResponse AS uploadedResponseOn, gibbonMarkbookEntry.comment AS comment FROM gibbonMarkbookEntry JOIN gibbonMarkbookColumn ON (gibbonMarkbookEntry.gibbonMarkbookColumnID=gibbonMarkbookColumn.gibbonMarkbookColumnID) WHERE gibbonPersonIDStudent=:gibbonPersonIDStudent AND gibbonCourseClassID=:gibbonCourseClassID AND gibbonMarkbookColumn.viewableStudents='Y' AND complete='Y' AND completeDate<='".date('Y-m-d')."' $and2  ORDER BY completeDate";
-                $resultEntry = $connection2->prepare($sqlEntry);
-                $resultEntry->execute($dataEntry);
+            $dataEntry['gibbonPersonIDStudent'] = $session->get('gibbonPersonID');
+            $dataEntry['gibbonCourseClassID'] = $rowList['gibbonCourseClassID'];
+            $sqlEntry = "SELECT *, gibbonMarkbookColumn.comment AS commentOn, gibbonMarkbookColumn.uploadedResponse AS uploadedResponseOn, gibbonMarkbookEntry.comment AS comment FROM gibbonMarkbookEntry JOIN gibbonMarkbookColumn ON (gibbonMarkbookEntry.gibbonMarkbookColumnID=gibbonMarkbookColumn.gibbonMarkbookColumnID) WHERE gibbonPersonIDStudent=:gibbonPersonIDStudent AND gibbonCourseClassID=:gibbonCourseClassID AND gibbonMarkbookColumn.viewableStudents='Y' AND complete='Y' AND completeDate<='".date('Y-m-d')."' $and2  ORDER BY completeDate";
+            $resultEntry = $connection2->prepare($sqlEntry);
+            $resultEntry->execute($dataEntry);
             if ($resultEntry->rowCount() > 0) {
                 echo '<h4>'.$rowList['course'].'.'.$rowList['class']." <span style='font-size:85%; font-style: italic'>(".$rowList['name'].')</span></h4>';
 
-
-                    $dataTeachers = array('gibbonCourseClassID' => $rowList['gibbonCourseClassID']);
-                    $sqlTeachers = "SELECT title, surname, preferredName FROM gibbonPerson JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
-                    $resultTeachers = $connection2->prepare($sqlTeachers);
-                    $resultTeachers->execute($dataTeachers);
+                $dataTeachers = array('gibbonCourseClassID' => $rowList['gibbonCourseClassID']);
+                $sqlTeachers = "SELECT title, surname, preferredName FROM gibbonPerson JOIN gibbonCourseClassPerson ON (gibbonCourseClassPerson.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE role='Teacher' AND gibbonCourseClassID=:gibbonCourseClassID ORDER BY surname, preferredName";
+                $resultTeachers = $connection2->prepare($sqlTeachers);
+                $resultTeachers->execute($dataTeachers);
 
                 $teachers = '<p><b>'.__('Taught by:').'</b> ';
                 while ($rowTeachers = $resultTeachers->fetch()) {

--- a/src/Domain/School/SchoolYearTermGateway.php
+++ b/src/Domain/School/SchoolYearTermGateway.php
@@ -74,12 +74,24 @@ class SchoolYearTermGateway extends QueryableGateway
     public function selectSchoolClosuresByTerm($gibbonSchoolYearTermID)
     {
         $data = array('gibbonSchoolYearTermID' => $gibbonSchoolYearTermID);
-        $sql = "SELECT date, name 
-                FROM gibbonSchoolYearSpecialDay 
-                WHERE gibbonSchoolYearTermID=:gibbonSchoolYearTermID 
-                AND type='School Closure' 
+        $sql = "SELECT date, name
+                FROM gibbonSchoolYearSpecialDay
+                WHERE gibbonSchoolYearTermID=:gibbonSchoolYearTermID
+                AND type='School Closure'
                 ORDER BY date";
 
         return $this->db()->select($sql, $data);
+    }
+
+    public function getCurrentTermByDate($date)
+    {
+        $data = array('date' => $date);
+        $sql = "SELECT gibbonSchoolYearTermID, gibbonSchoolYearID, name, sequenceNumber, firstDay, lastDay
+                FROM gibbonSchoolYearTerm
+                WHERE firstDay<=:date AND lastDay>=:date
+                LIMIT 0, 1";
+
+        $result = $this->db()->select($sql, $data);
+        return ($result->rowCount() == 1) ? $result->fetch() : false;
     }
 }


### PR DESCRIPTION
**Description**
Adds a Term filter to the student view of the Markbook, which defaults to the current term when possible. This is only made available when the Markbook setting *Group Columns by Term* is set to Yes.

**Motivation and Context**
Requested by a school whose assessment tends to be oriented to term, and who already uses Group Columns by Term.

**How Has This Been Tested?**
Locally, with a limited set of testing data.

**Screenshots**
<img width="1103" alt="Screenshot 2022-09-29 at 7 52 40 PM" src="https://user-images.githubusercontent.com/5436438/193024702-a8459ac9-37cd-463b-be64-6d5f285ab3d4.png">