### PR TITLE
Format: new functions for readable date-time conversion

### DIFF
--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -125,6 +125,41 @@ class Format
     /**
      * Formats a YYYY-MM-DD date as a readable string with month names.
      *
+     * @param DateTime|string $dateString  The date string to format.
+     * @param string          $pattern     (Optional) The pattern string for Unicode formatting suppored by
+     *                                     IntlDateFormatter::setPattern().
+     *
+     *                                     See: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
+     *                                     Default: 'MMM d, Y'
+     *
+     * @return string  The formatted date string.
+     */
+    public static function dateIntlReadable($dateString, $pattern = 'MMM d, yyyy'): string
+    {
+        if (empty($dateString)) {
+            return '';
+        }
+        if (!static::$intlFormatterAvailable) {
+            throw new \Exception('IntlDateFormatter not available.');
+        }
+        $formatter = new \IntlDateFormatter(
+            static::$settings['code'],
+            \IntlDateFormatter::FULL,
+            \IntlDateFormatter::FULL,
+            null,
+            null,
+            $pattern,
+        );
+        return mb_convert_case(
+            $formatter->format(static::createDateTime($dateString)),
+            MB_CASE_TITLE,
+        );
+    }
+
+    /**
+     * Formats a YYYY-MM-DD date as a readable string with month names.
+     *
+     * @deprecated v27.0.00 Use dateIntlReadable() instead.
      * @param DateTime|string $dateString
      * @return string
      */
@@ -140,6 +175,24 @@ class Format
     /**
      * Formats a YYYY-MM-DD date as a readable string with month names and times.
      *
+     * @param DateTime|string $dateString  The date string to format.
+     * @param string          $pattern     (Optional) The pattern string for Unicode formatting suppored by
+     *                                     IntlDateFormatter::setPattern().
+     *
+     *                                     See: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
+     *                                     Default: 'MMM d, Y'
+     *
+     * @return string  The formatted date string.
+     */
+    public static function dateTimeIntlReadable($dateString, $pattern = 'MMM d, yyyy HH:mm'): string
+    {
+        return static::dateIntlReadable($dateString, $pattern);
+    }
+
+    /**
+     * Formats a YYYY-MM-DD date as a readable string with month names and times.
+     *
+     * @deprecated v27.0.00 Use dateTimeIntlReadable() instead.
      * @param DateTime|string $dateString
      * @return string
      */

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Format
  */
-class x extends TestCase
+class FormatTest extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Format
  */
-class FormatTest extends TestCase
+class x extends TestCase
 {
     public function setUp(): void
     {
@@ -79,6 +79,9 @@ class FormatTest extends TestCase
     public function testFormatsReadableDates()
     {
         $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
+        $this->assertEquals('May 18, 2018', Format::dateIntlReadable('2018-05-18'));
+        $this->assertEquals('May 18, 2018 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
+        $this->assertEquals('May 18, 2018 13:24', Format::dateTimeIntlReadable('2018-05-18 13:24'));
     }
 
     public function testFormatsDateRanges()


### PR DESCRIPTION
**Description**
* dateIntlReadable to replace dateReadable
* dateTimeIntlReadable to replace dateTimeReadable
* Add test coverage to Format::dateTimeReadable, Format::dateIntlReadable and Format::dateTimeIntlReadable.

**Motivation and Context**
* Pave way to refactor away the remaining usages of strftime (see #1643).

**How Has This Been Tested?**
* Locally.
* CI environment.