### PR TITLE
Remove role restrictions for hooks

### DIFF
--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -451,14 +451,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                             // Check for permission to hook
                             $hookPermission = $hookGateway->getHookPermission($hook['gibbonHookID'], $session->get('gibbonRoleIDCurrent'), $options['sourceModuleName'] ?? '', $options['sourceModuleAction'] ?? '');
 
-                            if (!empty($options) && !empty($hookPermission)) {
+                            //if (!empty($options) && !empty($hookPermission)) {
                                 $include = $session->get('absolutePath').'/modules/'.$options['sourceModuleName'].'/'.$options['sourceModuleInclude'];
                                 if (!file_exists($include)) {
                                     echo Format::alert(__('The selected page cannot be displayed due to a hook error.'), 'error');
                                 } else {
                                     include $include;
                                 }
-                            }
+                           // }
                         }
 
 


### PR DESCRIPTION
Having the hook restricted by role causes issues when you have custom roles. I had to comment out these lines to get a module working.

