### PR TITLE
Timetable Admin: refactor to use Url class for paths and url generation

### DIFF
--- a/modules/Timetable Admin/courseEnrolment_manage.php
+++ b/modules/Timetable Admin/courseEnrolment_manage.php
@@ -22,6 +22,7 @@ use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\Timetable\CourseGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage.php') == false) {
     // Access denied
@@ -55,13 +56,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         echo __('Filters');
         echo '</h3>';
 
-        $form = Form::create('searchForm', $session->get('absoluteURL').'/index.php', 'get');
+        $form = Form::create(
+            'searchForm',
+            Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage')
+                ->withQueryParam('gibbonSchoolYearID', $gibbonSchoolYearID),
+            'get'
+        );
         $form->setFactory(DatabaseFormFactory::create($pdo));
 
         $form->setClass('noIntBorder fullWidth');
-
-        $form->addHiddenValue('q', '/modules/'.$session->get('module').'/courseEnrolment_manage.php');
-        $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'));
@@ -123,7 +126,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                 ->addParam('gibbonCourseClassID')
                 ->format(function ($class, $actions) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/courseEnrolment_manage_class_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit'));
                 });
 
             echo $table->render($classes->toDataSet());

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Students\StudentGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_byPerson.php') == false) {
     // Access denied
@@ -52,13 +53,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
         echo '<h3>';
         echo __('Filters');
-        echo '</h3>'; 
-        
-        $form = Form::create('searchForm', $session->get('absoluteURL').'/index.php', 'get');
-        $form->setClass('noIntBorder fullWidth');
+        echo '</h3>';
 
-        $form->addHiddenValue('q', '/modules/'.$session->get('module').'/courseEnrolment_manage_byPerson.php');
-        $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
+        $form = Form::create(
+            'searchForm',
+            Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson')
+                ->withQueryParam('gibbonSchoolYearID', $gibbonSchoolYearID),
+            'get'
+        );
+        $form->setClass('noIntBorder fullWidth');
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'))->description(__('Preferred, surname, username.'));
@@ -76,7 +79,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         echo '<h3>';
         echo __('View');
         echo '</h3>';
-            
+
         $users = $studentGateway->queryStudentsAndTeachersBySchoolYear($criteria, $gibbonSchoolYearID, $gibbon->session->get('gibbonRoleIDCurrentCategory'));
 
         // DATA TABLE
@@ -122,7 +125,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             ->format(function ($person, $actions) {
                 $actions->addAction('edit', __('Edit'))
                         ->addParam('type', $person['roleCategory'])
-                        ->setURL('/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit'));
             });
 
         echo $table->render($users);

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
@@ -240,7 +240,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             $gibbonTTID = isset($_GET['gibbonTTID'])? $_GET['gibbonTTID'] : null;
             $ttDate = isset($_POST['ttDate'])? Format::timestamp(Format::dateConvert($_POST['ttDate'])) : null;
 
