### PR TITLE
School Admin: enable Off Timetable days by form group, update CLI scripts

### DIFF
--- a/cli/attendance_dailyIncompleteEmail.php
+++ b/cli/attendance_dailyIncompleteEmail.php
@@ -22,6 +22,7 @@ use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
 use Gibbon\Domain\System\NotificationGateway;
+use Gibbon\Domain\School\SchoolYearSpecialDayGateway;
 
 require getcwd().'/../gibbon.php';
 
@@ -51,14 +52,23 @@ if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $rem
             die('Attendance CLI cancelled: Notifications not enabled in Attendance Settings.');
         }
 
+        $specialDay = $container->get(SchoolYearSpecialDayGateway::class)->getSpecialDayByDate($currentDate);
+        $gibbonYearGroupIDList = !empty($specialDay) && $specialDay['type'] == 'Off Timetable' 
+            ? $specialDay['gibbonYearGroupIDList'] ?? ''
+            : '';
+        $gibbonFormGroupIDArray = !empty($specialDay) && $specialDay['type'] == 'Off Timetable' 
+            ? explode(',', $specialDay['gibbonFormGroupIDList'] ?? '')
+            : [];
+
         //Produce array of attendance data ------------------------------------------------------------------------------------------------------
 
         if ($enabledByFormGroup == 'Y') {
             try {
-                $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
+                $data = ['gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonYearGroupIDList' => $gibbonYearGroupIDList];
 
                 // Looks for form groups with attendance='Y', also grabs primary tutor name
-                $sql = "SELECT gibbonFormGroupID, gibbonFormGroup.name, gibbonPersonIDTutor, gibbonPersonIDTutor2, gibbonPersonIDTutor3, gibbonPerson.preferredName, gibbonPerson.surname, (SELECT count(*) FROM gibbonStudentEnrolment WHERE gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID) AS studentCount
+                // Excludes students in year groups with Off Timetable days
+                $sql = "SELECT gibbonFormGroupID, gibbonFormGroup.name, gibbonPersonIDTutor, gibbonPersonIDTutor2, gibbonPersonIDTutor3, gibbonPerson.preferredName, gibbonPerson.surname, (SELECT count(DISTINCT gibbonStudentEnrolment.gibbonPersonID) FROM gibbonStudentEnrolment WHERE gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID AND NOT FIND_IN_SET(gibbonStudentEnrolment.gibbonYearGroupID, :gibbonYearGroupIDList)) AS studentCount
                 FROM gibbonFormGroup
                 JOIN gibbonPerson ON (gibbonFormGroup.gibbonPersonIDTutor=gibbonPerson.gibbonPersonID)
                 WHERE gibbonSchoolYearID=:gibbonSchoolYearID
@@ -74,7 +84,6 @@ if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $rem
 
             // Proceed if we have attendance-able Form Groups
             if ($result->rowCount() > 0) {
-
                 try {
                     $data = array('date' => $currentDate);
                     $sql = 'SELECT gibbonFormGroupID FROM gibbonAttendanceLogFormGroup WHERE date=:date';
@@ -93,6 +102,9 @@ if (!(isCommandLineInterface() OR ($remoteCLIKey != '' AND $remoteCLIKey == $rem
                 while ($row = $result->fetch()) {
                     // Skip form groups with no students
                     if ($row['studentCount'] <= 0) continue;
+
+                    // Skip special days by form group ID
+                    if (in_array($row['gibbonFormGroupID'], $gibbonFormGroupIDArray)) continue;
 
                     // Check for a current log
                     if (isset($log[$row['gibbonFormGroupID']]) == false) {

--- a/modules/School Admin/schoolYearSpecialDay_manage.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage.php
@@ -158,7 +158,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
                             $rowSpecial = $resultSpecial->fetch();
                             echo '</td>';
                         } else {
-                            echo "<td style='text-align: center; background-color: #eeeeee; font-size: 10px'>";
+                            $class = date('Y-m-d', $i) == date('Y-m-d') ? 'bg-yellow-200' : 'bg-gray-200';
+                            echo "<td class='{$class}' style='text-align: center;  font-size: 10px'>";
 
                             echo "<span style='color: #000000'>".Format::date(date('Y-m-d', $i)).'<br/>'.__('School Day').'</span>';
                             echo '<br/>';

--- a/modules/School Admin/schoolYearSpecialDay_manage_add.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_add.php
@@ -88,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 
     $contexts = [
         'Year Group' => __('Year Group'),
-        // 'Form Group' => __('Form Group'),
+        'Form Group' => __('Form Group'),
     ];
 
     $row = $form->addRow()->addClass('offTimetable');

--- a/modules/School Admin/schoolYearSpecialDay_manage_edit.php
+++ b/modules/School Admin/schoolYearSpecialDay_manage_edit.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/schoolYearSpe
 
     $contexts = [
         'Year Group' => __('Year Group'),
-        // 'Form Group' => __('Form Group'),
+        'Form Group' => __('Form Group'),
     ];
 
     $row = $form->addRow()->addClass('offTimetable');

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -1165,7 +1165,7 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
         $output .= "<div style='position: relative'>";
         $output .= "<div class='".($offTimetable ? 'bg-blue-200 border border-blue-700 text-blue-700' : 'ttClosure text-red-700')."' style='z-index: $zCount; position: absolute; width: 100%; min-width: $width ; height: ".ceil($diffTime / 60)."px; margin: 0px; padding: 0px; opacity: $ttAlpha'>";
         $output .= "<div style='position: relative; top: 50%' title='".($specialDay['description'] ?? '' )."'>";
-        $output .= $offTimetable ? __('Off Timetable') : __('School Closed');
+        $output .= $offTimetable ? __('School Day').'<br/><br/>'.__('Off Timetable') : __('School Closed');
         $output .= '<br/><br/>'.($specialDay['name'] ?? '');
         $output .= '</div>';
         $output .= '</div>';


### PR DESCRIPTION
Earlier in the dev cycle we added Off Timetable as an option for Special Days, with an option to select year groups. This PR extend that functionality with the option to alternatively set form groups off timetable for the day.

- Enables the selection of Form Groups when adding/editing a special day
- Updates the timetable logic to display full days off timetable to students by form group or year group
- Updates the timetable logic to show classes off timetable to teachers, provided all students in the class are also off timetable
- Updates the attendance CLI scripts to not sent to teachers if their class/form group is off timetable for the day
- Highlights the current day in the Special Days list, making it easier to find

**Motivation and Context**
More flexibility for schools to have off timetable days.

**How Has This Been Tested?**
Locally.
