### PR TITLE
System: fix dateRangeReadable usage of IntlDateFormatter

### DIFF
--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -178,7 +178,7 @@ class Format
 
         $startTime = $startDate->getTimestamp();
         $endTime = $endDate->getTimestamp();
-        $formatter = new \IntlDateFormatter(null);
+        $formatter = new \IntlDateFormatter(null, \IntlDateFormatter::FULL, \IntlDateFormatter::FULL);
 
         if ($startDate->format('Y-m-d') == $endDate->format('Y-m-d')) {
             $formatter->setPattern('MMM d, yyyy');


### PR DESCRIPTION
**Description**
* phpstan seems to think IntlDateFormatter constructor to require at least the first 3 parameter (despite documented otherwise in php.net). Update to fix phpstan warning.

**Motivation and Context**
* Fix phpstan warning message.

**How Has This Been Tested?**
* Locally.
* CI environment.