-            $tt = renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, false, $ttDate, '/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php', "&gibbonPersonID=$gibbonPersonID&gibbonSchoolYearID=$gibbonSchoolYearID&type=$type&allUsers=$allUsers#tt", 'full', true);
+            $tt = renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, false, $ttDate, Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit'), "&gibbonPersonID=$gibbonPersonID&gibbonSchoolYearID=$gibbonSchoolYearID&type=$type&allUsers=$allUsers#tt", 'full', true);
             if ($tt != false) {
                 echo $tt;
             } else {

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $type = $_POST['type'] ?? '';
@@ -26,22 +28,26 @@ $action = $_POST['action'] ?? '';
 $allUsers = $_GET['allUsers'] ?? '';
 $search = $_GET['search'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_byPerson_edit.php&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonPersonID=$gibbonPersonID&type=$type&allUsers=$allUsers&search=$search";
+$URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit')
+    ->withQueryParams([
+        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        'gibbonPersonID' => $gibbonPersonID,
+        'type' => $type,
+        'allUsers' => $allUsers,
+        'search' => $search,
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else if ($gibbonPersonID == '' or $gibbonSchoolYearID == '' or $action == '') {
-    $URL .= '&return=error1';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error1'));
 } else {
     $classes = isset($_POST['gibbonCourseClassID'])? $_POST['gibbonCourseClassID'] : array();
 
     //Proceed!
     //Check if person specified
     if (count($classes) <= 0) {
-        $URL .= '&return=error3';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error3'));
     } else {
         $partialFail = false;
         if ($action == 'Delete') {
@@ -69,11 +75,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         }
 
         if ($partialFail == true) {
-            $URL .= '&return=warning1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('warning1'));
         } else {
-            $URL .= '&return=success0';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('success0'));
         }
     }
 

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_editProcessBulk.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $type = $_POST['type'] ?? '';
 $gibbonPersonID = $_POST['gibbonPersonID'] ?? '';

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -30,11 +31,17 @@ $search = $_GET['search'] ?? '';
 
 if ($gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_byPerson_edit.php&type=$type&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonPersonID=$gibbonPersonID&allUsers=$allUsers&search=$search";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit')
+        ->withQueryParams([
+            'type' => $type,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonPersonID' => $gibbonPersonID,
+            'allUsers' => $allUsers,
+            'search' => $search,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Run through each of the selected participants.
@@ -43,8 +50,7 @@ if ($gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error load
         $role = $_POST['role'] ?? '';
 
         if (count($choices) < 1 or $role == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             foreach ($choices as $t) {
                 //Check to see if student is already registered in this class
@@ -81,11 +87,9 @@ if ($gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error load
             }
             //Write to database
             if ($update == false) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
-                $URL .= '&return=success0';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php') == false) {
     // Access denied
@@ -34,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     if ($gibbonPersonID == '' or $gibbonCourseClassID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
             $sql = 'SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonPerson.gibbonPersonID=:gibbonPersonID';
             $result = $connection2->prepare($sql);
@@ -45,7 +46,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         } else {
             //Let's go!
             $row = $result->fetch();
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/courseEnrolment_manage_byPerson_edit_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&type=$type&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonPersonID=$gibbonPersonID&allUsers=$allUsers&search=$search");
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit_deleteProcess')
+                    ->withQueryParams([
+                        'gibbonCourseClassID' => $gibbonCourseClassID,
+                        'type' => $type,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'gibbonPersonID' => $gibbonPersonID,
+                        'allUsers' => $allUsers,
+                        'search' => $search,
+                    ])
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_deleteProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
@@ -28,18 +30,32 @@ $search = $_GET['search'] ?? '';
 
 if ($gibbonPersonID == '' or $gibbonCourseClassID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_byPerson_edit_edit.php&type=$type&gibbonPersonID=$gibbonPersonID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseClassID=$gibbonCourseClassID&allUsers=$allUsers&search=$search";
-    $URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_byPerson_edit.php&type=$type&gibbonPersonID=$gibbonPersonID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseClassID=$gibbonCourseClassID&allUsers=$allUsers&search=$search";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit_edit')
+        ->withQueryParams([
+            'type' => $type,
+            'gibbonPersonID' => $gibbonPersonID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'allUsers' => $allUsers,
+            'search' => $search,
+        ]);
+    $URLDelete = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit')
+        ->withQueryParams([
+            'type' => $type,
+            'gibbonPersonID' => $gibbonPersonID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'allUsers' => $allUsers,
+            'search' => $search,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonPersonID specified
         if ($gibbonPersonID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
@@ -47,14 +63,12 @@ if ($gibbonPersonID == '' or $gibbonCourseClassID == '' or $gibbonSchoolYearID =
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -63,13 +77,11 @@ if ($gibbonPersonID == '' or $gibbonCourseClassID == '' or $gibbonSchoolYearID =
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URLDelete = $URLDelete.'&return=success0';
-                header("Location: {$URLDelete}");
+                header('Location: ' . $URLDelete->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
 $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_editProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -31,17 +32,23 @@ $search = $_GET['search'] ?? '';
 
 if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_byPerson_edit_edit.php&type=$type&gibbonPersonID=$gibbonPersonID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseClassID=$gibbonCourseClassID&allUsers=$allUsers&search=$search";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_byPerson_edit_edit')
+        ->withQueryParams([
+            'type' => $type,
+            'gibbonPersonID' => $gibbonPersonID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'allUsers' => $allUsers,
+            'search' => $search,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if person specified
         if ($gibbonPersonID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonPersonID' => $gibbonPersonID);
@@ -49,14 +56,12 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Validate Inputs
                 $values = $result->fetch();
@@ -64,8 +69,7 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
                 $reportable = $_POST['reportable'] ?? '';
 
                 if ($role == '') {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Write to database
                     $dateEnrolled = $role != $values['role'] && stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
@@ -76,13 +80,11 @@ if ($gibbonCourseClassID == '' or $gibbonSchoolYearID == '' or $gibbonPersonID =
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
-                    $URL .= '&return=success0';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('success0'));
                 }
             }
         }

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit.php
@@ -74,7 +74,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             echo __('Add Participants');
             echo '</h2>';
 
-            $form = Form::create('manageEnrolment', $session->get('absoluteURL').'/modules/'.$session->get('module')."/courseEnrolment_manage_class_edit_addProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID&search=$search");
+            $form = Form::create(
+                'manageEnrolment',
+                Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_addProcess')
+                    ->withQueryParams([
+                        'gibbonCourseClassID' => $gibbonCourseClassID,
+                        'gibbonCourseID' => $gibbonCourseID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'search' => $search,
+                    ])
+            );
 
             $form->addHiddenValue('address', $session->get('address'));
 
@@ -121,7 +130,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                 $isStudent = stripos($person['role'], 'Student') !== false;
                 $name = Format::name('', $person['preferredName'], $person['surname'], $isStudent ? 'Student' : 'Staff', true, true);
                 return $isStudent
-                    ? Format::link('./index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$person['gibbonPersonID'].'&subpage=Timetable', $name).'<br/>'.Format::userStatusInfo($person)
+                    ? Format::link(
+                        Url::fromModuleRoute('Students', 'student_view_details')
+                            ->withQueryParams([
+                                'gibbonPersonID' => $person['gibbonPersonID'],
+                                'subpage' => 'Timetable',
+                            ]),
+                        $name
+                    ).'<br/>'.Format::userStatusInfo($person)
                     : $name;
             };
 
@@ -134,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             $enrolment = $courseEnrolmentGateway->queryCourseEnrolmentByClass($criteria, $gibbonSchoolYearID, $gibbonCourseClassID, false, true);
 
             // FORM
-            $form = BulkActionForm::create('bulkAction', $session->get('absoluteURL') . '/modules/' . $session->get('module') . '/courseEnrolment_manage_class_editProcessBulk.php');
+            $form = BulkActionForm::create('bulkAction', Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_editProcessBulk'));
             $form->setTitle(__('Current Participants'));
 
             $form->addHiddenValue('gibbonCourseID', $gibbonCourseID);
@@ -187,9 +203,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                 ->addParams($linkParams)
                 ->format(function ($person, $actions) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_edit'));
                     $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_delete'));
                 });
 
             $table->addCheckboxColumn('gibbonCourseClassPersonID');
@@ -219,9 +235,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                 ->addParams($linkParams)
                 ->format(function ($person, $actions) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_edit'));
                     $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_delete'));
                 });
 
             echo $table->render($enrolmentLeft);

--- a/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_POST['gibbonCourseClassID'] ?? '';
@@ -25,22 +27,25 @@ $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 $action = $_POST['action'] ?? '';
 $search = $_POST['search'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_class_edit.php&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseClassID=$gibbonCourseClassID&search=$search";
+$URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit')
+    ->withQueryParams([
+        'gibbonCourseID' => $gibbonCourseID,
+        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        'gibbonCourseClassID' => $gibbonCourseClassID,
+        'search' => $search,
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_class_edit.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID == '' or $action == '') {
-    $URL .= '&return=error1';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error1'));
 } else {
     $people = isset($_POST['gibbonCourseClassPersonID']) ? $_POST['gibbonCourseClassPersonID'] : array();
 
     //Proceed!
     //Check if person specified
     if (count($people) < 1) {
-        $URL .= '&return=error3';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error3'));
     } else {
         $partialFail = false;
         if ($action == 'Delete') {
@@ -85,8 +90,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
                 }
             } else {
-                $URL .= '&return=error3';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error3'));
             }
         } else if ($action == 'Mark as left') {
             foreach ($people as $gibbonCourseClassPersonID) {
@@ -102,11 +106,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         }
 
         if ($partialFail == true) {
-            $URL .= '&return=warning1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('warning1'));
         } else {
-            $URL .= '&return=success0';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('success0'));
         }
     }
 

--- a/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_editProcessBulk.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_POST['gibbonCourseClassID'] ?? '';
 $gibbonCourseID = $_POST['gibbonCourseID'] ?? '';

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -29,11 +30,16 @@ $search = $_GET['search'] ?? '';
 
 if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_class_edit.php&gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID&search=$search";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit')
+        ->withQueryParams([
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'gibbonCourseID' => $gibbonCourseID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'search' => $search,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_class_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Run through each of the selected participants.
@@ -42,8 +48,7 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID =
         $role = $_POST['role'] ?? '';
 
         if (count($choices) < 1 or $role == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             foreach ($choices as $t) {
                 //Check to see if student is already registered in this class
@@ -80,11 +85,9 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID =
             }
             //Write to database
             if ($update == false) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
-                $URL .= '&return=success0';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php') == false) {
     // Access denied
@@ -29,11 +30,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
     $gibbonCourseClassPersonID = $_GET['gibbonCourseClassPersonID'];
     $search = $_GET['search'] ?? '';
-    
+
     if ($gibbonCourseClassPersonID == '' or $gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
             $sql = 'SELECT role, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID';
             $result = $connection2->prepare($sql);
@@ -44,7 +45,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         } else {
             //Let's go!
             $row = $result->fetch();
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/courseEnrolment_manage_class_edit_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseClassPersonID=$gibbonCourseClassPersonID&search=$search");
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_deleteProcess')
+                    ->withQueryParams([
+                        'gibbonCourseClassID' => $gibbonCourseClassID,
+                        'gibbonCourseID' => $gibbonCourseID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID,
+                        'search' => $search,
+                    ])
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
 $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_deleteProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
@@ -27,18 +29,28 @@ $search = $_GET['search'] ?? '';
 
 if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassPersonID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_class_edit_edit.php&gibbonCourseID=$gibbonCourseID&gibbonCourseClassPersonID=$gibbonCourseClassPersonID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseClassID=$gibbonCourseClassID";
-    $URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_class_edit.php&gibbonCourseID=$gibbonCourseID&gibbonCourseClassID=$gibbonCourseClassID&gibbonSchoolYearID=$gibbonSchoolYearID&search=$search";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_edit')
+        ->withQueryParams([
+            'gibbonCourseID' => $gibbonCourseID,
+            'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+        ]);
+    $URLDelete = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit')
+        ->withQueryParams([
+            'gibbonCourseID' => $gibbonCourseID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'search' => $search,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_class_edit_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonCourseClassPersonID specified
         if ($gibbonCourseClassPersonID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
@@ -46,14 +58,12 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -62,13 +72,11 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URLDelete = $URLDelete.'&return=success0';
-                header("Location: {$URLDelete}");
+                header('Location: ' . $URLDelete->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 use Gibbon\Services\Format;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php') == false) {
@@ -32,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassPersonID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
             $sql = "SELECT role, gibbonCourseClassPerson.dateEnrolled, gibbonCourseClassPerson.dateUnenrolled, gibbonPerson.preferredName, gibbonPerson.surname, gibbonPerson.gibbonPersonID, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.name, gibbonCourseClass.nameShort, gibbonCourse.gibbonCourseID, gibbonCourse.name AS courseName, gibbonCourse.nameShort as courseNameShort, gibbonCourse.description AS courseDescription, gibbonCourse.gibbonSchoolYearID, gibbonSchoolYear.name as yearName, gibbonCourseClassPerson.reportable FROM gibbonPerson, gibbonCourseClass, gibbonCourseClassPerson,gibbonCourse, gibbonSchoolYear WHERE gibbonPerson.gibbonPersonID=gibbonCourseClassPerson.gibbonPersonID AND gibbonCourseClassPerson.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID AND gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourse.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonCourse.gibbonCourseID=:gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID AND gibbonCourseClassPerson.gibbonCourseClassPersonID=:gibbonCourseClassPersonID AND (gibbonPerson.status='Full' OR gibbonPerson.status='Expected')";
             $result = $connection2->prepare($sql);
@@ -51,15 +52,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                 ->add(__('Edit %1$s.%2$s Enrolment', ['%1$s' => $values['courseNameShort'], '%2$s' => $values['name']]), 'courseEnrolment_manage_class_edit.php', $urlParams)
                 ->add(__('Edit Participant'));
 
-			$form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module')."/courseEnrolment_manage_class_edit_editProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID");
-                
+			$form = Form::create(
+                'action',
+                Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_editProcess')
+                    ->withQueryParams([
+                        'gibbonCourseClassID' => $gibbonCourseClassID,
+                        'gibbonCourseID' => $gibbonCourseID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                    ])
+            );
+
 			$form->addHiddenValue('address', $session->get('address'));
 			$form->addHiddenValue('gibbonCourseClassPersonID', $gibbonCourseClassPersonID);
 
 			$row = $form->addRow();
 				$row->addLabel('yearName', __('School Year'));
 				$row->addTextField('yearName')->readonly()->setValue($values['yearName']);
-			
+
 			$row = $form->addRow();
 				$row->addLabel('courseName', __('Course'));
 				$row->addTextField('courseName')->readonly()->setValue($values['courseName']);
@@ -85,7 +94,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             $row = $form->addRow();
                 $row->addLabel('role', __('Role'));
 				$row->addSelect('role')->fromArray($roles)->required()->selected($values['role']);
-			
+
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable'))->description(__("Students set to non-reportable won't display in reports. Teachers set to non-reportable won't display in lists of class teachers."));
 				$row->addYesNo('reportable')->required()->selected($values['reportable']);
@@ -95,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
                     $row->addLabel('dateEnrolled', __('Date Enrolled'));
                     $row->addTextField('dateEnrolled')->readonly()->setValue(Format::date($values['dateEnrolled']));
             }
-                
+
             if (!empty($values['dateUnenrolled']) && stripos($values['role'], 'Left') !== false) {
                 $row = $form->addRow();
                     $row->addLabel('dateUnenrolled', __('Date Unenrolled'));

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_class_edit_editProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -29,17 +30,21 @@ $gibbonCourseClassPersonID = $_POST['gibbonCourseClassPersonID'] ?? '';
 
 if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassPersonID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/courseEnrolment_manage_class_edit_edit.php&gibbonCourseID=$gibbonCourseID&gibbonCourseClassPersonID=$gibbonCourseClassPersonID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonCourseClassID=$gibbonCourseClassID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit_edit')
+        ->withQueryParams([
+            'gibbonCourseID' => $gibbonCourseID,
+            'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_manage_class_edit_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if person specified
         if ($gibbonCourseClassPersonID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonCourseID' => $gibbonCourseID, 'gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonCourseClassPersonID' => $gibbonCourseClassPersonID);
@@ -47,14 +52,12 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Validate Inputs
                 $values = $result->fetch();
@@ -62,8 +65,7 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                 $reportable = $_POST['reportable'] ?? '';
 
                 if ($role == '') {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Write to database
                     $dateEnrolled = $role != $values['role'] && stripos($role, 'Left') === false ? date('Y-m-d') : $values['dateEnrolled'];
@@ -74,13 +76,11 @@ if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID =
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
-                    $URL .= '&return=success0';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('success0'));
                 }
             }
         }

--- a/modules/Timetable Admin/courseEnrolment_sync.php
+++ b/modules/Timetable Admin/courseEnrolment_sync.php
@@ -21,6 +21,7 @@ use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Domain\Timetable\CourseSyncGateway;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -35,7 +36,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
 
     $page->navigator->addSchoolYearNavigation($gibbonSchoolYearID);
 
-    $form = Form::create('settings', $session->get('absoluteURL').'/modules/Timetable Admin/courseEnrolment_sync_settingsProcess.php');
+    $form = Form::create(
+        'settings',
+        Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_settingsProcess')
+    );
     $form->setTitle(__('Settings'));
     $form->addHiddenValue('address', $session->get('address'));
 
@@ -65,13 +69,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     $table->setDescription(__('Syncing enrolment lets you enrol students into courses by mapping them to a Form Group and Year Group within the school. If auto-enrol is turned on, new students accepted through the application form and student enrolment process will be enrolled in courses automatically.'));
 
     $table->addHeaderAction('add', __('Add'))
-        ->setURL('/modules/Timetable Admin/courseEnrolment_sync_add.php')
+        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_add'))
         ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
         ->displayLabel()
         ->append('&nbsp;|&nbsp;');
 
     $table->addHeaderAction('sync', __('Sync All'))
-        ->setURL('/modules/Timetable Admin/courseEnrolment_sync_run.php')
+        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_run'))
         ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
         ->addParam('gibbonYearGroupIDList', $classMapsAllYearGroups)
         ->setIcon('refresh')
@@ -87,15 +91,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         ->addParam('gibbonYearGroupID')
         ->format(function ($row, $actions) {
             $actions->addAction('edit', __('Edit'))
-                ->setURL('/modules/Timetable Admin/courseEnrolment_sync_edit.php');
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_edit'));
 
             $actions->addAction('delete', __('Delete'))
-                ->setURL('/modules/Timetable Admin/courseEnrolment_sync_delete.php');
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_delete'));
 
             $actions->addAction('sync', __('Sync Now'))
                 ->setIcon('refresh')
                 ->addParam('gibbonYearGroupIDList', $row['gibbonYearGroupID'])
-                ->setURL('/modules/Timetable Admin/courseEnrolment_sync_run.php');
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_run'));
         });
 
     echo $table->render($classMaps);

--- a/modules/Timetable Admin/courseEnrolment_sync_add.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_add.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -40,7 +41,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         return;
     }
 
-    $form = Form::create('courseEnrolmentSyncAdd', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/courseEnrolment_sync_edit.php');
+    $form = Form::create(
+        'courseEnrolmentSyncAdd',
+        Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_edit')
+    );
 
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->addHiddenValue('address', $session->get('address'));

--- a/modules/Timetable Admin/courseEnrolment_sync_addEditProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_addEditProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/courseEnrolment_sync_addEditProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_addEditProcess.php
@@ -25,7 +25,7 @@ $_POST = $container->get(Validator::class)->sanitize($_POST);
 $gibbonYearGroupID = $_REQUEST['gibbonYearGroupID'] ?? null;
 $gibbonSchoolYearID = $_REQUEST['gibbonSchoolYearID'] ?? null;
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/courseEnrolment_sync_edit.php&gibbonYearGroupID='.$gibbonYearGroupID.'&gibbonSchoolYearID='.$gibbonSchoolYearID;
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync_edit.php&gibbonYearGroupID='.$gibbonYearGroupID.'&gibbonSchoolYearID='.$gibbonSchoolYearID;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/courseEnrolment_sync_addEditProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_addEditProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -25,11 +26,14 @@ $_POST = $container->get(Validator::class)->sanitize($_POST);
 $gibbonYearGroupID = $_REQUEST['gibbonYearGroupID'] ?? null;
 $gibbonSchoolYearID = $_REQUEST['gibbonSchoolYearID'] ?? null;
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync_edit.php&gibbonYearGroupID='.$gibbonYearGroupID.'&gibbonSchoolYearID='.$gibbonSchoolYearID;
+$URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_edit')
+    ->withQueryParams([
+        'gibbonYearGroupID' => $gibbonYearGroupID,
+        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_edit.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
     exit;
 } else {
     //Proceed!
@@ -37,8 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     $syncTo = (isset($_POST['syncTo']))? $_POST['syncTo'] : null;
 
     if (empty($gibbonYearGroupID) || empty($gibbonSchoolYearID) || empty($syncTo) || empty($syncEnabled)) {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
         exit;
     } else {
         $partialFail = false;
@@ -67,12 +70,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         }
 
         if ($partialFail) {
-            $URL .= '&return=warning3';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('warning3'));
             exit;
         } else {
-            $URL .= '&return=success0';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('success0'));
             exit;
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_sync_delete.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -31,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     if (empty($gibbonYearGroupID) || empty($gibbonSchoolYearID)) {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module').'/courseEnrolment_sync_deleteProcess.php');
+        $form = DeleteForm::createForm(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_deleteProcess'));
         echo $form->getOutput();
     }
 }

--- a/modules/Timetable Admin/courseEnrolment_sync_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_deleteProcess.php
@@ -21,7 +21,7 @@ require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/courseEnrolment_sync.php&gibbonSchoolYearID='.$gibbonSchoolYearID;
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync.php&gibbonSchoolYearID='.$gibbonSchoolYearID;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/courseEnrolment_sync_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_deleteProcess.php
@@ -17,22 +17,26 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync.php&gibbonSchoolYearID='.$gibbonSchoolYearID;
+$URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync')
+    ->withQueryParams([
+        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_delete.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
+    exit();
 } else {
     //Proceed!
     $gibbonYearGroupID = (isset($_POST['gibbonYearGroupID']))? $_POST['gibbonYearGroupID'] : null;
 
     if (empty($gibbonYearGroupID)) {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
         exit;
     } else {
         $data = array('gibbonYearGroupID' => $gibbonYearGroupID);
@@ -41,12 +45,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         $pdo->executeQuery($data, $sql);
 
         if ($pdo->getQuerySuccess() == false) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit;
         } else {
-            $URL .= "&return=success0";
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('success0'));
             exit;
         }
     }

--- a/modules/Timetable Admin/courseEnrolment_sync_deleteProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 

--- a/modules/Timetable Admin/courseEnrolment_sync_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_edit.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -42,7 +43,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         return;
     }
 
-    $form = Form::create('courseEnrolmentSyncEdit', $session->get('absoluteURL').'/modules/'.$session->get('module').'/courseEnrolment_sync_addEditProcess.php');
+    $form = Form::create(
+        'courseEnrolmentSyncEdit',
+        Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_addEditProcess')
+    );
     $form->setClass('w-full blank');
     $form->setFactory(DatabaseFormFactory::create($pdo));
 

--- a/modules/Timetable Admin/courseEnrolment_sync_run.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_run.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 use Gibbon\Services\Format;
 
 //Module includes
@@ -73,7 +74,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
         return;
     }
 
-    $form = Form::create('courseEnrolmentSyncRun', $session->get('absoluteURL').'/modules/'.$session->get('module').'/courseEnrolment_sync_runProcess.php');
+    $form = Form::create(
+        'courseEnrolmentSyncRun',
+        Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync_runProcess')
+    );
     $form->setClass('w-full blank');
     $form->setFactory(DatabaseFormFactory::create($pdo));
 

--- a/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_runProcess.php
@@ -25,8 +25,8 @@ $_POST = $container->get(Validator::class)->sanitize($_POST);
 $gibbonYearGroupIDList = $_POST['gibbonYearGroupIDList'] ?? null;
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? null;
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/courseEnrolment_sync_run.php&gibbonSchoolYearID='.$gibbonSchoolYearID.'&gibbonYearGroupIDList='.$gibbonYearGroupIDList;
-$URLSuccess = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/courseEnrolment_sync.php';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync_run.php&gibbonSchoolYearID='.$gibbonSchoolYearID.'&gibbonYearGroupIDList='.$gibbonYearGroupIDList;
+$URLSuccess = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync_run.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/courseEnrolment_sync_settingsProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_settingsProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/courseEnrolment_sync_settingsProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_settingsProcess.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/courseEnrolment_sync.php';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/courseEnrolment_sync_settingsProcess.php
+++ b/modules/Timetable Admin/courseEnrolment_sync_settingsProcess.php
@@ -17,16 +17,16 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/courseEnrolment_sync.php';
+$URL = Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_sync');
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnrolment_sync.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
     exit;
 } else {
     //Proceed!
@@ -43,12 +43,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
     }
 
     if ($partialFail) {
-        $URL .= '&return=error2';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error2'));
         exit;
     } else {
-        $URL .= '&return=success0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('success0'));
         exit;
     }
 }

--- a/modules/Timetable Admin/course_manage.php
+++ b/modules/Timetable Admin/course_manage.php
@@ -23,6 +23,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\CourseGateway;
 use Gibbon\Domain\School\SchoolYearGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage.php') == false) {
     // Access denied
@@ -53,13 +54,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         echo __('Filters');
         echo '</h3>';
 
-        $form = Form::create('action', $session->get('absoluteURL').'/index.php','get');
+        $form = Form::create(
+            'action',
+            Url::fromModuleRoute('Timetable Admin', 'course_manage')
+                ->withQueryParam('gibbonSchoolYearID', $gibbonSchoolYearID),
+            'get'
+        );
 
         $form->setFactory(DatabaseFormFactory::create($pdo));
         $form->setClass('noIntBorder fullWidth');
-
-        $form->addHiddenValue('q', "/modules/".$session->get('module')."/course_manage.php");
-        $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
 
         $row = $form->addRow();
             $row->addLabel('search', __('Search For'));
@@ -85,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
         if (!empty($nextYear)) {
             $table->addHeaderAction('copy', __('Copy All To Next Year'))
-                ->setURL('/modules/Timetable Admin/course_manage_copyProcess.php')
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'course_manage_copyProcess'))
                 ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
                 ->addParam('gibbonSchoolYearIDNext', $nextYear['gibbonSchoolYearID'])
                 ->addParam('search', $search)
@@ -97,9 +100,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         }
 
         $table->addHeaderAction('add', __('Add'))
-            ->setURL('/modules/Timetable Admin/course_manage_add.php')
-            ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
-            ->addParam('search', $search)
+            ->setURL(Url::fromModuleRoute('Timetable Admin', 'course_manage_add')
+                ->withQueryParams([
+                    'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                    'search' => $search,
+                ]))
             ->displayLabel();
 
         // COLUMNS
@@ -115,10 +120,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             ->addParam('search', $criteria->getSearchText(true))
             ->format(function ($course, $actions) {
                 $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/course_manage_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'course_manage_edit'));
 
                 $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/course_manage_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'course_manage_delete'));
             });
 
         echo $table->render($courses);

--- a/modules/Timetable Admin/course_manage_add.php
+++ b/modules/Timetable Admin/course_manage_add.php
@@ -44,7 +44,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
     $editLink = '';
     if (isset($_GET['editID'])) {
-        $editLink = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/course_manage_edit.php&gibbonCourseID='.$_GET['editID'].'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
+        $editLink = Url::fromModuleRoute('Timetable Admin', 'course_manage_edit')
+            ->withQueryParams([
+                'gibbonCourseID' => $_GET['editID'],
+                'gibbonSchoolYearID' => $_GET['gibbonSchoolYearID'],
+            ]);
     }
     $page->return->setEditLink($editLink);
 
@@ -53,7 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
     if ($gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
             $sql = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
             $result = $connection2->prepare($sql);
@@ -64,61 +68,61 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             echo __('The specified record does not exist.');
             echo '</div>';
         } else {
-			$schoolYear = $result->fetch(); 
-			
-			$form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/course_manage_addProcess.php');
+			$schoolYear = $result->fetch();
+
+			$form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'course_manage_addProcess'));
 			$form->setFactory(DatabaseFormFactory::create($pdo));
 
 			$form->addHiddenValue('address', $session->get('address'));
 			$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);
-			
+
             $row = $form->addRow()->addHeading('Basic Details', __('Basic Details'));
 
 			$row = $form->addRow();
 				$row->addLabel('schoolYearName', __('School Year'));
 				$row->addTextField('schoolYearName')->required()->readonly()->setValue($schoolYear['name']);
-			
+
 			$sql = "SELECT gibbonDepartmentID as value, name FROM gibbonDepartment WHERE type='Learning Area' ORDER BY name";
 			$row = $form->addRow();
 				$row->addLabel('gibbonDepartmentID', __('Learning Area'));
 				$row->addSelect('gibbonDepartmentID')->fromQuery($pdo, $sql)->placeholder();
-			
+
 			$row = $form->addRow();
 				$row->addLabel('name', __('Name'))->description(__('Must be unique for this school year.'));
 				$row->addTextField('name')->required()->maxLength(60);
-			
+
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'));
 				$row->addTextField('nameShort')->required()->maxLength(12);
-			
+
 			$row = $form->addRow();
 				$row->addLabel('orderBy', __('Order'))->description(__('May be used to adjust arrangement of courses in reports.'));
 				$row->addNumber('orderBy')->maxLength(3);
-			
+
             $row = $form->addRow()->addHeading('Display Information', __('Display Information'));
 
 			$row = $form->addRow();
 				$column = $row->addColumn('blurb');
 				$column->addLabel('description', __('Blurb'));
 				$column->addEditor('description', $guid)->setRows(20);
-			
+
 			$row = $form->addRow();
 				$row->addLabel('map', __('Include In Curriculum Map'));
 				$row->addYesNo('map')->required();
-			
+
             $row = $form->addRow()->addHeading('Configure', __('Configure'));
 
 			$row = $form->addRow();
 				$row->addLabel('gibbonYearGroupIDList', __('Year Groups'))->description(__('Enrolable year groups.'));
 				$row->addCheckboxYearGroup('gibbonYearGroupIDList');
-			
+
             // Custom Fields
             $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Course', []);
 
 			$row = $form->addRow();
 				$row->addFooter();
 				$row->addSubmit();
-			
+
 			echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/course_manage_addProcess.php
+++ b/modules/Timetable Admin/course_manage_addProcess.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -33,17 +34,15 @@ $map = $_POST['map'] ?? 'N';
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 $gibbonYearGroupIDList = implode(',', $_POST['gibbonYearGroupIDList'] ?? []);
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/course_manage_add.php&gibbonSchoolYearID=$gibbonSchoolYearID";
+$URL = Url::fromModuleRoute('Timetable Admin', 'course_manage_add')->withQueryParam('gibbonSchoolYearID', $gibbonSchoolYearID);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_add.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Validate Inputs
     if ($gibbonSchoolYearID == '' or $name == '' or $nameShort == '' or $map == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         //Check unique inputs for uniquness
         try {
@@ -52,8 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
@@ -61,14 +59,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Course', [], $customRequireFail);
 
         if ($customRequireFail) {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
             exit;
         }
 
         if ($result->rowCount() > 0) {
-            $URL .= '&return=error3';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error3'));
         } else {
             //Write to database
             try {
@@ -77,16 +73,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             //Last insert ID
             $AI = str_pad($connection2->lastInsertID(), 8, '0', STR_PAD_LEFT);
-
-            $URL .= "&return=success0&editID=$AI";
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withQueryParam('editID', $AI)->withReturn('success0'));
         }
     }
 }

--- a/modules/Timetable Admin/course_manage_addProcess.php
+++ b/modules/Timetable Admin/course_manage_addProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST, ['description' => 'HTML']);
 

--- a/modules/Timetable Admin/course_manage_class_add.php
+++ b/modules/Timetable Admin/course_manage_class_add.php
@@ -38,12 +38,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         ->add(__('Add Class'));
 
     if (!empty($search)) {
-        $page->navigator->addSearchResultsAction(Url::fromModuleRoute('Timetable Admin', 'course_manage.php')->withQueryParams($urlParams));
+        $page->navigator->addSearchResultsAction(Url::fromModuleRoute('Timetable Admin', 'course_manage')->withQueryParams($urlParams));
     }
 
     $editLink = '';
     if (isset($_GET['editID'])) {
-        $editLink = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/course_manage_class_edit.php&gibbonCourseClassID='.$_GET['editID'].'&gibbonCourseID='.$gibbonCourseID.'&gibbonSchoolYearID='.$gibbonSchoolYearID;
+        $editLink = Url::fromModuleRoute('Timetable Admin', 'course_manage_class_edit')
+            ->withQueryParams([
+                'gibbonCourseClassID' => $_GET['editID'],
+                'gibbonCourseID' => $gibbonCourseID,
+                'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            ]);
     }
 
     $page->return->setEditLink($editLink);
@@ -65,7 +70,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
             $settingGateway = $container->get(SettingGateway::class);
 
-			$form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/course_manage_class_addProcess.php');
+			$form = Form::create(
+                'action',
+                Url::fromModuleRoute('Timetable Admin', 'course_manage_class_addProcess')
+            );
 
 			$form->addHiddenValue('address', $session->get('address'));
 			$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);

--- a/modules/Timetable Admin/course_manage_class_addProcess.php
+++ b/modules/Timetable Admin/course_manage_class_addProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/course_manage_class_delete.php
+++ b/modules/Timetable Admin/course_manage_class_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_class_delete.php') == false) {
     // Access denied
@@ -31,7 +32,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
     if ($gibbonCourseClassID == '' or $gibbonCourseID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
             $sql = 'SELECT * FROM gibbonCourseClass WHERE gibbonCourseClassID=:gibbonCourseClassID';
             $result = $connection2->prepare($sql);
@@ -40,7 +41,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         if ($result->rowCount() != 1) {
             $page->addError(__('The specified record cannot be found.'));
         } else {
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/course_manage_class_deleteProcess.php?gibbonCourseClassID=$gibbonCourseClassID&gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=$gibbonSchoolYearID");
+            $form = DeleteForm::createForm(Url::fromModuleRoute('Timetable Admin', 'course_manage_class_deleteProcess')
+                ->withQueryParams([
+                    'gibbonCourseClassID' => $gibbonCourseClassID,
+                    'gibbonCourseID' => $gibbonCourseID,
+                    'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                ])
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/course_manage_class_deleteProcess.php
+++ b/modules/Timetable Admin/course_manage_class_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
 $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';

--- a/modules/Timetable Admin/course_manage_class_deleteProcess.php
+++ b/modules/Timetable Admin/course_manage_class_deleteProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
@@ -25,18 +27,26 @@ $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
 
 if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/course_manage_class_delete.php&gibbonCourseID=$gibbonCourseID&gibbonCourseClassID=$gibbonCourseClassID&gibbonSchoolYearID=$gibbonSchoolYearID";
-    $URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/course_manage_edit.php&gibbonCourseID=$gibbonCourseID&gibbonCourseClassID=$gibbonCourseClassID&gibbonSchoolYearID=$gibbonSchoolYearID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'course_manage_class_delete')
+        ->withQueryParams([
+            'gibbonCourseID' => $gibbonCourseID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        ]);
+    $URLDelete = Url::fromModuleRoute('Timetable Admin', 'course_manage_edit')
+        ->withQueryParams([
+            'gibbonCourseID' => $gibbonCourseID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_class_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonCourseClassID specified
         if ($gibbonCourseClassID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
@@ -44,14 +54,12 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Try to delete entries in gibbonTTDayRowClass
 
@@ -94,8 +102,7 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                     exit();
                 }
 
-                $URLDelete = $URLDelete.'&return=success0';
-                header("Location: {$URLDelete}");
+                header('Location: ' . $URLDelete->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/course_manage_class_edit.php
+++ b/modules/Timetable Admin/course_manage_class_edit.php
@@ -57,7 +57,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             //Let's go!
 			$values = $result->fetch();
 
-			$form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/course_manage_class_editProcess.php');
+			$form = Form::create(
+                'action',
+                Url::fromModuleRoute('Timetable Admin', 'course_manage_class_editProcess')
+            );
 
 			$form->addHiddenValue('address', $session->get('address'));
 			$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);

--- a/modules/Timetable Admin/course_manage_class_editProcess.php
+++ b/modules/Timetable Admin/course_manage_class_editProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/course_manage_class_editProcess.php
+++ b/modules/Timetable Admin/course_manage_class_editProcess.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -28,19 +29,23 @@ $gibbonCourseClassID = $_POST['gibbonCourseClassID'] ?? '';
 $gibbonCourseID = $_POST['gibbonCourseID'] ?? '';
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 
-if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
+if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') {
+    echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/course_manage_class_edit.php&gibbonCourseID=$gibbonCourseID&gibbonCourseClassID=$gibbonCourseClassID&gibbonSchoolYearID=$gibbonSchoolYearID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'course_manage_class_edit')
+        ->withQueryParams([
+            'gibbonCourseID' => $gibbonCourseID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_class_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if course specified
         if ($gibbonCourseClassID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
@@ -48,14 +53,12 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Validate Inputs
                 $name = $_POST['name'] ?? '';
@@ -69,14 +72,12 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                 $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Class', [], $customRequireFail);
 
                 if ($customRequireFail) {
-                    $URL .= '&return=error1';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error1'));
                     exit;
                 }
 
                 if ($name == '' or $nameShort == '') {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Check unique inputs for uniquness
                     try {
@@ -85,14 +86,12 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
                     if ($result->rowCount() > 0) {
-                        $URL .= '&return=error3';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error3'));
                     } else {
                         //Write to database
                         try {
@@ -101,13 +100,11 @@ if ($gibbonCourseID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error load
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            $URL .= '&return=error2';
-                            header("Location: {$URL}");
+                            header('Location: ' . $URL->withReturn('error2'));
                             exit();
                         }
 
-                        $URL .= '&return=success0';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('success0'));
                     }
                 }
             }

--- a/modules/Timetable Admin/course_manage_copyProcess.php
+++ b/modules/Timetable Admin/course_manage_copyProcess.php
@@ -20,7 +20,7 @@ use Gibbon\Data\Validator;
 use Gibbon\Domain\Timetable\CourseGateway;
 use Gibbon\Domain\Timetable\CourseClassGateway;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/course_manage_copyProcess.php
+++ b/modules/Timetable Admin/course_manage_copyProcess.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Data\Validator;
 use Gibbon\Domain\Timetable\CourseGateway;
 use Gibbon\Domain\Timetable\CourseClassGateway;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -26,19 +27,17 @@ $_POST = $container->get(Validator::class)->sanitize($_POST);
 
 $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
 $gibbonSchoolYearIDNext = $_GET['gibbonSchoolYearIDNext'] ?? '';
-$URL = $session->get('absoluteURL')."/index.php?q=/modules/Timetable Admin/course_manage.php&gibbonSchoolYearID=$gibbonSchoolYearIDNext";
+$URL = Url::fromModuleRoute('Timetable Admin', 'course_manage')->withQueryParam('gibbonSchoolYearID', $gibbonSchoolYearIDNext);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
-    
+
     // Check if school years specified (current and next)
     if (empty($gibbonSchoolYearID) || empty($gibbonSchoolYearIDNext)) {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
-    } 
+        header('Location: ' . $URL->withReturn('error1'));
+    }
 
     $courseGateway = $container->get(CourseGateway::class);
     $courseClassGateway = $container->get(CourseClassGateway::class);
@@ -46,8 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
     // Get current courses
     $courses = $courseGateway->selectBy(['gibbonSchoolYearID' => $gibbonSchoolYearID])->fetchAll();
     if (empty($courses)) {
-        $URL .= '&return=error2';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error2'));
     }
 
     $partialFail = false;
@@ -72,12 +70,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
         // Insert course into database
         $gibbonCourseIDNew = $courseGateway->insert($data);
-            
+
         if (empty($gibbonCourseIDNew)) {
             $partialFail = true;
             continue;
         }
-        
+
         $classes = $courseClassGateway->selectBy(['gibbonCourseID' => $course['gibbonCourseID']])->fetchAll();
 
         foreach ($classes as $class) {
@@ -107,9 +105,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         }
     }
 
-    $URL .= $partialFail == true
-        ? '&return=error5'
-        : '&return=success0';
+    $URL = $partialFail == true
+        ? $URL->withReturn('error5')
+        : $URL->withReturn('success0');
 
     header("Location: {$URL}");
 }

--- a/modules/Timetable Admin/course_manage_delete.php
+++ b/modules/Timetable Admin/course_manage_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_delete.php') == false) {
     // Access denied
@@ -29,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
     if ($gibbonCourseID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonCourseID' => $gibbonCourseID);
             $sql = 'SELECT * FROM gibbonCourse WHERE gibbonCourseID=:gibbonCourseID';
             $result = $connection2->prepare($sql);
@@ -38,7 +39,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         if ($result->rowCount() != 1) {
             $page->addError(__('The specified record cannot be found.'));
         } else {
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/course_manage_deleteProcess.php?gibbonCourseID=$gibbonCourseID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID']);
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'course_manage_deleteProcess')
+                    ->withQueryParams([
+                        'gibbonCourseID' => $gibbonCourseID,
+                        'gibbonSchoolYearID' => $_GET['gibbonSchoolYearID'],
+                    ])
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/course_manage_deleteProcess.php
+++ b/modules/Timetable Admin/course_manage_deleteProcess.php
@@ -20,8 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 include '../../gibbon.php';
 
 $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/course_manage_delete.php&gibbonCourseID='.$gibbonCourseID.'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'].'&search='.$_POST['search'];
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/course_manage.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'].'&search='.$_POST['search'];
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/course_manage_delete.php&gibbonCourseID='.$gibbonCourseID.'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'].'&search='.$_POST['search'];
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/course_manage.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'].'&search='.$_POST['search'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/course_manage_edit.php
+++ b/modules/Timetable Admin/course_manage_edit.php
@@ -75,7 +75,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             //Let's go!
             $values = $result->fetch();
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/course_manage_editProcess.php?gibbonCourseID='.$gibbonCourseID);
+            $form = Form::create(
+                'action',
+                Url::fromModuleRoute('Timetable Admin', 'course_manage_editProcess')->withQueryParam('gibbonCourseID', $gibbonCourseID)
+            );
 			$form->setFactory(DatabaseFormFactory::create($pdo));
 
 			$form->addHiddenValue('address', $session->get('address'));
@@ -144,10 +147,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             $table = DataTable::create('courseClassManage');
 
             $table->addHeaderAction('add', __('Add'))
-                ->setURL('/modules/Timetable Admin/course_manage_class_add.php')
-                ->addParam('gibbonSchoolYearID', $values['gibbonSchoolYearID'])
-                ->addParam('gibbonCourseID', $gibbonCourseID)
-                ->addParam('search', $search)
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'course_manage_class_add')
+                    ->withQueryParams([
+                        'gibbonSchoolYearID' => $values['gibbonSchoolYearID'],
+                        'gibbonCourseID' => $gibbonCourseID,
+                        'search' => $search,
+                    ]))
                 ->displayLabel();
 
             $table->addColumn('nameShort', __('Short Name'));
@@ -172,21 +177,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             $table->addColumn('reportable', __('Reportable'))->format(Format::using('yesNo', 'reportable'));
 
             // ACTIONS
+            $params = [
+                'gibbonSchoolYearID' => $values['gibbonSchoolYearID'],
+                'gibbonCourseID' => $gibbonCourseID,
+                'search' => $search,
+                'gibbonCourseClassID' => '',
+            ];
             $table->addActionColumn()
-                ->addParam('gibbonSchoolYearID', $values['gibbonSchoolYearID'])
-                ->addParam('gibbonCourseID', $gibbonCourseID)
-                ->addParam('search', $search)
-                ->addParam('gibbonCourseClassID')
-                ->format(function ($class, $actions) {
+                ->format(function ($class, $actions) use ($params) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/course_manage_class_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'course_manage_class_edit')->withQueryParams($params));
 
                     $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/course_manage_class_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'course_manage_class_delete')->withQueryParams($params));
 
                     $actions->addAction('enrolment', __('Enrolment'))
                         ->setIcon('attendance')
-                        ->setURL('/modules/Timetable Admin/courseEnrolment_manage_class_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'courseEnrolment_manage_class_edit')->withQueryParams($params));
                 });
 
             echo $table->render($classes->toDataSet());

--- a/modules/Timetable Admin/course_manage_editProcess.php
+++ b/modules/Timetable Admin/course_manage_editProcess.php
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST, ['description' => 'HTML']);
 

--- a/modules/Timetable Admin/course_manage_editProcess.php
+++ b/modules/Timetable Admin/course_manage_editProcess.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../../gibbon.php';
 $_POST = $container->get(Validator::class)->sanitize($_POST, ['description' => 'HTML']);
 
 $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/course_manage_edit.php&gibbonCourseID='.$gibbonCourseID.'&gibbonSchoolYearID='.$_POST['gibbonSchoolYearID'];
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/course_manage_edit.php&gibbonCourseID='.$gibbonCourseID.'&gibbonSchoolYearID='.$_POST['gibbonSchoolYearID'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/course_manage_editProcess.php
+++ b/modules/Timetable Admin/course_manage_editProcess.php
@@ -19,23 +19,26 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\CustomFieldHandler;
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST, ['description' => 'HTML']);
 
 $gibbonCourseID = $_GET['gibbonCourseID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/course_manage_edit.php&gibbonCourseID='.$gibbonCourseID.'&gibbonSchoolYearID='.$_POST['gibbonSchoolYearID'];
+$URL = Url::fromModuleRoute('Timetable Admin', 'course_manage_edit')
+    ->withQueryParams([
+        'gibbonCourseID' => $gibbonCourseID,
+        'gibbonSchoolYearID' => $_POST['gibbonSchoolYearID'] ?? '',
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_manage_edit.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Check if special day specified
     if ($gibbonCourseID == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         try {
             $data = array('gibbonCourseID' => $gibbonCourseID);
@@ -43,14 +46,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() != 1) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
         } else {
             //Validate Inputs
             $gibbonDepartmentID = !empty($_POST['gibbonDepartmentID']) ? $_POST['gibbonDepartmentID'] : null;
@@ -63,8 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
             $gibbonYearGroupIDList = implode(',', $_POST['gibbonYearGroupIDList'] ?? []);
 
             if ($name == '' or $nameShort == '' or $gibbonSchoolYearID == '' or $map == '') {
-                $URL .= '&return=error3';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error3'));
             } else {
                 //Check unique inputs for uniquness
                 try {
@@ -73,8 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
@@ -82,14 +81,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
                 $fields = $container->get(CustomFieldHandler::class)->getFieldDataFromPOST('Course', [], $customRequireFail);
 
                 if ($customRequireFail) {
-                    $URL .= '&return=error1';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error1'));
                     exit;
                 }
 
                 if ($result->rowCount() > 0) {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Write to database
                     try {
@@ -98,13 +95,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
-                    $URL .= '&return=success0';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('success0'));
                 }
             }
         }

--- a/modules/Timetable Admin/course_rollover.php
+++ b/modules/Timetable Admin/course_rollover.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -48,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
+
                 $dataNext = array('gibbonSchoolYearID' => $nextYear);
                 $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $resultNext = $connection2->prepare($sqlNext);
@@ -63,7 +64,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                 echo '</div>';
             } else {
 
-                $form = Form::create('courseRollover', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/course_rollover.php&step=2');
+                $form = Form::create(
+                    'courseRollover',
+                    Url::fromModuleRoute('Timetable Admin', 'course_rollover')->withQueryParam('step', 2)
+                );
 
                 $form->addHiddenValue('nextYear', $nextYear);
 
@@ -87,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
+
                 $dataNext = array('gibbonSchoolYearID' => $nextYear);
                 $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $resultNext = $connection2->prepare($sqlNext);
@@ -131,7 +135,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
                     return $currentCourse;
                 }, $currentCourses);
 
-                $form = Form::create('courseRollover', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/course_rollover.php&step=3');
+                $form = Form::create(
+                    'courseRollover',
+                    Url::fromModuleRoute('Timetable Admin', 'course_rollover')->withQueryParam('step', 3)
+                );
                 $form->setClass('w-full blank');
 
                 $form->addHiddenValue('nextYear', $nextYear);
@@ -181,7 +188,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_rol
             echo __('The next school year cannot be determined, so this action cannot be performed.');
             echo '</div>';
         } else {
-            
+
             $dataNext = array('gibbonSchoolYearID' => $nextYear);
             $sqlNext = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
             $rowNext = $pdo->selectOne($sqlNext, $dataNext);

--- a/modules/Timetable Admin/report_classEnrolment_byFormGroup.php
+++ b/modules/Timetable Admin/report_classEnrolment_byFormGroup.php
@@ -22,6 +22,7 @@ use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -39,11 +40,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/report_cla
 
     $gibbonFormGroupID = isset($_GET['gibbonFormGroupID'])? $_GET['gibbonFormGroupID'] : '';
 
-    $form = Form::create('filter', $session->get('absoluteURL').'/index.php', 'get');
+    $form = Form::create(
+        'filter',
+        Url::fromModuleRoute('Timetable Admin', 'report_classEnrolment_byFormGroup'),
+        'get'
+    );
     $form->setFactory(DatabaseFormFactory::create($pdo));
     $form->setClass('noIntBorder fullWidth');
-
-    $form->addHiddenValue('q', '/modules/'.$session->get('module').'/report_classEnrolment_byFormGroup.php');
 
     $row = $form->addRow();
         $row->addLabel('gibbonFormGroupID', __('Form Group'));
@@ -70,7 +73,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/report_cla
         $table->addColumn('student', __('Student'))
             ->sortable(['surname', 'preferredName'])
             ->format(function($person) use ($session) {
-                return Format::link($session->get('absoluteURL').'/index.php?q=/modules/Timetable/tt_view.php&gibbonPersonID='.$person['gibbonPersonID'], Format::name('', $person['preferredName'], $person['surname'], 'Student', true) );
+                return Format::link(
+                    Url::fromModuleRoute('Timetable', 'tt_view')->withQueryParam('gibbonPersonID', $person['gibbonPersonID']),
+                    Format::name('', $person['preferredName'], $person['surname'], 'Student', true)
+                );
             });
         $table->addColumn('classCount', __('Class Count'));
 

--- a/modules/Timetable Admin/tt.php
+++ b/modules/Timetable Admin/tt.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\TimetableGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt.php') == false) {
     // Access denied
@@ -41,7 +42,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt.php') =
         $table = DataTable::create('timetables');
 
         $table->addHeaderAction('add', __('Add'))
-            ->setURL('/modules/Timetable Admin/tt_add.php')
+            ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_add'))
             ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
             ->displayLabel();
 
@@ -61,18 +62,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt.php') =
             ->addParam('gibbonSchoolYearID')
             ->format(function ($person, $actions) {
                 $actions->addAction('edit', __('Edit'))
-                    ->setURL('/modules/Timetable Admin/tt_edit.php');
+                    ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit'));
 
                 $actions->addAction('delete', __('Delete'))
-                    ->setURL('/modules/Timetable Admin/tt_delete.php');
+                    ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_delete'));
 
                 $actions->addAction('import', __('Import'))
                     ->setIcon('upload')
-                    ->setURL('/modules/Timetable Admin/tt_import.php');
+                    ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_import'));
 
                 $actions->addAction('notify', __('Notify Subscribers'))
                     ->setIcon('copyforward')
-                    ->setURL('/modules/Timetable Admin/tt_notifyProcess.php')->directLink()
+                    ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_notifyProcess'))->directLink()
                     ->addConfirmation(__('Are you sure you wish to process this action? It cannot be undone.'));
             });
 

--- a/modules/Timetable Admin/ttColumn.php
+++ b/modules/Timetable Admin/ttColumn.php
@@ -21,6 +21,7 @@ use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Forms\Prefab\BulkActionForm;
 use Gibbon\Domain\Timetable\TimetableColumnGateway;
+use Gibbon\Http\Url;
 
 $page->breadcrumbs->add(__('Manage Columns'));
     echo '<p>';
@@ -43,7 +44,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.p
     $columns = $timetableColumnGateway->queryTTColumns($criteria);
 
     // FORM
-    $form = BulkActionForm::create('bulkAction', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttColumnProcessBulk.php');
+    $form = BulkActionForm::create(
+        'bulkAction',
+        Url::fromModuleRoute('Timetable Admin', 'ttColumnProcessBulk')
+    );
     $form->addHiddenValue('address', $session->get('address'));
 
     // BULK ACTIONS
@@ -59,7 +63,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.p
     $table->addMetaData('bulkActions', $col);
 
     $table->addHeaderAction('add', __('Add'))
-        ->setURL('/modules/Timetable Admin/ttColumn_add.php')
+        ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttColumn_add'))
         ->displayLabel();
 
     // COLUMNS
@@ -72,10 +76,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.p
         ->addParam('gibbonTTColumnID')
         ->format(function ($values, $actions) {
             $actions->addAction('edit', __('Edit'))
-                ->setURL('/modules/Timetable Admin/ttColumn_edit.php');
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit'));
 
             $actions->addAction('delete', __('Delete'))
-                ->setURL('/modules/Timetable Admin/ttColumn_delete.php');
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttColumn_delete'));
         });
 
     $table->addCheckboxColumn('gibbonTTColumnIDList', 'gibbonTTColumnID');

--- a/modules/Timetable Admin/ttColumnProcessBulk.php
+++ b/modules/Timetable Admin/ttColumnProcessBulk.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Domain\Timetable\TimetableColumnGateway;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $action = $_POST['action'] ?? '';
 

--- a/modules/Timetable Admin/ttColumnProcessBulk.php
+++ b/modules/Timetable Admin/ttColumnProcessBulk.php
@@ -18,27 +18,25 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Domain\Timetable\TimetableColumnGateway;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
 $action = $_POST['action'] ?? '';
 
-$URL = $session->get('absoluteURL')."/index.php?q=/modules/Timetable Admin/ttColumn.php";
+$URL = Url::fromModuleRoute('Timetable Admin', 'ttColumn');
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else if ($action == '') {
-    $URL .= '&return=error1';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error1'));
 } else {
 
     $columns = isset($_POST['gibbonTTColumnIDList']) ? $_POST['gibbonTTColumnIDList'] : array();
 
     //Proceed!
     if (count($columns) < 1) {
-        $URL .= '&return=error3';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error3'));
     } else {
         $timetableColumnGateway = $container->get(TimetableColumnGateway::class);
         $partialFail = false;
@@ -69,11 +67,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn.p
         }
 
         if ($partialFail == true) {
-            $URL .= '&return=warning1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('warning1'));
         } else {
-            $URL .= '&return=success0';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('success0'));
         }
     }
 

--- a/modules/Timetable Admin/ttColumn_add.php
+++ b/modules/Timetable Admin/ttColumn_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -33,11 +34,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_a
 
     $editLink = '';
     if (isset($_GET['editID'])) {
-        $editLink = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_edit.php&gibbonTTColumnID='.$_GET['editID'];
+        $editLink = Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit')->withQueryParam('gibbonTTColumnID', $_GET['editID']);
     }
     $page->return->setEditLink($editLink);
 
-    $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttColumn_addProcess.php');
+    $form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'ttColumn_addProcess'));
 
     $form->addHiddenValue('address', $session->get('address'));
 

--- a/modules/Timetable Admin/ttColumn_addProcess.php
+++ b/modules/Timetable Admin/ttColumn_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -25,17 +26,15 @@ $_POST = $container->get(Validator::class)->sanitize($_POST);
 $name = $_POST['name'] ?? '';
 $nameShort = $_POST['nameShort'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_add.php';
+$URL = Url::fromModuleRoute('Timetable Admin', 'ttColumn_add');
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_add.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Validate Inputs
     if ($name == '' or $nameShort == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         //Check unique inputs for uniquness
         try {
@@ -44,14 +43,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_a
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() > 0) {
-            $URL .= '&return=error3';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error3'));
         } else {
             //Write to database
             try {
@@ -60,16 +57,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_a
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             //Last insert ID
             $AI = str_pad($connection2->lastInsertID(), 6, '0', STR_PAD_LEFT);
 
-            $URL .= "&return=success0&editID=$AI";
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withQueryParam('editID', $AI)->withReturn('success0'));
         }
     }
 }

--- a/modules/Timetable Admin/ttColumn_addProcess.php
+++ b/modules/Timetable Admin/ttColumn_addProcess.php
@@ -25,7 +25,7 @@ $_POST = $container->get(Validator::class)->sanitize($_POST);
 $name = $_POST['name'] ?? '';
 $nameShort = $_POST['nameShort'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/ttColumn_add.php';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_add.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_add.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/ttColumn_addProcess.php
+++ b/modules/Timetable Admin/ttColumn_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/ttColumn_delete.php
+++ b/modules/Timetable Admin/ttColumn_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_delete.php') == false) {
     // Access denied
@@ -29,7 +30,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_d
     if ($gibbonTTColumnID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
             $data = array('gibbonTTColumnID' => $gibbonTTColumnID);
             $sql = 'SELECT * FROM gibbonTTColumn WHERE gibbonTTColumnID=:gibbonTTColumnID';
             $result = $connection2->prepare($sql);
@@ -38,7 +38,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_d
         if ($result->rowCount() != 1) {
             $page->addError(__('The specified record cannot be found.'));
         } else {
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/ttColumn_deleteProcess.php?gibbonTTColumnID=$gibbonTTColumnID", true);
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'ttColumn_deleteProcess')->withQueryParam('gibbonTTColumnID', $gibbonTTColumnID),
+                true
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/ttColumn_deleteProcess.php
+++ b/modules/Timetable Admin/ttColumn_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTColumnID = $_GET['gibbonTTColumnID'] ?? '';
 $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/ttColumn_delete.php&gibbonTTColumnID='.$gibbonTTColumnID;

--- a/modules/Timetable Admin/ttColumn_deleteProcess.php
+++ b/modules/Timetable Admin/ttColumn_deleteProcess.php
@@ -20,8 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTColumnID = $_GET['gibbonTTColumnID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/ttColumn_delete.php&gibbonTTColumnID='.$gibbonTTColumnID;
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/ttColumn.php';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_delete.php&gibbonTTColumnID='.$gibbonTTColumnID;
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/ttColumn_deleteProcess.php
+++ b/modules/Timetable Admin/ttColumn_deleteProcess.php
@@ -17,21 +17,21 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTColumnID = $_GET['gibbonTTColumnID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_delete.php&gibbonTTColumnID='.$gibbonTTColumnID;
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn.php';
+$URL = Url::fromModuleRoute('Timetable Admin', 'ttColumn_delete')->withQueryParam('gibbonTTColumnID', $gibbonTTColumnID);
+$URLDelete = Url::fromModuleRoute('Timetable Admin', 'ttColumn.php');
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_delete.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Check if gibbonTTColumnID specified
     if ($gibbonTTColumnID == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         try {
             $data = array('gibbonTTColumnID' => $gibbonTTColumnID);
@@ -39,14 +39,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_d
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() != 1) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
         } else {
             //Delete Course
             try {
@@ -55,13 +53,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_d
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
-            $URLDelete = $URLDelete.'&return=success0';
-            header("Location: {$URLDelete}");
+            header('Location: ' . $URLDelete->withReturn('success0'));
         }
     }
 }

--- a/modules/Timetable Admin/ttColumn_edit.php
+++ b/modules/Timetable Admin/ttColumn_edit.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\TimetableColumnGateway;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -48,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
             $page->addError(__('The specified record cannot be found.'));
         } else {
             //Let's go!
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttColumn_editProcess.php');
+            $form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'ttColumn_editProcess'));
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTColumnID', $values['gibbonTTColumnID']);
@@ -79,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
             $table = DataTable::create('timetableColumnRows');
 
             $table->addHeaderAction('add', __('Add'))
-                ->setURL('/modules/Timetable Admin/ttColumn_edit_row_add.php')
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_add'))
                 ->addParam('gibbonTTColumnID', $gibbonTTColumnID)
                 ->displayLabel();
 
@@ -94,10 +95,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                 ->addParam('gibbonTTColumnRowID')
                 ->format(function ($values, $actions) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/ttColumn_edit_row_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_edit'));
 
                     $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/ttColumn_edit_row_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_delete'));
                 });
 
             echo $table->render($rows->toDataSet());

--- a/modules/Timetable Admin/ttColumn_editProcess.php
+++ b/modules/Timetable Admin/ttColumn_editProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/ttColumn_editProcess.php
+++ b/modules/Timetable Admin/ttColumn_editProcess.php
@@ -26,7 +26,7 @@ $name = $_POST['name'] ?? '';
 $nameShort = $_POST['nameShort'] ?? '';
 $gibbonTTColumnID = $_POST['gibbonTTColumnID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/ttColumn_edit.php&gibbonTTColumnID='.$gibbonTTColumnID;
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_edit.php&gibbonTTColumnID='.$gibbonTTColumnID;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/ttColumn_editProcess.php
+++ b/modules/Timetable Admin/ttColumn_editProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -26,17 +27,15 @@ $name = $_POST['name'] ?? '';
 $nameShort = $_POST['nameShort'] ?? '';
 $gibbonTTColumnID = $_POST['gibbonTTColumnID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_edit.php&gibbonTTColumnID='.$gibbonTTColumnID;
+$URL = Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit')->withQueryParam('gibbonTTColumnID', $gibbonTTColumnID);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Check if special day specified
     if ($gibbonTTColumnID == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         try {
             $data = array('gibbonTTColumnID' => $gibbonTTColumnID);
@@ -44,19 +43,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() != 1) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
         } else {
             //Validate Inputs
             if ($name == '' or $nameShort == '') {
-                $URL .= '&return=error3';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error3'));
             } else {
                 //Check unique inputs for uniquness
                 try {
@@ -65,14 +61,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
                 if ($result->rowCount() > 0) {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Write to database
                     try {
@@ -81,13 +75,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
-                    $URL .= '&return=success0';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('success0'));
                 }
             }
         }

--- a/modules/Timetable Admin/ttColumn_edit_row_add.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit_row_add.php') == false) {
     // Access denied
@@ -48,12 +49,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
 
             $editLink = '';
             if (isset($_GET['editID'])) {
-                $editLink = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttColumn_edit_row_edit.php&gibbonTTColumnRowID='.$_GET['editID'].'&gibbonTTColumnID='.$_GET['gibbonTTColumnID'];
+                $editLink = Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_edit')
+                    ->withQueryParams([
+                        'gibbonTTColumnRowID' => $_GET['editID'],
+                        'gibbonTTColumnID' => $_GET['gibbonTTColumnID'],
+                    ]);
             }
             $page->return->setEditLink($editLink);
 
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttColumn_edit_row_addProcess.php');
+            $form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_addProcess'));
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTColumnID', $gibbonTTColumnID);

--- a/modules/Timetable Admin/ttColumn_edit_row_addProcess.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -30,17 +31,15 @@ $type = $_POST['type'] ?? '';
 
 $gibbonTTColumnID = $_POST['gibbonTTColumnID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/ttColumn_edit_row_add.php&gibbonTTColumnID=$gibbonTTColumnID";
+$URL = Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_add')->withQueryParam('gibbonTTColumnID', $gibbonTTColumnID);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit_row_add.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Validate Inputs
     if ($gibbonTTColumnID == '' or $name == '' or $nameShort == '' or $timeStart == '' or $timeEnd == '' or $type == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         //Check unique inputs for uniquness
         try {
@@ -49,14 +48,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() > 0) {
-            $URL .= '&return=error3';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error3'));
         } else {
             //Write to database
             try {
@@ -65,16 +62,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             //Last insert ID
             $AI = str_pad($connection2->lastInsertID(), 8, '0', STR_PAD_LEFT);
 
-            $URL .= "&return=success0&editID=$AI";
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withQueryParam('editID', $AI)->withReturn('error0'));
         }
     }
 }

--- a/modules/Timetable Admin/ttColumn_edit_row_addProcess.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/ttColumn_edit_row_delete.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit_row_delete.php') == false) {
     // Access denied
@@ -29,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
     if ($gibbonTTColumnRowID == '' or $gibbonTTColumnID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID);
             $sql = 'SELECT * FROM gibbonTTColumnRow WHERE gibbonTTColumnRowID=:gibbonTTColumnRowID';
             $result = $connection2->prepare($sql);
@@ -39,7 +40,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
             $page->addError(__('The specified record cannot be found.'));
         } else {
             //Let's go!
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/ttColumn_edit_row_deleteProcess.php?gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTColumnID=$gibbonTTColumnID", true);
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_deleteProcess')
+                    ->withQueryParams([
+                        'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+                        'gibbonTTColumnID' => $gibbonTTColumnID,
+                    ]),
+                true
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/ttColumn_edit_row_deleteProcess.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_deleteProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTColumnRowID = $_GET['gibbonTTColumnRowID'] ?? '';
@@ -24,18 +26,24 @@ $gibbonTTColumnID = $_GET['gibbonTTColumnID'] ?? '';
 
 if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/ttColumn_edit_row_delete.php&gibbonTTColumnID=$gibbonTTColumnID&gibbonTTColumnRowID=$gibbonTTColumnRowID";
-    $URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/ttColumn_edit.php&gibbonTTColumnID=$gibbonTTColumnID&gibbonTTColumnRowID=$gibbonTTColumnRowID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_delete')
+        ->withQueryParams([
+            'gibbonTTColumnID' => $gibbonTTColumnID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+        ]);
+    $URLDelete = Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit')
+        -> withQueryParams([
+            'gibbonTTColumnID' => $gibbonTTColumnID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit_row_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonTTColumnRowID specified
         if ($gibbonTTColumnRowID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID);
@@ -43,14 +51,12 @@ if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -59,13 +65,11 @@ if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URLDelete = $URLDelete.'&return=success0';
-                header("Location: {$URLDelete}");
+                header('Location: ' . $URLDelete->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/ttColumn_edit_row_deleteProcess.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTColumnRowID = $_GET['gibbonTTColumnRowID'] ?? '';
 $gibbonTTColumnID = $_GET['gibbonTTColumnID'] ?? '';

--- a/modules/Timetable Admin/ttColumn_edit_row_edit.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_edit.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit_row_edit.php') == false) {
     // Access denied
@@ -47,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_e
                 ->add(__('Edit Column'), 'ttColumn_edit.php', ['gibbonTTColumnID' => $gibbonTTColumnID])
                 ->add(__('Edit Column Row'));
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttColumn_edit_row_editProcess.php');
+            $form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_editProcess'));
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTColumnID', $gibbonTTColumnID);

--- a/modules/Timetable Admin/ttColumn_edit_row_editProcess.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_editProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/ttColumn_edit_row_editProcess.php
+++ b/modules/Timetable Admin/ttColumn_edit_row_editProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -27,17 +28,19 @@ $gibbonTTColumnID = $_POST['gibbonTTColumnID'] ?? '';
 
 if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/ttColumn_edit_row_edit.php&gibbonTTColumnID=$gibbonTTColumnID&gibbonTTColumnRowID=$gibbonTTColumnRowID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'ttColumn_edit_row_edit')
+        ->withQueryParams([
+            'gibbonTTColumnID' => $gibbonTTColumnID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttColumn_edit_row_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if tt specified
         if ($gibbonTTColumnRowID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID);
@@ -45,14 +48,12 @@ if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Validate Inputs
                 $name = $_POST['name'] ?? '';
@@ -62,8 +63,7 @@ if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
                 $type = $_POST['type'] ?? '';
 
                 if ($name == '' or $nameShort == '' or $timeStart == '' or $timeEnd == '' or $type == '') {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Check unique inputs for uniquness
                     try {
@@ -72,14 +72,12 @@ if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
                     if ($result->rowCount() > 0) {
-                        $URL .= '&return=error3';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error3'));
                     } else {
                         //Write to database
                         try {
@@ -88,13 +86,11 @@ if ($gibbonTTColumnID == '') { echo 'Fatal error loading this page!';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            $URL .= '&return=error2';
-                            header("Location: {$URL}");
+                            header('Location: ' . $URL->withReturn('error2'));
                             exit();
                         }
 
-                        $URL .= '&return=success0';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('success0'));
                     }
                 }
             }

--- a/modules/Timetable Admin/ttDates.php
+++ b/modules/Timetable Admin/ttDates.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.php') == false) {
     // Access denied
@@ -44,7 +45,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
 
             $page->addData('preventOverflow', true);
 
-            $form = Form::createTable('ttDates', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttDates_addMultiProcess.php?gibbonSchoolYearID='.$gibbonSchoolYearID);
+            $form = Form::createTable('ttDates', Url::fromModuleRoute('Timetable Admin', 'ttDates_addMultiProcess')->withQueryParam('gibbonSchoolYearID', $gibbonSchoolYearID));
             $form->setClass('w-full blank');
 
             $form->addHiddenValue('q', $session->get('address'));
@@ -143,7 +144,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates.ph
 
                             $column->addCheckbox('dates[]')->setValue($i)->setClass($dayOfWeek.$values['nameShort'])->alignCenter();
 
-                            $column->addContent("<br/><a href='".$session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module')."/ttDates_edit.php&gibbonSchoolYearID=$gibbonSchoolYearID&dateStamp=".$i."'><img style='margin-top: 3px' title='".__('Edit')."' src='./themes/".$session->get('gibbonThemeName')."/img/config.png'/></a><br/>");
+                            $column->addContent("<br/><a href='".Url::fromModuleRoute('Timetable Admin', 'ttDates_edit')
+                                ->withQueryParams([
+                                    'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                                    'dateStamp' => $i,
+                                ])."'><img style='margin-top: 3px' title='".__('Edit')."' src='./themes/".$session->get('gibbonThemeName')."/img/config.png'/></a><br/>");
 
                             if (isset($ttDays[$date])) {
                                 foreach ($ttDays[$date] as $day) {

--- a/modules/Timetable Admin/ttDates_addMultiProcess.php
+++ b/modules/Timetable Admin/ttDates_addMultiProcess.php
@@ -22,7 +22,7 @@ use Gibbon\Domain\Timetable\TimetableDayGateway;
 use Gibbon\Domain\Timetable\TimetableDayDateGateway;
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/ttDates_edit.php
+++ b/modules/Timetable Admin/ttDates_edit.php
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
+
+use Gibbon\Http\Url;
 use Gibbon\Tables\DataTable;
 
 //Module includes
@@ -37,7 +39,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
     if ($gibbonSchoolYearID == '' or $dateStamp == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
         $data = array('date' => date('Y-m-d', $dateStamp));
         $sql = 'SELECT gibbonTTDay.gibbonTTDayID, gibbonTTDay.name AS dayName, gibbonTT.name AS ttName FROM gibbonTTDayDate JOIN gibbonTTDay ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) JOIN gibbonTT ON (gibbonTTDay.gibbonTTID=gibbonTT.gibbonTTID) WHERE date=:date';
         $result = $connection2->prepare($sql);
@@ -50,7 +52,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
                 ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
                 ->addParam('dateStamp', $dateStamp)
                 ->displayLabel()
-                ->setURL('/modules/' . $gibbon->session->get('module') . '/ttDates_edit_add.php');
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttDates_edit_add'));
 
         $table->addColumn('ttName', __('Timetable'));
         $table->addColumn('dayName', __('Day'));
@@ -60,10 +62,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
                 ->addParam('gibbonTTDayID')
                 ->format(function ($subcategory, $actions) use ($gibbon) {
                     $actions->addAction('delete', __('Delete'))
-                            ->setURL('/modules/' . $gibbon->session->get('module') . '/ttDates_edit_delete.php');
+                            ->setURL(Url::fromModuleRoute('Timetable Admin', 'ttDates_edit_delete'));
                 });
 
         echo $table->render($result->toDataSet());
     }
-    
+
 }

--- a/modules/Timetable Admin/ttDates_edit_add.php
+++ b/modules/Timetable Admin/ttDates_edit_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_edit_add.php') == false) {
     // Access denied
@@ -34,7 +35,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
             echo __('School is not open on the specified day.');
             echo '</div>';
         } else {
-            
+
                 $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
                 $sql = 'SELECT * FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
                 $result = $connection2->prepare($sql);
@@ -53,7 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
                     ->add(__('Edit Days in Date'), 'ttDates_edit.php', ['gibbonSchoolYearID' => $gibbonSchoolYearID, 'dateStamp' => $dateStamp])
                     ->add(__('Add Day to Date'));
 
-				$form = Form::create('addTTDate', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttDates_edit_addProcess.php');
+				$form = Form::create('addTTDate', Url::fromModuleRoute('Timetable Admin', 'ttDates_edit_addProcess'));
 
 				$form->addHiddenValue('address', $session->get('address'));
 				$form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);

--- a/modules/Timetable Admin/ttDates_edit_addProcess.php
+++ b/modules/Timetable Admin/ttDates_edit_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -26,21 +27,22 @@ $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 $dateStamp = $_POST['dateStamp'] ?? '';
 $gibbonTTDayID = $_POST['gibbonTTDayID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/ttDates_edit_add.php&gibbonSchoolYearID=$gibbonSchoolYearID&dateStamp=".$dateStamp;
+$URL = Url::fromModuleRoute('Timetable Admin', 'ttDates_edit_add')
+    ->withQueryParams([
+        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        'dateStamp' => $dateStamp,
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_edit_add.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Validate Inputs
     if ($gibbonSchoolYearID == '' or $dateStamp == '' or $gibbonTTDayID == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         if (isSchoolOpen($guid, date('Y-m-d', $dateStamp), $connection2, true) == false) {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
@@ -48,14 +50,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -64,13 +64,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URL .= '&return=success0';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/ttDates_edit_addProcess.php
+++ b/modules/Timetable Admin/ttDates_edit_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/ttDates_edit_delete.php
+++ b/modules/Timetable Admin/ttDates_edit_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_edit_delete.php') == false) {
     // Access denied
@@ -30,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
     if ($gibbonSchoolYearID == '' or $dateStamp == '' or $gibbonTTDayID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('date' => date('Y-m-d', $dateStamp), 'gibbonTTDayID' => $gibbonTTDayID);
             $sql = 'SELECT * FROM gibbonTTDayDate JOIN gibbonTTDay ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDay.gibbonTTDayID) JOIN gibbonTT ON (gibbonTTDay.gibbonTTID=gibbonTT.gibbonTTID) WHERE date=:date AND gibbonTTDay.gibbonTTDayID=:gibbonTTDayID';
             $result = $connection2->prepare($sql);
@@ -43,7 +44,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_ed
             $row = $result->fetch();
 
             //Proceed!
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/ttDates_edit_deleteProcess.php?gibbonSchoolYearID=$gibbonSchoolYearID&dateStamp=$dateStamp&gibbonTTDayID=$gibbonTTDayID");
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'ttDates_edit_deleteProcess')
+                    ->withQueryParams([
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'dateStamp' => $dateStamp,
+                        'gibbonTTDayID' => $gibbonTTDayID,
+                    ])
+                );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/ttDates_edit_deleteProcess.php
+++ b/modules/Timetable Admin/ttDates_edit_deleteProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
@@ -25,17 +27,19 @@ $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
 
 if ($gibbonSchoolYearID == '' or $dateStamp == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/ttDates_edit.php&gibbonSchoolYearID=$gibbonSchoolYearID&dateStamp=$dateStamp";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'ttDates_edit')
+        ->withQueryParams([
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'dateStamp' => $dateStamp,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttDates_edit_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('date' => date('Y-m-d', $dateStamp), 'gibbonTTDayID' => $gibbonTTDayID);
@@ -43,14 +47,12 @@ if ($gibbonSchoolYearID == '' or $dateStamp == '') { echo 'Fatal error loading t
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() < 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -59,13 +61,11 @@ if ($gibbonSchoolYearID == '' or $dateStamp == '') { echo 'Fatal error loading t
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URL .= '&return=success0';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/ttDates_edit_deleteProcess.php
+++ b/modules/Timetable Admin/ttDates_edit_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
 $dateStamp = $_GET['dateStamp'] ?? '';

--- a/modules/Timetable Admin/ttSettings.php
+++ b/modules/Timetable Admin/ttSettings.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttSettings.php') == false) {
     // Access denied
@@ -27,11 +28,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttSettings
     // Proceed!
     $page->breadcrumbs->add(__('Timetable Settings'));
 
-    $form = Form::create('ttSettings', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttSettingsProcess.php');
-
     $settingGateway = $container->get(SettingGateway::class);
 
-    $form = Form::create('ttSettings', $session->get('absoluteURL').'/modules/'.$session->get('module').'/ttSettingsProcess.php');
+    $form = Form::create('ttSettings', Url::fromModuleRoute('Timetable Admin', 'ttSettingsProcess'));
     $form->setTitle(__('Settings'));
     $form->addHiddenValue('address', $session->get('address'));
 

--- a/modules/Timetable Admin/ttSettingsProcess.php
+++ b/modules/Timetable Admin/ttSettingsProcess.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/ttSettings.php';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttSettings.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttSettings.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/ttSettingsProcess.php
+++ b/modules/Timetable Admin/ttSettingsProcess.php
@@ -18,16 +18,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/ttSettings.php';
+$URL = Url::fromModuleRoute('Timetable Admin', 'ttSettings');
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttSettings.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
 
     $partialFail = false;
@@ -49,8 +49,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/ttSettings
         }
     }
 
-    $URL .= $partialFail
-        ? '&return=error2'
-        : '&return=success0';
-    header("Location: {$URL}");
+    if ($partialFail) {
+        header('Location: ' . $URL->withReturn('error2'));
+        exit();
+    }
+
+    header('Location: ' . $URL->withReturn('success0'));
 }

--- a/modules/Timetable Admin/ttSettingsProcess.php
+++ b/modules/Timetable Admin/ttSettingsProcess.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Data\Validator;
 use Gibbon\Domain\System\SettingGateway;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_add.php
+++ b/modules/Timetable Admin/tt_add.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Domain\Timetable\TimetableGateway;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -36,14 +37,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php
 
     $editLink = '';
     if (isset($_GET['editID'])) {
-        $editLink = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt_edit.php&gibbonTTID='.$_GET['editID'].'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
+        $editLink = Url::fromModuleRoute('Timetable Admin', 'tt_edit')
+            ->withQueryParams([
+                'gibbonTTID' => $_GET['editID'],
+                'gibbonSchoolYearID' => $_GET['gibbonSchoolYearID'],
+            ]);
     }
     $page->return->setEditLink($editLink);
 
     if ($gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);
             $sql = 'SELECT name AS schoolYear FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
             $result = $connection2->prepare($sql);
@@ -58,7 +63,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php
 
             $timetableGateway = $container->get(TimetableGateway::class);
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/tt_addProcess.php');
+            $form = Form::create(
+                'action',
+                Url::fromModuleRoute('Timetable Admin', 'tt_addProcess')
+            );
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonSchoolYearID', $gibbonSchoolYearID);

--- a/modules/Timetable Admin/tt_addProcess.php
+++ b/modules/Timetable Admin/tt_addProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -31,17 +32,15 @@ $count = $_POST['count'] ?? '';
 $gibbonYearGroupIDList = implode(',', $_POST['gibbonYearGroupID'] ?? []);
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_add.php&gibbonSchoolYearID=$gibbonSchoolYearID";
+$URL = Url::fromModuleRoute('Timetable Admin', 'tt_add')->withQueryParam('gibbonSchoolYearID', $gibbonSchoolYearID);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Validate Inputs
     if ($gibbonSchoolYearID == '' or $name == '' or $nameShort == '' or $nameShortDisplay == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         //Check unique inputs for uniquness
         try {
@@ -50,14 +49,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() > 0) {
-            $URL .= '&return=error3';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error3'));
         } else {
             //Write to database
             try {
@@ -66,16 +63,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_add.php
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             //Last insert ID
             $AI = str_pad($connection2->lastInsertID(), 8, '0', STR_PAD_LEFT);
 
-            $URL .= "&return=success0&editID=$AI";
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withQueryParam('editID', $AI)->withReturn('error0'));
         }
     }
 }

--- a/modules/Timetable Admin/tt_addProcess.php
+++ b/modules/Timetable Admin/tt_addProcess.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_delete.php
+++ b/modules/Timetable Admin/tt_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.php') == false) {
     // Access denied
@@ -29,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
     if ($gibbonTTID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonTTID' => $gibbonTTID);
             $sql = 'SELECT * FROM gibbonTT WHERE gibbonTTID=:gibbonTTID';
             $result = $connection2->prepare($sql);
@@ -39,7 +40,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
             $page->addError(__('The specified record cannot be found.'));
         } else {
             //Let's go!
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_deleteProcess.php?gibbonTTID=$gibbonTTID&gibbonSchoolYearID=".$_GET['gibbonSchoolYearID'], true);
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'tt_deleteProcess')
+                    ->withQueryParams([
+                        'gibbonTTID' => $gibbonTTID,
+                        'gibbonSchoolYearID' => $_GET['gibbonSchoolYearID'],
+                    ]),
+                    true
+                );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/tt_deleteProcess.php
+++ b/modules/Timetable Admin/tt_deleteProcess.php
@@ -17,21 +17,25 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt_delete.php&gibbonTTID='.$gibbonTTID.'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
+$URL = Url::fromModuleRoute('Timetable Admin', 'tt_delete')
+    ->withQueryParams([
+        'gibbonTTID' => $gibbonTTID,
+        'gibbonSchoolYearID' => $_GET['gibbonSchoolYearID'] ?? '',
+    ]);
+$URLDelete = Url::fromModuleRoute('Timetable Admin', 'tt')->withQueryParam('gibbonSchoolYearID', $_GET['gibbonSchoolYearID'] ?? '');
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Check if gibbonTTID specified
     if ($gibbonTTID == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         try {
             $data = array('gibbonTTID' => $gibbonTTID);
@@ -39,14 +43,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() != 1) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
         } else {
             //Delete Course
             try {
@@ -55,13 +57,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
-            $URLDelete = $URLDelete.'&return=success0';
-            header("Location: {$URLDelete}");
+            header('Location: ' . $URLDelete->withReturn('success0'));
         }
     }
 }

--- a/modules/Timetable Admin/tt_deleteProcess.php
+++ b/modules/Timetable Admin/tt_deleteProcess.php
@@ -20,8 +20,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/tt_delete.php&gibbonTTID='.$gibbonTTID.'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
-$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/tt.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt_delete.php&gibbonTTID='.$gibbonTTID.'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
+$URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt.php&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/tt_deleteProcess.php
+++ b/modules/Timetable Admin/tt_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';
 $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/tt_delete.php&gibbonTTID='.$gibbonTTID.'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'];

--- a/modules/Timetable Admin/tt_edit.php
+++ b/modules/Timetable Admin/tt_edit.php
@@ -23,6 +23,7 @@ use Gibbon\Tables\DataTable;
 use Gibbon\Forms\Prefab\BulkActionForm;
 use Gibbon\Domain\Timetable\TimetableGateway;
 use Gibbon\Domain\Timetable\TimetableDayGateway;
+use Gibbon\Http\Url;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -52,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
             $page->addError(__('The specified record cannot be found.'));
         } else {
             //Let's go!
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/tt_editProcess.php');
+            $form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'tt_editProcess'));
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTID', $gibbonTTID);
@@ -114,7 +115,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
             $ttDays = $timetableDayGateway->queryTTDays($criteria, $gibbonTTID);
 
             // FORM
-            $form = BulkActionForm::create('bulkAction', $session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_editProcessBulk.php?gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID");
+            $form = BulkActionForm::create(
+                'bulkAction',
+                Url::fromModuleRoute('Timetable Admin', 'tt_editProcessBulk')
+                    ->withQueryParams([
+                        'gibbonTTID' => $gibbonTTID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                    ])
+            );
             $form->addHiddenValue('address', $session->get('address'));
 
             // BULK ACTIONS
@@ -130,7 +138,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
             $table->addMetaData('bulkActions', $col);
 
             $table->addHeaderAction('add', __('Add'))
-                ->setURL('/modules/Timetable Admin/tt_edit_day_add.php')
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_add'))
                 ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
                 ->addParam('gibbonTTID', $gibbonTTID)
                 ->displayLabel();
@@ -146,10 +154,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
                 ->addParam('gibbonTTDayID')
                 ->format(function ($values, $actions) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/tt_edit_day_edit.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit'));
 
                     $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/tt_edit_day_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_delete'));
                 });
 
             $table->addCheckboxColumn('gibbonTTDayIDList', 'gibbonTTDayID');

--- a/modules/Timetable Admin/tt_editProcess.php
+++ b/modules/Timetable Admin/tt_editProcess.php
@@ -32,7 +32,7 @@ $gibbonYearGroupIDList = (isset($_POST["gibbonYearGroupID"]) ? implode(',', $_PO
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'];
 $gibbonTTID = $_POST['gibbonTTID'];
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/tt_edit.php&gibbonTTID='.$gibbonTTID.'&gibbonSchoolYearID='.$_POST['gibbonSchoolYearID'];
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt_edit.php&gibbonTTID='.$gibbonTTID.'&gibbonSchoolYearID='.$_POST['gibbonSchoolYearID'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.php') == false) {
     $URL .= '&return=error0';

--- a/modules/Timetable Admin/tt_editProcess.php
+++ b/modules/Timetable Admin/tt_editProcess.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -32,17 +33,19 @@ $gibbonYearGroupIDList = (isset($_POST["gibbonYearGroupID"]) ? implode(',', $_PO
 $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'];
 $gibbonTTID = $_POST['gibbonTTID'];
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt_edit.php&gibbonTTID='.$gibbonTTID.'&gibbonSchoolYearID='.$_POST['gibbonSchoolYearID'];
+$URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit')
+    ->withQueryParams([
+        'gibbonTTID' => $gibbonTTID,
+        'gibbonSchoolYearID' => $_POST['gibbonSchoolYearID'] ?? '',
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Check if special day specified
     if ($gibbonTTID == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         try {
             $data = array('gibbonTTID' => $gibbonTTID);
@@ -50,19 +53,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() != 1) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
         } else {
             //Validate Inputs
             if ($name == '' or $nameShort == '' or $nameShortDisplay == '' or $gibbonSchoolYearID == '') {
-                $URL .= '&return=error3';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error3'));
             } else {
                 //Check unique inputs for uniquness
                 try {
@@ -71,14 +71,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
                 if ($result->rowCount() > 0) {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Write to database
                     try {
@@ -87,13 +85,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
-                    $URL .= '&return=success0';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('success0'));
                 }
             }
         }

--- a/modules/Timetable Admin/tt_editProcess.php
+++ b/modules/Timetable Admin/tt_editProcess.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_editProcessBulk.php
+++ b/modules/Timetable Admin/tt_editProcessBulk.php
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Domain\Timetable\TimetableDayGateway;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';
 $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';

--- a/modules/Timetable Admin/tt_editProcessBulk.php
+++ b/modules/Timetable Admin/tt_editProcessBulk.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Domain\Timetable\TimetableDayGateway;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -25,21 +26,21 @@ $gibbonTTID = $_GET['gibbonTTID'] ?? '';
 $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
 $action = $_POST['action'];
 
-$URL = $session->get('absoluteURL')."/index.php?q=/modules/Timetable Admin/tt_edit.php&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID";
+$URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit')->withQueryParams([
+    'gibbonTTID' => $gibbonTTID,
+    'gibbonSchoolYearID' => $gibbonSchoolYearID,
+]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else if ($action == '') {
-    $URL .= '&return=error1';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error1'));
 } else {
     $days = isset($_POST['gibbonTTDayIDList']) ? $_POST['gibbonTTDayIDList'] : array();
 
     //Proceed!
     if (count($days) < 1) {
-        $URL .= '&return=error3';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error3'));
     } else {
         $timetableDayGateway = $container->get(TimetableDayGateway::class);
         $partialFail = false;
@@ -82,11 +83,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
         }
 
         if ($partialFail == true) {
-            $URL .= '&return=warning1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('warning1'));
         } else {
-            $URL .= '&return=success0';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('success0'));
         }
     }
 }

--- a/modules/Timetable Admin/tt_edit_day_add.php
+++ b/modules/Timetable Admin/tt_edit_day_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_add.php') == false) {
     // Access denied
@@ -49,12 +50,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
 
             $editLink = '';
             if (isset($_GET['editID'])) {
-                $editLink = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt_edit_day_edit.php&gibbonTTDayID='.$_GET['editID'].'&gibbonSchoolYearID='.$_GET['gibbonSchoolYearID'].'&gibbonTTID='.$_GET['gibbonTTID'];
+                $editLink = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit')
+                    ->withQueryParams([
+                        'gibbonTTDayID' => $_GET['editID'],
+                        'gibbonSchoolYearID' => $_GET['gibbonSchoolYearID'],
+                        'gibbonTTID' => $_GET['gibbonTTID'],
+                    ]);
             }
             $page->return->setEditLink($editLink);
 
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/tt_edit_day_addProcess.php');
+            $form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_addProcess'));
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTID', $gibbonTTID);

--- a/modules/Timetable Admin/tt_edit_day_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_edit_day_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -30,17 +31,19 @@ $gibbonSchoolYearID = $_POST['gibbonSchoolYearID'] ?? '';
 $gibbonTTID = $_POST['gibbonTTID'] ?? '';
 $gibbonTTColumnID = $_POST['gibbonTTColumnID'] ?? '';
 
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_add.php&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTID=$gibbonTTID";
+$URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_add')
+    ->withQueryParams([
+        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        'gibbonTTID' => $gibbonTTID,
+    ]);
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_add.php') == false) {
-    $URL .= '&return=error0';
-    header("Location: {$URL}");
+    header('Location: ' . $URL->withReturn('error0'));
 } else {
     //Proceed!
     //Validate Inputs
     if ($gibbonSchoolYearID == '' or $gibbonTTID == '' or $name == '' or $nameShort == '' or $gibbonTTColumnID == '') {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error1'));
     } else {
         //Check unique inputs for uniquness
         try {
@@ -49,14 +52,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $URL .= '&return=error2';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error2'));
             exit();
         }
 
         if ($result->rowCount() > 0) {
-            $URL .= '&return=error3';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error3'));
         } else {
             //Write to database
             try {
@@ -65,16 +66,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             //Last insert ID
             $AI = str_pad($connection2->lastInsertID(), 6, '0', STR_PAD_LEFT);
 
-            $URL .= "&return=success0&editID=$AI";
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withQueryParam('editID', $AI)->withReturn('success0'));
         }
     }
 }

--- a/modules/Timetable Admin/tt_edit_day_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_delete.php') == false) {
     // Access denied
@@ -30,7 +31,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonTTDayID' => $gibbonTTDayID);
             $sql = 'SELECT * FROM gibbonTTDay WHERE gibbonTTDayID=:gibbonTTDayID';
             $result = $connection2->prepare($sql);
@@ -42,7 +43,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             //Let's go!
             $row = $result->fetch();
 
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_edit_day_deleteProcess.php?gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID", true);
+            $form = DeleteForm::createForm(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_deleteProcess')
+                ->withQueryParams([
+                    'gibbonTTDayID' => $gibbonTTDayID,
+                    'gibbonTTID' => $gibbonTTID,
+                    'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                ]),
+                true
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_deleteProcess.php
@@ -17,26 +17,37 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';
 $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
 
-if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
+if ($gibbonTTID == '' or $gibbonSchoolYearID == '') {
+    echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_delete.php&gibbonTTID=$gibbonTTID&gibbonTTDayID=$gibbonTTDayID&gibbonSchoolYearID=$gibbonSchoolYearID";
-    $URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit.php&gibbonTTID=$gibbonTTID&gibbonTTDayID=$gibbonTTDayID&gibbonSchoolYearID=$gibbonSchoolYearID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_delete')
+        ->withQueryParams([
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        ]);
+    $URLDelete = Url::fromModuleRoute('Timetable Admin', 'tt_edit')
+        ->withQueryParams([
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTDayID' => $gibbonTTDayID);
@@ -44,14 +55,12 @@ if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading 
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -60,13 +69,11 @@ if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading 
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URLDelete = $URLDelete.'&return=success0';
-                header("Location: {$URLDelete}");
+                header('Location: ' . $URLDelete->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_edit.php
+++ b/modules/Timetable Admin/tt_edit_day_edit.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\TimetableDayGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit.php') == false) {
     // Access denied
@@ -46,7 +47,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 ->add(__('Edit Timetable'), 'tt_edit.php', ['gibbonTTID' => $gibbonTTID, 'gibbonSchoolYearID' => $gibbonSchoolYearID])
                 ->add(__('Edit Timetable Day'));
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_edit_day_editProcess.php?gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID");
+            $form = Form::create('action', Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_editProcess')
+                ->withQueryParams([
+                    'gibbonTTDayID' => $gibbonTTDayID,
+                    'gibbonTTID' => $gibbonTTID,
+                    'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                ])
+            );
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTID', $gibbonTTID);
@@ -112,7 +119,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 ->addParam('gibbonTTColumnRowID')
                 ->format(function ($values, $actions) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/tt_edit_day_edit_class.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class'));
                 });
 
             echo $table->render($ttDayRows->toDataSet());

--- a/modules/Timetable Admin/tt_edit_day_editProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_editProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -28,17 +29,19 @@ $gibbonSchoolYearID = $_GET['gibbonSchoolYearID'] ?? '';
 
 if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit.php&gibbonTTID=$gibbonTTID&gibbonTTDayID=$gibbonTTDayID&gibbonSchoolYearID=$gibbonSchoolYearID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit')->withQueryParams([
+        'gibbonTTID' => $gibbonTTID,
+        'gibbonTTDayID' => $gibbonTTDayID,
+        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+    ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if tt specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTDayID' => $gibbonTTDayID);
@@ -46,14 +49,12 @@ if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading 
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Validate Inputs
                 $name = $_POST['name'] ?? '';
@@ -63,8 +64,7 @@ if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading 
                 $gibbonTTColumnID = $_POST['gibbonTTColumnID'] ?? '';
 
                 if ($name == '' or $nameShort == '' or $gibbonTTColumnID == '') {
-                    $URL .= '&return=error3';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error3'));
                 } else {
                     //Check unique inputs for uniquness
                     try {
@@ -73,14 +73,12 @@ if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading 
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
                     if ($result->rowCount() > 0) {
-                        $URL .= '&return=error3';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error3'));
                     } else {
                         //Write to database
                         try {
@@ -89,13 +87,11 @@ if ($gibbonTTID == '' or $gibbonSchoolYearID == '') { echo 'Fatal error loading 
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            $URL .= '&return=error2';
-                            header("Location: {$URL}");
+                            header('Location: ' . $URL->withReturn('error2'));
                             exit();
                         }
 
-                        $URL .= '&return=success0';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('success0'));
                     }
                 }
             }

--- a/modules/Timetable Admin/tt_edit_day_editProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_editProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_edit_day_edit_class.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\TimetableDayGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class.php') == false) {
     // Access denied
@@ -68,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             $table->setTitle(__('Classes in Period'));
 
             $table->addHeaderAction('add', __('Add'))
-                ->setURL('/modules/Timetable Admin/tt_edit_day_edit_class_add.php')
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_add'))
                 ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
                 ->addParam('gibbonTTID', $gibbonTTID)
                 ->addParam('gibbonTTDayID', $gibbonTTDayID)
@@ -88,14 +89,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 ->addParam('gibbonCourseClassID')
                 ->format(function ($values, $actions) {
                     $actions->addAction('edit', __('Edit'))
-                        ->setURL('/modules/Timetable Admin/tt_edit_day_edit_class_edit.php');
-                        
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_edit'));
+
                     $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/tt_edit_day_edit_class_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_delete'));
 
                     $actions->addAction('exceptions', __('Exceptions'))
                         ->setIcon('attendance')
-                        ->setURL('/modules/Timetable Admin/tt_edit_day_edit_class_exception.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception'));
                 });
 
             echo $table->render($ttDayRowClasses->toDataSet());

--- a/modules/Timetable Admin/tt_edit_day_edit_class_add.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_add.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_add.php') == false) {
     // Access denied
@@ -32,7 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTID' => $gibbonTTID, 'gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID);
             $sql = 'SELECT gibbonTT.name AS ttName, gibbonTTDay.name AS dayName, gibbonTTColumnRow.name AS rowName, gibbonYearGroupIDList FROM gibbonTT JOIN gibbonTTDay ON (gibbonTT.gibbonTTID=gibbonTTDay.gibbonTTID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) JOIN gibbonTTColumnRow ON (gibbonTTColumn.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID) WHERE gibbonTTDay.gibbonTTDayID=:gibbonTTDayID AND gibbonTT.gibbonTTID=:gibbonTTID AND gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonTTColumnRowID=:gibbonTTColumnRowID';
             $result = $connection2->prepare($sql);
@@ -53,7 +54,16 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 ->add(__('Classes in Period'), 'tt_edit_day_edit_class.php', $urlParams)
                 ->add(__('Add Class to Period'));
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_edit_day_edit_class_addProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID");
+            $form = Form::create(
+                'action',
+                Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_addProcess')
+                    ->withQueryParams([
+                        'gibbonTTDayID' => $gibbonTTDayID,
+                        'gibbonTTID' => $gibbonTTID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+                    ])
+                );
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTID', $gibbonTTID);
@@ -91,7 +101,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 $resultSelect->execute($dataSelect);
             } catch (PDOException $e) {}
             while ($rowSelect = $resultSelect->fetch()) {
-                
+
                     $dataUnique = array('gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonCourseClassID' => $rowSelect['gibbonCourseClassID']);
                     $sqlUnique = 'SELECT * FROM gibbonTTDayRowClass WHERE gibbonTTDayID=:gibbonTTDayID AND gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonCourseClassID=:gibbonCourseClassID';
                     $resultUnique = $connection2->prepare($sqlUnique);
@@ -105,13 +115,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 $row->addSelect('gibbonCourseClassID')->fromArray($classes)->required()->placeholder();
 
             $locations = array() ;
-            
+
                 $dataSelect = array();
                 $sqlSelect = 'SELECT * FROM gibbonSpace ORDER BY name';
                 $resultSelect = $connection2->prepare($sqlSelect);
                 $resultSelect->execute($dataSelect);
             while ($rowSelect = $resultSelect->fetch()) {
-                
+
                     $dataUnique = array('gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonSpaceID' => $rowSelect['gibbonSpaceID']);
                     $sqlUnique = 'SELECT * FROM gibbonTTDayRowClass WHERE gibbonTTDayID=:gibbonTTDayID AND gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonSpaceID=:gibbonSpaceID';
                     $resultUnique = $connection2->prepare($sqlUnique);

--- a/modules/Timetable Admin/tt_edit_day_edit_class_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_edit_day_edit_class_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -32,17 +33,21 @@ $gibbonSpaceID = !empty($_POST['gibbonSpaceID']) ? $_POST['gibbonSpaceID'] : nul
 
 if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit_class_add.php&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_add')
+        ->withQueryParams([
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_add.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
 
                 $data = array('gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTID' => $gibbonTTID, 'gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID);
@@ -51,8 +56,7 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                 $result->execute($data);
 
             if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -61,16 +65,17 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
                 //Last insert ID
                 $AI = str_pad($connection2->lastInsertID(), 8, '0', STR_PAD_LEFT);
 
-                $URL .= "&return=success0&editID=$AI&gibbonCourseClassID=gibbonCourseClassID";
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('success0')->withQueryParams([
+                    'editID' => $AI,
+                    'gibbonCourseClassID' => 'gibbonCourseClassID',
+                ]));
             }
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_delete.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Prefab\DeleteForm;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_delete.php') == false) {
     // Access denied
@@ -33,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '' or $gibbonCourseClassID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonCourseClassID' => $gibbonCourseClassID);
             $sql = 'SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonTTDayRowClassID FROM gibbonTTDayRowClass JOIN gibbonCourseClass ON (gibbonTTDayRowClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonTTDayID=:gibbonTTDayID AND gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID';
             $result = $connection2->prepare($sql);
@@ -46,7 +47,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             $row = $result->fetch();
             $gibbonTTDayRowClassID = $row['gibbonTTDayRowClassID'];
 
-            $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_edit_day_edit_class_deleteProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID");
+            $form = DeleteForm::createForm(
+                Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_deleteProcess')
+                    ->withQueryParams([
+                        'gibbonTTDayID' => $gibbonTTDayID,
+                        'gibbonTTID' => $gibbonTTID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+                        'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID,
+                        'gibbonCourseClassID' => $gibbonCourseClassID,
+                    ])
+            );
             echo $form->getOutput();
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_deleteProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
@@ -28,18 +30,31 @@ $gibbonTTDayRowClassID = $_GET['gibbonTTDayRowClassID'] ?? '';
 
 if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '' or $gibbonCourseClassID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit_class_delete.php&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID";
-    $URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit_class.php&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_delete')
+        ->withQueryParams([
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+            'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+        ]);
+    $URLDelete = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class')
+        ->withQueryParams([
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+            'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonCourseClassID' => $gibbonCourseClassID);
@@ -47,14 +62,12 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() < 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -63,13 +76,11 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URLDelete = $URLDelete.'&return=success0';
-                header("Location: {$URLDelete}");
+                header('Location: ' . $URLDelete->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_edit.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_edit.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_edit.php') == false) {
     // Access denied
@@ -33,7 +34,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
     if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '' or $gibbonCourseClassID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonCourseClassID' => $gibbonCourseClassID);
             $sql = 'SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonTTDayRowClassID, gibbonSpaceID FROM gibbonTTDayRowClass JOIN gibbonCourseClass ON (gibbonTTDayRowClass.gibbonCourseClassID=gibbonCourseClass.gibbonCourseClassID) JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) WHERE gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonTTDayID=:gibbonTTDayID AND gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID';
             $result = $connection2->prepare($sql);
@@ -49,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             $gibbonSpaceID = $row['gibbonSpaceID'];
             $gibbonTTDayRowClassID = $row['gibbonTTDayRowClassID'];
 
-            
+
                 $data = array('gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTID' => $gibbonTTID, 'gibbonSchoolYearID' => $gibbonSchoolYearID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID);
                 $sql = 'SELECT gibbonTT.name AS ttName, gibbonTTDay.name AS dayName, gibbonTTColumnRow.name AS rowName, gibbonYearGroupIDList FROM gibbonTT JOIN gibbonTTDay ON (gibbonTT.gibbonTTID=gibbonTTDay.gibbonTTID) JOIN gibbonTTColumn ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumn.gibbonTTColumnID) JOIN gibbonTTColumnRow ON (gibbonTTColumn.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID) WHERE gibbonTTDay.gibbonTTDayID=:gibbonTTDayID AND gibbonTT.gibbonTTID=:gibbonTTID AND gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonTTColumnRowID=:gibbonTTColumnRowID';
                 $result = $connection2->prepare($sql);
@@ -71,7 +72,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                     ->add(__('Classes in Period'), 'tt_edit_day_edit_class.php', $urlParams)
                     ->add(__('Edit Class in Period'));
 
-                $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_edit_day_edit_class_editProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID");
+                $form = Form::create(
+                    'action',
+                    Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_editProcess')
+                        ->withQueryParams([
+                            'gibbonTTDayID' => $gibbonTTDayID,
+                            'gibbonTTID' => $gibbonTTID,
+                            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+                            'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID,
+                            'gibbonCourseClassID' => $gibbonCourseClassID,
+                        ])
+                );
 
                 $form->addHiddenValue('address', $session->get('address'));
                 $form->addHiddenValue('gibbonTTID', $gibbonTTID);
@@ -94,13 +106,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                     $row->addTextField('class')->maxLength(20)->required()->readonly()->setValue($course.'.'.$class);
 
                 $locations = array() ;
-                
+
                     $dataSelect = array();
                     $sqlSelect = 'SELECT * FROM gibbonSpace ORDER BY name';
                     $resultSelect = $connection2->prepare($sqlSelect);
                     $resultSelect->execute($dataSelect);
                 while ($rowSelect = $resultSelect->fetch()) {
-                    
+
                         $dataUnique = array('gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonSpaceID' => $rowSelect['gibbonSpaceID']);
                         $sqlUnique = 'SELECT * FROM gibbonTTDayRowClass WHERE gibbonTTDayID=:gibbonTTDayID AND gibbonTTColumnRowID=:gibbonTTColumnRowID AND gibbonSpaceID=:gibbonSpaceID';
                         $resultUnique = $connection2->prepare($sqlUnique);

--- a/modules/Timetable Admin/tt_edit_day_edit_class_editProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_editProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-require_once '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_edit_day_edit_class_editProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_editProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -31,19 +32,25 @@ $gibbonTTDayRowClassID = $_GET['gibbonTTDayRowClassID'] ?? '';
 
 if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '' or $gibbonCourseClassID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit_class_edit.php&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID";
+    $URL = Url::fromHandlerRoute('Timetable Admin', 'tt_edit_day_edit_class_edit')
+        ->withQueryParams([
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+            'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_edit.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         $gibbonSpaceID = !empty($_POST['gibbonSpaceID']) ? $_POST['gibbonSpaceID'] : null;
 
         //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonTTDayID' => $gibbonTTDayID, 'gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonCourseClassID' => $gibbonCourseClassID);
@@ -51,14 +58,12 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() < 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Write to database
                 try {
@@ -67,13 +72,11 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
-                $URL .= '&return=success0';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('success0'));
             }
         }
     }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception.php
@@ -21,6 +21,7 @@ use Gibbon\Forms\Form;
 use Gibbon\Tables\DataTable;
 use Gibbon\Services\Format;
 use Gibbon\Domain\Timetable\TimetableDayGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_exception.php') == false) {
     // Access denied
@@ -66,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             $table = DataTable::create('timetableDayRowClassExceptions');
 
             $table->addHeaderAction('add', __('Add'))
-                ->setURL('/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php')
+                ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception_add'))
                 ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
                 ->addParam('gibbonTTID', $gibbonTTID)
                 ->addParam('gibbonTTDayID', $gibbonTTDayID)
@@ -88,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 ->addParam('gibbonTTDayRowClassExceptionID')
                 ->format(function ($values, $actions) {
                     $actions->addAction('delete', __('Delete'))
-                        ->setURL('/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php');
+                        ->setURL(Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception_delete'));
                 });
 
             echo $table->render($ttDayRowClassExceptions->toDataSet());

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Domain\Timetable\TimetableDayGateway;
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 use Gibbon\Services\Format;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php') == false) {
@@ -60,7 +61,19 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
             //Let's go!
             $gibbonTTDayRowClassID = $values['gibbonTTDayRowClassID'];
 
-            $form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_edit_day_edit_class_exception_addProcess.php?gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClass=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID");
+            $form = Form::create(
+                'action',
+                Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception_addProcess')
+                    ->withQueryParams([
+                        'gibbonTTDayID' => $gibbonTTDayID,
+                        'gibbonTTID' => $gibbonTTID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+                        'gibbonTTDayRowClass' => $gibbonTTDayRowClassID,
+                        'gibbonCourseClassID' => $gibbonCourseClassID,
+                        'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID,
+                    ])
+            );
 
             $form->addHiddenValue('address', $session->get('address'));
             $form->addHiddenValue('gibbonTTID', $gibbonTTID);

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_addProcess.php
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $_POST = $container->get(Validator::class)->sanitize($_POST);
 

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_addProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 use Gibbon\Data\Validator;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -31,17 +32,23 @@ $gibbonTTDayRowClassID = $_GET['gibbonTTDayRowClassID'] ?? '';
 
 if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '' or $gibbonCourseClassID == '' or $gibbonTTDayRowClassID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit_class_exception_add.php&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClass=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception_add')
+        ->withQueryParams([
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+            'gibbonTTDayRowClass' => $gibbonTTDayRowClassID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonTTDayID' => $gibbonTTDayID, 'gibbonCourseClassID' => $gibbonCourseClassID);
@@ -49,22 +56,19 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() < 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 //Run through each of the selected participants.
                 $update = true;
                 $choices = $_POST['Members'];
 
                 if (count($choices) < 1) {
-                    $URL .= '&return=error1';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error1'));
                 } else {
                     foreach ($choices as $t) {
                         //Check to see if person is already exempted from this class
@@ -91,11 +95,9 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                     }
                     //Write to database
                     if ($update == false) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                     } else {
-                        $URL .= '&return=success0';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('success0'));
                     }
                 }
             }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Prefab\DeleteForm;
 use Gibbon\Domain\Timetable\TimetableDayGateway;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php') == false) {
     // Access denied
@@ -50,7 +51,18 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                 echo __('The specified record cannot be found.');
                 echo '</div>';
             } else {
-                $form = DeleteForm::createForm($session->get('absoluteURL').'/modules/'.$session->get('module')."/tt_edit_day_edit_class_exception_deleteProcess.php?&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID&gibbonTTDayRowClassExceptionID=$gibbonTTDayRowClassExceptionID");
+                $form = DeleteForm::createForm(
+                    Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception_deleteProcess')
+                        ->withQueryParams([
+                            'gibbonTTDayID' => $gibbonTTDayID,
+                            'gibbonTTID' => $gibbonTTID,
+                            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+                            'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID,
+                            'gibbonCourseClassID' => $gibbonCourseClassID,
+                            'gibbonTTDayRowClassExceptionID' => $gibbonTTDayRowClassExceptionID,
+                        ])
+                );
                 echo $form->getOutput();
             }
         }

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_deleteProcess.php
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
 $gibbonTTID = $_GET['gibbonTTID'] ?? '';

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_deleteProcess.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_deleteProcess.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Http\Url;
+
 require_once __DIR__ . '/../../gibbon.php';
 
 $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
@@ -29,18 +31,33 @@ $gibbonTTDayRowClassExceptionID = $_GET['gibbonTTDayRowClassExceptionID'] ?? '';
 
 if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $gibbonTTColumnRowID == '' or $gibbonCourseClassID == '' or $gibbonTTDayRowClassID == '' or $gibbonTTDayRowClassExceptionID == '') { echo 'Fatal error loading this page!';
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit_class_exception_delete.php&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClass=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID&gibbonTTDayRowClassExceptionID=$gibbonTTDayRowClassExceptionID";
-    $URLDelete = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/tt_edit_day_edit_class_exception.php&gibbonTTDayID=$gibbonTTDayID&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&gibbonTTColumnRowID=$gibbonTTColumnRowID&gibbonTTDayRowClass=$gibbonTTDayRowClassID&gibbonCourseClassID=$gibbonCourseClassID";
+    $URL = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception_delete')
+        ->withQueryParams([
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+            'gibbonTTDayRowClass' => $gibbonTTDayRowClassID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'gibbonTTDayRowClassExceptionID' => $gibbonTTDayRowClassExceptionID,
+        ]);
+    $URLDelete = Url::fromModuleRoute('Timetable Admin', 'tt_edit_day_edit_class_exception')
+        ->withQueryParams([
+            'gibbonTTDayID' => $gibbonTTDayID,
+            'gibbonTTID' => $gibbonTTID,
+            'gibbonSchoolYearID' => $gibbonSchoolYearID,
+            'gibbonTTColumnRowID' => $gibbonTTColumnRowID,
+            'gibbonTTDayRowClass' => $gibbonTTDayRowClassID,
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+        ]);
 
     if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_day_edit_class_exception_delete.php') == false) {
-        $URL .= '&return=error0';
-        header("Location: {$URL}");
+        header('Location: ' . $URL->withReturn('error0'));
     } else {
         //Proceed!
         //Check if gibbonTTDayID specified
         if ($gibbonTTDayID == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
+            header('Location: ' . $URL->withReturn('error1'));
         } else {
             try {
                 $data = array('gibbonTTColumnRowID' => $gibbonTTColumnRowID, 'gibbonTTDayID' => $gibbonTTDayID, 'gibbonCourseClassID' => $gibbonCourseClassID);
@@ -48,14 +65,12 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
                 exit();
             }
 
             if ($result->rowCount() < 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
+                header('Location: ' . $URL->withReturn('error2'));
             } else {
                 try {
                     $data = array('gibbonTTDayRowClassExceptionID' => $gibbonTTDayRowClassExceptionID);
@@ -63,14 +78,12 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                     exit();
                 }
 
                 if ($result->rowCount() < 1) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
+                    header('Location: ' . $URL->withReturn('error2'));
                 } else {
                     //Write to database
                     try {
@@ -79,13 +92,11 @@ if ($gibbonTTDayID == '' or $gibbonTTID == '' or $gibbonSchoolYearID == '' or $g
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
+                        header('Location: ' . $URL->withReturn('error2'));
                         exit();
                     }
 
-                    $URLDelete = $URLDelete.'&return=success0';
-                    header("Location: {$URLDelete}");
+                    header('Location: ' . $URLDelete->withReturn('success0'));
                 }
             }
         }

--- a/modules/Timetable Admin/tt_import.php
+++ b/modules/Timetable Admin/tt_import.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Forms\Form;
+use Gibbon\Http\Url;
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.php') == false) {
     // Access denied
@@ -84,7 +85,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
 					echo __('This page allows you to import timetable data from a CSV file. The import includes all classes and their teachers. There is no support for importing students: these need to be entered manually into the relevant classes. The system will do its best to keep existing data intact, whilst updating what is necessary (note: you will lose student exceptions from timetabled classes). Select the CSV files you wish to use for the synchronise operation.')."<br/>";
 				echo '</p>';
 
-                $form = Form::create('importTimetable', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module')."/tt_import.php&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&step=2");
+                $form = Form::create(
+                    'importTimetable',
+                    Url::fromModuleRoute('Timetable Admin', 'tt_import')->withQueryParams([
+                        'gibbonTTID' => $gibbonTTID,
+                        'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                        'step' => 2,
+                    ])
+                );
 
                 $form->addHiddenValue('address', $session->get('address'));
 
@@ -686,7 +694,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
                         echo '</div>';
                     } elseif ($proceed == true) {
                         echo "<div class='success'>";
-                        echo '<b><u>'.sprintf(__('You are ready to go. %1$sClick here to import the timetable. Your old timetable will be obliterated%2$s.'), "<a href='".$session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module')."/tt_import.php&gibbonTTID=$gibbonTTID&gibbonSchoolYearID=$gibbonSchoolYearID&step=3'>", '</a>').'</u></b>';
+                        echo '<b><u>'.sprintf(
+                            __('You are ready to go. %1$sClick here to import the timetable. Your old timetable will be obliterated%2$s.'),
+                            "<a href='".Url::fromModuleRoute('Timetable Admin', 'tt_import')->withQueryParams([
+                                'gibbonTTID' => $gibbonTTID,
+                                'gibbonSchoolYearID' => $gibbonSchoolYearID,
+                                'step' => 3,
+                            ]) . "'>",
+                            '</a>'
+                        ).'</u></b>';
                         echo '</div>';
                     }
                 }

--- a/modules/Timetable Admin/tt_notifyProcess.php
+++ b/modules/Timetable Admin/tt_notifyProcess.php
@@ -22,7 +22,7 @@ use Gibbon\Comms\NotificationSender;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\Timetable\TimetableGateway;
 
-include '../../gibbon.php';
+require_once __DIR__ . '/../../gibbon.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt.php') == false) {
     // Access denied

--- a/modules/Timetable Admin/tt_notifyProcess.php
+++ b/modules/Timetable Admin/tt_notifyProcess.php
@@ -21,6 +21,7 @@ use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\Timetable\TimetableGateway;
+use Gibbon\Http\Url;
 
 require_once __DIR__ . '/../../gibbon.php';
 
@@ -28,7 +29,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt.php') =
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    $URL = $session->get('absoluteURL').'/index.php?q=/modules/Timetable Admin/tt.php';
+    $URL = Url::fromModuleRoute('Timetable Admin', 'tt');
 
     $gibbonTTID = $_GET['gibbonTTID'] ?? '';
     $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
@@ -45,7 +46,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt.php') =
 
     // Raise a new notification event
     $event = new NotificationEvent('Timetable', 'Updated Timetable Subscriber');
-    $actionLink = "/index.php?q=/modules/Timetable/tt_view.php&gibbonPersonID=".$gibbonPersonID;
+    $actionLink = Url::fromModuleRoute('Timetable', 'tt_view')->withQueryParam('gibbonPersonID', $gibbonPersonID);
 
     $notificationText = __('The timetable {name} has been updated, please visit your timetable and export again to ensure it remains up to date.', ['name' => $tt['name']]);
 
@@ -58,9 +59,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt.php') =
     // Send all notifications
     $sendReport = $notificationSender->sendNotifications();
 
-    $URL .= $sendReport['emailFailed']  > 0
-        ? "&return=warning1"
-        : "&return=success0"; 
+    $URL = $sendReport['emailFailed']  > 0
+        ? $URL->withReturn('warning1')
+        : $URL->withReturn('success0');
     header("Location: {$URL}");
   }
 ?>

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -191,7 +191,7 @@ function getCalendarEvents($connection2, $guid, $xml, $startDayStamp, $endDaySta
         // Create a Graph client
         $oauthProvider = $container->get('Microsoft_Auth');
         if (empty($oauthProvider)) return;
-        
+
         $graph = new Graph();
         $graph->setAccessToken($session->get('microsoftAPIAccessToken'));
 
@@ -327,11 +327,32 @@ function getCalendarEvents($connection2, $guid, $xml, $startDayStamp, $endDaySta
     return $eventsSchool;
 }
 
-//TIMETABLE FOR INDIVIUDAL
-//$narrow can be "full", "narrow", or "trim" (between narrow and full)
-function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = '', $startDayStamp = '', $q = '', $params = '', $narrow = 'full', $edit = false)
+/**
+ * TIMETABLE FOR INDIVIUDAL
+ *
+ * @version v25
+ * @since   v12
+ *
+ * @param string       $guid
+ * @param \PDO         $connection2
+ * @param int          $gibbonPersonID
+ * @param int          $gibbonTTID
+ * @param int|string   $startDayStamp   Unix timestamp of the start day. Empty string if want to use the current time.
+ * @param Url|string   $url             Url instance of common timetable form action URL. Or the "q" parameter string for
+ *                                      backward compatibility.
+ * @param string       $params          Common suffix string of form action URLs.
+ * @param string       $narrow          The style of rendered timetable. Can be either "full", "narrow", or "trim"
+ *                                      (between narrow and full). Default: full.
+ * @param bool         $edit            Render in editing mode or not. Default: false.
+ */
+function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = '', $startDayStamp = '', $url = '', $params = '', $narrow = 'full', $edit = false)
 {
     global $session;
+
+    // For backward
+    if (!($url instanceof Url)) {
+        $url = Url::fromRoute()->withQueryParam('q', $url);
+    }
 
     $zCount = 0;
     $output = '';
@@ -424,7 +445,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $output .= '<td>';
             $output .= "<span style='font-size: 115%; font-weight: bold'>".__('Timetable Chooser').'</span>: ';
             while ($row = $result->fetch()) {
-                $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
+                $output .= "<form method='post' action='".$url->withQueryParam('gibbonTTID', $row['gibbonTTID'])."$params'>";
                 $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], $startDayStamp)."' type='hidden'>";
                 $output .= "<input name='schoolCalendar' value='".($session->get('viewCalendarSchool') == 'Y' ? 'Y' : '')."' type='hidden'>";
                 $output .= "<input name='personalCalendar' value='".($session->get('viewCalendarPersonal') == 'Y' ? 'Y' : '')."' type='hidden'>";
@@ -469,7 +490,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $output .= "<table cellspacing='0' class='noIntBorder' style='width: 100%; margin: 10px 0 10px 0'>";
             $output .= '<tr>';
             $output .= "<td style='vertical-align: top;width:360px'>";
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
+            $output .= "<form method='post' action='".$url->withQueryParam('gibbonTTID', $row['gibbonTTID'])."$params'>";
             $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], ($startDayStamp - (7 * 24 * 60 * 60)))."' type='hidden'>";
             $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
             $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
@@ -477,7 +498,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $output .= "<input name='fromTT' value='Y' type='hidden'>";
             $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='< ".__('Last Week')."'>";
             $output .= '</form>';
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
+            $output .= "<form method='post' action='".$url->withQueryParam('gibbonTTID', $row['gibbonTTID'])."$params'>";
             $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'],($thisWeek))."' type='hidden'>";
             $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
             $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
@@ -485,7 +506,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $output .= "<input name='fromTT' value='Y' type='hidden'>";
             $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='".__('This Week')."'>";
             $output .= '</form>';
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
+            $output .= "<form method='post' action='".$url->withQueryParam('gibbonTTID', $row['gibbonTTID'])."$params'>";
             $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], ($startDayStamp + (7 * 24 * 60 * 60)))."' type='hidden'>";
             $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
             $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
@@ -495,7 +516,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $output .= '</form>';
             $output .= '</td>';
             $output .= "<td style='vertical-align: top; text-align: right'>";
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
+            $output .= "<form method='post' action='".$url->withQueryParam('gibbonTTID', $row['gibbonTTID'])."$params'>";
             $output .= '<span class="relative">';
             $output .= "<input name='ttDate' id='ttDate' aria-label='".__('Choose Date')."' maxlength=10 value='".date($session->get('i18n')['dateFormatPHP'], $startDayStamp)."' type='text' style='width:120px; margin-right: 0px; float: none'> ";
             $output .= '</span>';
@@ -559,7 +580,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
 
             //Sunday week adjust for timetable on home page (so Sundays show next week if the week starts on Sunday or Monday—i.e. it's Sunday now and Sunday is not a school day)
             $homeSunday = true ;
-            if ($q == '' && ($session->get('firstDayOfTheWeek') == 'Monday' || $session->get('firstDayOfTheWeek') == 'Sunday')) {
+            if (empty($url->getQueryParams()['q'] ?? null) && ($session->get('firstDayOfTheWeek') == 'Monday' || $session->get('firstDayOfTheWeek') == 'Sunday')) {
                 try {
                     $dataDays = array();
                     $sqlDays = "SELECT nameShort FROM gibbonDaysOfWeek WHERE nameShort='Sun' AND schoolDay='N'";
@@ -650,7 +671,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                     }
 
                 }
-                
+
             }
 
             //Get personal calendar array
@@ -887,7 +908,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                 if ($self == true and ($session->get('calendarFeed') != '' || $session->get('calendarFeedPersonal') != '' || $session->get('viewCalendarSpaceBooking') != '')) {
                     $output .= "<tr class='head' style='height: 37px;'>";
                     $output .= "<th class='ttCalendarBar' colspan=".($daysInWeek + 1).'>';
-                    $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q".$params."' style='padding: 5px 5px 0 0'>";
+                    $output .= "<form method='post' action='".$url.$params."' style='padding: 5px 5px 0 0'>";
 
                     $displayCalendars = $session->has('googleAPIAccessToken') || $session->has('microsoftAPIAccessToken');
                     if ($session->has('calendarFeed') && $session->has('googleAPIAccessToken')) {
@@ -1056,7 +1077,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                         //Check for school closure day
                         $dateCheck = date('Y-m-d', ($startDayStamp + (86400 * $dateCorrection)));
                         $rowClosure = $specialDays[$dateCheck] ?? '';
-                        
+
                         if (!empty($rowClosure)) {
                             $rowClosure['gibbonYearGroupIDList'] = explode(',', $rowClosure['gibbonYearGroupIDList'] ?? '');
                             $rowClosure['gibbonFormGroupIDList'] = explode(',', $rowClosure['gibbonFormGroupIDList'] ?? '');
@@ -1619,7 +1640,7 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                         }
 
                         $output .= "<a class='thickbox' style='text-decoration: none; font-weight: bold; ' href='".$event[5]."'>".$label.'</a><br/>';
-                        
+
                         if (!empty($event[6]) && $event[6]['cancelActivities'] == 'Y') {
                             $output .= '<i>'.__('Cancelled').'</i><br/>';
                         } elseif (($height >= 55 && $charCut <= 20) || ($height >= 68 && $charCut >= 40)) {
@@ -1628,7 +1649,7 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                         $output .= '</div>';
                     }
                     ++$zCount;
-                    
+
                 }
             }
 
@@ -1760,7 +1781,7 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
 function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title = '', $startDayStamp = '', $q = '', $params = '')
 {
     global $session;
-    
+
     $output = '';
 
     $blank = true;
@@ -2185,7 +2206,7 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
                             $output .= "<div class='error'>".$e->getMessage().'</div>';
                         }
                         if ($resultClosure->rowCount() == 1) {
-                            
+
                             $rowClosure = $resultClosure->fetch();
                             if ($rowClosure['type'] == 'School Closure') {
                                 $dayOut .= "<td style='text-align: center; vertical-align: top; font-size: 11px'>";


### PR DESCRIPTION
**Description**
* Use `__DIR__` and require_once for a more stable behaviour when routed through index.php.
* Refactor to use Url class for paths and url generation.

**Motivation and Context**
* Remove the use of `$session->get('absoluteURL')` from the module.
* Fix all issue when using Timetable Admin through index.php routing. Some feature was still relying on direct routing on the script path.
* Pave way for future router routing efforts.

**How Has This Been Tested?**
* CI environment.