### PR TITLE
Refactor: Deprecate msort

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -666,7 +666,15 @@ function getTerms($connection2, $gibbonSchoolYearID, $short = false)
     return $output;
 }
 
-//Array sort for multidimensional arrays
+/**
+ * Array sort for multidimensional arrays.
+ *
+ * Deprecated in favor of native usort.
+ *
+ * @since 2013
+ * @version v12.0.00
+ * @deprecated v26.0.00
+ */
 function msort($array, $id = 'id', $sort_ascending = true)
 {
     $temp_array = array();

--- a/modules/Planner/moduleFunctions.php
+++ b/modules/Planner/moduleFunctions.php
@@ -674,7 +674,8 @@ function getResourcesTagCloud($guid, $connection2, $tagCount = 50) {
             ++$count;
         }
 
-        $tags = msort($tags, 0, true);
+        // Sort tags by the value of their tag name (i.e. key=0) asecendingly.
+        usort($tags, fn($a, $b) => $a[0] <=> $b[0]);
 
         $min_font_size = 16;
         $max_font_size = 30;

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -795,7 +795,9 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                     $eventsCombined = $eventsPersonal;
                 }
 
-                $eventsCombined = msort($eventsCombined, 2, true);
+                // Sort $eventsCombined by the value of their start timestamp (key = 2) ascendingly.
+                // See getCalendarEvents() for field details of each events.
+                usort($eventsCombined, fn($a, $b) => $a[2] <=> $b[2]);
 
                 $currentAllDays = 0;
                 $lastDate = '';


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
* Rewrite all usages of msort in core to usort with documentation.
* Properly document msort with phpdoc and mark it deprecated.

**Motivation and Context**
* Part of the effort to retire old functions. See #1689.
* msort is a really old function in Gibbon (First introduced to git repo in 2286c9b0b, which was when Gibbon first migrated to git). I'm not sure if it is used elsewhere in modules (although I've searched all modules to found no reference to it). Might be safer to make it deprecated here.

**How Has This Been Tested?**
* Locally.
* CI.