### PR TITLE
Deprecate nl2brr

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1328,7 +1328,7 @@ function getModuleCategory($address, $connection2)
  *
  * @deprecated v25
  *             This happens in SessionFactory::setCurrentSchoolYear instead,
- *             which is called by Core::initializeCore, so shouldn't need to 
+ *             which is called by Core::initializeCore, so shouldn't need to
  *             be called manually.
  *
  * @version v23
@@ -1365,6 +1365,17 @@ function setCurrentSchoolYear($guid,  $connection2)
     }
 }
 
+/**
+ * Convert linebreaks into <br/> tags.
+ * Deprecated. Use nl2br() instead.
+ *
+ * @deprecated v25
+ * @version v12
+ *
+ * @param string $string
+ *
+ * @return string
+ */
 function nl2brr($string)
 {
     return preg_replace("/\r\n|\n|\r/", '<br/>', $string);

--- a/modules/Behaviour/behaviour_letters.php
+++ b/modules/Behaviour/behaviour_letters.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_letter
             $output = '';
             if (!empty($letter['body'])) {
                 $output .= '<b>'.__('Letter Body').'</b><br/>';
-                $output .= nl2brr($letter['body']).'<br/><br/>';
+                $output .= nl2br($letter['body']).'<br/><br/>';
             }
             if (!empty($letter['recipientList'])) {
                 $output .= '<b>'.__('Recipients').'</b><br/>';

--- a/modules/Behaviour/behaviour_manage.php
+++ b/modules/Behaviour/behaviour_manage.php
@@ -137,11 +137,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 $output = '';
                 if (!empty($beahviour['comment'])) {
                     $output .= '<strong>'.__('Incident').'</strong><br/>';
-                    $output .= nl2brr($beahviour['comment']).'<br/>';
+                    $output .= nl2br($beahviour['comment']).'<br/>';
                 }
                 if (!empty($beahviour['followup'])) {
                     $output .= '<br/><strong>'.__('Follow Up').'</strong><br/>';
-                    $output .= nl2brr($beahviour['followup']).'<br/>';
+                    $output .= nl2br($beahviour['followup']).'<br/>';
                 }
                 return $output;
             });

--- a/modules/Behaviour/moduleFunctions.php
+++ b/modules/Behaviour/moduleFunctions.php
@@ -88,11 +88,11 @@ function getBehaviourRecord(ContainerInterface $container, $gibbonPersonID)
                     $output = '';
                     if (!empty($beahviour['comment'])) {
                         $output .= '<strong>'.__('Incident').'</strong><br/>';
-                        $output .= nl2brr($beahviour['comment']).'<br/>';
+                        $output .= nl2br($beahviour['comment']).'<br/>';
                     }
                     if (!empty($beahviour['followup'])) {
                         $output .= '<br/><strong>'.__('Follow Up').'</strong><br/>';
-                        $output .= nl2brr($beahviour['followup']).'<br/>';
+                        $output .= nl2br($beahviour['followup']).'<br/>';
                     }
                     return $output;
                 });

