### PR TITLE
System: translation function fallback

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -24,6 +24,7 @@ use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Domain\System\LogGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Forms\Input\Editor;
+use Gibbon\Locale;
 
 function getIPAddress() {
     $return = false;
@@ -114,7 +115,10 @@ function __($text, $params=[], $options=[])
         return $text;
     }
 
-    return $gibbon->locale->translate($text, $params, $options);
+    // Fallback to format string if global locale does not exists.
+    return isset($gibbon->locale)
+        ? $gibbon->locale->translate($text, $params, $options)
+        : Locale::formatString($text, $params);
 }
 
 /**

--- a/src/Gibbon/Locale.php
+++ b/src/Gibbon/Locale.php
@@ -152,7 +152,7 @@ class Locale implements LocaleInterface
     public function setStringReplacementList(Session $session, Connection $pdo, $forceRefresh = false)
     {
         $stringReplacements = $session->get('stringReplacement', null);
-        
+
         // Do this once per session, only if the value doesn't exist
         if ($forceRefresh || $stringReplacements === null) {
 
@@ -186,10 +186,10 @@ class Locale implements LocaleInterface
      *
      * @return string The substituted version of $text string.
      */
-    protected static function formatString(string $text, array $params = [])
+    public static function formatString(string $text, array $params = [])
     {
         if (empty($params)) return $text;
-        
+
         return strtr($text, array_reduce(array_keys($params), function ($carry, $key) use ($params) {
             $placeholder = stripos($key, '$s') !== false ? $key : '{'.$key.'}';
             $carry[$placeholder] = $params[$key]; // apply quote to the keys for replacement
@@ -235,7 +235,7 @@ class Locale implements LocaleInterface
     }
 
     /**
-     * Change the auth message when not logged in. Apply this as a string replacement 
+     * Change the auth message when not logged in. Apply this as a string replacement
      * rather than changing every instance of the string in the codebase.
      *
      * @param string  $text Raw string to apply the string replacement logics


### PR DESCRIPTION
**Description**
* If a global $gibbon->locale does not exists, the function __ can fallback on Locale::formatString. Prevent unit test using __ to rely on specific global $gibbon setup.

**Motivation and Context**
* Prevent error if the global variable is not setup properly.

**How Has This Been Tested?**
* Locally.
* CI environment.