### PR TITLE
System: deprecate randomPassword

### DIFF
--- a/cli/schoolAdmin_parentWeeklyEmailSummary.php
+++ b/cli/schoolAdmin_parentWeeklyEmailSummary.php
@@ -21,6 +21,7 @@ use Gibbon\View\View;
 use Gibbon\Services\Format;
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Domain\User\FamilyGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
@@ -178,8 +179,9 @@ foreach ($families as $gibbonFamilyID => $students) {
         }
 
         // Make and store unique code for confirmation.
+        $randStrGenerator = new PasswordPolicy(true, true, false, 40); // Use password policy to generate random string
         for ($count = 0; $count < 100; $count++) {
-            $key = randomPassword(40);
+            $key = $randStrGenerator->generate();
             $checkUnique = $emailSummaryGateway->getAnySummaryDetailsByKey($key);
 
             if (empty($checkUnique)) break;

--- a/functions.php
+++ b/functions.php
@@ -1538,6 +1538,17 @@ function getLastYearGroupID($connection2)
     return $output;
 }
 
+/**
+ * Generate a random password of the specified length.
+ * Deprecated. Use PasswordPolicy::generate() instead.
+ *
+ * @deprecated v25
+ * @version v12
+ *
+ * @param int $length
+ *
+ * @return string
+ */
 function randomPassword($length)
 {
     if (!(is_int($length))) {

--- a/modules/Activities/activities_paymentProcessBulk.php
+++ b/modules/Activities/activities_paymentProcessBulk.php
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Data\PasswordPolicy;
+
 include '../../gibbon.php';
 
 $action = $_POST['action'] ?? '';
@@ -115,8 +117,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_paym
                                     $key = '';
                                     $continue = false;
                                     $count = 0;
+
+                                    // Use password policy to generate random string
+                                    $randStrGenerator = new PasswordPolicy(true, true, false, 40);
+
                                     while ($continue == false and $count < 100) {
-                                        $key = randomPassword(40);
+                                        $key = $randStrGenerator->generate();
 
                                             $dataUnique = array('key' => $key);
                                             $sqlUnique = 'SELECT * FROM gibbonFinanceInvoice WHERE gibbonFinanceInvoice.`key`=:key';

--- a/modules/Finance/invoices_manage_addProcess.php
+++ b/modules/Finance/invoices_manage_addProcess.php
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Services\Format;
 use Gibbon\Data\Validator;
 
@@ -167,8 +168,12 @@ if ($gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
                                 //Let's go! Create key, send the invite
                                 $continue = false;
                                 $count = 0;
+
+                                // Use password policy to generate random string
+                                $randStrGenerator = new PasswordPolicy(true, true, false, 40);
+
                                 while ($continue == false and $count < 100) {
-                                    $key = randomPassword(40);
+                                    $key = $randStrGenerator->generate();
                                     $dataUnique = array('key' => $key);
                                     $sqlUnique = 'SELECT * FROM gibbonFinanceInvoice WHERE gibbonFinanceInvoice.`key`=:key';
                                     $resultUnique = $connection2->prepare($sqlUnique);
@@ -299,7 +304,7 @@ if ($gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
                                 $continue = false;
                                 $count = 0;
                                 while ($continue == false and $count < 100) {
-                                    $key = randomPassword(40);
+                                    $key = $randStrGenerator->generate();
                                     $dataUnique = array('key' => $key);
                                     $sqlUnique = 'SELECT * FROM gibbonFinanceInvoice WHERE gibbonFinanceInvoice.`key`=:key';
                                     $resultUnique = $connection2->prepare($sqlUnique);

--- a/modules/Messenger/src/MessageTargets.php
+++ b/modules/Messenger/src/MessageTargets.php
@@ -22,6 +22,7 @@ namespace Gibbon\Module\Messenger;
 use Gibbon\Services\Format;
 use Gibbon\Contracts\Services\Session;
 use Gibbon\Contracts\Database\Connection;
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Domain\System\LogGateway;
 
@@ -2218,6 +2219,10 @@ class MessageTargets
             $count = 0;
             $unique = true;
             $uniqueCount = 0;
+
+            // Use password policy to generate random string
+            $randStrGenerator = new PasswordPolicy(true, true, false, 40);
+
             foreach ($this->report as $reportEntry) {
                 if ($reportEntry[4] == $contactDetail && $unique) {
                     $unique = false;
@@ -2225,7 +2230,7 @@ class MessageTargets
                 }
                 $count ++;
             }
-    
+
             if ($unique) { //Entry is unique, so create
                 $count = count($this->report);
                 $this->report[$count][0] = $gibbonPersonID;
@@ -2234,7 +2239,7 @@ class MessageTargets
                 $this->report[$count][3] = $contactType;
                 $this->report[$count][4] = $contactDetail;
                 if ($contactType == 'Email' and $emailReceipt == 'Y') {
-                    $this->report[$count][5] = randomPassword(40);
+                    $this->report[$count][5] = $randStrGenerator->generate();
                 }
                 else {
                     $this->report[$count][5] = null;
@@ -2244,7 +2249,7 @@ class MessageTargets
             }
             else { //Entry is not unique, so apend student details
                 $this->report[$uniqueCount][6] = (empty($this->report[$uniqueCount][6])) ? $gibbonPersonIDListStudent : (!empty($gibbonPersonIDListStudent) ? $this->report[$uniqueCount][6].','.$gibbonPersonIDListStudent : $this->report[$uniqueCount][6]);
-    
+
                 if (empty($this->report[$uniqueCount][7])) {
                     $this->report[$uniqueCount][7] = [$nameStudent];
                 } else {

--- a/modules/Staff/applicationForm_manage_accept.php
+++ b/modules/Staff/applicationForm_manage_accept.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Http\Url;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Data\UsernameGenerator;
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Domain\System\SettingGateway;
@@ -73,12 +74,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 echo '</h3>';
 
                 $form = Form::create('action', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/applicationForm_manage_accept.php&step=2&gibbonStaffApplicationFormID='.$gibbonStaffApplicationFormID.'&search='.$search);
-                
+
                 $form->addHiddenValue('address', $session->get('address'));
                 $form->addHiddenValue('gibbonStaffApplicationFormID', $gibbonStaffApplicationFormID);
 
                 $col = $form->addRow()->addColumn()->addClass('stacked');
-                
+
                 $applicantName = Format::name('', $values['preferredName'], $values['surname'], 'Staff', false, true);
                 $col->addContent(sprintf(__('Are you sure you want to accept the application for %1$s?'), $applicantName))->wrap('<b>', '</b>');
 
@@ -112,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                 $form->addRow()->addSubmit(__('Accept'));
 
                 echo $form->getOutput();
-                
+
             } elseif ($step == 2) {
                 echo '<h3>';
                 echo __('Step')." $step";
@@ -140,7 +141,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
 
                     $username = $generator->generateByRole($gibbonRoleID);
 
-                    $password = randomPassword(8);
+                    // Generate a random password from site's password policy.
+                    /** @var PasswordPolicy */
+                    $p = $container->get(PasswordPolicy::class);
+                    $password = $p->generate();
                     $salt = getSalt();
                     $passwordStrong = hash('sha256', $salt.$password);
 
@@ -217,7 +221,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                         }
                         if ($insertOK == true) {
                             $gibbonPersonID = $connection2->lastInsertID();
-                            
+
                             $failapplicant = false;
 
                             //Populate informApplicant array

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -23,6 +23,7 @@ use Gibbon\Services\Format;
 use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Data\UsernameGenerator;
 use Gibbon\Comms\NotificationEvent;
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Domain\System\LogGateway;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Domain\User\PersonalDocumentGateway;
@@ -50,7 +51,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
     if ($gibbonApplicationFormID == '' or $gibbonSchoolYearID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonApplicationFormID' => $gibbonApplicationFormID);
             $sql = "SELECT * FROM gibbonApplicationForm WHERE gibbonApplicationFormID=:gibbonApplicationFormID AND (status='Pending' OR status='Waiting List')";
             $result = $connection2->prepare($sql);
@@ -226,7 +227,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
                 //CREATE STUDENT
                 $failStudent = true;
-                
+
                 // Generate a unique username for the new student, or use the pre-defined one.
                 if (!empty($values['username'])) {
                     $username = $values['username'];
@@ -239,8 +240,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                     $username = $generator->generateByRole('003');
                 }
 
-                // Generate a random password
-                $password = randomPassword(8);
+                // Generate a random password from site's password policy.
+                /** @var PasswordPolicy */
+                $passwordPolicy = $container->get(PasswordPolicy::class);
+                $password = $passwordPolicy->generate();
                 $salt = getSalt();
                 $passwordStrong = hash('sha256', $salt.$password);
 
@@ -279,7 +282,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                 $resultSchoolYear->execute($dataSchoolYear);
                 $schoolYearEntry = $resultSchoolYear->fetch();
                 $schoolYearName = $schoolYearEntry['name'] ?? '';
-                $status = $schoolYearEntry['status'] == 'Upcoming' && $informStudent != 'Y' ? 'Expected' : 'Full'; 
+                $status = $schoolYearEntry['status'] == 'Upcoming' && $informStudent != 'Y' ? 'Expected' : 'Full';
 
                 // Get student's year group info
                 $dataYearGroup = array('gibbonYearGroupID' => $values['gibbonYearGroupIDEntry']);
@@ -404,7 +407,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                     }
                     if ($insertOK == true) {
                         $gibbonPersonID = $connection2->lastInsertID();
-                    
+
                         $failStudent = false;
 
                         //Populate informStudent array
@@ -440,7 +443,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                     echo '</ul>';
 
                     //Move documents to student notes
-                    
+
                         $dataDoc = array('gibbonApplicationFormID' => $gibbonApplicationFormID);
                         $sqlDoc = 'SELECT * FROM gibbonApplicationFormFile WHERE gibbonApplicationFormID=:gibbonApplicationFormID';
                         $resultDoc = $connection2->prepare($sqlDoc);
@@ -451,7 +454,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             $note .= "<a href='".$session->get('absoluteURL').'/'.$rowDoc['path']."'>".$rowDoc['name'].'</a><br/>';
                         }
                         $note .= '</p>';
-                        
+
                             $data = array('gibbonPersonID' => $gibbonPersonID, 'title' => __('Application Documents'), 'note' => $note, 'gibbonPersonIDCreator' => $session->get('gibbonPersonID'), 'timestamp' => date('Y-m-d H:i:s'));
                             $sql = 'INSERT INTO gibbonStudentNote SET gibbonPersonID=:gibbonPersonID, gibbonStudentNoteCategoryID=NULL, title=:title, note=:note, gibbonPersonIDCreator=:gibbonPersonIDCreator, timestamp=:timestamp';
                             $result = $connection2->prepare($sql);
@@ -570,7 +573,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                         }
 
                         //CONNECT STUDENT TO FAMILY
-                        
+
                             $dataFamily = array('gibbonFamilyID' => $values['gibbonFamilyID']);
                             $sqlFamily = 'SELECT * FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
                             $resultFamily = $connection2->prepare($sqlFamily);
@@ -627,7 +630,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             }
                         }
 
-                        
+
                             $dataParents = array('gibbonFamilyID' => $values['gibbonFamilyID']);
                             $sqlParents = 'SELECT gibbonFamilyAdult.*, gibbonPerson.gibbonRoleIDAll FROM gibbonFamilyAdult JOIN gibbonPerson ON (gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonFamilyID=:gibbonFamilyID';
                             $resultParents = $connection2->prepare($sqlParents);
@@ -635,7 +638,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                         while ($rowParents = $resultParents->fetch()) {
                             //Update parent roles
                             if (strpos($rowParents['gibbonRoleIDAll'], '004') === false) {
-                                
+
                                     $dataRoleUpdate = array('gibbonPersonID' => $rowParents['gibbonPersonID']);
                                     $sqlRoleUpdate = "UPDATE gibbonPerson SET gibbonRoleIDAll=concat(gibbonRoleIDAll, ',004') WHERE gibbonPersonID=:gibbonPersonID";
                                     $resultRoleUpdate = $connection2->prepare($sqlRoleUpdate);
@@ -643,7 +646,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             }
 
                             //Add relationship record for each parent
-                            
+
                                 $dataRelationship = array('gibbonApplicationFormID' => $gibbonApplicationFormID, 'gibbonPersonID' => $rowParents['gibbonPersonID']);
                                 $sqlRelationship = 'SELECT * FROM gibbonApplicationFormRelationship WHERE gibbonApplicationFormID=:gibbonApplicationFormID AND gibbonPersonID=:gibbonPersonID';
                                 $resultRelationship = $connection2->prepare($sqlRelationship);
@@ -651,13 +654,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             if ($resultRelationship->rowCount() == 1) {
                                 $rowRelationship = $resultRelationship->fetch();
                                 $relationship = $rowRelationship['relationship'];
-                                
+
                                     $data = array('gibbonFamilyID' => $values['gibbonFamilyID'], 'gibbonPersonID1' => $rowParents['gibbonPersonID'], 'gibbonPersonID2' => $gibbonPersonID);
                                     $sql = 'SELECT * FROM gibbonFamilyRelationship WHERE gibbonFamilyID=:gibbonFamilyID AND gibbonPersonID1=:gibbonPersonID1 AND gibbonPersonID2=:gibbonPersonID2';
                                     $result = $connection2->prepare($sql);
                                     $result->execute($data);
                                 if ($result->rowCount() == 0) {
-                                    
+
                                         $data = array('gibbonFamilyID' => $values['gibbonFamilyID'], 'gibbonPersonID1' => $rowParents['gibbonPersonID'], 'gibbonPersonID2' => $gibbonPersonID, 'relationship' => $relationship);
                                         $sql = 'INSERT INTO gibbonFamilyRelationship SET gibbonFamilyID=:gibbonFamilyID, gibbonPersonID1=:gibbonPersonID1, gibbonPersonID2=:gibbonPersonID2, relationship=:relationship';
                                         $result = $connection2->prepare($sql);
@@ -666,7 +669,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                     $existingRelationship = $result->fetch();
 
                                     if ($existingRelationship['relationship'] != $relationship) {
-                                        
+
                                             $data = array('relationship' => $relationship, 'gibbonFamilyRelationshipID' => $existingRelationship['gibbonFamilyRelationshipID']);
                                             $sql = 'UPDATE gibbonFamilyRelationship SET relationship=:relationship WHERE gibbonFamilyRelationshipID=:gibbonFamilyRelationshipID';
                                             $result = $connection2->prepare($sql);
@@ -696,7 +699,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                     } else {
                         //CREATE A NEW FAMILY
                         $failFamily = true;
-                        
+
                         $familyName = $values['parent1preferredName'].' '.$values['parent1surname'];
                         if ($values['parent2preferredName'] != '' and $values['parent2surname'] != '') {
                             $familyName .= ' & '.$values['parent2preferredName'].' '.$values['parent2surname'];
@@ -731,7 +734,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
 
                         if ($insertOK == true) {
                             $failFamily = false;
-                            
+
                             $gibbonFamilyID = $connection2->lastInsertID();
                         }
 
@@ -752,7 +755,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             //LINK STUDENT INTO FAMILY
                             $failFamily = true;
                             if ($gibbonFamilyID != '') {
-                                
+
                                     $dataFamily = array('gibbonFamilyID' => $gibbonFamilyID);
                                     $sqlFamily = 'SELECT * FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
                                     $resultFamily = $connection2->prepare($sqlFamily);
@@ -807,7 +810,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 //LINK PARENT 1 INTO FAMILY
                                 $failFamily = true;
                                 if ($gibbonFamilyID != '') {
-                                    
+
                                         $dataFamily = array('gibbonFamilyID' => $gibbonFamilyID);
                                         $sqlFamily = 'SELECT * FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
                                         $resultFamily = $connection2->prepare($sqlFamily);
@@ -841,7 +844,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 }
 
                                 //Set parent relationship
-                                
+
                                     $data = array('gibbonFamilyID' => $gibbonFamilyID, 'gibbonPersonID1' => $gibbonPersonIDParent1, 'gibbonPersonID2' => $gibbonPersonID, 'relationship' => $values['parent1relationship']);
                                     $sql = 'INSERT INTO gibbonFamilyRelationship SET gibbonFamilyID=:gibbonFamilyID, gibbonPersonID1=:gibbonPersonID1, gibbonPersonID2=:gibbonPersonID2, relationship=:relationship';
                                     $result = $connection2->prepare($sql);
@@ -854,10 +857,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 $generator->addToken('surname', $values['parent1surname']);
 
                                 $username = $generator->generateByRole('004');
-                                $status = $schoolYearEntry['status'] == 'Upcoming' && $informParents != 'Y' ? 'Expected' : 'Full'; 
+                                $status = $schoolYearEntry['status'] == 'Upcoming' && $informParents != 'Y' ? 'Expected' : 'Full';
 
                                 // Generate a random password
-                                $password = randomPassword(8);
+                                $password = $passwordPolicy->generate();
                                 $salt = getSalt();
                                 $passwordStrong = hash('sha256', $salt.$password);
 
@@ -876,7 +879,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                     }
                                     if ($insertOK == true) {
                                         $failParent1 = false;
-                                        
+
                                         $gibbonPersonIDParent1 = $connection2->lastInsertID();
 
                                         //Populate parent1 in informParent array
@@ -912,7 +915,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                     //LINK PARENT 1 INTO FAMILY
                                     $failFamily = true;
                                     if ($gibbonFamilyID != '') {
-                                        
+
                                             $dataFamily = array('gibbonFamilyID' => $gibbonFamilyID);
                                             $sqlFamily = 'SELECT * FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
                                             $resultFamily = $connection2->prepare($sqlFamily);
@@ -945,7 +948,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                         }
 
                                         //Set parent relationship
-                                        
+
                                             $data = array('gibbonFamilyID' => $gibbonFamilyID, 'gibbonPersonID1' => $gibbonPersonIDParent1, 'gibbonPersonID2' => $gibbonPersonID, 'relationship' => $values['parent1relationship']);
                                             $sql = 'INSERT INTO gibbonFamilyRelationship SET gibbonFamilyID=:gibbonFamilyID, gibbonPersonID1=:gibbonPersonID1, gibbonPersonID2=:gibbonPersonID2, relationship=:relationship';
                                             $result = $connection2->prepare($sql);
@@ -957,7 +960,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             //CREATE PARENT 2
                             if ($values['parent2preferredName'] != '' and $values['parent2surname'] != '') {
                                 $failParent2 = true;
-                               
+
                                 // Generate a unique username for parent 2
                                 $generator = new UsernameGenerator($pdo);
                                 $generator->addToken('preferredName', $values['parent2preferredName']);
@@ -965,10 +968,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 $generator->addToken('surname', $values['parent2surname']);
 
                                 $username = $generator->generateByRole('004');
-                                $status = $schoolYearEntry['status'] == 'Upcoming' && $informParents != 'Y' ? 'Expected' : 'Full'; 
+                                $status = $schoolYearEntry['status'] == 'Upcoming' && $informParents != 'Y' ? 'Expected' : 'Full';
 
                                 // Generate a random password
-                                $password = randomPassword(8);
+                                $password = $passwordPolicy->generate();
                                 $salt = getSalt();
                                 $passwordStrong = hash('sha256', $salt.$password);
 
@@ -987,7 +990,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                     }
                                     if ($insertOK == true) {
                                         $failParent2 = false;
-                                        
+
                                         $gibbonPersonIDParent2 = $connection2->lastInsertID();
 
                                         //Populate parent2 in informParents array
@@ -1023,7 +1026,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                     //LINK PARENT 2 INTO FAMILY
                                     $failFamily = true;
                                     if ($gibbonFamilyID != '') {
-                                        
+
                                             $dataFamily = array('gibbonFamilyID' => $gibbonFamilyID);
                                             $sqlFamily = 'SELECT * FROM gibbonFamily WHERE gibbonFamilyID=:gibbonFamilyID';
                                             $resultFamily = $connection2->prepare($sqlFamily);
@@ -1056,7 +1059,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                         }
 
                                         //Set parent relationship
-                                        
+
                                             $data = array('gibbonFamilyID' => $gibbonFamilyID, 'gibbonPersonID1' => $gibbonPersonIDParent2, 'gibbonPersonID2' => $gibbonPersonID, 'relationship' => $values['parent2relationship']);
                                             $sql = 'INSERT INTO gibbonFamilyRelationship SET gibbonFamilyID=:gibbonFamilyID, gibbonPersonID1=:gibbonPersonID1, gibbonPersonID2=:gibbonPersonID2, relationship=:relationship';
                                             $result = $connection2->prepare($sql);
@@ -1217,7 +1220,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                         echo __('Student status could not be updated: student is in the system, but acceptance has failed.');
                         echo '</div>';
 
-                        
+
                     } else {
                         echo '<h4>';
                         echo __('Application Status');

--- a/modules/System Admin/import_history.php
+++ b/modules/System Admin/import_history.php
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 use Gibbon\Data\ImportType;
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Tables\DataTable;
 use Gibbon\Domain\DataSet;
@@ -33,7 +34,12 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_histor
         ->add(__('Import History'));
 
     // Get a list of available import options
-    $importTypeList = ImportType::loadImportTypeList($container->get(SettingGateway::class), $pdo, false);
+    $importTypeList = ImportType::loadImportTypeList(
+        $container->get(SettingGateway::class),
+        $container->get(PasswordPolicy::class),
+        $pdo,
+        false
+    );
 
     $logGateway = $container->get(LogGateway::class);
     $logsByType = $logGateway->selectLogsByModuleAndTitle('System Admin', 'Import - %')->fetchAll();
@@ -68,7 +74,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_histor
         ->format(function ($log) {
             return $log['data']['results']['filename'] ?? '';
         });
-        
+
     $table->addColumn('details', __('Details'))
         ->format(function ($log) {
             return !empty($log['data']['success']) ? Format::tag(__('Success'), 'success') : Format::tag(__('Failed'), 'error');

--- a/modules/System Admin/import_manage.php
+++ b/modules/System Admin/import_manage.php
@@ -20,6 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Form;
 use Gibbon\Domain\DataSet;
 use Gibbon\Data\ImportType;
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Domain\System\LogGateway;
@@ -57,7 +58,9 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_manage
     echo $form->getOutput();
 
     // Get a list of available import options
-    $importTypeList = ImportType::loadImportTypeList($settingGateway, $pdo, false);
+    /** @var PasswordPolicy */
+    $passwordPolicy = $container->get(PasswordPolicy::class);
+    $importTypeList = ImportType::loadImportTypeList($settingGateway, $passwordPolicy, $pdo, false);
 
     // Build an array of combined import type info and log data
     $importTypeGroups = array_reduce($importTypeList, function ($group, $importType) use ($guid, $connection2, $logsByType) {

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -24,8 +24,12 @@ use Gibbon\Http\Url;
 
 include './gibbon.php';
 
-//Create password
-$password = randomPassword(8);
+// Load site's password policy
+/** @var PasswordPolicy */
+$passwordPolicy = $container->get(PasswordPolicy::class);
+
+// Create password
+$password = $passwordPolicy->generate();
 
 // Sanitize the $_GET and $_POST arrays
 $validator = $container->get(Validator::class);
@@ -83,8 +87,11 @@ else {
         $username = $row['username'];
 
         if ($step == 1) { //This is the request phase
+            // Use password policy to generate random string
+            $randStrGenerator = new PasswordPolicy(true, true, false, 40);
+
             //Generate key
-            $key = randomPassword(40);
+            $key = $randStrGenerator->generate();
 
             //Try to delete other recors for this user
 

--- a/src/Data/ImportType.php
+++ b/src/Data/ImportType.php
@@ -80,13 +80,31 @@ class ImportType
     protected $useSerializedFields = false;
 
     /**
+     * Password policy to generate password with
+     *
+     * @var PasswordPolicy
+     */
+    protected $passwordPolicy;
+
+    /**
      * Constructor
      *
-     * @param   array   importType information
-     * @param   Object  PDO Connection
+     * @version v25
+     * @since   v17
+     *
+     * @param   array           ImportType information
+     * @param   PasswordPolicy  Password policy to generate password with
+     * @param   Connection      Database connection
      */
-    public function __construct($data, Connection $pdo = null, $validateStructure = true)
+    public function __construct(
+        array $data,
+        PasswordPolicy $passwordPolicy,
+        Connection $pdo = null,
+        $validateStructure = true
+    )
     {
+        $this->passwordPolicy = $passwordPolicy;
+
         if (isset($data['details'])) {
             $this->details = $data['details'];
         }
@@ -218,10 +236,21 @@ class ImportType
     /**
      * Loads all YAML files from a folder and creates an importType object for each
      *
-     * @param   Object  PDO Connection
+     * @version v25
+     * @since   v17
+     *
+     * @param   Connection       Database connection
+     * @param   SettingGateway   Database access
+     * @param   PasswordPolicy   Site's password policy to generate password with
+     *
      * @return  array   2D array of importType objects
      */
-    public static function loadImportTypeList(SettingGateway $settingGateway, Connection $pdo = null, $validateStructure = false)
+    public static function loadImportTypeList(
+        SettingGateway $settingGateway,
+        PasswordPolicy $passwordPolicy,
+        Connection $pdo = null,
+        $validateStructure = false
+    )
     {
         $yaml = new Yaml();
         $importTypes = [];
@@ -235,7 +264,7 @@ class ImportType
 
             if (isset($fileData['details']) && isset($fileData['details']['type'])) {
                 $fileData['details']['grouping'] = (isset($fileData['access']['module']))? $fileData['access']['module'] : 'General';
-                $importTypes[ $fileData['details']['type'] ] = new ImportType($fileData, $pdo, $validateStructure);
+                $importTypes[ $fileData['details']['type'] ] = new ImportType($fileData, $passwordPolicy, $pdo, $validateStructure);
             }
         }
 
@@ -252,7 +281,12 @@ class ImportType
             if (isset($fileData['details']) && isset($fileData['details']['type'])) {
                 $fileData['details']['grouping'] = '* Custom Imports';
                 $fileData['details']['custom'] = true;
-                $importTypes[ $fileData['details']['type'] ] = new ImportType($fileData, $pdo, $validateStructure);
+                $importTypes[ $fileData['details']['type'] ] = new ImportType(
+                    $fileData,
+                    $passwordPolicy,
+                    $pdo,
+                    $validateStructure
+                );
             }
         }
 
@@ -281,11 +315,19 @@ class ImportType
     /**
      * Loads a YAML file and creates an importType object
      *
-     * @param   string  Filename of the Import Type
-     * @param   Object  PDO Conenction
-     * @return  [importType]
+     * @param   string          Filename of the Import Type
+     * @param   SettingGateway  SettingGateway instance
+     * @param   PasswordPolicy  Password policy to generate password with.
+     * @param   Connection      Database conenction
+     *
+     * @return  ImportType
      */
-    public static function loadImportType($importTypeName, SettingGateway $settingGateway, Connection $pdo = null)
+    public static function loadImportType(
+        $importTypeName,
+        SettingGateway $settingGateway,
+        PasswordPolicy $passwordPolicy,
+        Connection $pdo = null
+    )
     {
         // Check custom first, this allows for local overrides
         $path = self::getCustomImportTypeDir($settingGateway).'/'.$importTypeName.'.yml';
@@ -302,14 +344,14 @@ class ImportType
         $yaml = new Yaml();
         $fileData = $yaml::parse(file_get_contents($path));
 
-        return new ImportType($fileData, $pdo);
+        return new ImportType($fileData, $passwordPolicy, $pdo);
     }
 
     /**
      * Is Import Accessible
      *
-     * @param   string  guid
-     * @param   Object  PDO Conenction
+     * @param   string      guid
+     * @param   Connection  Database conenction
      * @return  bool
      */
     public function isImportAccessible($guid, $connection2)
@@ -327,8 +369,8 @@ class ImportType
     /**
      * Compares the importType structure with the database table to ensure imports will succeed
      *
-     * @param   Connection  PDO
-     * @return  bool    true if all fields match existing table columns
+     * @param   Connection  Database connection
+     * @return  bool        true if all fields match existing table columns
      */
     protected function validateWithDatabase(Connection $pdo)
     {
@@ -1232,7 +1274,7 @@ class ImportType
      */
     protected function userFunc_generatePassword()
     {
-        return randomPassword(10);
+        return $this->passwordPolicy->generate();
     }
 
     /**

--- a/src/Forms/Builder/Process/CreateParents.php
+++ b/src/Forms/Builder/Process/CreateParents.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Forms\Builder\Process;
 
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Data\UsernameGenerator;
 use Gibbon\Domain\User\FamilyAdultGateway;
 use Gibbon\Domain\User\UserGateway;
@@ -36,11 +37,26 @@ class CreateParents extends CreateStudent implements ViewableProcess
 
     protected $familyAdultGateway;
 
-    public function __construct(UserGateway $userGateway, UserStatusLogGateway $userStatusLogGateway, UsernameGenerator $usernameGenerator, CustomFieldGateway $customFieldGateway, PersonalDocumentGateway $personalDocumentGateway, FamilyAdultGateway $familyAdultGateway)
+    public function __construct(
+        UserGateway $userGateway,
+        UserStatusLogGateway $userStatusLogGateway,
+        UsernameGenerator $usernameGenerator,
+        CustomFieldGateway $customFieldGateway,
+        PersonalDocumentGateway $personalDocumentGateway,
+        FamilyAdultGateway $familyAdultGateway,
+        PasswordPolicy $passwordPolicy
+    )
     {
         $this->familyAdultGateway = $familyAdultGateway;
 
-        parent::__construct($userGateway, $userStatusLogGateway, $usernameGenerator, $customFieldGateway, $personalDocumentGateway);
+        parent::__construct(
+            $userGateway,
+            $userStatusLogGateway,
+            $usernameGenerator,
+            $customFieldGateway,
+            $personalDocumentGateway,
+            $passwordPolicy
+        );
     }
 
     public function getViewClass() : string
@@ -107,7 +123,7 @@ class CreateParents extends CreateStudent implements ViewableProcess
         if ($formData->has('parent2roleChanged')) {
             $this->userGateway->removeRoleFromUser($formData->get('gibbonPersonIDParent2'), '004');
         }
-        
+
         // Only remove users if they were created during this process
         if ($formData->has('parent1created')) {
             $this->userGateway->delete($formData->get('gibbonPersonIDParent1'));
@@ -152,7 +168,7 @@ class CreateParents extends CreateStudent implements ViewableProcess
     protected function updateParentData(FormDataInterface $formData, $i)
     {
         $excludeFields = ['gibbonRoleIDPrimary', 'gibbonRoleIDAll', 'username', 'passwordStrong', 'passwordStrongSalt'];
-        
+
         $userData = $this->getUserData($formData, '004', "parent{$i}");
         $userData = array_diff_key($userData, array_flip($excludeFields));
 

--- a/src/Forms/Builder/Process/CreateStudent.php
+++ b/src/Forms/Builder/Process/CreateStudent.php
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\Forms\Builder\Process;
 
+use Gibbon\Data\PasswordPolicy;
 use Gibbon\Data\UsernameGenerator;
 use Gibbon\Domain\User\UserGateway;
 use Gibbon\Domain\User\UserStatusLogGateway;
@@ -74,13 +75,28 @@ class CreateStudent extends AbstractFormProcess implements ViewableProcess
      */
     protected $personalDocumentGateway;
 
-    public function __construct(UserGateway $userGateway, UserStatusLogGateway $userStatusLogGateway, UsernameGenerator $usernameGenerator, CustomFieldGateway $customFieldGateway, PersonalDocumentGateway $personalDocumentGateway)
+    /**
+     * The PasswordPolicy instance to generate password with.
+     *
+     * @var PasswordPolicy
+     */
+    protected $passwordPolicy;
+
+    public function __construct(
+        UserGateway $userGateway,
+        UserStatusLogGateway $userStatusLogGateway,
+        UsernameGenerator $usernameGenerator,
+        CustomFieldGateway $customFieldGateway,
+        PersonalDocumentGateway $personalDocumentGateway,
+        PasswordPolicy $passwordPolicy
+    )
     {
         $this->userGateway = $userGateway;
         $this->userStatusLogGateway = $userStatusLogGateway;
         $this->usernameGenerator = $usernameGenerator;
         $this->customFieldGateway = $customFieldGateway;
         $this->personalDocumentGateway = $personalDocumentGateway;
+        $this->passwordPolicy = $passwordPolicy;
     }
 
     public function getViewClass() : string
@@ -207,7 +223,7 @@ class CreateStudent extends AbstractFormProcess implements ViewableProcess
     protected function generatePassword(FormDataInterface $formData, $prefix = '')
     {
         $salt = getSalt();
-        $password = randomPassword(8);
+        $password = $this->passwordPolicy->generate();
 
         $formData->set($prefix.'password', $password);
         $formData->set($prefix.'passwordStrongSalt', $salt);

--- a/src/Gibbon/FileUploader.php
+++ b/src/Gibbon/FileUploader.php
@@ -21,6 +21,7 @@ namespace Gibbon;
 
 use Gibbon\Contracts\Database\Connection;
 use Gibbon\Contracts\Services\Session;
+use Gibbon\Data\PasswordPolicy;
 use ZipArchive;
 
 /**
@@ -295,7 +296,7 @@ class FileUploader
         $size = getimagesize($sourcePath);
         $width = $srcWidth = $size[0];
         $height = $srcHeight = $size[1];
-        $ratio = $height / $width; 
+        $ratio = $height / $width;
         $maxWidth = $maxHeight = $maxSize;
         $srcX = $srcY = $destX = $destY = 0;
 
@@ -329,7 +330,7 @@ class FileUploader
             $destWidth = $srcWidth * $newRatio;
         }
 
-        // Zoom and focal adjustments 
+        // Zoom and focal adjustments
         if ($zoom != 100) {
             $srcWidth = $destWidth / ($zoom / 100.0);
             $srcX = ($width - $srcWidth) * ($focalX / 100.0);
@@ -389,11 +390,14 @@ class FileUploader
         $name = mb_substr($filename, 0, mb_strrpos($filename, '.'));
         $name = preg_replace('/[^a-zA-Z0-9_-]/', '', $name);
 
+        // Use password policy to generate random string
+        $randStrGenerator = new PasswordPolicy(true, true, false, 16);
+
         for ($count = 0; $count < 100; $count++) {
             if ($this->fileSuffixType == self::FILE_SUFFIX_INCREMENTAL) {
                 $suffix = ($count > 0)? '_'.$count : '';
             } else {
-                $suffix = '_'.randomPassword(16);
+                $suffix = '_'.$randStrGenerator->generate();
             }
 
             $randomizedFilename = $name.$suffix.'.'.$extension;

--- a/tests/unit/Data/PasswordPolicyCest.php
+++ b/tests/unit/Data/PasswordPolicyCest.php
@@ -163,4 +163,106 @@ class PasswordPolicyCest
         );
     }
 
+    public function testPolicyGenerateRandomPasswordWithMinimalRules(\UnitTester $I)
+    {
+        $I->wantToTest('generate password with minimal rules');
+        $policy = new PasswordPolicy(
+            false,
+            false,
+            false,
+            0
+        );
+        $password = $policy->generate();
+        $I->assertEquals(8, strlen($password), 'Generated password is 8 characters long: ' . var_export($password, true));
+        $I->assertMatchesRegularExpression('/^[a-z]+$/', $password, 'Password only contains lower case characters');
+        $I->assertEmpty($policy->evaluate($password), 'Password should pass the policy itself');
+    }
+
+    public function testPolicyGenerateRandomPasswordWithMixedAlphabet(\UnitTester $I)
+    {
+        $I->wantToTest('generate password with mixed alphabet');
+        $policy = new PasswordPolicy(
+            true,
+            false,
+            false,
+            0
+        );
+        $password = $policy->generate();
+        $I->assertEquals(8, strlen($password), 'Generated password is 8 characters long: ' . var_export($password, true));
+        $I->assertMatchesRegularExpression('/^[a-zA-Z]+$/', $password, 'Password only contain both upper and lower case characters');
+        $I->assertMatchesRegularExpression('/[a-z]+/', $password, 'Password contains lower cases characters');
+        $I->assertMatchesRegularExpression('/[A-Z]+/', $password, 'Password contains upper cases characters');
+        $I->assertEmpty($policy->evaluate($password), 'Password should pass the policy itself');
+    }
+
+    public function testPolicyGenerateRandomPasswordWithNumber(\UnitTester $I)
+    {
+        $I->wantToTest('generate password with numeric characters');
+        $policy = new PasswordPolicy(
+            false,
+            true,
+            false,
+            0
+        );
+        $password = $policy->generate();
+        $I->assertEquals(8, strlen($password), 'Generated password is 8 characters long: ' . var_export($password, true));
+        $I->assertMatchesRegularExpression('/^[a-z0-9]+$/', $password, 'Password only contain both lower case and numeric characters');
+        $I->assertMatchesRegularExpression('/[a-z]+/', $password, 'Password contains lower cases characters');
+        $I->assertMatchesRegularExpression('/[0-9]+/', $password, 'Password contains numeric characters');
+        $I->assertEmpty($policy->evaluate($password), 'Password should pass the policy itself');
+    }
+
+    public function testPolicyGenerateRandomPasswordWithPunctuation(\UnitTester $I)
+    {
+        $I->wantToTest('generate password with punctuation characters');
+        $policy = new PasswordPolicy(
+            false,
+            false,
+            true,
+            0
+        );
+        $password = $policy->generate();
+        $I->assertEquals(8, strlen($password), 'Generated password is 8 characters long: ' . var_export($password, true));
+        $I->assertMatchesRegularExpression('/^[a-z!@#$%^&*?_\+\-]+$/', $password, 'Password only contain both lower case and punctuation characters');
+        $I->assertMatchesRegularExpression('/[a-z]+/', $password, 'Password contains lower cases characters');
+        $I->assertMatchesRegularExpression('/[^a-zA-Z0-9]/', $password, 'Password contains non-alphanumeric characters');
+        $I->assertEmpty($policy->evaluate($password), 'Password should pass the policy itself');
+    }
+
+    public function testPolicyGenerateRandomPasswordWithMinLength(\UnitTester $I)
+    {
+        $I->wantToTest('generate password with minimal length set');
+        $length = rand(10, 255);
+        $policy = new PasswordPolicy(
+            false,
+            false,
+            false,
+            $length
+        );
+        $password = $policy->generate();
+        $I->assertEquals($length, strlen($password), sprintf('Generated password is %d characters long: ', $length) . var_export($password, true));
+        $I->assertMatchesRegularExpression('/^[a-z]+$/', $password, 'Password only contain only lower case characters');
+        $I->assertEmpty($policy->evaluate($password), 'Password should pass the policy itself');
+    }
+
+    public function testPolicyGenerateRandomPasswordWithEverythingEnforced(\UnitTester $I)
+    {
+        $I->wantToTest('generate password with everything enforced');
+        $length = rand(10, 255);
+        $policy = new PasswordPolicy(
+            true,
+            true,
+            true,
+            $length
+        );
+        $password = $policy->generate();
+        $I->assertEquals($length, strlen($password), sprintf('Generated password is %d characters long: ', $length) . var_export($password, true));
+        $I->assertMatchesRegularExpression('/^[a-zA-Z0-9!@#$%^&*?_\+\-]+$/', $password, 'Password only contain both lower case and punctuation characters');
+        $I->assertMatchesRegularExpression('/[a-z]+/', $password, 'Password contains lower cases characters');
+        $I->assertMatchesRegularExpression('/[A-Z]+/', $password, 'Password contains upper cases characters');
+        $I->assertMatchesRegularExpression('/[0-9]+/', $password, 'Password contains numeric characters');
+        $I->assertMatchesRegularExpression('/[^a-zA-Z0-9]/', $password, 'Password contains non-alphanumeric characters');
+        $I->assertEmpty($policy->evaluate($password), 'Password should pass the policy itself');
+    }
+
 }


### PR DESCRIPTION
**Description**
* Add a new PasswordPolicy::generate method to generate a random password that's conforming to the rules defined for the instance.
* Rewrite all randomPassword usages with PasswordPolicy::generate().

**Motivation and Context**
* Fix issue when randomly generated password doesn't meet site password policy settings.
* Deprecate usage of randomPassword.

**How Has This Been Tested?**
* Locally.
* CI environment.