### PR TITLE
GitHub Actions: upgrade actions used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           ini-values: date.timezone="Etc/UTC", xdebug.max_nesting_level=-1, opcache.jit="off"
 
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: "recursive"
           fetch-depth: 0
@@ -64,7 +64,7 @@ jobs:
             >/dev/null 2>./tests/log/server_log &
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/composer-cache
           key: ${{ runner.os }}-php${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
@@ -145,7 +145,7 @@ jobs:
           mysqldump -u root --protocol=tcp --column-statistics=0 gibbon_test > ./tests/log/mysqldump.sql
 
       - name: Save Test Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() || matrix.experimental }}
         with:
           name: Test Artifacts (PHP ${{ matrix.php-version }})


### PR DESCRIPTION
**Description**
* Updating [actions/checkout](https://github.com/actions/checkout), [actions/cache](https://github.com/actions/cache) and [actions/upload-artifact](https://github.com/actions/upload-artifact) used in the CI configuration.

**Motivation and Context**
* Remove "save-state" warning messages in GitHub actions page.
* Fix node version warning in GitHub workflow process.

**How Has This Been Tested?**
* GitHub.

**Screenshots**
![Screenshot from 2022-10-26 18-46-10](https://user-images.githubusercontent.com/91274/198007046-9187fac1-bf64-4adb-aa2e-5b996ccb37d4.png)

