### PR TITLE
Timetable: add an Edit Timetable by Class tool to Manage Timetables

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -700,4 +700,5 @@ UPDATE `gibbonMessengerReceipt` SET sent='Y';end
 UPDATE `gibbonAction` SET URLList='messenger_manage.php,messenger_manage_delete.php,messenger_manage_edit.php,messenger_manage_report.php,messenger_send.php' WHERE name LIKE 'Manage Messages_%' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Messenger');end
 ALTER TABLE gibbonMarkbookColumn MODIFY name VARCHAR(40);end
 ALTER TABLE `gibbonTTSpaceBooking` ADD `reason` VARCHAR(255) NOT NULL AFTER `timeEnd`;end
+UPDATE `gibbonAction` SET `URLList` = 'tt.php, tt_add.php, tt_edit.php, tt_delete.php, tt_import.php, tt_edit_day_add.php, tt_edit_day_edit.php, tt_edit_day_delete.php, tt_edit_day_edit_class.php, tt_edit_day_edit_class_delete.php, tt_edit_day_edit_class_add.php, tt_edit_day_edit_class_edit.php, tt_edit_day_edit_class_exception.php, tt_edit_day_edit_class_exception_add.php, tt_edit_day_edit_class_exception_delete.php,tt_edit_byClass.php' WHERE name='Manage Timetables' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Timetable Admin');end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ v25.0.00
         Timetable: enabled View Available Facilities for non-lesson periods
         Timetable: enabled booking facilities for other users with Manage Facility Bookings_allBookings permission
         Timetable: added an option to add a reason when booking facilities
+        Timetable: added an Edit Timetable by Class tool to Manage Timetables
         User Admin: added last login timestamp and IP address to password troubleshooting page
         User Admin: added the ability to search users by first name
 

--- a/modules/Timetable Admin/tt_edit.php
+++ b/modules/Timetable Admin/tt_edit.php
@@ -129,6 +129,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit.ph
 
             $table->addMetaData('bulkActions', $col);
 
+            $table->addHeaderAction('edit', __('Edit Timetable by Class'))
+                ->setURL('/modules/Timetable Admin/tt_edit_byClass.php')
+                ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)
+                ->addParam('gibbonTTID', $gibbonTTID)
+                ->displayLabel()
+                ->append('&nbsp;&nbsp;|&nbsp;&nbsp;');
+
             $table->addHeaderAction('add', __('Add'))
                 ->setURL('/modules/Timetable Admin/tt_edit_day_add.php')
                 ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)

