### PR TITLE
System: refactor birthday calculation logics and functions

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -237,7 +237,20 @@ function archiveNotification($connection2, $guid, $gibbonPersonID, $actionLink)
     return $return;
 }
 
-//Accepts birthday in mysql date (YYYY-MM-DD) ;
+/**
+ * Calculate the number of days before next birthday.
+ *
+ * Deprecated because it was only used in \Gibbon\Services\Format.
+ * Replaced by the private method \Gibbon\Services\Format::daysUntilNextBirthday().
+ *
+ * @deprecated v25
+ * @version v12
+ * @since   v12
+ *
+ * @param string $birthday  Accepts birthday in mysql date (YYYY-MM-DD).
+ *
+ * @return int  Number of days before the next birthday. If today is a birthday, returns 0.
+ */
 function daysUntilNextBirthday($birthday)
 {
     $today = date('Y-m-d');
@@ -268,7 +281,16 @@ function daysUntilNextBirthday($birthday)
     return $days;
 }
 
-//This function written by David Walsh, shared under MIT License (http://davidwalsh.name/checking-for-leap-year-using-php)
+/**
+ * This function written by David Walsh, shared under MIT License
+ * (http://davidwalsh.name/checking-for-leap-year-using-php)
+ *
+ * @deprecated v25
+ *
+ * @param int  $year  The year.
+ *
+ * @return bool
+ */
 function is_leap_year($year)
 {
     return (($year % 4) == 0) && ((($year % 100) != 0) || (($year % 400) == 0));

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -351,7 +351,7 @@ class Format
     public static function genderName($value, $translate = true)
     {
         if (empty($value)) return '';
-        
+
         $genderNames = [
             'F'           => __('Female'),
             'M'           => __('Male'),
@@ -777,7 +777,7 @@ class Format
         $icon .= stripos($icon, '.') === false ? '.png' : '';
         return "<img title='{$title}' src='./themes/".static::$settings['gibbonThemeName']."/img/{$icon}'/>";
     }
-    
+
     /**
      * Returns an HTML <img> based on the supplied photo path, using a placeholder image if none exists. Size may be either 75 or 240 at this time. Works using local images or linked images using HTTP(S)
      *
@@ -872,7 +872,7 @@ class Format
     public static function userBirthdayIcon($dob, $preferredName)
     {
         // HEY SHORTY IT'S YOUR BIRTHDAY!
-        $daysUntilNextBirthday = daysUntilNextBirthday($dob);
+        $daysUntilNextBirthday = static::daysUntilNextBirthday($dob);
 
         if (empty($dob) || $daysUntilNextBirthday >= 8) {
             return '';
@@ -892,6 +892,33 @@ class Format
         }
 
         return sprintf('<img class="absolute bottom-0 -ml-4" title="%1$s" src="%2$s">', $title, static::$settings['absoluteURL'].'/themes/'.static::$settings['gibbonThemeName'].'/img/'.$icon);
+    }
+
+    /**
+     * Calculate the number of days before next birthday.
+     *
+     * @version v25
+     * @since   v25
+     *
+     * @param string $birthday  Accepts birthday in mysql date (YYYY-MM-DD).
+     *
+     * @return int  Number of days before the next birthday. If today is a birthday, returns 0.
+     */
+    protected static function daysUntilNextBirthday(string $birthday): int
+    {
+        // DateTime of 00:00:00 today
+        $today = new \DateTime('today');
+
+        // DateTime of 00:00:00 on this year birthday's date.
+        $nextBirthday = \DateTime::createFromFormat('m-d H:i:s', substr($birthday, 5) . ' 00:00:00');
+
+        // If birthday this year has past, increment for a 1 year period.
+        if ($nextBirthday < $today) {
+            $nextBirthday->add(new \DateInterval('P1Y'));
+        }
+
+        // Return the absolute difference between 2 DateTime formatted as number of days.
+        return (int) $nextBirthday->diff($today, true)->format('%a');
     }
 
     public static function userStatusInfo($person = [])


### PR DESCRIPTION
**Description**
* Mark daysUntilNextBirthday and is_leap_year deprecated.
* A new Format::daysUntilNextBirthday protected method to replace daysUntilNextBirthday() in functions.php. The new method is re-implemented with PHP core's \DateTime.

**Motivation and Context**
* The function daysUntilNextBirthday() is only used by the Format class.
* The function is_leap_year() is only used by daysUntilNextBirthday().
* The logics are based on explicit leap year calculation, which is also done internally with PHP's own DateTime implementation.
* Functions that do not needed to be public should be kept as implementation details within a class.

**How Has This Been Tested?**
* Locally.