### PR TITLE
Attendance: fix attendance for classes timetabled multiple times on the same day

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -701,4 +701,6 @@ UPDATE `gibbonAction` SET URLList='messenger_manage.php,messenger_manage_delete.
 ALTER TABLE gibbonMarkbookColumn MODIFY name VARCHAR(40);end
 ALTER TABLE `gibbonTTSpaceBooking` ADD `reason` VARCHAR(255) NOT NULL AFTER `timeEnd`;end
 UPDATE `gibbonAction` SET `URLList` = 'tt.php, tt_add.php, tt_edit.php, tt_delete.php, tt_import.php, tt_edit_day_add.php, tt_edit_day_edit.php, tt_edit_day_delete.php, tt_edit_day_edit_class.php, tt_edit_day_edit_class_delete.php, tt_edit_day_edit_class_add.php, tt_edit_day_edit_class_edit.php, tt_edit_day_edit_class_exception.php, tt_edit_day_edit_class_exception_add.php, tt_edit_day_edit_class_exception_delete.php,tt_edit_byClass.php' WHERE name='Manage Timetables' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Timetable Admin');end
+ALTER TABLE `gibbonAttendanceLogPerson` ADD `gibbonTTDayRowClassID` INT(12) UNSIGNED ZEROFILL NULL AFTER `gibbonCourseClassID`;end
+ALTER TABLE `gibbonAttendanceLogCourseClass` ADD `gibbonTTDayRowClassID` INT(12) UNSIGNED ZEROFILL NULL AFTER `gibbonCourseClassID`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -176,6 +176,7 @@ v24.0.00
         System: fixed missing password reset link in plain-text copy of emails
         Activities: fixed sidebar disappearing when opening View Details window
         Attendance: fixed the Available to Roles setting in Attendance Codes
+        Attendance: fixed attendance for classes timetabled multiple times on the same day
         Finance: fixed online payment option not available on invoice print page
         Finance: fixed reminder emails not handling comma separated company email addresses
         Library: fixed missing cost field when duplicating library item

--- a/modules/Attendance/attendance_take_byCourseClassProcess.php
+++ b/modules/Attendance/attendance_take_byCourseClassProcess.php
@@ -28,17 +28,18 @@ require __DIR__ . '/../../gibbon.php';
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php' ;
 
-$gibbonCourseClassID=$_POST["gibbonCourseClassID"] ?? '';
-$currentDate=$_POST["currentDate"] ?? '';
-$today=date("Y-m-d");
+$gibbonCourseClassID=$_POST['gibbonCourseClassID'] ?? '';
+$gibbonTTDayRowClassID=!empty($_POST['gibbonTTDayRowClassID']) ? $_POST['gibbonTTDayRowClassID'] : null;
+$currentDate=$_POST['currentDate'] ?? '';
+$today=date('Y-m-d');
 
-$moduleName = getModuleName($_POST["address"] ?? '');
+$moduleName = getModuleName($_POST['address'] ?? '');
 