--- a/modules/Timetable Admin/tt_edit_byClass.php
+++ b/modules/Timetable Admin/tt_edit_byClass.php
@@ -1,0 +1,151 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Services\Format;
+use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Domain\Timetable\TimetableGateway;
+use Gibbon\Domain\Timetable\TimetableDayGateway;
+use Gibbon\Domain\Timetable\TimetableColumnGateway;
+
+if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_byClass.php') == false) {
+    //Acess denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+	$settingGateway = $container->get(SettingGateway::class);
+    $timetableGateway = $container->get(TimetableGateway::class);
+    $timetableDayGateway = $container->get(TimetableDayGateway::class);
+    $timetableColumnGateway = $container->get(TimetableColumnGateway::class);
+
+    $gibbonCourseClassID = $_REQUEST['gibbonCourseClassID'] ?? '';
+    $gibbonTTID = $_REQUEST['gibbonTTID'] ?? '';
+
+    $timetable = $timetableGateway->getByID($gibbonTTID);
+    if (empty($timetable)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+    $page->breadcrumbs
+        ->add(__('Manage Timetables'), 'tt.php', ['gibbonSchoolYearID' => $timetable['gibbonSchoolYearID']])
+        ->add(__('Edit Timetable'), 'tt_edit.php', ['gibbonSchoolYearID' => $timetable['gibbonSchoolYearID'], 'gibbonTTID' => $gibbonTTID])
+        ->add(__('Edit Timetable by Class'));
+    
+    // SELECT TIMETABLE & CLASS
+    $form = Form::create('timetableByClass', $session->get('absoluteURL').'/index.php', 'get');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+
+    $form->addHiddenValue('q', '/modules/Timetable Admin/tt_edit_byClass.php');
+    $form->addHiddenValue('gibbonSchoolYearID', $timetable['gibbonSchoolYearID']);
+    $form->addHiddenValue('gibbonTTID', $gibbonTTID);
+
+    $row = $form->addRow();
+        $row->addLabel('gibbonCourseClassID', __('Class'));
+        $row->addSelectClass('gibbonCourseClassID', $timetable['gibbonSchoolYearID'])
+            ->required()
+            ->placeholder()
+            ->selected($gibbonCourseClassID);
+
+    $row = $form->addRow();
+        $row->addSubmit('Next');
+
+    echo $form->getOutput();
+
+    if (!empty($gibbonCourseClassID)) {
+        $form = Form::create('ttAdd', $session->get('absoluteURL').'/modules/Timetable Admin/tt_edit_byClassProcess.php');
+        $form->setFactory(DatabaseFormFactory::create($pdo));
+
+        $form->addHiddenValue('gibbonSchoolYearID', $timetable['gibbonSchoolYearID']);
+        $form->addHiddenValue('gibbonTTID', $gibbonTTID);
+        $form->addHiddenValue('gibbonCourseClassID', $gibbonCourseClassID);
+
+        $form->addHiddenValue('address', $session->get('address'));
+
+        $dayResults = $timetableDayGateway->selectTTDaysByTimetable($gibbonTTID);
+        $columnResults = $timetableColumnGateway->selectTTColumnsByTimetable($gibbonTTID);
+
+        $columnRows = ($columnResults->rowCount() > 0)? $columnResults->fetchAll() : array();
+        $columnRowsChained = array_combine(array_column($columnRows, 'value'), array_column($columnRows, 'gibbonTTDayID'));
+        $columnRowsOptions = array_combine(array_column($columnRows, 'value'), array_column($columnRows, 'name'));
+
+        $gibbonTTDayID = $_GET['gibbonTTDayID'] ?? '';
+        $gibbonTTColumnRowID = $_GET['gibbonTTColumnRowID'] ?? '';
+        $gibbonTTSpaceID = $_GET['gibbonTTSpaceID'] ?? '';
+
+        $ttBlock = $form->getFactory()->createTable()->setClass('blank');
+            $row = $ttBlock->addRow();
+                $row->addLabel('gibbonTTDayID', __('Day'))->addClass('ml-4');
+                $row->addSelect('gibbonTTDayID')
+                    ->fromResults($dayResults)
+                    ->required()
+                    ->selected($gibbonTTDayID)
+                    ->addClass('float-left');
+
+                $row->addLabel('gibbonTTColumnRowID', __('Period'))->addClass('ml-4');
+                $row->addSelect('gibbonTTColumnRowID')
+                    ->fromArray($columnRowsOptions)
+                    ->required()
+                    ->chainedTo('', $columnRowsChained)
+                    ->selected($gibbonTTColumnRowID)
+                    ->addClass('chainTo float-left');
+
+            // $row = $ttBlock->addRow();
+                $row->addLabel('gibbonTTSpaceID', __('Location'))->addClass('ml-4');
+                $row->addSelectSpace('gibbonTTSpaceID')->selected($gibbonTTSpaceID)->addClass('float-left');
+
+        $addTTButton = $form->getFactory()->createButton(__('Add Timetable Entry'))->addClass('addBlock');
+
+        $row = $form->addRow();
+            $ttBlocks = $row->addCustomBlocks('ttBlocks', $gibbon->session)
+                ->fromTemplate($ttBlock)
+                ->settings([
+                    'placeholder' => __('Timetable Entries will appear here.')
+                ])
+                ->addToolInput($addTTButton);
+
+        $ttResults = $timetableDayGateway->selectTTDayRowClassesByClass($gibbonTTID, $gibbonCourseClassID);
+
+        while ($ttDay = $ttResults->fetch()) {
+            $ttDay['gibbonTTColumnRowID'] .= '-' . $ttDay['gibbonTTDayID'];
+            $ttDay['gibbonTTSpaceID'] = $ttDay['gibbonSpaceID'];
+            $ttBlocks->addBlock($ttDay['gibbonTTDayRowClassID'], $ttDay);
+        }
+
+        $row = $form->addRow();
+            $row->addSubmit(__('Submit'));
+
+        echo $form->getOutput();
+
+    }
+}
+
+?>
+ <script>
+    function chainSelects() {
+            $('div.blocks').find('select.chainTo').each(function () {
+            var index = $(this).attr('id').replace('gibbonTTColumnRowID' ,'');
+            $(this).removeClass('chainTo').chainedTo('#gibbonTTDayID' + index);
+        });
+    }
+
+    $(document).ready(chainSelects);
+
+    $(document).on('click', '.addBlock', chainSelects);
+</script>

