### PR TITLE
GitHub Actions: make phpstan (level 0) test essential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,8 @@ jobs:
           DB_USERNAME: root
           DB_PASSWORD: ""
 
-      - name: Run composer test:phpstan (experimental)
+      - name: Run phpstan static analysis
         run: composer test:phpstan
-        continue-on-error: true
 
       - name: Check PHP warning and deprecated messages in server_log
         run: |


### PR DESCRIPTION
**Description**
* phpstan test will be essential to pass for every CI test.
* That would also make the test essential for all PRs.

**Motivation and Context**
* phpstan starts to catch some issue in PRs that format test don't.
* Level 0 is mild and easy to handle for developers. Should be a nice start.

**How Has This Been Tested?**
* CI environment.