### PR TITLE
System: fix phpdocs for ModuleGateway

### DIFF
--- a/src/Domain/System/ModuleGateway.php
+++ b/src/Domain/System/ModuleGateway.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Domain\System;
 
+use Gibbon\Contracts\Database\Result;
 use Gibbon\Domain\Traits\TableAware;
 use Gibbon\Domain\QueryCriteria;
 use Gibbon\Domain\QueryableGateway;
@@ -137,7 +138,8 @@ class ModuleGateway extends QueryableGateway
      *
      * @param string $gibbonRoleID
      * @param string $gibbonModuleID
-     * @return array
+     *
+     * @return Result
      */
     public function selectModuleActionsByRole($gibbonRoleID, $gibbonModuleID)
     {


### PR DESCRIPTION
**Description**
* Fix `@return` of ModuleGateway::selectModuleActionsByRole.

**Motivation and Context**
* The method ModuleGateway::selectModuleActionsByRole was documented to have return array. It actually returns Gibbon\Contracts\Database\Result.
* Found out the issue from intelephense error message (attempt to call the Result::fetchGrouped method from, according to phpdocs, an array).

**How Has This Been Tested?**
* Locally with VSCode

**Screenshots**

### Before
![Screenshot from 2022-10-25 17-54-17](https://user-images.githubusercontent.com/91274/197744163-b0c57d7b-c15c-40de-a3da-2d8bd2a99e06.png)

### After
![Screenshot from 2022-10-25 18-00-13](https://user-images.githubusercontent.com/91274/197744374-56da3096-8433-44f9-9759-09fb5061b224.png)