--- a/modules/Timetable Admin/tt_edit_byClassProcess.php
+++ b/modules/Timetable Admin/tt_edit_byClassProcess.php
@@ -1,0 +1,72 @@
+<?php
+/*
+Gibbon, Flexible & Open School System
+Copyright (C) 2010, Ross Parker
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Timetable\TimetableDayGateway;
+
+require_once '../../gibbon.php';
+
+$gibbonCourseClassID = $_REQUEST['gibbonCourseClassID'] ?? '';
+$gibbonTTID = $_REQUEST['gibbonTTID'] ?? '';
+
+$URL = $session->get('absoluteURL') . "/index.php?q=/modules/Timetable Admin/tt_edit_byClass.php&gibbonTTID={$gibbonTTID}&gibbonCourseClassID={$gibbonCourseClassID}";
+
+if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_byClass.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    //Proceed!
+    if (empty($gibbonCourseClassID) || empty($gibbonTTID)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $timetableDayGateway = $container->get(TimetableDayGateway::class);
+
+    $timetableDayGateway->deleteTTDayRowClasses($gibbonTTID, $gibbonCourseClassID);
+
+    $entryOrders = $_POST['order'] ?? [];
+    $inserted = 0;
+
+    foreach ($entryOrders as $order) {
+        $entry = $_POST['ttBlocks'][$order];
+
+        if (empty($entry['gibbonTTColumnRowID']) || empty($entry['gibbonTTDayID'])) {
+            continue;
+        }
+
+        $data = [
+            'gibbonTTColumnRowID' => strstr($entry['gibbonTTColumnRowID'], '-', true),
+            'gibbonTTDayID' => $entry['gibbonTTDayID'],
+            'gibbonCourseClassID' => $gibbonCourseClassID,
+            'gibbonSpaceID' => $entry['gibbonTTSpaceID'] ?? ''
+        ]; 
+
+        if ($timetableDayGateway->insertDayRowClass($data) > 0) {
+            $inserted++;
+        }
+    }
+
+    $URL .= $inserted != count($entryOrders)
+        ? '&return=warning1'
+        : '&return=success0';
+    header("Location: {$URL}");
+    exit;
+}

--- a/src/Domain/Timetable/TimetableColumnGateway.php
+++ b/src/Domain/Timetable/TimetableColumnGateway.php
@@ -24,7 +24,7 @@ use Gibbon\Domain\QueryCriteria;
 use Gibbon\Domain\QueryableGateway;
 
 /**
- * @version v21
+ * @version v25
  * @since   v16
  */
 class TimetableColumnGateway extends QueryableGateway
@@ -61,6 +61,20 @@ class TimetableColumnGateway extends QueryableGateway
                 ORDER BY gibbonTTColumn.name";
 
         return $this->db()->select($sql);
+    }
+
+    public function selectTTColumnsByTimetable($gibbonTTID)
+    {
+        $data = array('gibbonTTID' => $gibbonTTID);
+        $sql = "SELECT CONCAT(gibbonTTColumnRow.gibbonTTColumnRowID, '-', gibbonTTDay.gibbonTTDayID) as value, gibbonTTColumnRow.name, gibbonTTDay.gibbonTTDayID
+                FROM gibbonTTDay
+                JOIN gibbonTTColumnRow ON (gibbonTTDay.gibbonTTColumnID=gibbonTTColumnRow.gibbonTTColumnID)
+                WHERE gibbonTTDay.gibbonTTID=:gibbonTTID
+                GROUP BY value
+                ORDER BY gibbonTTColumnRow.timeStart
+        ";
+
+        return $this->db()->select($sql, $data);
     }
 
     public function getTTColumnByID($gibbonTTColumnID)

--- a/src/Domain/Timetable/TimetableDayGateway.php
+++ b/src/Domain/Timetable/TimetableDayGateway.php
@@ -24,7 +24,7 @@ use Gibbon\Domain\QueryCriteria;
 use Gibbon\Domain\QueryableGateway;
 
 /**
- * @version v21
+ * @version v25
  * @since   v16
  */
 class TimetableDayGateway extends QueryableGateway
@@ -64,6 +64,18 @@ class TimetableDayGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
+    public function selectTTDaysByTimetable($gibbonTTID)
+    {
+        $data = array('gibbonTTID' => $gibbonTTID);
+        $sql = "SELECT gibbonTTDayID as value, name
+                FROM gibbonTTDay
+                WHERE gibbonTTDay.gibbonTTID=:gibbonTTID
+                ORDER BY gibbonTTDay.name
+        ";
+
+        return $this->db()->select($sql, $data);
+    }
+
     public function selectTTDayRowsByID($gibbonTTDayID)
     {
         $data = array('gibbonTTDayID' => $gibbonTTDayID);
@@ -92,6 +104,21 @@ class TimetableDayGateway extends QueryableGateway
                 }
                 $sql .= " ORDER BY courseName, className";
 
