### PR TITLE
Tests: moved service behaviour away from FormTest

### DIFF
--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -87,26 +87,6 @@ class FormTest extends TestCase
         $this->assertSame($newRenderer, $form->getRenderer());
     }
 
-    public function testEachNewFormHasAFactory()
-    {
-        $form = Form::create('testID', 'testAction');
-
-        $this->assertInstanceOf(
-            FormFactoryInterface::class,
-            $form->getFactory()
-        );
-    }
-
-    public function testEachNewFormHasARenderer()
-    {
-        $form = Form::create('testID', 'testAction');
-
-        $this->assertInstanceOf(
-            FormRendererInterface::class,
-            $form->getRenderer()
-        );
-    }
-
     public function testEachNewFormHasBasicAttributes()
     {
         $form = Form::create('testID', 'testAction');

--- a/tests/unit/Services/ViewServiceProviderTest.php
+++ b/tests/unit/Services/ViewServiceProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+*/
+
+namespace Gibbon\Services;
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\FormFactoryInterface;
+use Gibbon\Forms\View\FormRendererInterface;
+use PHPUnit\Framework\TestCase;
+use League\Container\Container;
+
+/**
+ * @cover ViewServiceProvider
+ */
+class ViewServiceProviderTest extends TestCase
+{
+    public function testCanProvideForm()
+    {
+        $container = new Container();
+        $container->add('twig', $this->createMock(\Twig\Environment::class));
+        $service = new ViewServiceProvider();
+        $service->setContainer($container);
+        $service->register();
+
+        /**
+         * @var Form $form
+         */
+        $form = $container->get(Form::class);
+        $this->assertInstanceOf(FormRendererInterface::class, $form->getRenderer());
+        $this->assertInstanceOf(FormFactoryInterface::class, $form->getFactory());
+    }
+}


### PR DESCRIPTION
**Description**
* The behaviour of From::create was actually testing the behaviour of container with ViewServiceProvider. Moved the unit test out to its own thing to improve the tests.

**Motivation and Context**
* To remove dependency of test that requires gibbon.php setup.

**How Has This Been Tested?**
* Locally
* CI environment.