--- a/modules/Individual Needs/investigations_manage.php
+++ b/modules/Individual Needs/investigations_manage.php
@@ -106,22 +106,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
             ->format(function ($investigations) {
                 $output = '';
                 $output .= '<strong>'.__('Reason').'</strong><br/>';
-                $output .= nl2brr($investigations['reason']).'<br/>';
+                $output .= nl2br($investigations['reason']).'<br/>';
                 if (!empty($investigations['strategiesTried'])) {
                     $output .= '<br/><strong>'.__('Strategies Tried').'</strong><br/>';
-                    $output .= nl2brr($investigations['strategiesTried']).'<br/>';
+                    $output .= nl2br($investigations['strategiesTried']).'<br/>';
                 }
                 if ($investigations['parentsInformed'] == 'Y') {
                     $output .= '<br/><strong>'.__('Parents Informed?').'</strong><br/>';
                     $output .= Format::yesNo($investigations['parentsInformed']).'<br/>';
                     if (!empty($investigations['parentsResponse'])) {
                         $output .= '<br/><strong>'.__('Parent Response').'</strong><br/>';
-                        $output .= nl2brr($investigations['parentsResponse']).'<br/>';
+                        $output .= nl2br($investigations['parentsResponse']).'<br/>';
                     }
                 }
                 if (!empty($investigations['resolutionDetails'])) {
                     $output .= '<br/><strong>'.__('Resolution Details').'</strong><br/>';
-                    $output .= nl2brr($investigations['resolutionDetails']).'<br/>';
+                    $output .= nl2br($investigations['resolutionDetails']).'<br/>';
                 }
 
                 return $output;

--- a/modules/Individual Needs/investigations_manage_edit.php
+++ b/modules/Individual Needs/investigations_manage_edit.php
@@ -209,7 +209,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
                                 if (!empty($investigations['cognition'])) {
                                     $output .= '<br/><strong>'.__('Cognition').'</strong><br/>';
                                     $output .= '<ul>';
-                                        $output .= '<li>'.nl2brr(__($investigations['cognition'])).'</li>';
+                                        $output .= '<li>'.nl2br(__($investigations['cognition'])).'</li>';
                                     $output .= '</ul>';
                                 }
                                 $fields = getInvestigationCriteriaStrands();
@@ -226,7 +226,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Individual Needs/investiga
                                 if (!empty($investigations['comment'])) {
                                     $output .= '<br/><strong>'.__('Comment').'</strong><br/>';
                                     $output .= '<ul>';
-                                        $output .= '<li>'.nl2brr(__($investigations['comment'])).'</li>';
+                                        $output .= '<li>'.nl2br(__($investigations['comment'])).'</li>';
                                     $output .= '</ul>';
                                 }
                                 return $output;

--- a/modules/Students/firstAidRecord.php
+++ b/modules/Students/firstAidRecord.php
@@ -99,12 +99,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.ph
         // COLUMNS
         $table->addExpandableColumn('details')->format(function($person) use ($firstAidGateway) {
             $output = '';
-            if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2brr($person['description']).'<br/><br/>';
-            if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2brr($person['actionTaken']).'<br/><br/>';
-            if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeReadable($person['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2brr($person['followUp']).'<br/><br/>';
+            if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2br($person['description']).'<br/><br/>';
+            if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2br($person['actionTaken']).'<br/><br/>';
+            if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeReadable($person['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
             $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
             foreach ($resultLog AS $rowLog) {
-                $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeReadable($rowLog['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2brr($rowLog['followUp']).'<br/><br/>';
+                $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeReadable($rowLog['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
             }
 
             return $output;

--- a/modules/Students/medicalForm_manage.php
+++ b/modules/Students/medicalForm_manage.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/medicalForm_manag
 
     // COLUMNS
     $table->addExpandableColumn('comment')->format(function($person) {
-        return !empty($person['comment'])? '<b>'.__('Comment').'</b><br/>'.nl2brr($person['comment']) : '';
+        return !empty($person['comment'])? '<b>'.__('Comment').'</b><br/>'.nl2br($person['comment']) : '';
     });
 
     $table->addColumn('student', __('Student'))


### PR DESCRIPTION
**Description**
* Replace nl2brr() calls with nl2br().
* Mark nl2brr() as deprecated.
* Changed behaviour: "\r\n" would have been converted to 2 `<br/>` will now be converted to 1 single `<br/>`.

**Motivation and Context**
* From the source code, nl2brr turns \r\n, \r and \n into HTML `<br/>` tag. And PHP's native nl2br does that and also converts \n\r.
So it seems nl2brr specifically single out \n\r and not handle it. This doesn't seem to really matter in most cases.
* nl2br() is a C native implementation while nl2brr() is written with preg_replace(), which is much slower.
* Reduce unnecessary function would reduce effort if handling the code base.

**How Has This Been Tested?**
* Locally.
* CI environment.