+        return $this->db()->select($sql, $data);
+    }
+
+    public function selectTTDayRowClassesByClass($gibbonTTID, $gibbonCourseClassID) {
+        $data = ['gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonTTID' => $gibbonTTID];
+        $sql = "SELECT gibbonTTDayRowClassID, gibbonTTDayRowClass.gibbonTTDayID, gibbonTTDayRowClass.gibbonTTColumnRowID, gibbonTTDayRowClass.gibbonSpaceID
+                FROM gibbonTTDayRowClass
+                JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID)
+                JOIN gibbonTTDay ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID)
+                JOIN gibbonTT ON (gibbonTT.gibbonTTID=gibbonTTDay.gibbonTTID)
+                LEFT JOIN gibbonSpace ON (gibbonSpace.gibbonSpaceID=gibbonTTDayRowClass.gibbonSpaceID)
+                WHERE gibbonTT.gibbonTTID=:gibbonTTID
+                AND gibbonTTDayRowClass.gibbonCourseClassID=:gibbonCourseClassID
+                ORDER BY gibbonTTDay.name, gibbonTTColumnRow.name";
+                
         return $this->db()->select($sql, $data);
     }
 
@@ -201,5 +228,18 @@ class TimetableDayGateway extends QueryableGateway
         $sql = "INSERT INTO gibbonTTDayRowClassException SET gibbonTTDayRowClassID=:gibbonTTDayRowClassID, gibbonPersonID=:gibbonPersonID ON DUPLICATE KEY UPDATE gibbonTTDayRowClassID=:gibbonTTDayRowClassID";
 
         return $this->db()->insert($sql, $data);
+    }
+
+    public function deleteTTDayRowClasses($gibbonTTID, $gibbonCourseClassID)
+    {
+        $data = array('gibbonCourseClassID' => $gibbonCourseClassID, 'gibbonTTID' => $gibbonTTID);
+        $sql = "DELETE gibbonTTDayRowClass
+                FROM gibbonTTDayRowClass
+                INNER JOIN gibbonTTDay ON (gibbonTTDay.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID)
+                INNER JOIN gibbonTT ON (gibbonTT.gibbonTTID=gibbonTTDay.gibbonTTID)
+                WHERE gibbonTT.gibbonTTID=:gibbonTTID
+                AND gibbonTTDayRowClass.gibbonCourseClassID=:gibbonCourseClassID";
+
+        return $this->db()->delete($sql, $data);
     }
 }

--- a/src/Domain/Timetable/TimetableGateway.php
+++ b/src/Domain/Timetable/TimetableGateway.php
@@ -19,14 +19,21 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Domain\Timetable;
 
-use Gibbon\Domain\Gateway;
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
 
 /**
- * @version v16
+ * @version v25
  * @since   v16
  */
-class TimetableGateway extends Gateway
+class TimetableGateway extends QueryableGateway
 {
+    use TableAware;
+
+    private static $tableName = 'gibbonTT';
+    private static $primaryKey = 'gibbonTTID';
+
     public function selectTimetablesBySchoolYear($gibbonSchoolYearID) 
     {
         $data = array('gibbonSchoolYearID' => $gibbonSchoolYearID);


### PR DESCRIPTION
This is a very handy timetabling tool that exists in the Course Selection module. I've now added it to the core when editing a timetable in Timetable Admin > Manage Timetables.

**Description**
Adds an "Edit Timetable by Class" option to the Edit Timetable page in Manage Timetables. Added it here, rather than as a separate action, because it is a logical location for tools related to editing a timetable, and it reduces the complexity of needing to select a timetable and school year first.

**Motivation and Context**
Changing the timetable for a class currently requires hunting down the individual entries in each timetable day and period. This makes it easier to add/edit/remove timetabling for a single class. Thanks to Ray Clark for adding the smart-block-style interface.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="856" alt="Screen Shot 2022-11-02 at 1 44 38 PM" src="https://user-images.githubusercontent.com/897700/199407995-b05c4323-8520-4c8f-a3a1-ad6b3cda7481.png">

<img width="896" alt="Screen Shot 2022-11-02 at 1 49 48 PM" src="https://user-images.githubusercontent.com/897700/199408649-6f6d3d21-bc75-4101-ad1c-f025ea8b3193.png">
