### PR TITLE
System: remove obsoleted include in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,11 +34,6 @@ use Gibbon\Http\Url;
 // Gibbon system-wide include
 require_once './gibbon.php';
 
-// Module include: Messenger has a bug where files have been relying on these
-// functions because this file was included via getNotificationTray()
-// TODO: Fix that :)
-require_once './modules/Messenger/moduleFunctions.php';
-
 // Setup the Page and Session objects
 $theme = $container->get('theme');
 $page = $container->get('page');


### PR DESCRIPTION
**Description**
* Remove Messenger module's moduleFunctions.php include statement from index.php. According to comment, the statement was needed because the function getNotificationTray() needs it. The function was removed since v18.

**Motivation and Context**
Checked "TODO"s in the code base and noticed this.

**How Has This Been Tested?**
* CI environment