### PR TITLE
Attendance: add the option to take future attendance for ad hoc groups

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ v25.0.00
     Significant Changes
         School Admin: added an Off Timetable option for special days
         Planner: enabled custom fields for Lesson Plans
+        Attendance: added the option to take future attendance for ad hoc groups
 
     Changes With Important Notices
         Timetable Admin: changed Participant counts to Student counts in Course Enrolment by Class, adding minimum and maximum enrolment controls to courses

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -64,7 +64,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
     $target = $_GET['target'] ?? '';
     $gibbonActivityID = $_GET['gibbonActivityID'] ?? '';
     $gibbonGroupID = $_GET['gibbonGroupID'] ?? '';
-
     $absenceType = $_GET['absenceType'] ?? 'full';
     $date = $_GET['date'] ?? '';
     $timeStart = $_GET['timeStart'] ?? '';
@@ -321,9 +320,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                             return $group;
                         }, []);
 
-                        $disabled = array_reduce($classes, function ($group, $class) use (&$logs) {
+                        $disabled = array_reduce($classes, function ($group, $class) use (&$logs, $targetDate) {
                             foreach ($logs as $log) {
-                                if ($log['context'] == 'Class' && $class['gibbonCourseClassID'] == $log['gibbonCourseClassID']) {
+                                if ($log['context'] == 'Class' && $class['gibbonCourseClassID'] == $log['gibbonCourseClassID'] && $log['date'] == $targetDate) {
                                     $group[] = $class['gibbonCourseClassID'];
                                 }
                             }
@@ -336,7 +335,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                             ->fromArray($classOptions)
                             ->setClass('')
                             ->alignLeft()
-                            ->checked($checked + $disabled, $disabled);
+                            ->checked($checked + $disabled)
+                            ->disabled($disabled);
                         
                     } else {
                         $col->addContent(Format::small(__('N/A')));

--- a/modules/Attendance/attendance_take_adHoc.php
+++ b/modules/Attendance/attendance_take_adHoc.php
@@ -55,8 +55,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
     $form->addHiddenValue('q', '/modules/Attendance/attendance_take_adHoc.php');
 
     $targetOptions = [
-        'Activity' => __('Activity Enrolment'),
         'Messenger'    => __('Messenger Group'),
+        'Activity' => __('Activity Enrolment'),
         'Select'   => __('Select Students'),
     ];
     $row = $form->addRow();

--- a/src/Domain/Attendance/AttendanceLogPersonGateway.php
+++ b/src/Domain/Attendance/AttendanceLogPersonGateway.php
@@ -359,6 +359,18 @@ class AttendanceLogPersonGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
+    function selectNonClassAttendanceLogsByPersonAndDate($gibbonPersonID, $date)
+    {
+        $data = ['gibbonPersonID' => $gibbonPersonID, 'date' => $date];
+        $sql = "SELECT gibbonAttendanceLogPerson.type, reason, comment, direction, context, timestampTaken FROM gibbonAttendanceLogPerson
+                WHERE gibbonAttendanceLogPerson.gibbonPersonID=:gibbonPersonID
+                AND date=:date
+                AND context <> 'Class'
+                ORDER BY timestampTaken DESC";
+
+        return $this->db()->select($sql, $data);
+    }
+
     public function selectFutureAttendanceLogsByPersonAndDate($gibbonPersonID, $date)
     {
         $data = array('gibbonPersonID' => $gibbonPersonID, 'date' => $date);

--- a/src/Forms/Input/Checkbox.php
+++ b/src/Forms/Input/Checkbox.php
@@ -88,7 +88,7 @@ class Checkbox extends Input
      * @param   string  $values
      * @return  self
      */
-    public function checked($values, $disabled = [])
+    public function checked($values)
     {
         if ($values === 1 || $values === true) $values = 'on';
 
@@ -100,6 +100,16 @@ class Checkbox extends Input
             $this->checked = [trim($values ?? '')];
         }
 
+        return $this;
+    }
+
+    /**
+     * Set a value or array of values that are currently disabled.
+     * @param   string  $disabled
+     * @return  self
+     */
+    public function disabled($disabled = [])
+    {
         $this->disabled = is_array($disabled) ? $disabled : [$disabled];
 
         return $this;

--- a/src/Forms/Input/Checkbox.php
+++ b/src/Forms/Input/Checkbox.php
@@ -33,6 +33,7 @@ class Checkbox extends Input
 
     protected $description;
     protected $checked = array();
+    protected $disabled = array();
     protected $checkall = false;
     protected $inline = false;
     protected $align = 'right';
@@ -87,7 +88,7 @@ class Checkbox extends Input
      * @param   string  $values
      * @return  self
      */
-    public function checked($values)
+    public function checked($values, $disabled = [])
     {
         if ($values === 1 || $values === true) $values = 'on';
 
@@ -98,6 +99,8 @@ class Checkbox extends Input
         } else {
             $this->checked = [trim($values ?? '')];
         }
+
+        $this->disabled = is_array($disabled) ? $disabled : [$disabled];
 
         return $this;
     }
@@ -189,10 +192,24 @@ class Checkbox extends Input
     protected function getIsChecked($value)
     {
         if (empty($value) || empty($this->checked)) {
-            return '';
+            return false;
         }
 
-        return (in_array($value, $this->checked))? 'checked' : '';
+        return in_array($value, $this->checked);
+    }
+
+    /**
+     * Return true if the passed value has been disabled.
+     * @param   mixed  $value
+     * @return  bool
+     */
+    protected function getIsDisabled($value)
+    {
+        if (empty($value) || empty($this->disabled)) {
+            return false;
+        }
+
+        return in_array($value, $this->disabled);
     }
 
     /**
@@ -252,6 +269,8 @@ class Checkbox extends Input
                     }
                     $this->setName($name);
                     $this->setAttribute('checked', $this->getIsChecked($value));
+                    $this->setAttribute('disabled', $this->getIsDisabled($value));
+
                     if ($value != 'on') $this->setValue($value);
 
                     if ($this->inline) {


### PR DESCRIPTION
Improves the Set Future Absence tool to enable using ad hoc groups for attendance, and setting partial class attendance for a group of students. When selecting a group of students for a partial absence, a time range is entered, and then a grid of student photos will be displayed with the classes for each student selected for that time range. Prior absences will be listed but disabled so they cannot be checked.

Adds a disabled method to the Checkbox input to enable setting an array of checkbox value-keys that are disabled in the list. This enabled displaying specific values that are not selectable in a single checkbox list.

I've tidied up the code along the way, but this has certainly added some complexity to the future absence scripts. Overall, worth the trade-off given the usability it adds.

**Motivation and Context**
Schools often have groups of students going offsite for the day or leaving early in the school day. The additional Future Absence tools let teachers enter this attendance data into the system so that it's visible to other form group and class teachers when they go to take attendance on the day.

**How Has This Been Tested?**
Locally.

**Screenshots**
![Screenshot 2022-11-04 at 09-14-06 TEST - Gibbon - Attendance](https://user-images.githubusercontent.com/897700/199864502-3230b852-858c-4cbd-b60c-35f0af27bb62.png)

![Screenshot 2022-11-04 at 09-14-39 TEST - Gibbon - Attendance](https://user-images.githubusercontent.com/897700/199864682-c02f4b61-1930-438f-8e0f-7af51f4c712b.png)
