### PR TITLE
System: replace getAlert with AlertLevelGateway method

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,6 +21,7 @@ use Gibbon\Http\Url;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
 use Gibbon\Contracts\Comms\Mailer;
+use Gibbon\Domain\System\AlertLevelGateway;
 use Gibbon\Domain\System\LogGateway;
 use Gibbon\Domain\System\SettingGateway;
 
@@ -367,6 +368,21 @@ function getFastFinder($connection2, $guid)
     return $templateData;
 }
 
+/**
+ * Get alert of the especified alert level.
+ *
+ * @deprecated v25
+ *             Use AlertLevelGateway::getByID instead.
+ *
+ * @since    v12
+ * @version  v23
+ *
+ * @param string  $guid
+ * @param \PDO    $connection2
+ * @param int     $gibbonAlertLevelID
+ *
+ * @return array|false
+ */
 function getAlert($guid, $connection2, $gibbonAlertLevelID)
 {
     $output = false;
@@ -862,7 +878,11 @@ function getAlertBar($guid, $connection2, $gibbonPersonID, $privacy = '', $divEx
             $alertThresholdText = sprintf(__('This alert level occurs when there are between %1$s and %2$s events recorded for a student.'), $academicAlertLowThreshold, ($academicAlertMediumThreshold-1));
         }
         if ($gibbonAlertLevelID != '') {
-            if ($alert = getAlert($guid, $connection2, $gibbonAlertLevelID)) {
+            /**
+             * @var AlertLevelGateway
+             */
+            $alertLevelGateway = $container->get(AlertLevelGateway::class);
+            if ($alert = $alertLevelGateway->getByID($gibbonAlertLevelID)) {
                 $alerts[] = [
                     'highestLevel'    => __($alert['name']),
                     'highestColour'   => $alert['color'],
@@ -904,7 +924,11 @@ function getAlertBar($guid, $connection2, $gibbonPersonID, $privacy = '', $divEx
         }
 
         if ($gibbonAlertLevelID != '') {
-            if ($alert = getAlert($guid, $connection2, $gibbonAlertLevelID)) {
+            /**
+             * @var AlertLevelGateway
+             */
+            $alertLevelGateway = $container->get(AlertLevelGateway::class);
+            if ($alert = $alertLevelGateway->getByID($gibbonAlertLevelID)) {
                 $alerts[] = [
                     'highestLevel'    => __($alert['name']),
                     'highestColour'   => $alert['color'],
@@ -933,7 +957,11 @@ function getAlertBar($guid, $connection2, $gibbonPersonID, $privacy = '', $divEx
         // Privacy
         $privacySetting = $settingGateway->getSettingByScope('User Admin', 'privacy');
         if ($privacySetting == 'Y' and $privacy != '') {
-            if ($alert = getAlert($guid, $connection2, 001)) {
+            /**
+             * @var AlertLevelGateway
+             */
+            $alertLevelGateway = $container->get(AlertLevelGateway::class);
+            if ($alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_HIGH)) {
                 $alerts[] = [
                     'highestLevel'    => __($alert['name']),
                     'highestColour'   => $alert['color'],

--- a/modules/Data Updater/data_medical_manage_editProcess.php
+++ b/modules/Data Updater/data_medical_manage_editProcess.php
@@ -23,6 +23,7 @@ use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Domain\Students\MedicalGateway;
 use Gibbon\Domain\Students\StudentGateway;
 use Gibbon\Data\Validator;
+use Gibbon\Domain\System\AlertLevelGateway;
 
 require_once '../../gibbon.php';
 
@@ -459,7 +460,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
 
             if (!empty($conditions)) {
                 $student = $container->get(StudentGateway::class)->selectActiveStudentByPerson($gibbon->session->get('gibbonSchoolYearID'), $gibbonPersonID)->fetch();
-                $alert = getAlert($guid, $connection2, $gibbonAlertLevelID);
+                $alert = $container->get(AlertLevelGateway::class)->getByID($gibbonAlertLevelID);
 
                 // Raise a new notification event
                 $event = new NotificationEvent('Students', 'Medical Condition');

--- a/modules/Formal Assessment/internalAssessment_write.php
+++ b/modules/Formal Assessment/internalAssessment_write.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\System\AlertLevelGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 
@@ -43,7 +44,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
         echo __('The highest grouped action cannot be determined.');
         echo '</div>';
     } else {
-        $alert = getAlert($guid, $connection2, 002);
+        /**
+         * @var AlertLevelGateway
+         */
+        $alertLevelGateway = $container->get(AlertLevelGateway::class);
+        $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
 
         //Proceed!
         //Get class variable

--- a/modules/Markbook/markbook_view.php
+++ b/modules/Markbook/markbook_view.php
@@ -19,6 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
 //Module includes
+
+use Gibbon\Domain\System\AlertLevelGateway;
 use Gibbon\Domain\System\SettingGateway;
 
 require_once __DIR__ . '/moduleFunctions.php';
@@ -41,7 +43,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
         echo '</div>';
     } else {
         $enableModifiedAssessment = $container->get(SettingGateway::class)->getSettingByScope('Markbook', 'enableModifiedAssessment');
-        $alert = getAlert($guid, $connection2, 002);
+
+        /**
+         * @var AlertLevelGateway
+         */
+        $alertLevelGateway = $container->get(AlertLevelGateway::class);
+        $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
 
         // Define a randomized lock for this script
         define("MARKBOOK_VIEW_LOCK", sha1( $highestAction . $session->get('gibbonPersonID') ) . date('zWy') );

--- a/modules/Markbook/markbook_viewExportAllContents.php
+++ b/modules/Markbook/markbook_viewExportAllContents.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\System\AlertLevelGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
@@ -61,7 +62,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
         return;
     }
 
-    $alert = getAlert($guid, $connection2, 002);
+    /**
+     * @var AlertLevelGateway
+     */
+    $alertLevelGateway = $container->get(AlertLevelGateway::class);
+    $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
 
     //Count number of columns
 	$data = array('gibbonCourseClassID' => $gibbonCourseClassID);

--- a/modules/Markbook/markbook_viewExportContents.php
+++ b/modules/Markbook/markbook_viewExportContents.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\System\AlertLevelGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 use PhpOffice\PhpSpreadsheet\Style\Fill;
@@ -58,7 +59,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
         return;
     }
 
-    $alert = getAlert($guid, $connection2, 002);
+    /**
+     * @var AlertLevelGateway
+     */
+    $alertLevelGateway = $container->get(AlertLevelGateway::class);
+    $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
 
     //Proceed!
 	$dataStudents = array('gibbonCourseClassID' => $gibbonCourseClassID);

--- a/modules/Students/medicalForm_manage_condition_addProcess.php
+++ b/modules/Students/medicalForm_manage_condition_addProcess.php
@@ -22,6 +22,7 @@ use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Domain\Students\StudentGateway;
 use Gibbon\Data\Validator;
+use Gibbon\Domain\System\AlertLevelGateway;
 
 include '../../gibbon.php';
 
@@ -111,7 +112,12 @@ if ($gibbonPersonMedicalID == '') { echo 'Fatal error loading this page!';
                     $AI = str_pad($connection2->lastInsertID() , 12, '0', STR_PAD_LEFT);
 
                     $student = $container->get(StudentGateway::class)->selectActiveStudentByPerson($gibbon->session->get('gibbonSchoolYearID'), $values['gibbonPersonID'])->fetch();
-                    $alert = getAlert($guid, $connection2, $gibbonAlertLevelID);
+
+                    /**
+                     * @var AlertLevelGateway
+                     */
+                    $alertLevelGateway = $container->get(AlertLevelGateway::class);
+                    $alert = $alertLevelGateway->getByID($gibbonAlertLevelID);
 
                     // Raise a new notification event
                     $event = new NotificationEvent('Students', 'Medical Condition');

--- a/modules/Students/medicalForm_manage_condition_editProcess.php
+++ b/modules/Students/medicalForm_manage_condition_editProcess.php
@@ -23,6 +23,7 @@ use Gibbon\Comms\NotificationEvent;
 use Gibbon\Domain\Students\MedicalGateway;
 use Gibbon\Domain\Students\StudentGateway;
 use Gibbon\Data\Validator;
+use Gibbon\Domain\System\AlertLevelGateway;
 
 require_once '../../gibbon.php';
 
@@ -98,7 +99,11 @@ if ($gibbonPersonMedicalID == '' or $gibbonPersonMedicalConditionID == '') { ech
                         exit();
                     }
 
-                    $alert = getAlert($guid, $connection2, $gibbonAlertLevelID);
+                    /**
+                     * @var AlertLevelGateway
+                     */
+                    $alertLevelGateway = $container->get(AlertLevelGateway::class);
+                    $alert = $alertLevelGateway->getByID($gibbonAlertLevelID);
 
                     // Has the medical condition risk changed?
                     if ($values['gibbonAlertLevelID'] != $gibbonAlertLevelID && ($alert['gibbonAlertLevelID'] == '001' || $alert['gibbonAlertLevelID'] == '002')) {

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -36,6 +36,7 @@ use Gibbon\Domain\FormGroups\FormGroupGateway;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
 use Gibbon\Domain\Students\StudentNoteGateway;
 use Gibbon\Domain\Library\LibraryReportGateway;
+use Gibbon\Domain\System\AlertLevelGateway;
 use Gibbon\Domain\User\PersonalDocumentGateway;
 use Gibbon\Module\Planner\Tables\HomeworkTable;
 use Gibbon\Module\Attendance\StudentHistoryData;
@@ -515,7 +516,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     ->format(function ($person) use ($canViewStaff) {
                                         $photo = Format::userPhoto($person['image_240'], 'sm');
                                         $url = './index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$person['gibbonPersonID'];
-                                        return $canViewStaff 
+                                        return $canViewStaff
                                             ? Format::link($url, $photo)
                                             : $photo;
                                     });
@@ -527,7 +528,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     ->format(function ($person) use ($canViewStaff) {
                                         $text = Format::name('', $person['preferredName'], $person['surname'], 'Staff', false, true);
                                         $url = './index.php?q=/modules/Staff/staff_view_details.php&gibbonPersonID='.$person['gibbonPersonID'];
-                                        return $canViewStaff 
+                                        return $canViewStaff
                                             ? Format::link($url, $text, ['class' => 'font-bold underline leading-normal'])
                                             : $text;
                                     });
@@ -1424,7 +1425,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                 $effortAlternativeNameAbrev = $settingGateway->getSettingByScope('Markbook', 'effortAlternativeNameAbrev');
                                 $enableModifiedAssessment = $settingGateway->getSettingByScope('Markbook', 'enableModifiedAssessment');
 
-                                $alert = getAlert($guid, $connection2, 002);
+                                /**
+                                 * @var AlertLevelGateway
+                                 */
+                                $alertLevelGateway = $container->get(AlertLevelGateway::class);
+                                $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
                                 $role = getRoleCategory($session->get('gibbonRoleIDCurrent'), $connection2);
                                 if ($role == 'Parent') {
                                     $showParentAttainmentWarning = $settingGateway->getSettingByScope('Markbook', 'showParentAttainmentWarning');

--- a/src/Domain/System/AlertLevelGateway.php
+++ b/src/Domain/System/AlertLevelGateway.php
@@ -1,0 +1,76 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\System;
+
+use Gibbon\Domain\QueryableGateway;
+use Gibbon\Domain\Traits\TableAware;
+
+/**
+ * AlarmLevel Gateway.
+ *
+ * @version v25
+ * @since   v25
+ */
+class AlertLevelGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonAlertLevel';
+    private static $primaryKey = 'gibbonAlertLevelID';
+
+    const LEVEL_HIGH = 1;
+    const LEVEL_MEDIUM = 2;
+    const LEVEL_LOW = 3;
+
+    /**
+     * Get the specified alert level.
+     *
+     * @version v25
+     * @since   v25
+     *
+     * @param integer $gibbonAlertLevelID  The ID of the alert level.
+     * @param bool    $translated          To translate name and description field of the
+     *                                     alert. Default: true.
+     *
+     * @return array|false  An assoc array of the selected alert,
+     *                      or false if not exists.
+     *                      The field 'name' and 'description' are
+     *                      translated unless $translated is false.
+     */
+    public function getByID(int $gibbonAlertLevelID, bool $translated = true)
+    {
+        $sql = 'SELECT * FROM gibbonAlertLevel WHERE gibbonAlertLevelID=:gibbonAlertLevelID';
+        $row = $this->db()
+            ->selectOne($sql, [
+                'gibbonAlertLevelID' => $gibbonAlertLevelID,
+            ]);
+        return ($row !== false && $translated)
+            ? [
+                'gibbonAlertLevelID' => $row['gibbonAlertLevelID'],
+                'name' => __($row['name']),
+                'nameShort' => $row['nameShort'],
+                'color' => $row['color'],
+                'colorBG' => $row['colorBG'],
+                'description' => __($row['description']),
+                'sequenceNumber' => $row['sequenceNumber'],
+            ]
+            : $row;
+    }
+}

--- a/src/Domain/System/AlertLevelGateway.php
+++ b/src/Domain/System/AlertLevelGateway.php
@@ -61,7 +61,7 @@ class AlertLevelGateway extends QueryableGateway
             ->selectOne($sql, [
                 'gibbonAlertLevelID' => $gibbonAlertLevelID,
             ]);
-        return ($row !== false && $translated)
+        return (!empty($row) && $translated)
             ? [
                 'gibbonAlertLevelID' => $row['gibbonAlertLevelID'],
                 'name' => __($row['name']),

--- a/src/UI/Dashboard/ParentDashboard.php
+++ b/src/UI/Dashboard/ParentDashboard.php
@@ -22,6 +22,7 @@ namespace Gibbon\UI\Dashboard;
 use Gibbon\Contracts\Database\Connection;
 use Gibbon\Contracts\Services\Session;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
+use Gibbon\Domain\System\AlertLevelGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Forms\OutputableInterface;
 use Gibbon\Http\Url;
@@ -145,6 +146,7 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
 
     protected function renderChildDashboard($gibbonPersonID, $dateStart)
     {
+        global $container;
         $guid = $this->session->get('guid');
         $connection2 = $this->db->getConnection();
         $session = $this->session;
@@ -153,7 +155,11 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
 
         $return = false;
 
-        $alert = getAlert($guid, $connection2, 002);
+        /**
+         * @var AlertLevelGateway
+         */
+        $alertLevelGateway = $container->get(AlertLevelGateway::class);
+        $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
         $entryCount = 0;
 
         //PREPARE PLANNER SUMMARY
@@ -830,7 +836,7 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
             foreach ($hooks as $hook) {
                 // Set the module for this hook for translations
                 $this->session->set('module', $hook['sourceModuleName']);
-                
+
                 if ($parentDashboardDefaultTab == $hook['name'])
                     $parentDashboardDefaultTabCount = $tabCountExtra+1;
                 ++$tabCountExtra;

--- a/src/UI/Dashboard/ParentDashboard.php
+++ b/src/UI/Dashboard/ParentDashboard.php
@@ -146,7 +146,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
 
     protected function renderChildDashboard($gibbonPersonID, $dateStart)
     {
-        global $container;
         $guid = $this->session->get('guid');
         $connection2 = $this->db->getConnection();
         $session = $this->session;
@@ -158,7 +157,7 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
         /**
          * @var AlertLevelGateway
          */
-        $alertLevelGateway = $container->get(AlertLevelGateway::class);
+        $alertLevelGateway = $this->getContainer()->get(AlertLevelGateway::class);
         $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
         $entryCount = 0;
 


### PR DESCRIPTION
**Description**
* Create AlertLevelGateway class with a getByID() method.
* Mark getAlert() deprecated.
* Rewrite all getAlert() calls with AlertLevelGateway::getByID().

**Motivation and Context**
* Replace functions.php function with gateway implementation.

**How Has This Been Tested?**
* Locally.
* CI environment.