### PR TITLE
System: move school year session setup to SessionFactory

### DIFF
--- a/cli/attendance_dailyIncompleteEmail.php
+++ b/cli/attendance_dailyIncompleteEmail.php
@@ -21,27 +21,9 @@ use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 
 require getcwd().'/../gibbon.php';
-
-getSystemSettings($guid, $connection2);
-
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-//Set up for i18n via gettext
-if (!empty($session->get('i18n')['code'])) {
-    putenv('LC_ALL='.$session->get('i18n')['code']);
-    setlocale(LC_ALL, $session->get('i18n')['code']);
-    bindtextdomain('gibbon', getcwd().'/../i18n');
-    textdomain('gibbon');
-}
 
 $settingGateway = $container->get(SettingGateway::class);
 

--- a/cli/attendance_dailyIncompleteEmail_byClass.php
+++ b/cli/attendance_dailyIncompleteEmail_byClass.php
@@ -21,28 +21,10 @@ use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\School\SchoolYearSpecialDayGateway;
 use Gibbon\Domain\System\NotificationGateway;
 
 require getcwd().'/../gibbon.php';
-
-getSystemSettings($guid, $connection2);
-
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-//Set up for i18n via gettext
-if (!empty($session->get('i18n')['code'])) {
-    putenv('LC_ALL='.$session->get('i18n')['code']);
-    setlocale(LC_ALL, $session->get('i18n')['code']);
-    bindtextdomain('gibbon', getcwd().'/../i18n');
-    textdomain('gibbon');
-}
 
 $settingGateway = $container->get(SettingGateway::class);
 

--- a/cli/attendance_weeklySummaryEmail.php
+++ b/cli/attendance_weeklySummaryEmail.php
@@ -19,20 +19,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Module\Attendance\AttendanceView;
 use Gibbon\Services\Format;
 
 require getcwd().'/../gibbon.php';
-
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
 
 //Check for CLI, so this cannot be run through browser
 $settingGateway = $container->get(SettingGateway::class);