-if ($moduleName == "Planner") {
+if ($moduleName == 'Planner') {
     $gibbonPlannerEntryID = $_POST['gibbonPlannerEntryID'] ?? '';
-    $URL=$session->get("absoluteURL") . "/index.php?q=/modules/" . $moduleName . "/planner_view_full.php&gibbonPlannerEntryID=$gibbonPlannerEntryID&viewBy=date&gibbonCourseClassID=$gibbonCourseClassID&date=" . $currentDate ;
+    $URL=$session->get('absoluteURL') . "/index.php?q=/modules/" . $moduleName . "/planner_view_full.php&gibbonPlannerEntryID=$gibbonPlannerEntryID&viewBy=date&gibbonCourseClassID=$gibbonCourseClassID&date=" . $currentDate ;
 } else {
-    $URL=$session->get("absoluteURL") . "/index.php?q=/modules/" . $moduleName . "/attendance_take_byCourseClass.php&gibbonCourseClassID=$gibbonCourseClassID&currentDate=" . Format::date($currentDate) ;
+    $URL=$session->get('absoluteURL') . "/index.php?q=/modules/" . $moduleName . "/attendance_take_byCourseClass.php&gibbonCourseClassID=$gibbonCourseClassID&gibbonTTDayRowClassID=$gibbonTTDayRowClassID&currentDate=" . Format::date($currentDate) ;
 }
 
 if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take_byCourseClass.php")==FALSE) {
@@ -113,13 +114,13 @@ else {
                     }
 
                     if ($resultLog->rowCount()<1) {
-                        $data=array("gibbonPersonIDTaker"=>$session->get("gibbonPersonID"), "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
-                        $sql="INSERT INTO gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken" ;
+                        $data=array("gibbonPersonIDTaker"=>$session->get("gibbonPersonID"), "gibbonCourseClassID"=>$gibbonCourseClassID, 'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
+                        $sql="INSERT INTO gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, gibbonTTDayRowClassID=:gibbonTTDayRowClassID, date=:date, timestampTaken=:timestampTaken" ;
 
                     } else {
                         $resultUpdate=$resultLog->fetch() ;
-                        $data=array("gibbonAttendanceLogCourseClassID" => $resultUpdate['gibbonAttendanceLogCourseClassID'], "gibbonPersonIDTaker"=>$session->get("gibbonPersonID"), "gibbonCourseClassID"=>$gibbonCourseClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
-                        $sql="UPDATE gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, date=:date, timestampTaken=:timestampTaken WHERE gibbonAttendanceLogCourseClassID=:gibbonAttendanceLogCourseClassID" ;
+                        $data=array("gibbonAttendanceLogCourseClassID" => $resultUpdate['gibbonAttendanceLogCourseClassID'], "gibbonPersonIDTaker"=>$session->get("gibbonPersonID"), "gibbonCourseClassID"=>$gibbonCourseClassID, 'gibbonTTDayRowClassID' => $gibbonTTDayRowClassID, "date"=>$currentDate, "timestampTaken"=>date("Y-m-d H:i:s"));
+                        $sql="UPDATE gibbonAttendanceLogCourseClass SET gibbonPersonIDTaker=:gibbonPersonIDTaker, gibbonCourseClassID=:gibbonCourseClassID, gibbonTTDayRowClassID=:gibbonTTDayRowClassID, date=:date, timestampTaken=:timestampTaken WHERE gibbonAttendanceLogCourseClassID=:gibbonAttendanceLogCourseClassID" ;
                     }
 
                     try {
@@ -170,7 +171,7 @@ else {
                         $gibbonAttendanceLogPersonID = '';
                         if ($result->rowCount()>0) {
                             while ($row=$result->fetch()) {
-                                if ($row['context'] == 'Class' && $row['gibbonCourseClassID'] == $gibbonCourseClassID) {
+                                if ($row['context'] == 'Class' && $row['gibbonCourseClassID'] == $gibbonCourseClassID && (empty($row['gibbonTTDayRowClassID']) || $row['gibbonTTDayRowClassID'] == $gibbonTTDayRowClassID) ) {
                                     $existing = true ;
                                     $gibbonAttendanceLogPersonID = $row['gibbonAttendanceLogPersonID'];
                                     break;
@@ -188,6 +189,7 @@ else {
                             'comment'                => $comment,
                             'gibbonPersonIDTaker'    => $session->get('gibbonPersonID'),
                             'gibbonCourseClassID'    => $gibbonCourseClassID,
+                            'gibbonTTDayRowClassID'  => $gibbonTTDayRowClassID,
                             'date'                   => $currentDate,
                             'timestampTaken'         => date('Y-m-d H:i:s'),
                         ];

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -29,6 +29,7 @@ use Gibbon\Domain\Attendance\AttendanceLogPersonGateway;
 use Gibbon\Domain\Attendance\AttendanceLogCourseClassGateway;
 use Gibbon\Tables\DataTable;
 use Gibbon\Forms\CustomFieldHandler;
+use Gibbon\Domain\Timetable\TimetableDayDateGateway;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -1227,8 +1228,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                         $form->setAutocomplete('off');
                         $form->setTitle($attendanceEnabled ? __('Participants & Attendance') : __('Participants'));
 
-                        // Display the dated this attendance was taken, if any
+                        // Display the date this attendance was taken, if any
                         if ($canTakeAttendance) {
+                            // Try to determine the timetable period for this lesson
+                            $ttPeriod = $container->get(TimetableDayDateGateway::class)->getTimetabledPeriodByClassAndTime($gibbonCourseClassID, $values['date'], $values['timeStart'], $values['timeEnd']);
+                            $form->addHiddenValue('gibbonTTDayRowClassID', $ttPeriod['gibbonTTDayRowClassID']);
+
                             $classLogs = $container->get(AttendanceLogCourseClassGateway::class)->selectClassAttendanceLogsByDate($gibbonCourseClassID, $values['date'])->fetchAll();
                             if (empty($classLogs)) {
                                 $form->setDescription(Format::alert(__('Attendance has not been taken. The entries below are a best-guess, not actual data.')));

--- a/src/Domain/Timetable/TimetableDayDateGateway.php
+++ b/src/Domain/Timetable/TimetableDayDateGateway.php
@@ -52,4 +52,32 @@ class TimetableDayDateGateway extends QueryableGateway
 
         return $this->db()->selectOne($sql, $data);
     }
+
+    public function selectTimetabledPeriodsByClass($gibbonCourseClassID, $date)
+    {
+        $data = ['gibbonCourseClassID' => $gibbonCourseClassID, 'date' => $date];
+        $sql = "SELECT gibbonTTDayRowClass.gibbonTTDayRowClassID, gibbonTTColumnRow.name as period,  gibbonTTColumnRow.timeStart, gibbonTTColumnRow.timeEnd, gibbonTTDayRowClass.gibbonCourseClassID
+                FROM gibbonTTDayRowClass
+                JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID)
+                JOIN gibbonTTDayDate ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID)
+                WHERE gibbonTTDayRowClass.gibbonCourseClassID=:gibbonCourseClassID
+                AND gibbonTTDayDate.date=:date";
+
+        return $this->db()->select($sql, $data);
+    }
+
+    public function getTimetabledPeriodByClassAndTime($gibbonCourseClassID, $date, $timeStart, $timeEnd)
+    {
+        $data = ['gibbonCourseClassID' => $gibbonCourseClassID, 'date' => $date, 'timeStart' => $timeStart, 'timeEnd' => $timeEnd];
+        $sql = "SELECT gibbonTTDayRowClass.gibbonTTDayRowClassID, gibbonTTColumnRow.name as period,  gibbonTTColumnRow.timeStart, gibbonTTColumnRow.timeEnd, gibbonTTDayRowClass.gibbonCourseClassID
+                FROM gibbonTTDayRowClass
+                JOIN gibbonTTColumnRow ON (gibbonTTColumnRow.gibbonTTColumnRowID=gibbonTTDayRowClass.gibbonTTColumnRowID)
+                JOIN gibbonTTDayDate ON (gibbonTTDayDate.gibbonTTDayID=gibbonTTDayRowClass.gibbonTTDayID)
+                WHERE gibbonTTDayRowClass.gibbonCourseClassID=:gibbonCourseClassID
+                AND gibbonTTDayDate.date=:date
+                AND gibbonTTColumnRow.timeStart=:timeStart 
+                AND gibbonTTColumnRow.timeEnd=:timeEnd";
+
+        return $this->db()->selectOne($sql, $data);
+    }
 }


### PR DESCRIPTION
Currently, if a class is timetabled for multiple lessons on the same day, it only has one attendance record, and submitting the attendance again with update the existing attendance. There was also a bug where students with timetable exceptions from one class were also not being listed in other classes on the same day.

This PR adds a gibbonTTDayRowClassID field to the attendance log for class attendance to track exactly which timetable period the attendance was taken for. It is backwards compatible, handling null values in the field by default, and has been prefilled in the background for lesson plan attendance.

When a class is timetabled multiple times, the user will be prompted to select which timetable period they are taking attendance for.

Also updates the fromArray method on input classes to enable specifying the name, value and groupBy fields, the same way that other MultipleOptionsTrait inputs do. This makes it easier to pass in a set of data that has more than just value => name key pairs.

**Motivation and Context**
Fixes issues with multiple classes on the same date and adds more relational data to the attendance log to enable future queries to refine their results.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="995" alt="Screen Shot 2022-11-14 at 2 45 37 PM" src="https://user-images.githubusercontent.com/897700/201593008-d81bd44c-c0ab-4c21-99fc-9e1611e77e99.png">
