### PR TITLE
School: replace functions with YearGroupGateway methods

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1289,7 +1289,20 @@ function getNextSchoolYearID($gibbonSchoolYearID, $connection2)
     return $output;
 }
 
-//Take a year group, and return the next one, or false if none
+/**
+ * Take a year group, and return the next one, or false if none.
+ * Use YearGroupGateway::getNextYearGroupID instead.
+ *
+ * @deprecated v25
+ *
+ * @version v12
+ * @since   v12
+ *
+ * @param int  $gibbonYearGroupID
+ * @param \PDO $connection2
+ *
+ * @return int|false
+ */
 function getNextYearGroupID($gibbonYearGroupID, $connection2)
 {
     $output = false;

--- a/functions.php
+++ b/functions.php
@@ -1346,7 +1346,19 @@ function getNextFormGroupID($gibbonFormGroupID, $connection2)
     return $output;
 }
 
-//Return the last school year in the school, or false if none
+/**
+ * Return the last school year in the school, or false if none.
+ * Use YearGroupGateway::getLastYearGroupID instead.
+ *
+ * @deprecated v25
+ *
+ * @version v12
+ * @since   v12
+ *
+ * @param \PDO $connection2
+ *
+ * @return int|false
+ */
 function getLastYearGroupID($connection2)
 {
     $output = false;

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\School\YearGroupGateway;
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\User\UserStatusLogGateway;
@@ -31,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 } else {
     //Proceed!
     $page->breadcrumbs->add(__('Rollover'));
-    
+
     $step = null;
     if (isset($_GET['step'])) {
         $step = $_GET['step'];
@@ -40,7 +41,10 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
         $step = 1;
     }
 
+    /** @var UserStatusLogGateway */
     $userStatusLogGateway = $container->get(UserStatusLogGateway::class);
+    /** @var YearGroupGateway */
+    $yearGroupGateway = $container->get(YearGroupGateway::class);
 
     //Step 1
     if ($step == 1) {
@@ -54,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
+
                 $dataNext = array('gibbonSchoolYearID' => $nextYear);
                 $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $resultNext = $connection2->prepare($sqlNext);
@@ -94,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
+
                 $dataNext = array('gibbonSchoolYearID' => $nextYear);
                 $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $resultNext = $connection2->prepare($sqlNext);
@@ -115,7 +119,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                 //Set up years, form groups and statuses arrays for use later on
                 $yearGroups = array();
-                
+
                     $dataSelect = array();
                     $sqlSelect = 'SELECT gibbonYearGroupID, name FROM gibbonYearGroup ORDER BY sequenceNumber';
                     $resultSelect = $connection2->prepare($sqlSelect);
@@ -125,7 +129,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                 }
 
                 $formGroups = array();
-                
+
                     $dataSelect = array('gibbonSchoolYearID' => $nextYear);
                     $sqlSelect = 'SELECT gibbonFormGroupID, name FROM gibbonFormGroup WHERE gibbonSchoolYearID=:gibbonSchoolYearID ORDER BY name';
                     $resultSelect = $connection2->prepare($sqlSelect);
@@ -411,7 +415,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                     $column->addCheckbox($count."-reenrol-enrol")->setValue('Y')->checked('Y')->alignLeft();
                                 //If no enrolment, try and work out next year and form group
                                 if (is_null($enrolmentCheckYearGroup)) {
-                                    $enrolmentCheckYearGroup=getNextYearGroupID($rowReenrol['gibbonYearGroupID'], $connection2);
+                                    $enrolmentCheckYearGroup=$yearGroupGateway->getNextYearGroupID($rowReenrol['gibbonYearGroupID']);
                                     $enrolmentCheckFormGroup=$rowReenrol['gibbonFormGroupIDNext'];
                                 }
                                 $column = $row->addColumn();
@@ -513,7 +517,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
+
                 $dataNext = array('gibbonSchoolYearID' => $nextYear);
                 $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $resultNext = $connection2->prepare($sqlNext);
@@ -551,7 +555,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                         echo '</div>';
                     } else {
                         //Check unique inputs for uniqueness
-                        
+
                             $data = array('name' => $name, 'sequenceNumber' => $sequenceNumber);
                             $sql = 'SELECT * FROM gibbonSchoolYear WHERE name=:name OR sequenceNumber=:sequenceNumber';
                             $result = $connection2->prepare($sql);
@@ -710,19 +714,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                     if ($enrolled) {
                                         ++$success;
 
-                                        
+
                                             $dataFamily = array('gibbonPersonID' => $gibbonPersonID);
                                             $sqlFamily = 'SELECT gibbonFamilyID FROM gibbonFamilyChild WHERE gibbonPersonID=:gibbonPersonID';
                                             $resultFamily = $connection2->prepare($sqlFamily);
                                             $resultFamily->execute($dataFamily);
                                         while ($rowFamily = $resultFamily->fetch()) {
-                                            
+
                                                 $dataFamily2 = array('gibbonFamilyID' => $rowFamily['gibbonFamilyID']);
                                                 $sqlFamily2 = 'SELECT gibbonPerson.gibbonPersonID, gibbonPerson.status FROM gibbonFamilyAdult JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonFamilyAdult.gibbonPersonID) WHERE gibbonFamilyID=:gibbonFamilyID';
                                                 $resultFamily2 = $connection2->prepare($sqlFamily2);
                                                 $resultFamily2->execute($dataFamily2);
                                             while ($rowFamily2 = $resultFamily2->fetch()) {
-                                                
+
                                                     $dataFamily3 = array('gibbonPersonID' => $rowFamily2['gibbonPersonID']);
                                                     $sqlFamily3 = "UPDATE gibbonPerson SET status='Full' WHERE gibbonPersonID=:gibbonPersonID";
                                                     $resultFamily3 = $connection2->prepare($sqlFamily3);
@@ -828,19 +832,19 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                                     if ($enrolled) {
                                         ++$success;
-                                        
+
                                             $dataFamily = array('gibbonPersonID' => $gibbonPersonID);
                                             $sqlFamily = 'SELECT gibbonFamilyID FROM gibbonFamilyChild WHERE gibbonPersonID=:gibbonPersonID';
                                             $resultFamily = $connection2->prepare($sqlFamily);
                                             $resultFamily->execute($dataFamily);
                                         while ($rowFamily = $resultFamily->fetch()) {
-                                            
+
                                                 $dataFamily2 = array('gibbonFamilyID' => $rowFamily['gibbonFamilyID']);
                                                 $sqlFamily2 = 'SELECT gibbonPerson.gibbonPersonID, gibbonPerson.status FROM gibbonFamilyAdult JOIN gibbonPerson ON (gibbonPerson.gibbonPersonID=gibbonFamilyAdult.gibbonPersonID) WHERE gibbonFamilyID=:gibbonFamilyID';
                                                 $resultFamily2 = $connection2->prepare($sqlFamily2);
                                                 $resultFamily2->execute($dataFamily2);
                                             while ($rowFamily2 = $resultFamily2->fetch()) {
-                                                
+
                                                     $dataFamily3 = array('gibbonPersonID' => $rowFamily2['gibbonPersonID']);
                                                     $sqlFamily3 = "UPDATE gibbonPerson SET status='Full' WHERE gibbonPersonID=:gibbonPersonID";
                                                     $resultFamily3 = $connection2->prepare($sqlFamily3);

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -358,7 +358,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                 $form->addRow()->addHeading('Re-Enrol Other Students', __('Re-Enrol Other Students'));
                 $form->addRow()->addContent(__('Any students who are not re-enrolled will have their status set to "Left".').' '.__('Students who are already enrolled will have their enrolment updated.'));
 
-                $lastYearGroup = getLastYearGroupID($connection2);
+                $lastYearGroup = $yearGroupGateway->getLastYearGroupID();
 
                 if (count($yearGroups) < 1 or count($formGroups) < 1) {
                     $form->addRow()->addAlert(__('Year groups or form groups are not properly set up, so you cannot proceed with this section.'), 'error');

--- a/src/Domain/School/YearGroupGateway.php
+++ b/src/Domain/School/YearGroupGateway.php
@@ -103,4 +103,33 @@ class YearGroupGateway extends QueryableGateway
         $sql = "SELECT gibbonYearGroupID as value, name FROM gibbonYearGroup WHERE FIND_IN_SET(gibbonYearGroupID, :gibbonYearGroupIDList) ORDER BY sequenceNumber";
         return $this->db()->select($sql, $data);
     }
+
+    /**
+     * Take a year group, and return the next one, or false if none.
+     *
+     * @version v25
+     * @since   v25
+     *
+     * @param int $gibbonYearGroupID
+     *
+     * @return int|false
+     */
+    public function getNextYearGroupID(int $gibbonYearGroupID)
+    {
+        $sql = 'SELECT * FROM gibbonYearGroup WHERE gibbonYearGroupID=:gibbonYearGroupID';
+        $result = $this->db()->select($sql, [
+            'gibbonYearGroupID' => $gibbonYearGroupID,
+        ]);
+        if ($result->rowCount() == 1) {
+            $row = $result->fetch();
+            $sqlPrevious = 'SELECT gibbonYearGroupID FROM gibbonYearGroup WHERE sequenceNumber>:sequenceNumber ORDER BY sequenceNumber ASC';
+            $resultPrevious = $this->db()->select($sqlPrevious, [
+                'sequenceNumber' => $row['sequenceNumber'],
+            ]);
+            if ($resultPrevious->rowCount() >= 1) {
+                return $resultPrevious->fetchColumn();
+            }
+        }
+        return false;
+    }
 }

--- a/src/Domain/School/YearGroupGateway.php
+++ b/src/Domain/School/YearGroupGateway.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Domain\School;
 
+use Gibbon\Domain\DataSet;
 use Gibbon\Domain\Traits\TableAware;
 use Gibbon\Domain\QueryCriteria;
 use Gibbon\Domain\QueryableGateway;
@@ -37,6 +38,16 @@ class YearGroupGateway extends QueryableGateway
     private static $primaryKey = 'gibbonYearGroupID';
     private static $searchableColumns = [];
 
+    /**
+     * Query for the year group.
+     *
+     * @version v16
+     * @since   v16
+     *
+     * @param QueryCriteria $criteria
+     *
+     * @return DataSet
+     */
     public function queryYearGroups(QueryCriteria $criteria)
     {
         $query = $this
@@ -50,6 +61,16 @@ class YearGroupGateway extends QueryableGateway
         return $this->runQuery($query, $criteria);
     }
 
+    /**
+     * Get student count by year group.
+     *
+     * @version v16
+     * @since   v16
+     *
+     * @param int $gibbonYearGroupID
+     *
+     * @return array|false
+     */
     public function studentCountByYearGroup($gibbonYearGroupID)
     {
         $data = array('gibbonYearGroupID' => $gibbonYearGroupID, 'today' => date('Y-m-d'));
@@ -67,6 +88,15 @@ class YearGroupGateway extends QueryableGateway
         return $this->db()->selectOne($sql, $data);
     }
 
+    /**
+     * Select year group by ids.
+     *
+     * @version v24
+     * @since   v24
+     *
+     * @param int[] $gibbonYearGroupIDList  An array of year group IDs.
+     * @return void
+     */
     public function selectYearGroupsByIDs($gibbonYearGroupIDList)
     {
         $data = ['gibbonYearGroupIDList' => is_array($gibbonYearGroupIDList) ? implode(',', $gibbonYearGroupIDList) : $gibbonYearGroupIDList];

--- a/src/Domain/School/YearGroupGateway.php
+++ b/src/Domain/School/YearGroupGateway.php
@@ -132,4 +132,22 @@ class YearGroupGateway extends QueryableGateway
         }
         return false;
     }
+
+    /**
+     * Return the last school year in the school, or false if none.
+     *
+     * @version v25
+     * @since   v25
+     *
+     * @return int|false
+     */
+    public function getLastYearGroupID()
+    {
+        $sql = 'SELECT gibbonYearGroupID FROM gibbonYearGroup ORDER BY sequenceNumber DESC';
+        $result = $this->db()->select($sql);
+        if ($result->rowCount() > 1) {
+            return $result->fetchColumn();
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
**Description**
* Mark getNextYearGroupID() deprecated.
* Implemented YearGroupGateway::getNextYearGroupID().
* Replace usage of getNextYearGroupID() with YearGroupGateway::getNextYearGroupID().
* Mark getLastYearGroupID() deprecated.
* Implemented YearGroupGateway::getLastYearGroupID().
* Replace usage of getLastYearGroupID() with YearGroupGateway::getLastYearGroupID().

**Motivation and Context**
* Replace functions.php functions with gateway methods.

**How Has This Been Tested?**
* CI environment.