@@ -41,11 +33,6 @@ $remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;
 if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $remoteCLIKeyInput))) {
     echo __('This script cannot be run from a browser, only via CLI.');
 } else {
-    try {
-        $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-    } catch (\Exception $e) {
-        die($e->getMessage());
-    }
 
     require_once __DIR__ . '/../modules/Attendance/moduleFunctions.php';
     require_once __DIR__ . '/../modules/Attendance/src/AttendanceView.php';

--- a/cli/behaviour_dailySummaryEmail.php
+++ b/cli/behaviour_dailySummaryEmail.php
@@ -18,27 +18,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 
 require getcwd().'/../gibbon.php';
-
-getSystemSettings($guid, $connection2);
-
-try {
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-//Set up for i18n via gettext
-if (!empty($session->get('i18n')['code'])) {
-    putenv('LC_ALL='.$session->get('i18n')['code']);
-    setlocale(LC_ALL, $session->get('i18n')['code']);
-    bindtextdomain('gibbon', getcwd().'/../i18n');
-    textdomain('gibbon');
-}
 
 //Check for CLI, so this cannot be run through browser
 $remoteCLIKey = $container->get(SettingGateway::class)->getSettingByScope('System Admin', 'remoteCLIKey');

--- a/cli/behaviour_lettersNegative.php
+++ b/cli/behaviour_lettersNegative.php
@@ -24,29 +24,11 @@ use Gibbon\Comms\EmailTemplate;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
 use Gibbon\Domain\Behaviour\BehaviourLetterGateway;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\System\EmailTemplateGateway;
 use Gibbon\Domain\User\UserGateway;
 
 require getcwd().'/../gibbon.php';
-
-getSystemSettings($guid, $connection2);
-
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-//Set up for i18n via gettext
-if (!empty($session->get('i18n')['code'])) {
-    putenv('LC_ALL='.$session->get('i18n')['code']);
-    setlocale(LC_ALL, $session->get('i18n')['code']);
-    bindtextdomain('gibbon', getcwd().'/../i18n');
-    textdomain('gibbon');
-}
 
 //Check for CLI, so this cannot be run through browser
 $remoteCLIKey = $settingGateway->getSettingByScope('System Admin', 'remoteCLIKey');

--- a/cli/behaviour_lettersPositive.php
+++ b/cli/behaviour_lettersPositive.php
@@ -23,7 +23,6 @@ use Gibbon\Comms\EmailTemplate;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
 use Gibbon\Domain\Behaviour\BehaviourLetterGateway;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\System\EmailTemplateGateway;
 use Gibbon\Domain\User\UserGateway;
@@ -35,23 +34,6 @@ require getcwd().'/../gibbon.php';
 ini_set('max_execution_time', 7200);
 ini_set('memory_limit','1024M');
 set_time_limit(1200);
-
-getSystemSettings($guid, $connection2);
-
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-//Set up for i18n via gettext
-if (!empty($session->get('i18n')['code'])) {
-    putenv('LC_ALL='.$session->get('i18n')['code']);
-    setlocale(LC_ALL, $session->get('i18n')['code']);
-    bindtextdomain('gibbon', getcwd().'/../i18n');
-    textdomain('gibbon');
-}
 
 //Check for CLI, so this cannot be run through browser
 if (!isCommandLineInterface()) { echo __('This script cannot be run from a browser, only via CLI.');

--- a/cli/library_overdueNotification.php
+++ b/cli/library_overdueNotification.php
@@ -19,27 +19,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\System\SettingGateway;
 
 require getcwd().'/../gibbon.php';
-
-getSystemSettings($guid, $connection2);
-
-try {
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-//Set up for i18n via gettext
-if (!empty($session->get('i18n')['code'])) {
-    putenv('LC_ALL='.$session->get('i18n')['code']);
-    setlocale(LC_ALL, $session->get('i18n')['code']);
-    bindtextdomain('gibbon', getcwd().'/../i18n');
-    textdomain('gibbon');
-}
 
 //Check for CLI, so this cannot be run through browser
 $remoteCLIKey = $container->get(SettingGateway::class)->getSettingByScope('System Admin', 'remoteCLIKey');

--- a/cli/schoolAdmin_parentDailyEmailSummary.php
+++ b/cli/schoolAdmin_parentDailyEmailSummary.php
@@ -17,28 +17,17 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\System\SettingGateway;
 use Gibbon\View\View;
 use Gibbon\Services\Format;
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Domain\User\FamilyGateway;
+use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Domain\Attendance\AttendanceLogPersonGateway;
-use Gibbon\Domain\School\SchoolYearGateway;
 
 $_POST['address'] = '/modules/School Admin/emailSummarySettings.php';
 
 require __DIR__.'/../gibbon.php';
-
-// Setup some of the globals
-getSystemSettings($guid, $connection2);
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-    Format::setupFromSession($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
 
 //Check for CLI, so this cannot be run through browser
 $settingGateway = $container->get(SettingGateway::class);

--- a/cli/schoolAdmin_parentWeeklyEmailSummary.php
+++ b/cli/schoolAdmin_parentWeeklyEmailSummary.php
@@ -32,16 +32,6 @@ $_POST['address'] = '/modules/School Admin/emailSummarySettings.php';
 
 require __DIR__.'/../gibbon.php';
 
-// Setup some of the globals
-getSystemSettings($guid, $connection2);
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-    Format::setupFromSession($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
 $settingGateway = $container->get(SettingGateway::class);
 
 //Check for CLI, so this cannot be run through browser

--- a/cli/schoolAdmin_tutorDailyEmailSummary.php
+++ b/cli/schoolAdmin_tutorDailyEmailSummary.php
@@ -33,16 +33,6 @@ $_POST['address'] = '/modules/School Admin/emailSummarySettings.php';
 
 require __DIR__.'/../gibbon.php';
 
-// Setup some of the globals
-getSystemSettings($guid, $connection2);
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-    Format::setupFromSession($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
 //Check for CLI, so this cannot be run through browser
 $remoteCLIKey = $container->get(SettingGateway::class)->getSettingByScope('System Admin', 'remoteCLIKey');
 $remoteCLIKeyInput = $_GET['remoteCLIKey'] ?? null;

--- a/cli/system_backgroundProcess.php
+++ b/cli/system_backgroundProcess.php
@@ -17,9 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\School\SchoolYearGateway;
-use Gibbon\Services\BackgroundProcessor;
 use Gibbon\Services\Format;
+use Gibbon\Services\BackgroundProcessor;
+use Gibbon\Session\SessionFactory;
+use Gibbon\Domain\School\SchoolYearGateway;
 
 $_POST['address'] = '/modules/'.($argv[3] ?? 'System Admin').'/index.php';
 
@@ -28,16 +29,6 @@ require __DIR__.'/../gibbon.php';
 // Cancel out now if we're not running via CLI
 if (!isCommandLineInterface()) {
     die(__('This script cannot be run from a browser, only via CLI.'));
-}
-
-// Setup some of the globals
-getSystemSettings($guid, $connection2);
-try {
-    $session = $container->get('session');
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-    Format::setupFromSession($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
 }
 
 // Override the ini to keep this process alive

--- a/cli/userAdmin_statusCheckAndFix.php
+++ b/cli/userAdmin_statusCheckAndFix.php
@@ -18,28 +18,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Comms\NotificationEvent;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Domain\User\UserGateway;
 use Gibbon\Domain\User\UserStatusLogGateway;
 
 require getcwd().'/../gibbon.php';
-
-getSystemSettings($guid, $connection2);
-
-try {
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-//Set up for i18n via gettext
-if (!empty($session->get('i18n')['code'])) {
-    putenv('LC_ALL='.$session->get('i18n')['code']);
-    setlocale(LC_ALL, $session->get('i18n')['code']);
-    bindtextdomain('gibbon', getcwd().'/../i18n');
-    textdomain('gibbon');
-}
 
 //Check for CLI, so this cannot be run through browser
 $remoteCLIKey = $container->get(SettingGateway::class)->getSettingByScope('System Admin', 'remoteCLIKey');

--- a/functions.php
+++ b/functions.php
@@ -1313,7 +1313,9 @@ function getModuleCategory($address, $connection2)
  * (i.e. global $session instance)
  *
  * @deprecated v25
- *             Use SchoolYearGateway::setCurrentSchoolYear instead.
+ *             This happens in SessionFactory::setCurrentSchoolYear instead,
+ *             which is called by Core::initializeCore, so shouldn't need to 
+ *             be called manually.
  *
  * @version v23
  * @since   v12

--- a/gibbon.php
+++ b/gibbon.php
@@ -89,7 +89,14 @@ if ($gibbon->isInstalled()) {
         }
 
         // Initialize core
-        $gibbon->initializeCore($container);
+        try {
+            $gibbon->initializeCore($container);
+        } catch (\Exception $e) {
+            $message = __('Configuration Error: there is a problem accessing the current Academic Year from the database.');
+            include __DIR__.'/error.php';
+            exit;
+        }
+        
     } else {
         if (!$gibbon->isInstalling()) {
             $message = sprintf(__('A database connection could not be established. Please %1$stry again%2$s.'), '', '');

--- a/login.php
+++ b/login.php
@@ -28,28 +28,14 @@ use Gibbon\Auth\Adapter\OAuthAdapterInterface;
 use Gibbon\Auth\Adapter\OAuthGoogleAdapter;
 use Gibbon\Auth\Adapter\OAuthMicrosoftAdapter;
 use Gibbon\Auth\Adapter\OAuthGenericAdapter;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\LogGateway;
 use League\Container\Exception\NotFoundException;
 
 // Gibbon system-wide include
 require_once './gibbon.php';
 
-try {
-    $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-} catch (\Exception $e) {
-    die($e->getMessage());
-}
-
-// The current/actual school year info, just in case we are working in a different year
-$session->set('gibbonSchoolYearIDCurrent', $session->get('gibbonSchoolYearID'));
-$session->set('gibbonSchoolYearNameCurrent', $session->get('gibbonSchoolYearName'));
-$session->set('gibbonSchoolYearSequenceNumberCurrent', $session->get('gibbonSchoolYearSequenceNumber'));
-
 $session->forget('pageLoads');
 $URL = Url::fromRoute();
-
-
 
 // Sanitize the whole $_POST array
 $_POST = $container->get(Validator::class)->sanitize($_POST);

--- a/preferencesPasswordProcess.php
+++ b/preferencesPasswordProcess.php
@@ -17,20 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Http\Url;
 use Gibbon\Domain\User\UserGateway;
 
 include './gibbon.php';
-
-//Check to see if academic year id variables are set, if not set them
-if ($session->exists('gibbonAcademicYearID') == false or $session->exists('gibbonSchoolYearName') == false) {
-    try {
-        $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-    } catch (\Exception $e) {
-        die($e->getMessage());
-    }
-}
 
 //Check password address is not blank
 $password = $_POST['password'] ?? '';

--- a/preferencesProcess.php
+++ b/preferencesProcess.php
@@ -18,19 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Data\Validator;
-use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Http\Url;
 
 include './gibbon.php';
-
-//Check to see if academic year id variables are set, if not set them
-if ($session->exists('gibbonAcademicYearID') == false or $session->exists('gibbonSchoolYearName') == false) {
-    try {
-        $container->get(SchoolYearGateway::class)->setCurrentSchoolYear($session);
-    } catch (\Exception $e) {
-        die($e->getMessage());
-    }
-}
 
 // Sanitize the whole $_POST array
 $validator = $container->get(Validator::class);

--- a/src/Domain/School/SchoolYearGateway.php
+++ b/src/Domain/School/SchoolYearGateway.php
@@ -155,33 +155,15 @@ class SchoolYearGateway extends QueryableGateway
     }
 
     /**
-     * Set the current school year information on session.
+     * Get the current school year information.
      *
      * @version v25
      * @since   v25
-     *
-     * @param Session $session  The session instance to set.
-     *
-     * @return $this
-     *
-     * @throws \Exception  If cannot find current school year row.
+
+     * @return array
      */
-    public function setCurrentSchoolYear(Session $session)
+    public function getCurrentSchoolYear()
     {
-        $result = $this->db()->select("SELECT * FROM gibbonSchoolYear WHERE status='Current'");
-
-        // If the result set is empty, throw exception.
-        if ($result->isEmpty()) {
-            throw new \Exception(__('Configuration Error: there is a problem accessing the current Academic Year from the database.'));
-        }
-
-        $row = $result->fetch();
-        $session->set('gibbonSchoolYearID', $row['gibbonSchoolYearID']);
-        $session->set('gibbonSchoolYearName', $row['name']);
-        $session->set('gibbonSchoolYearSequenceNumber', $row['sequenceNumber']);
-        $session->set('gibbonSchoolYearFirstDay',$row['firstDay']);
-        $session->set('gibbonSchoolYearLastDay', $row['lastDay']);
-
-        return $this;
+        return $this->db()->selectOne("SELECT * FROM gibbonSchoolYear WHERE status='Current'");
     }
 }

--- a/src/Gibbon/Core.php
+++ b/src/Gibbon/Core.php
@@ -21,9 +21,10 @@ namespace Gibbon;
 
 use Gibbon\Services\Format;
 use Gibbon\Session\SessionFactory;
-use Psr\Container\ContainerInterface;
 use Gibbon\Contracts\Services\Session;
+use Gibbon\Domain\School\SchoolYearGateway;
 use Gibbon\Domain\System\SessionGateway;
+use Psr\Container\ContainerInterface;
 
 /**
  * Gibbon Core
@@ -85,11 +86,15 @@ class Core
         $db = $container->get('db');
         $this->session = $container->get('session');
         
-        Format::setupFromSession($this->session);
-
         if (empty($this->session->get('systemSettingsSet'))) {
             SessionFactory::populateSettings($this->session, $db);
         }
+
+        if (empty($this->session->get('gibbonSchoolYearID'))) {
+            SessionFactory::setCurrentSchoolYear($this->session, $container->get(SchoolYearGateway::class)->getCurrentSchoolYear());
+        }
+
+        Format::setupFromSession($this->session);
 
         $installType = $this->session->get('installType');
         if (empty($installType) || $installType == 'Production') {

--- a/src/Session/SessionFactory.php
+++ b/src/Session/SessionFactory.php
@@ -20,14 +20,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 namespace Gibbon\Session;
 
 use SessionHandler;
-use Gibbon\Services\Format;
 use Gibbon\Session\Session;
-use Psr\Container\ContainerInterface;
 use Gibbon\Domain\System\SessionGateway;
 use Gibbon\Session\NativeSessionHandler;
-use Gibbon\Contracts\Database\Connection;
 use Gibbon\Session\DatabaseSessionHandler;
+use Gibbon\Contracts\Database\Connection;
 use Gibbon\Contracts\Services\Session as SessionInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * SessionFactory Class
@@ -124,6 +123,25 @@ class SessionFactory
 
         while ($row = $result->fetch()) {
             $session->set('i18n', $row);
+        }
+    }
+
+    public static function setCurrentSchoolYear(Session $session, array $schoolYear)
+    {
+        if (empty($schoolYear['gibbonSchoolYearID']) || empty($schoolYear['name'])) {
+            throw new \Exception();
+        }
+
+        $session->set('gibbonSchoolYearID', $schoolYear['gibbonSchoolYearID']);
+        $session->set('gibbonSchoolYearName', $schoolYear['name']);
+        $session->set('gibbonSchoolYearSequenceNumber', $schoolYear['sequenceNumber']);
+        $session->set('gibbonSchoolYearFirstDay',$schoolYear['firstDay']);
+        $session->set('gibbonSchoolYearLastDay', $schoolYear['lastDay']);
+
+        if (!$session->exists('gibbonSchoolYearIDCurrent')) {
+            $session->set('gibbonSchoolYearIDCurrent', $schoolYear['gibbonSchoolYearID']);
+            $session->set('gibbonSchoolYearNameCurrent', $schoolYear['name']);
+            $session->set('gibbonSchoolYearSequenceNumberCurrent', $schoolYear['sequenceNumber']);
         }
     }
 }

--- a/src/UI/Components/Sidebar.php
+++ b/src/UI/Components/Sidebar.php
@@ -198,13 +198,6 @@ class Sidebar implements OutputableInterface, ContainerAwareInterface
                     echo __('Login');
                 echo '</h2>';
 
-                if (!$this->session->has('gibbonSchoolYearID')) {
-                    try {
-                        $this->schoolYearGateway->setCurrentSchoolYear($this->session);
-                    } catch (\Exception $e) {
-                        die($e->getMessage());
-                    }
-                }
                 unset($_GET['return']);
 
                 $enablePublicRegistration = $this->settingGateway->getSettingByScope('User Admin', 'enablePublicRegistration');


### PR DESCRIPTION
After merging #1669 I got looking at the code and there appeared to be some school year setup code that ended up scattered throughout CLI scripts and other locations, rather than in one initialization step.

@yookoala I've moved the setCurrentSchoolYear method out of the SchoolYearGateway into the SessionFactory, as this prevents the Gateway class from needing session dependencies, and puts more of the session initialization code in the SessionFactory, which is then called during the Gibbon initializeCore method. This enabled using a single try-catch for exception handling, instead of needing several throughout the system.

This also has fixed an esoteric bug where the current school year wasn't available directly after logging out unless setCurrentSchoolYear was called manually, so I've been able to remove the code from the sidebar.

**Motivation and Context**
Enabled us to delete even more old code and centralize the session initialization.

**How Has This Been Tested?**
Locally.