### PR TITLE
Fix CI environments language setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           cat <<- EOF |
           en_US.UTF-8 UTF-8
+          en_GB.UTF-8 UTF-8
           es_ES.UTF-8 UTF-8
           fr_FR.UTF-8 UTF-8
           zh_TW.UTF-8 UTF-8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,8 @@
     - |
       # setup system locale for test
       cat <<- EOF | tee -a /etc/locale.gen >/dev/null
+      en_US.UTF-8 UTF-8
+      en_GB.UTF-8 UTF-8
       es_ES.UTF-8 UTF-8
       fr_FR.UTF-8 UTF-8
       zh_TW.UTF-8 UTF-8

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -43,6 +43,9 @@ class FormatTest extends TestCase
         );
 
         Format::setup($settings);
+
+        // Verify test environment has correct locale setup.
+       $this->assertStringStartsWith($settings['code'], setlocale(LC_TIME, 0), 'Test environment has correct locale setup');
     }
 
     public function testFormatsDates()


### PR DESCRIPTION
**Description**
* Add en_GB and en_US to CI environment.

**Motivation and Context**
* Found out that the setlocale was incorrect in testing environment, which makes test results unstable for some of the test I'd want to add (in another PR).

**How Has This Been Tested?**
* GitHub Workflows
* GitLab CI