### PR TITLE
Refactor: SchoolYearGateway methods to replace functions.php relevant functions

### DIFF
--- a/cli/attendance_dailyIncompleteEmail.php
+++ b/cli/attendance_dailyIncompleteEmail.php
@@ -21,13 +21,19 @@ use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 
 require getcwd().'/../gibbon.php';
 
 getSystemSettings($guid, $connection2);
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Set up for i18n via gettext
 if (!empty($session->get('i18n')['code'])) {

--- a/cli/attendance_dailyIncompleteEmail_byClass.php
+++ b/cli/attendance_dailyIncompleteEmail_byClass.php
@@ -21,6 +21,7 @@ use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\School\SchoolYearSpecialDayGateway;
 use Gibbon\Domain\System\NotificationGateway;
 
@@ -28,7 +29,12 @@ require getcwd().'/../gibbon.php';
 
 getSystemSettings($guid, $connection2);
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Set up for i18n via gettext
 if (!empty($session->get('i18n')['code'])) {

--- a/cli/attendance_weeklySummaryEmail.php
+++ b/cli/attendance_weeklySummaryEmail.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Module\Attendance\AttendanceView;
@@ -26,7 +27,12 @@ use Gibbon\Services\Format;
 
 require getcwd().'/../gibbon.php';
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Check for CLI, so this cannot be run through browser
 $settingGateway = $container->get(SettingGateway::class);
@@ -35,7 +41,11 @@ $remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
 if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
     echo __('This script cannot be run from a browser, only via CLI.');
 } else {
-    setCurrentSchoolYear($guid, $connection2);
+    try {
+        $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+    } catch (\Exception $e) {
+        die($e->getMessage());
+    }
 
     require_once __DIR__ . '/../modules/Attendance/moduleFunctions.php';
     require_once __DIR__ . '/../modules/Attendance/src/AttendanceView.php';

--- a/cli/behaviour_dailySummaryEmail.php
+++ b/cli/behaviour_dailySummaryEmail.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 
@@ -25,7 +26,11 @@ require getcwd().'/../gibbon.php';
 
 getSystemSettings($guid, $connection2);
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Set up for i18n via gettext
 if (!empty($session->get('i18n')['code'])) {

--- a/cli/behaviour_lettersPositive.php
+++ b/cli/behaviour_lettersPositive.php
@@ -23,6 +23,7 @@ use Gibbon\Comms\EmailTemplate;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
 use Gibbon\Domain\Behaviour\BehaviourLetterGateway;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\System\EmailTemplateGateway;
 use Gibbon\Domain\User\UserGateway;
@@ -37,7 +38,12 @@ set_time_limit(1200);
 
 getSystemSettings($guid, $connection2);
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Set up for i18n via gettext
 if (!empty($session->get('i18n')['code'])) {
@@ -100,7 +106,7 @@ if (!isCommandLineInterface()) { echo __('This script cannot be run from a brows
                     $dataBehaviour = array('gibbonPersonID' => $student['gibbonPersonID'], 'gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
                     $sqlBehaviour = "SELECT * FROM gibbonBehaviour WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND type='Positive'";
                     $resultBehaviour = $pdo->select($sqlBehaviour, $dataBehaviour);
-                        
+
                     $behaviourCount = $resultBehaviour->rowCount();
                     if ($behaviourCount > 0) { //Only worry about students with more than zero positive records in the current year
                         //Get most recent letter entry
@@ -192,7 +198,7 @@ if (!isCommandLineInterface()) { echo __('This script cannot be run from a brows
                             $dataBehaviourRecord = array('gibbonPersonID' => $student['gibbonPersonID'], 'gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
                             $sqlBehaviourRecord = "SELECT * FROM gibbonBehaviour WHERE gibbonPersonID=:gibbonPersonID AND gibbonSchoolYearID=:gibbonSchoolYearID AND type='Positive' ORDER BY timestamp DESC";
                             $resultBehaviourRecord = $pdo->select($sqlBehaviourRecord, $dataBehaviourRecord);
-                            
+
                             while ($rowBehaviourRecord = $resultBehaviourRecord->fetch()) {
                                 $behaviourRecord .= '<li>';
                                 $behaviourRecord .= Format::date(substr($rowBehaviourRecord['timestamp'], 0, 10));
@@ -259,7 +265,7 @@ if (!isCommandLineInterface()) { echo __('This script cannot be run from a brows
                             $dataMember = array('gibbonPersonID' => $student['gibbonPersonID']);
                             $sqlMember = "SELECT DISTINCT email, preferredName, surname, title FROM gibbonFamilyChild JOIN gibbonFamily ON (gibbonFamilyChild.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonFamilyAdult ON (gibbonFamilyAdult.gibbonFamilyID=gibbonFamily.gibbonFamilyID) JOIN gibbonPerson ON (gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonFamilyChild.gibbonPersonID=:gibbonPersonID AND gibbonPerson.status='Full' AND contactEmail='Y' ORDER BY contactPriority, surname, preferredName";
                             $resultMember = $pdo->select($sqlMember, $dataMember);
-                            
+
                             while ($parent = $resultMember->fetch()) {
                                 ++$emailSendCount;
                                 if ($parent['email'] == '') {

--- a/cli/library_overdueNotification.php
+++ b/cli/library_overdueNotification.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\System\SettingGateway;
 
@@ -26,7 +27,11 @@ require getcwd().'/../gibbon.php';
 
 getSystemSettings($guid, $connection2);
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Set up for i18n via gettext
 if (!empty($session->get('i18n')['code'])) {

--- a/cli/schoolAdmin_parentDailyEmailSummary.php
+++ b/cli/schoolAdmin_parentDailyEmailSummary.php
@@ -24,6 +24,7 @@ use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Domain\User\FamilyGateway;
 use Gibbon\Domain\Attendance\AttendanceLogPersonGateway;
+use Gibbon\Domain\School\SchoolYearGateway;
 
 $_POST['address'] = '/modules/School Admin/emailSummarySettings.php';
 
@@ -31,8 +32,13 @@ require __DIR__.'/../gibbon.php';
 
 // Setup some of the globals
 getSystemSettings($guid, $connection2);
-setCurrentSchoolYear($guid, $connection2);
-Format::setupFromSession($container->get('session'));
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+    Format::setupFromSession($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Check for CLI, so this cannot be run through browser
 $settingGateway = $container->get(SettingGateway::class);

--- a/cli/schoolAdmin_parentWeeklyEmailSummary.php
+++ b/cli/schoolAdmin_parentWeeklyEmailSummary.php
@@ -34,8 +34,13 @@ require __DIR__.'/../gibbon.php';
 
 // Setup some of the globals
 getSystemSettings($guid, $connection2);
-setCurrentSchoolYear($guid, $connection2);
-Format::setupFromSession($container->get('session'));
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+    Format::setupFromSession($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 $settingGateway = $container->get(SettingGateway::class);
 

--- a/cli/schoolAdmin_tutorDailyEmailSummary.php
+++ b/cli/schoolAdmin_tutorDailyEmailSummary.php
@@ -27,6 +27,7 @@ use Gibbon\Domain\School\YearGroupGateway;
 use Gibbon\Domain\Students\StudentGateway;
 use Gibbon\Domain\FormGroups\FormGroupGateway;
 use Gibbon\Domain\Attendance\AttendanceLogPersonGateway;
+use Gibbon\Domain\School\SchoolYearGateway;
 
 $_POST['address'] = '/modules/School Admin/emailSummarySettings.php';
 
@@ -34,8 +35,13 @@ require __DIR__.'/../gibbon.php';
 
 // Setup some of the globals
 getSystemSettings($guid, $connection2);
-setCurrentSchoolYear($guid, $connection2);
-Format::setupFromSession($container->get('session'));
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+    Format::setupFromSession($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Check for CLI, so this cannot be run through browser
 $remoteCLIKey = $container->get(SettingGateway::class)->getSettingByScope('System Admin', 'remoteCLIKey');

--- a/cli/system_backgroundProcess.php
+++ b/cli/system_backgroundProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Services\BackgroundProcessor;
 use Gibbon\Services\Format;
 
@@ -30,9 +31,14 @@ if (!isCommandLineInterface()) {
 }
 
 // Setup some of the globals
-Format::setupFromSession($container->get('session'));
 getSystemSettings($guid, $connection2);
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $session = $container->get('session');
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+    Format::setupFromSession($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 // Override the ini to keep this process alive
 ini_set('memory_limit', '2048M');

--- a/cli/userAdmin_statusCheckAndFix.php
+++ b/cli/userAdmin_statusCheckAndFix.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Domain\User\UserGateway;
 use Gibbon\Domain\User\UserStatusLogGateway;
@@ -26,7 +27,11 @@ require getcwd().'/../gibbon.php';
 
 getSystemSettings($guid, $connection2);
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 //Set up for i18n via gettext
 if (!empty($session->get('i18n')['code'])) {

--- a/functions.php
+++ b/functions.php
@@ -1286,7 +1286,21 @@ function getModuleCategory($address, $connection2)
     return $output;
 }
 
-//GET THE CURRENT YEAR AND SET IT AS A GLOBAL VARIABLE
+/**
+ * Get the current year and set it as a global variable.
+ * (i.e. global $session instance)
+ *
+ * @deprecated v25
+ *             Use SchoolYearGateway::setCurrentSchoolYear instead.
+ *
+ * @version v23
+ * @since   v12
+ *
+ * @param  string $guid
+ * @param  \PDO $connection2
+ *
+ * @return void
+ */
 function setCurrentSchoolYear($guid,  $connection2)
 {
     global $session;

--- a/functions.php
+++ b/functions.php
@@ -1332,7 +1332,20 @@ function nl2brr($string)
     return preg_replace("/\r\n|\n|\r/", '<br/>', $string);
 }
 
-//Take a school year, and return the previous one, or false if none
+/**
+ * Take a school year, and return the previous one, or false if none.
+ *
+ * Please use SchoolYearGateway::getPreviousSchoolYearByID instead.
+ *
+ * @deprecated v25
+ * @version v12
+ * @since   v12
+ *
+ * @param int  $gibbonSchoolYearID
+ * @param \PDO $connection2
+ *
+ * @return int|false  The ID of the previous school year, or false if none.
+ */
 function getPreviousSchoolYearID($gibbonSchoolYearID, $connection2)
 {
     $output = false;
@@ -1358,7 +1371,20 @@ function getPreviousSchoolYearID($gibbonSchoolYearID, $connection2)
     return $output;
 }
 
-//Take a school year, and return the previous one, or false if none
+/**
+ * Take a school year, and return the previous one, or false if none.
+ *
+ * Please use SchoolYearGateway::getNextSchoolYearByID instead.
+ *
+ * @deprecated v25
+ * @version v12
+ * @since   v12
+ *
+ * @param int  $gibbonSchoolYearID
+ * @param \PDO $connection2
+ *
+ * @return int|false  The ID of the next school year, or false if none.
+ */
 function getNextSchoolYearID($gibbonSchoolYearID, $connection2)
 {
     $output = false;

--- a/login.php
+++ b/login.php
@@ -28,13 +28,18 @@ use Gibbon\Auth\Adapter\OAuthAdapterInterface;
 use Gibbon\Auth\Adapter\OAuthGoogleAdapter;
 use Gibbon\Auth\Adapter\OAuthMicrosoftAdapter;
 use Gibbon\Auth\Adapter\OAuthGenericAdapter;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\LogGateway;
 use League\Container\Exception\NotFoundException;
 
 // Gibbon system-wide include
 require_once './gibbon.php';
 
-setCurrentSchoolYear($guid, $connection2);
+try {
+    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+} catch (\Exception $e) {
+    die($e->getMessage());
+}
 
 // The current/actual school year info, just in case we are working in a different year
 $session->set('gibbonSchoolYearIDCurrent', $session->get('gibbonSchoolYearID'));

--- a/modules/Planner/units.php
+++ b/modules/Planner/units.php
@@ -39,6 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units.php') == fal
         return;
     }
 
+    /** @var SchoolYearGateway */
     $schoolYearGateway = $container->get(SchoolYearGateway::class);
     $courseGateway = $container->get(CourseGateway::class);
     $unitGateway = $container->get(UnitGateway::class);
@@ -58,7 +59,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units.php') == fal
         $row = $container->get(CourseGateway::class)->selectBy(['gibbonSchoolYearID' => $gibbonSchoolYearID, 'nameShort' => $courseName])->fetch();
         $gibbonCourseID = $row['gibbonCourseID'] ?? '';
     }
-    
+
     if (empty($gibbonCourseID)) {
         try {
             if ($highestAction == 'Unit Planner_all') {
@@ -93,10 +94,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units.php') == fal
 
     //Work out previous and next course with same name
     $gibbonCourseIDPrevious = '';
-    $gibbonSchoolYearIDPrevious = getPreviousSchoolYearID($gibbonSchoolYearID, $connection2);
-    if ($gibbonSchoolYearIDPrevious != false and isset($row['nameShort'])) {
-
-        $dataPrevious = array('gibbonSchoolYearID' => $gibbonSchoolYearIDPrevious, 'nameShort' => $row['nameShort']);
+    $gibbonSchoolYearPrevious = $schoolYearGateway->getPreviousSchoolYearByID($gibbonSchoolYearID);
+    if ($gibbonSchoolYearPrevious != false and isset($row['nameShort'])) {
+        $dataPrevious = array('gibbonSchoolYearID' => $gibbonSchoolYearPrevious['gibbonSchoolYearID'], 'nameShort' => $row['nameShort']);
         $sqlPrevious = 'SELECT * FROM gibbonCourse WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND nameShort=:nameShort';
         $resultPrevious = $connection2->prepare($sqlPrevious);
         $resultPrevious->execute($dataPrevious);
@@ -106,10 +106,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units.php') == fal
         }
     }
     $gibbonCourseIDNext = '';
-    $gibbonSchoolYearIDNext = getNextSchoolYearID($gibbonSchoolYearID, $connection2);
-    if ($gibbonSchoolYearIDNext != false and isset($row['nameShort'])) {
+    $gibbonSchoolYearNext = $schoolYearGateway->getNextSchoolYearByID($gibbonSchoolYearID);
+    if ($gibbonSchoolYearNext != false and isset($row['nameShort'])) {
 
-        $dataNext = array('gibbonSchoolYearID' => $gibbonSchoolYearIDNext, 'nameShort' => $row['nameShort']);
+        $dataNext = array('gibbonSchoolYearID' => $gibbonSchoolYearNext['gibbonSchoolYearID'], 'nameShort' => $row['nameShort']);
         $sqlNext = 'SELECT * FROM gibbonCourse WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND nameShort=:nameShort';
         $resultNext = $connection2->prepare($sqlNext);
         $resultNext->execute($dataNext);

--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Forms\Form;
 
 //Module includes
@@ -36,20 +37,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
         $step = 1;
     }
 
+    /**
+     * @var SchoolYearGateway
+     */
+    $schoolYearGateway = $container->get(SchoolYearGateway::class);
+
     //Step 1
     if ($step == 1) {
         echo '<h3>';
         echo __('Step 1');
         echo '</h3>';
 
-        $nextYear = getNextSchoolYearID($session->get('gibbonSchoolYearID'), $connection2);
-        if ($nextYear == false) {
+        $nextYearBySession = $schoolYearGateway->getNextSchoolYearByID($session->get('gibbonSchoolYearID'));
+        if ($nextYearBySession == false) {
             echo "<div class='error'>";
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
-                $dataNext = array('gibbonSchoolYearID' => $nextYear);
+                $dataNext = array('gibbonSchoolYearID' => $nextYearBySession['gibbonSchoolYearID']);
                 $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $resultNext = $connection2->prepare($sqlNext);
                 $resultNext->execute($dataNext);
@@ -65,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
 
                 $form = Form::create('courseRollover', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/course_rollover.php&step=2');
 
-                $form->addHiddenValue('nextYear', $nextYear);
+                $form->addHiddenValue('nextYear', $nextYearBySession);
 
                 $row = $form->addRow();
                     $row->addContent(sprintf(__('By clicking the "Proceed" button below you will initiate the course enrolment rollover from %1$s to %2$s. In a big school this operation may take some time to complete. %3$sYou are really, very strongly advised to backup all data before you proceed%4$s.'), '<b>'.$session->get('gibbonSchoolYearName').'</b>', '<b>'.$nameNext.'</b>', '<span style="color: #cc0000"><i>', '</span>'));
@@ -81,14 +86,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
         echo __('Step 2');
         echo '</h3>';
 
-        $nextYear = $_POST['nextYear'];
-        if ($nextYear == '' or $nextYear != getNextSchoolYearID($session->get('gibbonSchoolYearID'), $connection2)) {
+        $nextYearID = $_POST['nextYear'];
+        $nextYearBySession = $schoolYearGateway->getNextSchoolYearByID($session->get('gibbonSchoolYearID'));
+        if (empty($nextYearID) or $nextYearBySession === false or $nextYearID != $nextYearBySession['gibbonSchoolYearID']) {
             echo "<div class='error'>";
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
-                $dataNext = array('gibbonSchoolYearID' => $nextYear);
+                $dataNext = array('gibbonSchoolYearID' => $nextYearID);
                 $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $resultNext = $connection2->prepare($sqlNext);
                 $resultNext->execute($dataNext);
@@ -113,7 +118,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                 $currentCourses = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_GROUP|\PDO::FETCH_UNIQUE) : array();
 
                 // Get the next year's courses/classes
-                $data = array('gibbonSchoolYearID' => $nextYear);
+                $data = array('gibbonSchoolYearID' => $nextYearID);
                 $sql = "SELECT gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) as name FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name";
                 $result = $pdo->executeQuery($data, $sql);
                 $nextCourses = ($result->rowCount() > 0)? $result->fetchAll(\PDO::FETCH_KEY_PAIR) : array();
@@ -134,7 +139,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                 $form = Form::create('courseRollover', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/course_rollover.php&step=3');
                 $form->setClass('w-full blank');
 
-                $form->addHiddenValue('nextYear', $nextYear);
+                $form->addHiddenValue('nextYear', $nextYearID);
 
                 $table = $form->addRow()->addTable()->setClass('smallIntBorder fullWidth mb-4');
                 $row = $table->addRow();
@@ -175,14 +180,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
             }
         }
     } elseif ($step == 3) {
-        $nextYear = $_POST['nextYear'];
-        if ($nextYear == '' or $nextYear != getNextSchoolYearID($session->get('gibbonSchoolYearID'), $connection2)) {
+        $nextYearID = $_POST['nextYear'];
+        $nextYearBySession = $schoolYearGateway->getNextSchoolYearByID($session->get('gibbonSchoolYearID'));
+        if (empty($nextYearID) or $nextYearBySession === false or $nextYearID != $nextYearBySession['gibbonSchoolYearID']) {
             echo "<div class='error'>";
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
-            $dataNext = array('gibbonSchoolYearID' => $nextYear);
+            $dataNext = array('gibbonSchoolYearID' => $nextYearID);
             $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
             $rowNext = $pdo->selectOne($sqlNext, $dataNext);
 

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\School\YearGroupGateway;
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
@@ -621,7 +622,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                         $advance2 = false;
                     }
                     if ($advance2) {
-                        setCurrentSchoolYear($guid, $connection2);
+                        try {
+                            $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+                        } catch (\Exception $e) {
+                            die($e->getMessage());
+                        }
                         $session->set('gibbonSchoolYearIDCurrent', $session->get('gibbonSchoolYearID'));
                         $session->set('gibbonSchoolYearNameCurrent', $session->get('gibbonSchoolYearName'));
                         $session->set('gibbonSchoolYearSequenceNumberCurrent', $session->get('gibbonSchoolYearSequenceNumber'));

--- a/preferencesPasswordProcess.php
+++ b/preferencesPasswordProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Http\Url;
 use Gibbon\Domain\User\UserGateway;
 
@@ -24,7 +25,11 @@ include './gibbon.php';
 
 //Check to see if academic year id variables are set, if not set them
 if ($session->exists('gibbonAcademicYearID') == false or $session->exists('gibbonSchoolYearName') == false) {
-    setCurrentSchoolYear($guid, $connection2);
+    try {
+        $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+    } catch (\Exception $e) {
+        die($e->getMessage());
+    }
 }
 
 //Check password address is not blank

--- a/preferencesProcess.php
+++ b/preferencesProcess.php
@@ -18,13 +18,18 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Data\Validator;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Http\Url;
 
 include './gibbon.php';
 
 //Check to see if academic year id variables are set, if not set them
 if ($session->exists('gibbonAcademicYearID') == false or $session->exists('gibbonSchoolYearName') == false) {
-    setCurrentSchoolYear($guid, $connection2);
+    try {
+        $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
+    } catch (\Exception $e) {
+        die($e->getMessage());
+    }
 }
 
 // Sanitize the whole $_POST array

--- a/src/Domain/School/SchoolYearGateway.php
+++ b/src/Domain/School/SchoolYearGateway.php
@@ -19,9 +19,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Domain\School;
 
-use Gibbon\Domain\Traits\TableAware;
-use Gibbon\Domain\QueryCriteria;
+use Gibbon\Contracts\Services\Session;
+use Gibbon\Domain\DataSet;
 use Gibbon\Domain\QueryableGateway;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\Traits\TableAware;
 
 /**
  * School Year Gateway
@@ -36,6 +38,16 @@ class SchoolYearGateway extends QueryableGateway
     private static $tableName = 'gibbonSchoolYear';
     private static $primaryKey = 'gibbonSchoolYearID';
 
+    /**
+     * Query for school years.
+     *
+     * @version v17
+     * @since   v17
+     *
+     * @param QueryCriteria $criteria
+     *
+     * @return DataSet
+     */
     public function querySchoolYears(QueryCriteria $criteria)
     {
         $query = $this
@@ -47,7 +59,18 @@ class SchoolYearGateway extends QueryableGateway
 
         return $this->runQuery($query, $criteria);
     }
-    
+
+    /**
+     * Get a key value array with gibbonSchoolYearID as keys
+     * and the school year name as the values.
+     *
+     * @version v17
+     * @since   v17
+     *
+     * @param QueryCriteria $criteria
+     *
+     * @return array
+     */
     public function getSchoolYearList($activeOnly = false)
     {
         $sql = "SELECT gibbonSchoolYearID AS value, name FROM gibbonSchoolYear ";
@@ -57,6 +80,18 @@ class SchoolYearGateway extends QueryableGateway
         return $this->db()->select($sql)->fetchKeyPair();
     }
 
+    /**
+     * Get a key value array with gibbonSchoolYearID as keys
+     * and the school year name as the values of the specified
+     * school years.
+     *
+     * @version v17
+     * @since   v17
+     *
+     * @param array $schoolYearList  An array of school year IDs
+     *
+     * @return array
+     */
     public function getSchoolYearsFromList($schoolYearList = [])
     {
         $data = ['gibbonSchoolYearIDList' => is_array($schoolYearList) ? implode(',', $schoolYearList) : $schoolYearList];
@@ -65,6 +100,16 @@ class SchoolYearGateway extends QueryableGateway
         return $this->db()->select($sql, $data)->fetchKeyPair();
     }
 
+    /**
+     * Get a single school year by its ID.
+     *
+     * @version v17
+     * @since   v17
+     *
+     * @param int $gibbonSchoolYearID
+     *
+     * @return array|false  The information of the spcified school year, or false if not found.
+     */
     public function getSchoolYearByID($gibbonSchoolYearID)
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
@@ -73,6 +118,16 @@ class SchoolYearGateway extends QueryableGateway
         return $this->db()->selectOne($sql, $data);
     }
 
+    /**
+     * Get the school year next to the specified school year.
+     *
+     * @version v17
+     * @since   v17
+     *
+     * @param int $gibbonSchoolYearID  The ID of the specified school year.
+     *
+     * @return array|false  The information of the next school year, or false if not found.
+     */
     public function getNextSchoolYearByID($gibbonSchoolYearID)
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
@@ -81,11 +136,52 @@ class SchoolYearGateway extends QueryableGateway
         return $this->db()->selectOne($sql, $data);
     }
 
+    /**
+     * Get the school year previous of the specified school year.
+     *
+     * @version v17
+     * @since   v17
+     *
+     * @param int $gibbonSchoolYearID  The ID of the specified school year.
+     *
+     * @return array|false  The information of the previous school year, or false if not found.
+     */
     public function getPreviousSchoolYearByID($gibbonSchoolYearID)
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
         $sql = "SELECT * FROM gibbonSchoolYear WHERE sequenceNumber=(SELECT MAX(sequenceNumber) FROM gibbonSchoolYear WHERE sequenceNumber < (SELECT sequenceNumber FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID))";
 
         return $this->db()->selectOne($sql, $data);
+    }
+
+    /**
+     * Set the current school year information on session.
+     *
+     * @version v25
+     * @since   v25
+     *
+     * @param Session $session  The session instance to set.
+     *
+     * @return $this
+     *
+     * @throws \Exception  If cannot find current school year row.
+     */
+    public function setCurrentSchoolYear(Session $session)
+    {
+        $result = $this->db()->select("SELECT * FROM gibbonSchoolYear WHERE status='Current'");
+
+        // If the result set is empty, throw exception.
+        if ($result->isEmpty()) {
+            throw new \Exception(__('Configuration Error: there is a problem accessing the current Academic Year from the database.'));
+        }
+
+        $row = $result->fetch();
+        $session->set('gibbonSchoolYearID', $row['gibbonSchoolYearID']);
+        $session->set('gibbonSchoolYearName', $row['name']);
+        $session->set('gibbonSchoolYearSequenceNumber', $row['sequenceNumber']);
+        $session->set('gibbonSchoolYearFirstDay',$row['firstDay']);
+        $session->set('gibbonSchoolYearLastDay', $row['lastDay']);
+
+        return $this;
     }
 }

--- a/src/UI/Components/Sidebar.php
+++ b/src/UI/Components/Sidebar.php
@@ -31,6 +31,7 @@ use Gibbon\Domain\System\SettingGateway;
 use League\Container\ContainerAwareTrait;
 use League\Container\ContainerAwareInterface;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
+use Gibbon\Domain\School\SchoolYearGateway;
 
 /**
  * Sidebar View Composer
@@ -45,14 +46,32 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
     protected $db;
     protected $session;
     protected $category;
+
+    /**
+     * Setting gateway
+     *
+     * @var SettingGateway
+     */
     protected $settingGateway;
 
-    public function __construct(Connection $db, Session $session, SettingGateway $settingGateway)
-    {
+    /**
+     * School Year gateway.
+     *
+     * @var SchoolYearGateway
+     */
+    protected $schoolYearGateway;
+
+    public function __construct(
+        Connection $db,
+        Session $session,
+        SettingGateway $settingGateway,
+        SchoolYearGateway $schoolYearGateway
+    ) {
         $this->db = $db;
         $this->session = $session;
         $this->category = getRoleCategory($this->session->get('gibbonRoleIDCurrent'), $this->db->getConnection());
         $this->settingGateway = $settingGateway;
+        $this->schoolYearGateway = $schoolYearGateway;
     }
 
     public function getOutput()
@@ -97,8 +116,8 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
                 echo Format::alert($loginReturnMessage, 'error');
             }
         }
-        
-        
+
+
 
         if ($this->session->get('sidebarExtra') != '' and $this->session->get('sidebarExtraPosition') != 'bottom') {
             echo "<div class='sidebarExtra'>";
@@ -179,7 +198,13 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
                     echo __('Login');
                 echo '</h2>';
 
-                if (!$this->session->has('gibbonSchoolYearID')) setCurrentSchoolYear($guid, $connection2);
+                if (!$this->session->has('gibbonSchoolYearID')) {
+                    try {
+                        $this->schoolYearGateway->setCurrentSchoolYear($this->session);
+                    } catch (\Exception $e) {
+                        die($e->getMessage());
+                    }
+                }
                 unset($_GET['return']);
 
                 $enablePublicRegistration = $this->settingGateway->getSettingByScope('User Admin', 'enablePublicRegistration');
@@ -206,7 +231,7 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
                     $form->addHiddenValue('address', $this->session->get('address'));
                     $form->addHiddenValue('method', 'mfa');
                     $form->addHiddenValue('mfaFormNonce', $nonce);
-                    
+
                     $col = $form->addRow()->addColumn();
                         $col->addLabel('mfaCode', __('Multi Factor Authentication Code'));
                         $col->addNumber('mfaCode');


### PR DESCRIPTION
**Description**
* Mark setCurrentSchoolYear() deprecated.
* Add SchoolYearGateway::setCurrentSchoolYear() that provdes the exact feature.
* Rewrite Finance module usage of setCurrentSchoolYear() to SchoolYearGateway::setCurrentSchoolYear().
* Mark getPreviousSchoolYearID() and getNextSchoolYearID() deprecated.
* Replace all getPreviousSchoolYearByID() calls with SchoolYearGateway::getPreviousSchoolYearByID().
* Replace all getNextSchoolYearByID() calls with SchoolYearGateway::getNextSchoolYearByID().

**Motivation and Context**
* Replace functions.php functions with relevant SchoolYearGateway method.

**How Has This Been Tested?**
* CI environment.