### PR TITLE
Services: replace emailBodyConvert calls with Format::emailBodyToPlain

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -47,7 +47,19 @@ function getIPAddress() {
     return $return;
 }
 
-//Convert an HTML email body into a plain text email body
+/**
+ * Convert an HTML email body into a plain text email body.
+ *
+ * Deprecated. Use \Gibbon\Services\Format::emailBodyToPlain() instead.
+ *
+ * @deprecated v25
+ * @version v12
+ * @since   v12
+ *
+ * @param string $body
+ *
+ * @return string
+ */
 function emailBodyConvert($body)
 {
     $return = $body;

--- a/modules/Staff/applicationForm_manage_accept.php
+++ b/modules/Staff/applicationForm_manage_accept.php
@@ -182,7 +182,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                         }
                         $body .= __('Job Type').': '.__($values['type'])."<br/>";
                         $body .= __('Job Title').': '.__($values['jobTitle'])."<br/>";
-                        $bodyPlain = emailBodyConvert($body);
+                        $bodyPlain = Format::emailBodyToPlain($body);
 
                         $mail = $container->get(Mailer::class);
                         $mail->SetFrom($session->get('organisationHREmail'), $session->get('organisationHRName'));
@@ -292,7 +292,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                                     } else {
                                         $body = 'Dear '.Format::name('', $informApplicantEntry['preferredName'], $informApplicantEntry['surname'], 'Student').",<br/><br/>Welcome to ".$session->get('systemName').', '.$session->get('organisationNameShort')."'s system for managing school information. You can access the system by going to ".$session->get('absoluteURL').' and logging in with your new username ('.$informApplicantEntry['username'].') and password ('.$informApplicantEntry['password'].").<br/><br/>In order to maintain the security of your data, we highly recommend you change your password to something easy to remember but hard to guess. This can be done by using the Preferences page after logging in (top-right of the screen).<br/><br/>Please feel free to reply to this email should you have any questions.<br/><br/>".$session->get('organisationHRName').",<br/><br/>".$session->get('systemName').' Administrator';
                                     }
-                                    $bodyPlain = emailBodyConvert($body);
+                                    $bodyPlain = Format::emailBodyToPlain($body);
 
                                     $mail = $container->get(Mailer::class);
                                     $mail->SetFrom($session->get('organisationHREmail'), $session->get('organisationHRName'));

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -1128,7 +1128,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 } else {
                                     $body = sprintf(__('Dear %1$s,<br/><br/>Welcome to %2$s, %3$s\'s system for managing school information. You can access the system by going to %4$s and logging in with your new username (%5$s) and password (%6$s). You can learn more about using %7$s on the official support website (https://docs.gibbonedu.org/parents).<br/><br/>In order to maintain the security of your data, we highly recommend you change your password to something easy to remember but hard to guess. This can be done by using the Preferences page after logging in (top-right of the screen).<br/><br/>'), Format::name('', $informParentsEntry['preferredName'], $informParentsEntry['surname'], 'Student'), $session->get('systemName'), $session->get('organisationNameShort'), $session->get('absoluteURL'), $informParentsEntry['username'], $informParentsEntry['password'], $session->get('systemName')).sprintf(__('Please feel free to reply to this email should you have any questions.<br/><br/>%1$s,<br/><br/>%2$s Admissions Administrator'), $session->get('organisationAdmissionsName'), $session->get('systemName'));
                                 }
-                                $bodyPlain = emailBodyConvert($body);
+                                $bodyPlain = Format::emailBodyToPlain($body);
 
                                 $mail = $container->get(Mailer::class);
                                 $mail->SetFrom($session->get('organisationAdmissionsEmail'), $session->get('organisationAdmissionsName'));

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -351,7 +351,7 @@ class Format
     public static function genderName($value, $translate = true)
     {
         if (empty($value)) return '';
-        
+
         $genderNames = [
             'F'           => __('Female'),
             'M'           => __('Male'),
@@ -777,7 +777,7 @@ class Format
         $icon .= stripos($icon, '.') === false ? '.png' : '';
         return "<img title='{$title}' src='./themes/".static::$settings['gibbonThemeName']."/img/{$icon}'/>";
     }
-    
+
     /**
      * Returns an HTML <img> based on the supplied photo path, using a placeholder image if none exists. Size may be either 75 or 240 at this time. Works using local images or linked images using HTTP(S)
      *
@@ -951,5 +951,25 @@ class Format
         return !empty($expectedFormat)
             ? DateTime::createFromFormat($expectedFormat, $dateOriginal, $timezone)
             : new DateTime($dateOriginal, $timezone);
+    }
+
+    /**
+     * Convert an HTML email body into a plain text email body.
+     *
+     * @param string $body  The supposed HTML email body.
+     *
+     * @return string  The sanitized plain text version of the body.
+     */
+    public static function emailBodyToPlain(string $body): string
+    {
+        $return = $body;
+
+        $return = preg_replace('#<br\s*/?>#i', "\n", $return);
+        $return = str_replace('</p>', "\n\n", $return);
+        $return = str_replace('</div>', "\n\n", $return);
+        $return = preg_replace("#\<a.+href\=[\"|\'](.+)[\"|\'].*\>.*\<\/a\>#U", '$1', $return);
+        $return = strip_tags($return, '<a>');
+
+        return $return;
     }
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
* Add Format::emailBodyConvert to replace emailBodyConvert() in
  functions.php.
* Mark emailBodyConvert() deprecated.
* Replace emailBodyConvert() calls with Format::emailBodyToPlain().

**Motivation and Context**
* Deprecated global functions in favour of class methods.

**How Has This Been Tested?**
* Locally.
* CI environment.