### PR TITLE
PHP 8.3 compatibility in all CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: ["7.4", "8.0", "8.1", "8.2"]
+        php-version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
         experimental: [false]
         name: ["CI Test"]
     services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,14 +126,18 @@
     when: on_failure
     expire_in: 1 week
 
-php:7.3:
-  image: php:7.3
-  extends: .tests
-
 php:7.4:
   image: php:7.4
   extends: .tests
 
 php:8.0:
   image: php:8.0
+  extends: .tests
+
+php:8.1:
+  image: php:8.1
+  extends: .tests
+
+php:8.2:
+  image: php:8.2
   extends: .tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,10 +24,10 @@
 
     # install apt packages
     - apt-get update -qy
-    - apt-get install -qy mariadb-client gettext git libzip-dev libgd-dev libpng-dev locales unzip zip zlib1g-dev
+    - apt-get install -qy mariadb-client gettext git libzip-dev libicu-dev libgd-dev libpng-dev locales unzip zip zlib1g-dev
 
     # install php extensions
-    - docker-php-ext-install gd gettext pdo_mysql zip > /dev/null
+    - docker-php-ext-install gd gettext intl pdo_mysql zip > /dev/null
 
     # properly setup php
     - cp -pdf /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,3 +141,7 @@ php:8.1:
 php:8.2:
   image: php:8.2
   extends: .tests
+
+php:8.3:
+  image: php:8.3-rc
+  extends: .tests


### PR DESCRIPTION
**Description**
* Add PHP 8.3 to CI in both GitHub Workflows and GitLab CI
* Includes change in #1756. Please merge #1756 first.

**Motivation and Context**
* PHP 8.3 has released RC.
* The list of [PHP 8.3 changes](https://php.watch/versions/8.3) don't seems to really matter for Gibbon.

**How Has This Been Tested?**
* CI environment.
* Locally.