### PR TITLE
System Admin / Authentication: LDAP Implementation

### DIFF
--- a/login.php
+++ b/login.php
@@ -28,6 +28,7 @@ use Gibbon\Auth\Adapter\OAuthAdapterInterface;
 use Gibbon\Auth\Adapter\OAuthGoogleAdapter;
 use Gibbon\Auth\Adapter\OAuthMicrosoftAdapter;
 use Gibbon\Auth\Adapter\OAuthGenericAdapter;
+use Gibbon\Auth\Adapter\LDAPAdapter;
 use Gibbon\Domain\System\LogGateway;
 use League\Container\Exception\NotFoundException;
 
@@ -73,6 +74,9 @@ try {
         case 'mfa':
             $authAdapter = $container->get(MFAAdapter::class);
             break;
+        case 'ldap':
+            $authAdapter = $container->get(LDAPAdapter::class);
+            break;
         default:
             $authAdapter = $container->get(DefaultAdapter::class);
     }
@@ -104,6 +108,7 @@ if (empty($authFactory) || empty($auth) || empty($authAdapter)) {
 // Handle login
 try {
     $loginService = $authFactory->newLoginService($authAdapter);
+    
     $loginService->login($auth, [
         'username' => $_POST['username'] ?? '',
         'password' => $_POST['password'] ?? '',
@@ -178,6 +183,9 @@ try {
     exit;
 } catch (Exception\MFATokenInvalid $e) {
     header("Location: {$URL->withQueryParam('loginReturn', 'fail11')}");
+    exit;
+} catch (Exception\LDAPBindFailed $e) {
+    header("Location: {$URL->withQueryParam('loginReturn', 'fail12')}");
     exit;
 } catch (Exception\MFATokenRequired $e) {
     header("Location: {$URL->withQueryParam('method', 'mfa')}");

--- a/modules/System Admin/thirdPartySettings.php
+++ b/modules/System Admin/thirdPartySettings.php
@@ -60,6 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $settingGateway = $container->get(SettingGateway::class);
     $ssoGoogle = json_decode($settingGateway->getSettingByScope('System Admin', 'ssoGoogle'), true);
     $ssoMicrosoft = json_decode($settingGateway->getSettingByScope('System Admin', 'ssoMicrosoft'), true);
+    $ssoLDAP = json_decode($settingGateway->getSettingByScope('System Admin', 'ssoLDAP'), true);
     $ssoOther = json_decode($settingGateway->getSettingByScope('System Admin', 'ssoOther'), true);
 
     $ssoList = [
@@ -76,6 +77,13 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
             'service' => __('Microsoft Azure Portal'),
             'url' => 'https://portal.azure.com',
             'enabled' => $ssoMicrosoft['enabled'] ?? 'N',
+        ],
+        [
+            'sso' => 'LDAP',
+            'name' => __('LDAP'),
+            'service' => __('Generic LDAP Connections'),
+            'url' => '',
+            'enabled' => $ssoLDAP['enabled'] ?? 'N',
         ],
         [
             'sso' => 'Other',

--- a/modules/System Admin/thirdPartySettings_ssoEdit.php
+++ b/modules/System Admin/thirdPartySettings_ssoEdit.php
@@ -96,6 +96,22 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
             $row->addLabel('enabled', __('API Enabled'))->description(__('Enable Gibbon-wide integration with the Microsoft APIs?'));
             $row->addYesNo('enabled')->required();
 
+    } else if ($sso == 'LDAP') {
+        // LDAP
+        $form->addRow()->addHeading('LDAP Integration', __('LDAP Integration'))->append(sprintf(__('todo: this')));
+
+        $row = $form->addRow();
+            $row->addLabel('enabled', __('API Enabled'))->description(__('Enable Gibbon-wide login integration with LDAP?'));
+            $row->addYesNo('enabled')->required();
+            
+        $row = $form->addRow()->addClass('settingActive');
+            $row->addLabel('ldapServer', __('LDAP Server'));
+            $row->addTextField('ldapServer')->required();
+
+        $row = $form->addRow()->addClass('settingActive');
+            $row->addLabel('ldapDN', __('LDAP Distinguished Name (DN)'));
+            $row->addTextField('ldapDN')->required();
+
     } else if ($sso == 'Other') {
         $form->addRow()->addHeading('Generic OAuth2 Provider', __('Generic OAuth2 Provider'))->append(__('This setting offers a generic implementation of industry-standard OAuth2 protocols. It uses standard Client ID and Client Secret parameters to connect to an OAuth2 API server. You will need to specify the API endpoints of your chosen service, which can often be found in that service\'s documentation. If your OAuth2 service requires specific API parameters, this feature is unlikely to work.'));
 

--- a/modules/System Admin/thirdPartySettings_ssoEditProcess.php
+++ b/modules/System Admin/thirdPartySettings_ssoEditProcess.php
@@ -53,11 +53,13 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
         'authorizeEndpoint' => $_POST['authorizeEndpoint'] ?? '',
         'tokenEndpoint'     => $_POST['tokenEndpoint'] ?? '',
         'userEndpoint'      => $_POST['userEndpoint'] ?? '',
+        'ldapServer'     => $_POST['ldapServer'] ?? '',
+        'ldapDN'      => $_POST['ldapDN'] ?? ''
     ];
 
     $calendarFeed = $_POST['calendarFeed'] ?? '';
 
-    if ($data['enabled'] == 'Y' && (empty($data['clientID']) || empty($data['clientSecret']))) {
+    if ($data['enabled'] == 'Y' && ((empty($data['clientID']) || empty($data['clientSecret'])) && ((empty($data['ldapServer']) || empty($data['ldapDN']))))) {
         $URL .= '&return=error1';
         header("Location: {$URL}");
         exit;

--- a/src/Auth/Adapter/LDAPAdapter.php
+++ b/src/Auth/Adapter/LDAPAdapter.php
@@ -1,0 +1,94 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Auth\Adapter;
+
+use Gibbon\Http\Url;
+use Gibbon\Auth\Exception;
+use Gibbon\Auth\Adapter\AuthenticationAdapter;
+use Gibbon\Contracts\Services\Session;
+use Aura\Auth\Exception as AuraException;
+use Gibbon\Domain\User\UserGateway;
+use Aura\Auth\AuthFactory;
+
+/**
+ * Generic OAuth2 adapter for Aura/Auth 
+ *
+ * @version  v23
+ * @since    v23
+ */
+class LDAPAdapter extends AuthenticationAdapter
+{
+    /**
+     * Constructor
+     *
+     * 
+     */
+    public function __construct()
+    {
+       
+    }
+    
+    /**
+     * Verifies a set of credentials against the database. Exceptions are thrown
+     * if any credentials are not valid.
+     *
+     * @param array $input Credential input.
+     *
+     * @return array An array of login data on success.
+     * 
+     * 
+     * 
+     *
+     */
+    public function login(array $input)
+    {
+        $this->userGateway = $this->getContainer()->get(UserGateway::class);
+
+        // Validate that the username and password are both present
+        
+        $authFactory = $this->getAuthFactory();
+        $auth = $authFactory->newInstance();
+        $ldapAdapter = $authFactory->newLdapAdapter(
+            'ip address', //TODO: GET THESE FROM SETTINGS
+            '%s@'.'bind domain', //TODO: GET THESE FROM SETTINGS
+            [LDAP_OPT_PROTOCOL_VERSION => 3]
+        );
+        $loginService = $authFactory->newLoginService($ldapAdapter);
+        try {
+        $loginService->login($auth, array(
+            'username' => $input['username'],
+            'password' => $input['password']
+        ));
+        } catch (AuraException\BindFailed $e) {
+            throw new Exception\LDAPBindFailed;
+        }
+        
+        // Get basic user data needed to verify login access
+        $userData = $this->getUserData($input);
+        return parent::verifyLogin($userData);
+    }
+
+
+
+    private function getAuthFactory()
+    {
+        return $this->getContainer()->get(AuthFactory::class);
+    }
+}

--- a/src/Auth/Adapter/LDAPAdapter.php
+++ b/src/Auth/Adapter/LDAPAdapter.php
@@ -46,7 +46,7 @@ class LDAPAdapter extends AuthenticationAdapter
     }
     
     /**
-     * Verifies a set of credentials against the database. Exceptions are thrown
+     * Attempts to connect to the LDAP server using the provided credentials. Exceptions are thrown
      * if any credentials are not valid.
      *
      * @param array $input Credential input.
@@ -72,10 +72,10 @@ class LDAPAdapter extends AuthenticationAdapter
         );
         $loginService = $authFactory->newLoginService($ldapAdapter);
         try {
-        $loginService->login($auth, array(
-            'username' => $input['username'],
-            'password' => $input['password']
-        ));
+            $loginService->login($auth, array(
+                'username' => $input['username'],
+                'password' => $input['password']
+            ));
         } catch (AuraException\BindFailed $e) {
             throw new Exception\LDAPBindFailed;
         }

--- a/src/Auth/Exception/LDAPBindFailed.php
+++ b/src/Auth/Exception/LDAPBindFailed.php
@@ -1,0 +1,24 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Auth\Exception;
+
+use Exception;
+
+class LDAPBindFailed extends Exception {}


### PR DESCRIPTION
This is an almost complete LDAP implementation using the Aura Auth library that is already used in Gibbon for other forms of authentication.

Still TODO for this PR:
 - Use LDAP domain and bind details from system admin configuration (rather than the current method that uses hardcoded details (that have been redacted))
 - Make it possible to set the LDAP login as the default for login attempts from the normal login form, potentially allowing it to be controlled on a role/individual user basis rather than just a blanket setting across all users. 
 - Better exception catching

TODO in future PRs:
- Enable creation of accounts upon new user LDAP credentials, mapping different fields to each other and probably basing roles off of OUs

Initially made this for use at my old workplace to facilitate easy login to Gibbon, as users were used to only ever needing to use their AD credentials that were linked to most other systems used in the school. Still some configuration that needs working on before merging but wanted to make sure this project doesn't just get lost in my piles of files.
