### PR TITLE
Format: Intl readable datetime rewrite usages

### DIFF
--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -181,7 +181,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
 
         $form->addHiddenValue('address', $session->get('address'));
         $form->addHiddenValue('gibbonPersonID', $session->get('gibbonPersonID'));
-        
+
         if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendanceExport.php')) {
             $form->addHeaderAction('download', __('Export to Excel'))
                 ->setURL('/modules/Activities/report_attendanceExport.php')
@@ -213,7 +213,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
         $i = 0;
         foreach ($activitySessions as $sessionDate => $sessionTimestamp) {
             $col = $row->addColumn()->addClass('h-24 px-2 text-center');
-            $dateLabel = $col->addContent(Format::dateReadable($sessionDate, '%a<br>%b %e'))->addClass('w-10 mx-auto whitespace-nowrap');
+            $dateLabel = $col->addContent(
+                Format::dateIntlReadable($sessionDate, 'EEE') . '<br>' .
+                Format::dateIntlReadable($sessionDate, 'MMM d')
+            )->addClass('w-10 mx-auto whitespace-nowrap');
 
             if (isset($sessionAttendanceData[$sessionDate]['data'])) {
                 $col->addWebLink(sprintf($icon, __('Edit'), 'config.png'))

--- a/modules/Activities/report_attendance.php
+++ b/modules/Activities/report_attendance.php
@@ -217,10 +217,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
                             echo "<td style='vertical-align:top; width: 50px;  white-space: nowrap;'>";
                         }
 
-                printf("<span title='%s'>%s</span><br/>&nbsp;<br/>", $sessionAttendanceData[$sessionDate]['info'], Format::dateReadable($sessionDate, '%a <br /> %b %e'));
+                printf("<span title='%s'>%s <br/> %s</span><br/>&nbsp;<br/>",
+                    $sessionAttendanceData[$sessionDate]['info'],
+                    Format::dateIntlReadable($sessionDate, 'EEE'),
+                    Format::dateIntlReadable($sessionDate, 'MMM d')
+                );
             } else {
                 echo "<td style='color: #bbb; vertical-align:top; width: 50px; white-space: nowrap;'>";
-                echo Format::dateReadable($sessionDate, '%a <br /> %b %e').'<br/>&nbsp;<br/>';
+                echo Format::dateIntlReadable($sessionDate, 'EEE').' <br/> '.
+                    Format::dateIntlReadable($sessionDate, 'MMM d').'<br/>&nbsp;<br/>';
             }
             echo '</td>';
         }

--- a/modules/Admissions/admissions_manage_edit.php
+++ b/modules/Admissions/admissions_manage_edit.php
@@ -68,14 +68,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Admissions/admissions_mana
             $url = Url::fromModuleRoute('User Admin', 'family_manage_edit')->withAbsoluteUrl();
 
             return !empty($family)
-                ? Format::link($url->withQueryParams(['gibbonFamilyID' => $family['gibbonFamilyID']]), $family['name']) 
+                ? Format::link($url->withQueryParams(['gibbonFamilyID' => $family['gibbonFamilyID']]), $family['name'])
                 : __('This account is not linked to a family.');
         });
 
-    $table->addColumn('created', __('Created'))->format(Format::using('dateReadable', 'timestampCreated'));
+    $table->addColumn('created', __('Created'))->format(Format::using('dateIntlReadable', 'timestampCreated'));
 
     $table->addColumn('active', __('Last Active'))->format(Format::using('relativeTime', 'timestampActive'));
-    
+
     $table->addColumn('ipAddress', __('IP Address'));
 
     echo $table->render([$values]);
@@ -84,10 +84,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Admissions/admissions_mana
     // FORM
     $form = Form::create('admissionsManage', $session->get('absoluteURL').'/modules/Admissions/admissions_manage_editProcess.php');
     $form->setFactory(DatabaseFormFactory::create($pdo));
-    
+
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('gibbonAdmissionsAccountID', $gibbonAdmissionsAccountID);
-    
+
     $row = $form->addRow();
         $row->addLabel('email', __('Email'));
         $row->addEmail('email')

--- a/modules/Admissions/applicationFormView.php
+++ b/modules/Admissions/applicationFormView.php
@@ -95,15 +95,15 @@ if (!$proceed) {
         echo $form->getOutput();
         return;
     }
-    
+
     if ($public && !empty($account['timestampTokenExpire'])) {
         echo Format::alert(__('Welcome back! You are accessing this page through a unique link sent to your email address {email}. Please keep this link secret to protect your personal details. This link will expire {expiry}.', ['email' => '<u>'.$account['email'].'</u>', 'expiry' => Format::relativeTime($account['timestampTokenExpire'])]), 'message');
-    }    
+    }
 
     $page->return->addReturns(['success1' => __('A new admissions account has been created for {email}', ['email' => $account['email'] ?? ''])]);
 
     $formPayment = $container->get(FormPayment::class);
-    
+
     $criteria = $admissionsApplicationGateway->newQueryCriteria(true)
         ->sortBy('timestampCreated', 'ASC');
 
@@ -120,16 +120,16 @@ if (!$proceed) {
         $table = DataTable::create('submissions');
         $table->setTitle(__('Current Applications'));
 
-        
+
         $table->addColumn('student', __('Applicant'))->format(function ($values) {
             return !empty($values['studentSurname'])
                 ? Format::name('', $values['studentPreferredName'], $values['studentSurname'], 'Student')
-                : Format::small(__('N/A')); 
+                : Format::small(__('N/A'));
 
         });
         $table->addColumn('formName', __('Application Form'));
         $table->addColumn('status', __('Status'))->translatable();
-        $table->addColumn('timestampCreated', __('Date'))->width('20%')->format(Format::using('dateTimeReadable', 'timestampCreated'));
+        $table->addColumn('timestampCreated', __('Date'))->width('20%')->format(Format::using('dateTimeIntlReadable', 'timestampCreated'));
 
         $table->modifyRows(function ($values, $row) {
             if ($values['status'] == 'Incomplete') $row->addClass('warning');
@@ -182,7 +182,7 @@ if (!$proceed) {
 
     if (count($forms) == 0) {
         return;
-    } 
+    }
 
     // FORM
     $form = Form::create('admissionsAccount', $session->get('absoluteURL').'/index.php?q=/modules/Admissions/applicationForm.php');
@@ -191,10 +191,10 @@ if (!$proceed) {
     $form->setDescription((count($submissions) > 0 ? __('You may continue submitting applications with the form below and they will be linked to your account data.').' ' : '').__('Some information has been pre-filled for you, feel free to change this information as needed.'));
 
     $form->setClass('w-full blank');
-    
+
     $form->addHiddenValue('address', $session->get('address'));
     $form->addHiddenValue('accessID', $account['accessID'] ?? '');
-    
+
     // Display all available public forms
     $firstForm = current($forms);
     foreach ($forms as $index => $applicationForm) {

--- a/modules/Admissions/applicationForm_payFee.php
+++ b/modules/Admissions/applicationForm_payFee.php
@@ -104,7 +104,7 @@ if (!$proceed) {
     // APPLICATION PROCESSING FEE
     if ($processPaymentRequired) {
         $form = Form::create('action', $session->get('absoluteURL').'/modules/Admissions/applicationForm_payFeeProcess.php');
-                    
+
         $form->addHiddenValue('address', $session->get('address'));
         $form->addHiddenValue('accessID', $accessID);
         $form->addHiddenValue('gibbonFormID', $gibbonFormID);
@@ -132,10 +132,10 @@ if (!$proceed) {
             $row = $form->addRow();
             $row->addLabel('statusLabel', __('Status'));
             $row->addTextField('status')->readOnly()->setValue($payment['status'] ?? __('Complete'));
-        
+
             $row = $form->addRow();
             $row->addLabel('timestampLabel', __('Date Paid'));
-            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeReadable($payment['timestamp'] ?? ''));
+            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntlReadable($payment['timestamp'] ?? ''));
 
             $row = $form->addRow();
             $row->addLabel('gatewayLabel', __('Payment Gateway'));
@@ -149,7 +149,7 @@ if (!$proceed) {
     // APPLICATION SUBMISSION FEE
     if ($submitPaymentRequired) {
         $form = Form::create('action', $session->get('absoluteURL').'/modules/Admissions/applicationForm_payFeeProcess.php');
-                
+
         $form->addHiddenValue('address', $session->get('address'));
         $form->addHiddenValue('accessID', $accessID);
         $form->addHiddenValue('gibbonFormID', $gibbonFormID);
@@ -177,10 +177,10 @@ if (!$proceed) {
             $row = $form->addRow();
             $row->addLabel('statusLabel', __('Status'));
             $row->addTextField('status')->readOnly()->setValue($payment['status'] ?? __('Complete'));
-        
+
             $row = $form->addRow();
             $row->addLabel('timestampLabel', __('Date Paid'));
-            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeReadable($payment['timestamp'] ?? ''));
+            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntlReadable($payment['timestamp'] ?? ''));
 
             $row = $form->addRow();
             $row->addLabel('gatewayLabel', __('Payment Gateway'));

--- a/modules/Admissions/src/Forms/ApplicationMilestonesForm.php
+++ b/modules/Admissions/src/Forms/ApplicationMilestonesForm.php
@@ -79,13 +79,13 @@ class ApplicationMilestonesForm extends Form
             $dateInfo = '';
             if ($checked) {
                 $user = $this->userGateway->getByID($milestonesData[$milestone]['user'], ['preferredName', 'surname']);
-                $dateInfo = Format::dateReadable($milestonesData[$milestone]['date']).' '.__('By').' '.Format::name('', $user['preferredName'], $user['surname'], 'Staff', false, true);
+                $dateInfo = Format::dateIntlReadable($milestonesData[$milestone]['date']).' '.__('By').' '.Format::name('', $user['preferredName'], $user['surname'], 'Staff', false, true);
             }
 
             $description = '<div class="milestone flex-1 text-left"><span class="milestoneCheck '.($checked ? '' : 'hidden').'">'.$checkIcon.'</span><span class="milestoneCross '.($checked ? 'hidden' : '').'">'.$crossIcon.'</span><span class="text-base leading-normal">'.__($milestone).'</span></div><div class="flex-1 text-left">'.$dateInfo.'</div>';
             $col->addCheckbox("milestones[{$milestone}]")
                 ->setValue('Y')
-                ->checked($checked ? 'Y' : 'N') 
+                ->checked($checked ? 'Y' : 'N')
                 ->description($description)
                 ->alignRight()
                 ->setLabelClass('w-full flex items-center')

--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -117,8 +117,8 @@ if ($session->has('username')) {
                                 'currentDate' => $day['currentDate'],
                             ]);
                             $content =
-                                '<div class="day text-xs">' . Format::dateReadable($day['currentDate'], '%d') . '</div>' .
-                                '<div class="month text-xxs mt-px">' . Format::dateReadable($day['currentDate'], '%b') . '</div>';
+                                '<div class="day text-xs">' . Format::dateIntlReadable($day['currentDate'], 'dd') . '</div>' .
+                                '<div class="month text-xxs mt-px">' . Format::dateIntlReadable($day['currentDate'], 'MMM') . '</div>';
                         }
 
                         // determine how to display link and content

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -252,7 +252,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                     }
                 });
                 $table->addColumn('staff', __('Recorded By'))->format(Format::using('name', ['', 'preferredName', 'surname', 'Staff', false, true]));
-                $table->addColumn('timestamp', __('On'))->format(Format::using('dateTimeReadable', 'timestampTaken', '%R, %b %d'));
+                $table->addColumn('timestamp', __('On'))->format(Format::using('dateIntlReadable', 'timestampTaken', 'HH:mm, MMM dd'));
 
                 $table->addActionColumn()
                     ->addParam('gibbonPersonID', $gibbonPersonIDList[0] ?? '')

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -112,7 +112,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
         $row = $form->addRow()->addClass('multiple');
             $row->addLabel('target', __('Target'));
             $row->addSelect('target')->fromArray($targetOptions)->required()->selected($target)->placeholder();
-    
+
         $form->toggleVisibilityByClass('targetActivity')->onSelect('target')->when('Activity');
         $form->toggleVisibilityByClass('targetMessenger')->onSelect('target')->when('Messenger');
         $form->toggleVisibilityByClass('targetSelect')->onSelect('target')->when('Select');
@@ -139,7 +139,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
     $studentList = $studentGateway->queryStudentsBySchoolYear($studentCriteria, $session->get('gibbonSchoolYearID'));
     $studentList = array_reduce($studentList->toArray(), function ($group, $student) use ($gibbonPersonIDList) {
         $list = in_array($student['gibbonPersonID'], $gibbonPersonIDList) ? 'destination' : 'source';
-        $group['students'][$list][$student['gibbonPersonID']] = Format::name($student['title'], $student['preferredName'], $student['surname'], 'Student', true) . ' - ' . $student['formGroup']; 
+        $group['students'][$list][$student['gibbonPersonID']] = Format::name($student['title'], $student['preferredName'], $student['surname'], 'Student', true) . ' - ' . $student['formGroup'];
         $group['form'][$student['gibbonPersonID']] = $student['formGroup'];
         return $group;
     });
@@ -150,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
         $select->addSortableAttribute(__('Form Group'), $studentList['form']);
         $select->source()->fromArray($studentList['students']['source'] ?? []);
         $select->destination()->fromArray($studentList['students']['destination'] ?? []);
-        
+
     if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take_byCourseClass.php')) {
         $availableAbsenceTypes = [
             'full' => __('Full Day'),
@@ -171,7 +171,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
             $row->addTime('timeStart')
                 ->required()
                 ->setValue($timeStart);
-        
+
         $row = $form->addRow()->addClass('partialDateRow');
             $row->addLabel('timeEnd', __('End Time'));
             $row->addTime('timeEnd')
@@ -322,11 +322,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                         $checked = array_reduce($classes, function ($group, $class) use ($targetDate, $effectiveStart, $effectiveEnd) {
                             $classStart = strtotime($targetDate.' '.$class['timeStart']);
                             $classEnd = strtotime($targetDate.' '.$class['timeEnd']);
-                            if (($classStart >= $effectiveStart && $classStart < $effectiveEnd) 
+                            if (($classStart >= $effectiveStart && $classStart < $effectiveEnd)
                                     || ($effectiveStart >= $classStart && $effectiveStart < $classEnd)) {
                                 $group[] = $class['gibbonCourseClassID'].'-'.$class['gibbonTTDayRowClassID'];
                             }
-                            
+
                             return $group;
                         }, []);
 
@@ -336,7 +336,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                                     $group[] = $class['gibbonCourseClassID'].'-'.$class['gibbonTTDayRowClassID'];
                                 }
                             }
-                            
+
                             return $group;
                         }, []);
 
@@ -347,7 +347,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                             ->alignLeft()
                             ->checked($checked + $disabled)
                             ->disabled($disabled);
-                        
+
                     } else {
                         $col->addContent(Format::small(__('N/A')));
                     }
@@ -387,7 +387,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                 $row->addLabel('periodSelectContainer', __('Periods Absent'));
 
                 $table = $row->addTable('periodSelectContainer')->setClass('standardWidth');
-                $table->addHeaderRow()->addHeading(Format::dateReadable(Format::dateConvert($date),'%B %e, %Y'));
+                $table->addHeaderRow()->addHeading(Format::dateIntlReadable(Format::dateConvert($date),'MMMM d, yyyy'));
 
                 foreach ($classes as $class) {
                     $name = $class['columnName'] . ' - ' . $class['courseNameShort'] . '.' . $class['classNameShort'];
@@ -396,7 +396,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                     $classStart = strtotime($targetDate.' '.$class['timeStart']);
                     $classEnd = strtotime($targetDate.' '.$class['timeEnd']);
 
-                    $checked = (($classStart >= $effectiveStart && $classStart < $effectiveEnd) 
+                    $checked = (($classStart >= $effectiveStart && $classStart < $effectiveEnd)
                             || ($effectiveStart >= $classStart && $effectiveStart < $classEnd));
 
                     $disabled = false;
@@ -420,7 +420,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                         ->checked($checked ? $class['gibbonCourseClassID'] : '');
                 }
             } else {
-               
+
             }
         }
 

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -129,8 +129,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                         if (empty($log['timestampTaken'])) return Format::small(__('N/A'));
 
                         return $currentDate != substr($log['timestampTaken'], 0, 10)
-                            ? Format::dateTimeReadable($log['timestampTaken'], '%H:%M, %b %d')
-                            : Format::dateTimeReadable($log['timestampTaken'], '%H:%M');
+                            ? Format::dateIntlReadable($log['timestampTaken'], 'HH:mm, MMM dd')
+                            : Format::dateIntlReadable($log['timestampTaken'], 'HH:mm');
                     });
 
                 $table->addColumn('direction', __('Attendance'))

--- a/modules/Attendance/report_courseClassesNotRegistered_byDate.php
+++ b/modules/Attendance/report_courseClassesNotRegistered_byDate.php
@@ -186,11 +186,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_courseCl
                 //Output row only if not registered on specified date, and timetabled for that day
                 if (isset($tt[$row['gibbonCourseClassID']]) == true && (isset($log[$row['gibbonCourseClassID']]) == false ||
                     count($log[$row['gibbonCourseClassID']]) < min(count($lastNSchoolDays), count($tt[$row['gibbonCourseClassID']])) ) ) {
-                        
+
                     if (!empty($offTimetableList[$row['gibbonCourseClassID']]) && (($dateStart == $dateEnd &&  $offTimetableList[$row['gibbonCourseClassID']][$dateStart] == true) || count(array_filter($offTimetableList[$row['gibbonCourseClassID']])) == count($lastNSchoolDays))) {
                         continue;
                     }
-                    
+
                     ++$count;
 
                     //COLOR ROW BY STATUS!
@@ -239,12 +239,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_courseCl
                                 echo "<td class='$class' style='padding: 12px !important;' title='{$title}'>";
                                 if ($link != '') {
                                     echo "<a href='$link'>";
-                                    echo Format::dateReadable($date, '%d').'<br/>';
-                                    echo "<span>".Format::dateReadable($date, '%b').'</span>';
+                                    echo Format::dateIntlReadable($date, 'dd').'<br/>';
+                                    echo "<span>".Format::dateIntlReadable($date, 'MMM').'</span>';
                                     echo '</a>';
                                 } else {
-                                    echo Format::dateReadable($date, '%d').'<br/>';
-                                    echo "<span>".Format::dateReadable($date, '%b').'</span>';
+                                    echo Format::dateIntlReadable($date, 'dd').'<br/>';
+                                    echo "<span>".Format::dateIntlReadable($date, 'MMM').'</span>';
                                 }
                                 echo '</td>';
 

--- a/modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+++ b/modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
@@ -164,8 +164,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_courseCl
                             }
 
                             echo "<td class='$class' style='padding: 12px !important;'>";
-                            echo Format::dateReadable($lastNSchoolDays[$i], '%d').'<br/>';
-                            echo "<span>".Format::dateReadable($lastNSchoolDays[$i], '%b').'</span>';
+                            echo Format::dateIntlReadable($lastNSchoolDays[$i], 'dd').'<br/>';
+                            echo "<span>".Format::dateIntlReadable($lastNSchoolDays[$i], 'MMM').'</span>';
                             echo '</td>';
 
                             // Wrap to a new line every 10 dates

--- a/modules/Attendance/report_formGroupsNotRegistered_byDate.php
+++ b/modules/Attendance/report_formGroupsNotRegistered_byDate.php
@@ -188,7 +188,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_formGrou
                         $historyCount = 0;
                         for ($i = count($lastNSchoolDays)-1; $i >= 0; --$i) {
                             $date = $lastNSchoolDays[$i];
-                            
+
                             $link = $title = '';
                             if ($i > ( count($lastNSchoolDays) - 1)) {
                                 echo "<td class='highlightNoData'>";
@@ -211,12 +211,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_formGrou
                                 echo "<td class='$class' style='padding: 12px !important;' title='{$title}'>";
                                 if ($link != '') {
                                     echo "<a href='$link'>";
-                                    echo Format::dateReadable($date, '%d').'<br/>';
-                                    echo "<span>".Format::dateReadable($date, '%b').'</span>';
+                                    echo Format::dateIntlReadable($date, 'dd').'<br/>';
+                                    echo "<span>".Format::dateIntlReadable($date, 'MMM').'</span>';
                                     echo '</a>';
                                 } else {
-                                    echo Format::dateReadable($date, '%d').'<br/>';
-                                    echo "<span>".Format::dateReadable($date, '%b').'</span>';
+                                    echo Format::dateIntlReadable($date, 'dd').'<br/>';
+                                    echo "<span>".Format::dateIntlReadable($date, 'MMM').'</span>';
                                 }
                                 echo '</td>';
                             }
@@ -267,11 +267,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_formGrou
                         });
                         $logAll[$index] = current($logPerForm);
                     }
-            
+
                     usort($logAll, function ($a, $b) {
                         return $b['timestamp'] <=> $a['timestamp'];
                     });
-            
+
                     $finalLog = current($logAll);
                     $person = $container->get(UserGateway::class)->getByID($finalLog['gibbonPersonIDTaker'], ['preferredName', 'surname']);
 
@@ -281,7 +281,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_formGrou
                         'time' => Format::time($finalLog['timestampTaken']),
                     ]), 'message');
                 }
-                
+
             }
             echo '</table>';
 

--- a/modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
+++ b/modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
@@ -144,12 +144,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_formGrou
                             echo "<td class='$class' style='padding: 12px !important;'>";
                             if ($link != '') {
                                 echo "<a href='$link'>";
-                                echo Format::dateReadable($lastNSchoolDays[$i], '%d').'<br/>';
-                                echo "<span>".Format::dateReadable($lastNSchoolDays[$i], '%b').'</span>';
+                                echo Format::dateIntlReadable($lastNSchoolDays[$i], 'dd').'<br/>';
+                                echo "<span>".Format::dateIntlReadable($lastNSchoolDays[$i], 'MMM').'</span>';
                                 echo '</a>';
                             } else {
-                                echo Format::dateReadable($lastNSchoolDays[$i], '%d').'<br/>';
-                                echo "<span>".Format::dateReadable($lastNSchoolDays[$i], '%b').'</span>';
+                                echo Format::dateIntlReadable($lastNSchoolDays[$i], 'dd').'<br/>';
+                                echo "<span>".Format::dateIntlReadable($lastNSchoolDays[$i], 'MMM').'</span>';
                             }
                             echo '</td>';
                         }

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -203,7 +203,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_graph_by
                     ],
                 ])
                 ->setLabels(array_map(function ($date) {
-                    return Format::dateReadable($date, '%b %d');
+                    return Format::dateIntlReadable($date, 'MMM dd');
                 }, $days));
 
             foreach ($data as $typeName => $dates) {

--- a/modules/Attendance/src/AttendanceView.php
+++ b/modules/Attendance/src/AttendanceView.php
@@ -250,8 +250,8 @@ class AttendanceView
 
                 $output .= '<td class="' . $class . '">';
                 $output .= '<a href="' . $link . '" title="' . $linkTitle . '">';
-                $output .= Format::dateReadable($currentDay, '%d') . '<br/>';
-                $output .= '<span>' . Format::dateReadable($currentDay, '%b') . '</span>';
+                $output .= Format::dateIntlReadable($currentDay, 'dd') . '<br/>';
+                $output .= '<span>' . Format::dateIntlReadable($currentDay, 'MMM') . '</span>';
                 $output .= '</a>';
                 $output .= '</td>';
             }
@@ -270,7 +270,7 @@ class AttendanceView
 
         foreach ($attendanceTypes as $attendanceType) {
             $attendanceType['restricted'] = 'N';
-            
+
             // Check if a role is restricted - blank for unrestricted use
             if (!empty($attendanceType['gibbonRoleIDAll'])) {
                 $allowAttendanceType = false;
@@ -286,7 +286,7 @@ class AttendanceView
                 }
             }
 
-            $this->attendanceTypes[$attendanceType['name']] = $attendanceType; 
+            $this->attendanceTypes[$attendanceType['name']] = $attendanceType;
         }
     }
 }

--- a/modules/Planner/units_edit_deploy.php
+++ b/modules/Planner/units_edit_deploy.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
     if ($result->rowCount() != 1) {
         $page->addError(__('The selected record does not exist, or you do not have access to it.'));
         return;
-    } 
+    }
     $values = $result->fetch();
 
     // Get the unit details
@@ -218,7 +218,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
 
         foreach ($lessons as $index => $lesson) {
 
-            $form->addRow()->addHeading(($index+1).'. '.Format::dateReadable($lesson['date'], '%a %e %b, %Y'))
+            $form->addRow()->addHeading(($index+1).'. '.Format::dateIntlReadable($lesson['date'], 'E d MMM, yyyy'))
                 ->append(Format::small($lesson['period'].' ('.Format::timeRange($lesson['timeStart'], $lesson['timeEnd']).')'));
 
             $col = $form->addRow()->addClass('')->addColumn()->addClass('blockLesson');
@@ -227,7 +227,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
             $form->addHiddenValue('date'.$index, $lesson['date']);
             $form->addHiddenValue('timeStart'.$index, $lesson['timeStart']);
             $form->addHiddenValue('timeEnd'.$index, $lesson['timeEnd']);
-            
+
             $col->addColumn()
                 ->setClass('-mt-4')
                 ->addSelect('blockAdd')
@@ -317,5 +317,5 @@ $('.blockAdd').change(function () {
     $(sortable).append($('<div class="draggable z-100">').load("<?php echo $session->get('absoluteURL'); ?>/modules/Planner/units_add_blockAjax.php?mode=workingDeploy&gibbonUnitID=<?php echo $gibbonUnitID; ?>&gibbonUnitBlockID=" + $(this).val(), "id=" + count) );
     count++;
 });
-    
+
 </script>

--- a/modules/Planner/units_edit_working.php
+++ b/modules/Planner/units_edit_working.php
@@ -53,14 +53,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
     if ($highestAction == false) {
         $page->addError(__('The highest grouped action cannot be determined.'));
         return;
-    } 
+    }
 
     // Proceed!
     // Check if course & school year specified
     if ($gibbonCourseID == '' or $gibbonSchoolYearID == '' or $gibbonCourseClassID == '' or $gibbonUnitClassID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
         return;
-    } 
+    }
 
     $plannerEntryGateway = $container->get(PlannerEntryGateway::class);
     $unitBlockGateway = $container->get(UnitBlockGateway::class);
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
     if ($result->rowCount() != 1) {
         $page->addError(__('The selected record does not exist, or you do not have access to it.'));
         return;
-    } 
+    }
 
     $values = $result->fetch();
 
@@ -155,7 +155,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
 
         // Display the heading
         $heading = $form->addRow()->addHeading($lessonLink . $deleteLink)
-            ->append(Format::small(Format::dateReadable($lesson['date'], '%a %e %b, %Y')).'<br/>')
+            ->append(Format::small(Format::dateIntlReadable($lesson['date'], 'EEE d MMM, yyyy')).'<br/>')
             ->append($lessonTiming.'<br/>')
             ->append(Format::small($times['spaceName'] ?? ''));
 
@@ -166,7 +166,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
         $form->addHiddenValue('date'.$index, $lesson['date']);
         $form->addHiddenValue('timeStart'.$index, $lesson['timeStart']);
         $form->addHiddenValue('timeEnd'.$index, $lesson['timeEnd']);
-        
+
         $col->addColumn()
             ->setClass('-mt-4')
             ->addSelect('blockAdd')
@@ -229,5 +229,5 @@ $('.blockAdd').change(function () {
     $(sortable).append($('<div class="draggable z-100">').load("<?php echo $session->get('absoluteURL'); ?>/modules/Planner/units_add_blockAjax.php?mode=workingEdit&gibbonUnitID=<?php echo $gibbonUnitID; ?>&gibbonUnitBlockID=" + $(this).val(), "id=" + count) );
     count++;
 });
-    
+
 </script>

--- a/modules/Reports/archive_byReport.php
+++ b/modules/Reports/archive_byReport.php
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport.p
     $table->setTitle(__('View'));
 
     $table->addColumn('reportIdentifier', __('Report'));
-    $table->addColumn('timestampModified', __('Date'))->format(Format::using('dateReadable', 'timestampModified'));
+    $table->addColumn('timestampModified', __('Date'))->format(Format::using('dateIntlReadable', 'timestampModified'));
     $table->addColumn('readCount', __('Read'))
         ->width('30%')
         ->format(function ($report) use (&$page) {

--- a/modules/Reports/archive_byReport_view.php
+++ b/modules/Reports/archive_byReport_view.php
@@ -129,7 +129,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport_v
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                     $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
-                    $title = Format::dateTimeReadable($archive['timestampModified']);
+                    $title = Format::dateTimeIntlReadable($archive['timestampModified']);
                     $output .= Format::link($url, $title).$tag;
                 }
 
@@ -169,7 +169,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport_v
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                     $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                    $title = Format::dateTimeReadable($archive['timestampModified']);
+                    $title = Format::dateTimeIntlReadable($archive['timestampModified']);
                     return Format::link($url, $title).$tag;
                 }
 

--- a/modules/Reports/archive_byStudent_view.php
+++ b/modules/Reports/archive_byStudent_view.php
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byStudent_
         $table->addColumn('timestampModified', __('Date'))
             ->width('30%')
             ->format(function ($report) {
-                $output = Format::dateReadable($report['timestampModified']);
+                $output = Format::dateIntlReadable($report['timestampModified']);
                 if ($report['status'] == 'Draft') {
                     $output .= '<span class="tag ml-2 dull">'.__($report['status']).'</span>';
                 }

--- a/modules/Reports/reporting_access_manage.php
+++ b/modules/Reports/reporting_access_manage.php
@@ -93,10 +93,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_access_m
         });
     $table->addColumn('roleName', __('Role'))->translatable();
     $table->addColumn('scopeName', __('Scope'));
-    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateReadable', 'dateStart'));
-    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateReadable', 'dateEnd'))
+    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntlReadable', 'dateStart'));
+    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntlReadable', 'dateEnd'))
         ->format(function ($values) {
-            $output = Format::dateReadable($values['dateEnd']);
+            $output = Format::dateIntlReadable($values['dateEnd']);
             if (date('Y-m-d') > $values['dateEnd']) {
                 $output .= Format::tag(__('Ended'), 'dull ml-2');
             }

--- a/modules/Reports/reporting_cycles_manage.php
+++ b/modules/Reports/reporting_cycles_manage.php
@@ -53,8 +53,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_cycles_m
     $table->addColumn('name', __('Name'))->width('30%');
     $table->addColumn('cycleNumber', __('Cycle'))->width('8%');
     $table->addColumn('yearGroups', __('Year Groups'))->width('15%');
-    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateReadable', 'dateStart'))->width('15%');
-    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateReadable', 'dateEnd'))->width('15%');
+    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntlReadable', 'dateStart'))->width('15%');
+    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntlReadable', 'dateEnd'))->width('15%');
 
     $table->addActionColumn()
         ->addParam('gibbonReportingCycleID')

--- a/modules/Reports/reporting_my.php
+++ b/modules/Reports/reporting_my.php
@@ -142,8 +142,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_my.php')
             $table = DataTable::create('reportsMy');
             $table->setTitle($scope['name']);
             $table->setDescription(__('You have access from {dateStart} to {dateEnd}.', [
-                'dateStart' => Format::dateReadable($scope['dateStart'], '%b %e'),
-                'dateEnd' => Format::dateReadable($scope['dateEnd'], '%b %e'),
+                'dateStart' => Format::dateIntlReadable($scope['dateStart'], 'MMM d'),
+                'dateEnd' => Format::dateIntlReadable($scope['dateEnd'], 'MMM d'),
             ]));
 
             $table->addColumn('criteriaName', __('Name'))->width('35%');

--- a/modules/Reports/reports_generate.php
+++ b/modules/Reports/reports_generate.php
@@ -60,8 +60,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
                       .'<img class="align-middle w-56 -mt-px" src="./themes/Default/img/loading.gif">'
                       .'<span class="tag ml-2 message">'.__('Running').'</span></div>';
             }
-            
-            return !empty($report['timestampGenerated'])? Format::dateTimeReadable($report['timestampGenerated']) : '';
+
+            return !empty($report['timestampGenerated'])? Format::dateTimeIntlReadable($report['timestampGenerated']) : '';
         });
 
     $table->addActionColumn()

--- a/modules/Reports/reports_generate_ajax.php
+++ b/modules/Reports/reports_generate_ajax.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
                 $tag = '<span class="tag success ml-2">'.__('Complete').'</span>';
                 $tag .= '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                 $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                $title = Format::dateTimeReadable($archive['timestampModified']);
+                $title = Format::dateTimeIntlReadable($archive['timestampModified']);
                 echo Format::link($url, $title).$tag;
             }
 

--- a/modules/Reports/reports_generate_batch.php
+++ b/modules/Reports/reports_generate_batch.php
@@ -37,12 +37,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
 
 
     $gibbonReportID = $_GET['gibbonReportID'] ?? '';
-    
+
     $reportGateway = $container->get(ReportGateway::class);
     $reportArchiveEntryGateway = $container->get(ReportArchiveEntryGateway::class);
-    
+
     $report = $reportGateway->getByID($gibbonReportID);
-    
+
     if (empty($gibbonReportID) || empty($report)) {
         $page->addError(__('The specified record cannot be found.'));
         return;
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
             if ($archive) {
                 $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                 $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                $title = Format::dateTimeReadable($archive['timestampModified']);
+                $title = Format::dateTimeIntlReadable($archive['timestampModified']);
                 return Format::link($url, $title).$tag;
             }
 
@@ -133,7 +133,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
         ->addParam('gibbonReportID', $gibbonReportID)
         ->format(function ($report, $actions) use (&$logs) {
             $reportLogs = $logs[$report['gibbonYearGroupID']] ?? [];
-            
+
             if (count($reportLogs) == 0) {
                 $actions->addAction('run', __('Run'))
                         ->setIcon('run')

--- a/modules/Reports/reports_generate_single.php
+++ b/modules/Reports/reports_generate_single.php
@@ -44,7 +44,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
         ->add(__('Run'), 'reports_generate_batch.php', ['gibbonReportID' => $gibbonReportID])
         ->add(__('Single'));
 
-    
+
     $reportGateway = $container->get(ReportGateway::class);
     $reportArchiveEntryGateway = $container->get(ReportArchiveEntryGateway::class);
 
@@ -106,14 +106,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
         ->format(function ($report) use ($gibbonReportID, &$reportArchiveEntryGateway) {
             if ($report['archive']) {
                 $tag = '<span class="tag ml-2 '.($report['archive']['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['archive']['status']).'</span>';
-                $title = Format::dateTimeReadable($report['archive']['timestampModified']);
+                $title = Format::dateTimeIntlReadable($report['archive']['timestampModified']);
                 $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$report['archive']['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
                 return Format::link($url, $title).$tag;
             }
 
             return '';
         });
-    
+
     $debugMode = $container->get(SettingGateway::class)->getSettingByScope('Reports', 'debugMode');
 
     $table->addActionColumn()
@@ -134,7 +134,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
                         ->addParam('gibbonPersonID', $report['gibbonPersonID'] ?? '')
                         ->addParam('gibbonReportArchiveEntryID', $report['archive']['gibbonReportArchiveEntryID'] ?? '')
                         ->setURL('/modules/Reports/archive_byStudent_download.php');
-                        
+
                 $actions->addAction('download', __('Download'))
                         ->directLink()
                         ->setIcon('download')

--- a/modules/Reports/reports_manage.php
+++ b/modules/Reports/reports_manage.php
@@ -37,7 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage.php
     if (!empty($gibbonSchoolYearID)) {
         $page->navigator->addSchoolYearNavigation($gibbonSchoolYearID);
     }
-    
+
     $reportGateway = $container->get(ReportGateway::class);
 
     // QUERY
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage.php
         });
 
     $table->addColumn('accessDate', __('Go Live'))
-        ->format(Format::using('dateTimeReadable', 'accessDate'));
+        ->format(Format::using('dateTimeIntlReadable', 'accessDate'));
 
     $table->addActionColumn()
         ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)

--- a/modules/Reports/reports_send.php
+++ b/modules/Reports/reports_send.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send.php')
         $table->addColumn('timestampModified', __('Last Created'))
             ->format(function ($report) {
                 $tag = '<span class="tag ml-2 success">'.__('Final').'</span>';
-                return Format::dateTimeReadable($report['timestampModified']).$tag;
+                return Format::dateTimeIntlReadable($report['timestampModified']).$tag;
             });
 
         $table->addActionColumn()
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send.php')
 
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
-                    return Format::dateTimeReadable($archive['timestampModified']).$tag;
+                    return Format::dateTimeIntlReadable($archive['timestampModified']).$tag;
                 }
 
                 return '';

--- a/modules/Reports/reports_send_batch.php
+++ b/modules/Reports/reports_send_batch.php
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send_batch
         ->format(function ($report) {
 
             $tag = '<span class="tag ml-2 '.($report['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['status']).'</span>';
-            $title = Format::dateTimeReadable($report['timestampModified']);
+            $title = Format::dateTimeIntlReadable($report['timestampModified']);
             $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$report['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
             return Format::link($url, $title).$tag;
         });

--- a/modules/Reports/templates/reports/coverPage.twig.html
+++ b/modules/Reports/templates/reports/coverPage.twig.html
@@ -36,17 +36,17 @@ config:
     </tr>
     <tr>
         <td colspan=3 style="text-align:center; line-height: 1.4; font-size: 48px; font-weight: bold; color: #444444;">
-            {{- report.name -}} 
+            {{- report.name -}}
         </td>
     </tr>
     <tr>
         <td colspan=3 style="text-align:center; line-height: 1.8; font-size: 24px; font-weight: normal; color: #444444;">
-            {{- school.organisationName -}} 
+            {{- school.organisationName -}}
         </td>
     </tr>
     <tr>
         <td colspan=3 style="text-align:center; line-height: 1.1; font-size: 14px; font-weight: normal; color: #888888;">
-            {{- formatUsing('dateReadable', report.date) -}} 
+            {{- formatUsing('dateIntlReadable', report.date) -}}
         </td>
     </tr>
     <tr>
@@ -57,9 +57,9 @@ config:
     </tr>
     <tr>
         <td colspan=3 style="text-align:center;">
-        
+
             <img src="{{ absoluteURL }}/{{ student.image_240|default('themes/'~gibbonThemeName~'/img/anonymous_240.jpg') }}" style="height: 64mm" >
-              
+
         </td>
     </tr>
     <tr>

--- a/modules/Reports/templates/reports/footers/signatureBox.twig.html
+++ b/modules/Reports/templates/reports/footers/signatureBox.twig.html
@@ -33,26 +33,26 @@ config:
     <tr>
         <td class="footer border-left border-top border-bottom" style="width:15%;font-size: 9.5pt;line-height:4.2;">
             &nbsp; <b>{{ __('Signature') }}:</b>
-        </td> 
+        </td>
         <td class="border-right border-top border-bottom" style="width:30%; height: 12mm; line-height: 1;">
             {% if isDraft %}
                 <span style="color: #cccccc; font-size: 22px; font-weight: bold; line-height:1.9;">DRAFT</span>
             {% elseif config.signatureImage %}
                 <img src="{{ basePath }}/{{ config.signatureImage }}" style="max-height: 12mm; width: auto" width="{{ config.signatureWidth|default('240') }}" height="{{ config.signatureHeight|default('80') }}"/>
             {% endif %}
-        </td> 
+        </td>
         <td class="footer border" style="width:30%;font-size: 9.5pt;line-height:4.2;">
             &nbsp; {{ config.signatureTitle|default("Principal") }}
         </td>
         <td class="footer border" style="width:25%;font-size: 9.5pt;line-height:4.2;">
-            &nbsp; {{ formatUsing('dateReadable', reportingCycle.dateEnd) }} 
+            &nbsp; {{ formatUsing('dateIntlReadable', reportingCycle.dateEnd) }}
         </td>
     </tr>
 </table>
 {%- if config.pageNumber == 'Y' -%}
 <table>
     <tr>
-        <td style="color: #000; text-align:right;line-height:1.8;">{{ __('Page') }} {{ pageNum -}}</td> 
+        <td style="color: #000; text-align:right;line-height:1.8;">{{ __('Page') }} {{ pageNum -}}</td>
     </tr>
 </table>
 {%- endif -%}

--- a/modules/Reports/templates/reports/footers/signatureLine.twig.html
+++ b/modules/Reports/templates/reports/footers/signatureLine.twig.html
@@ -37,28 +37,28 @@ config:
             {% elseif config.signatureImage %}
                 <img src="{{ basePath }}/{{ config.signatureImage }}" style="max-height: 12mm; width: auto" width="{{ config.signatureWidth|default('240') }}" height="{{ config.signatureHeight|default('80') }}"/>
             {% endif %}
-        </td> 
+        </td>
         <td style="width:5%;"></td>
         <td style="width:25%; line-height: 3; font-size: 10pt; border-bottom: 1.2pt solid #000000; vertical-align: middle;">
-            {{- formatUsing('dateReadable', reportingCycle.dateEnd) -}} 
+            {{- formatUsing('dateIntlReadable', reportingCycle.dateEnd) -}}
         </td>
         <td style="width:35%;"></td>
     </tr>
     <tr>
         <td class="" style="width:35%; font-size: 9.5pt; line-height:2; vertical-align: middle;">
             {{- config.signatureTitle|nl2br|default("Principal") -}}
-        </td> 
+        </td>
         <td style="width:5%;"></td>
         <td class="" style="width:25%; font-size: 9.5pt; line-height:2; vertical-align: middle;">
             {{- __('Date') -}}
-        </td> 
+        </td>
         <td style="width:35%;"></td>
     </tr>
 </table>
 {%- if config.pageNumber == 'Y' -%}
 <table>
     <tr>
-        <td style="color: #000; text-align:right;line-height:1.8;">{{ __('Page') }} {{ pageNum -}}</td> 
+        <td style="color: #000; text-align:right;line-height:1.8;">{{ __('Page') }} {{ pageNum -}}</td>
     </tr>
 </table>
 {%- endif -%}

--- a/modules/Reports/templates/reports/headers/reportInfo.twig.html
+++ b/modules/Reports/templates/reports/headers/reportInfo.twig.html
@@ -16,8 +16,8 @@ config:
 {{- stylesheet ? include(stylesheet) -}}
 <table class="w-full table" cellspacing="0">
     <tr>
-        <td style="text-align:left;width:50%;"><b>{{- report.name -}}</b> - {{ formatUsing('dateReadable', report.date) -}}</td> 
-        <td style="text-align:right;width:50%;"><b>{{ student.officialName }}</b>, {{ student.formGroupNameShort }}</td> 
+        <td style="text-align:left;width:50%;"><b>{{- report.name -}}</b> - {{ formatUsing('dateIntlReadable', report.date) -}}</td>
+        <td style="text-align:right;width:50%;"><b>{{ student.officialName }}</b>, {{ student.formGroupNameShort }}</td>
     </tr>
     {% if config.dividerLine|default('Y') == 'Y' %}
     <tr>

--- a/modules/Reports/templates/reports/studentDetails.twig.html
+++ b/modules/Reports/templates/reports/studentDetails.twig.html
@@ -20,7 +20,7 @@ sources:
                 <span style="font-size: 12pt; font-weight: bold;">{{- student.officialName -}}</span><br/><span style="font-size: 9pt;">{{- student.yearGroupName -}}</span><br/><br/><table class="w-full table" cellspacing="0" cellpadding="0" style="width: 100%; font-size: 8pt">
                     <tr>
                         <td class="border-right" style="width: 22%">{{- report.name -}}<br/>
-                            {{- formatUsing('dateReadable', report.date) -}}
+                            {{- formatUsing('dateIntlReadable', report.date) -}}
                         </td>
                         <td style="width: 4mm;"></td>
                         <td class="border-right" style="width: 22%">{{ __('Form Group') }}<br/>

--- a/modules/Reports/templates/ui/reportingCycleHeader.twig.html
+++ b/modules/Reports/templates/ui/reportingCycleHeader.twig.html
@@ -29,7 +29,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
 {% if proofsTotal > 0 %}
     <a class="flex items-center rounded border bg-gray-100  -mt-4 mb-8 p-3" href="{{ absoluteURL }}/index.php?q=/modules/Reports/reporting_proofread.php&gibbonPersonID={{ gibbonPersonID }}">
-        
+
         <div class="text-sm text-gray-700 mr-2 mt-1">
             {{ __("Proof Reading") }}
         </div>

--- a/modules/Reports/templates/ui/reportingCycleHeader.twig.html
+++ b/modules/Reports/templates/ui/reportingCycleHeader.twig.html
@@ -18,9 +18,9 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     <div class="flex flex-wrap rounded border bg-gray-100 mb-8">
     {% for milestone in milestones %}
         {% set dateClass = 'now'|date('Y-m-d') > milestone.milestoneDate ? 'bg-gray-400 text-gray-700' : 'text-gray-800' %}
-        
+
         <div class="flex-1 flex flex-col justify-start p-4 {{ dateClass }} {{ not loop.last ? 'border-r' }}">
-            <div class="text-xl text-center font-light">{{ formatUsing('dateReadable', milestone.milestoneDate, '%b %e') }}</div>
+            <div class="text-xl text-center font-light">{{ formatUsing('dateIntlReadable', milestone.milestoneDate, 'MMM d') }}</div>
             <div class="mt-4 text-xs text-center text-gray-600">{{ milestone.milestoneName }}</div>
         </div>
     {% endfor %}

--- a/modules/Staff/coverage_availability.php
+++ b/modules/Staff/coverage_availability.php
@@ -91,7 +91,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_availabilit
         ->fromPOST();
 
     $dates = $substituteGateway->queryUnavailableDatesBySub($criteria, $session->get('gibbonSchoolYearID'), $gibbonPersonID);
-    
+
     $bulkActions = array(
         'Delete' => __('Delete'),
     );
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_availabilit
     $table->addMetaData('bulkActions', $col);
 
     $table->addColumn('date', __('Date'))
-        ->format(Format::using('dateReadable', 'date'));
+        ->format(Format::using('dateIntlReadable', 'date'));
 
     $table->addColumn('timeStart', __('Time'))->format(function ($date) {
         if ($date['allDay'] == 'N') {
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_availabilit
 
     echo $form->getOutput();
 
-    
+
     $form = Form::create('staffAvailability', $session->get('absoluteURL').'/modules/Staff/coverage_availability_addProcess.php');
 
     $form->setFactory(DatabaseFormFactory::create($pdo));

--- a/modules/Staff/coverage_manage_addAjax.php
+++ b/modules/Staff/coverage_manage_addAjax.php
@@ -51,9 +51,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_add.
     // DATA TABLE
     $substitute = $substituteGateway->selectBy(['gibbonPersonID'=> $gibbonPersonIDCoverage])->fetch();
     $person = $container->get(UserGateway::class)->getByID($gibbonPersonIDCoverage);
-    
 
-    
+
+
     $start = new DateTime(Format::dateConvert($request['dateStart']).' 00:00:00');
     $end = new DateTime(Format::dateConvert($request['dateEnd']).' 23:00:00');
 
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_add.
     $dateRange = new DatePeriod($start, new DateInterval('P1D'), $end);
     foreach ($dateRange as $date) {
         if (!isSchoolOpen($guid, $date->format('Y-m-d'), $connection2)) continue;
-        
+
         $dates[] = ['date' => $date->format('Y-m-d')];
     }
 
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_add.
     });
 
     $table->addColumn('dateLabel', __('Date'))
-        ->format(Format::using('dateReadable', 'date'));
+        ->format(Format::using('dateIntlReadable', 'date'));
 
     $table->addCheckboxColumn('requestDates', 'date')
         ->width('15%')
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_add.
 
                 foreach ($times as $time) {
                     // Handle full day and partial day unavailability
-                    if ($time['allDay'] == 'Y' 
+                    if ($time['allDay'] == 'Y'
                     || ($time['allDay'] == 'N' && $request['allDay'] == 'Y')
                     || ($time['allDay'] == 'N' && $request['allDay'] == 'N'
                         && $time['timeStart'] < $request['timeEnd']

--- a/modules/Staff/coverage_my.php
+++ b/modules/Staff/coverage_my.php
@@ -37,10 +37,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_my.php') ==
 } else {
     // Proceed!
     $page->breadcrumbs->add(__('My Coverage'));
-    
+
     $gibbonPersonID = $session->get('gibbonPersonID');
     $displayCount = 0;
-    
+
     $schoolYearGateway = $container->get(SchoolYearGateway::class);
     $staffCoverageGateway = $container->get(StaffCoverageGateway::class);
     $substituteGateway = $container->get(SubstituteGateway::class);
@@ -122,9 +122,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_my.php') ==
 
         if ($coverageByTimetable) {
             $table->addColumn('date', __('Date'))
-                ->format(Format::using('dateReadable', 'date'))
+                ->format(Format::using('dateIntlReadable', 'date'))
                 ->formatDetails(function ($coverage) {
-                    return Format::small(Format::dateReadable($coverage['date'], '%A'));
+                    return Format::small(Format::dateIntlReadable($coverage['date'], 'EEEE'));
                 });
 
             $table->addColumn('period', __('Period'))
@@ -132,7 +132,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_my.php') ==
                     ->formatDetails([AbsenceFormats::class, 'timeDetails']);
 
             $table->addColumn('contextName', __('Cover'));
-        } else {            
+        } else {
             $table->addColumn('date', __('Date'))
                 ->context('primary')
                 ->format([AbsenceFormats::class, 'dateDetails']);
@@ -253,7 +253,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_my.php') ==
             ->width('30%')
             ->sortable(['surname', 'preferredName'])
             ->format([AbsenceFormats::class, 'personDetails']);
-            
+
         $table->addColumn('notesStatus', __('Comment'))
             ->format(function ($coverage) {
                 return Format::truncate($coverage['notesStatus'], 60);
@@ -281,7 +281,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_my.php') ==
         echo $table->render($coverage);
         $displayCount++;
     }
-    
+
     if ($displayCount == 0) {
         echo $page->getBlankSlate();
     }

--- a/modules/Staff/coverage_planner.php
+++ b/modules/Staff/coverage_planner.php
@@ -71,7 +71,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_planner.php
     // COVERAGE
     $coverage = $staffCoverageGateway->selectCoverageByTimetableDate($gibbonSchoolYearID, $date->format('Y-m-d'))->fetchGrouped();
     $times = $staffCoverageDateGateway->selectCoverageTimesByDate($gibbonSchoolYearID, $date->format('Y-m-d'))->fetchGroupedUnique();
-    
+
     $ttCount = count(array_unique(array_filter(array_column($times, 'ttName'))));
 
     if (empty($times)) {
@@ -94,8 +94,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_planner.php
         ->addClass('thickbox float-right mt-8')
         ->getOutput();
 
-    echo '<h2>'.__(Format::dateReadable($date->format('Y-m-d'), '%A')).'</h2>';
-    echo '<p>'.Format::dateReadable($date->format('Y-m-d')).'</p>';
+    echo '<h2>'.__(Format::dateIntlReadable($date->format('Y-m-d'), 'EEEE')).'</h2>';
+    echo '<p>'.Format::dateIntlReadable($date->format('Y-m-d')).'</p>';
 
     foreach ($times as $groupBy => $timeSlot) {
 
@@ -103,7 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_planner.php
 
         // DATA TABLE
         $gridRenderer = new GridView($container->get('twig'));
-        
+
         $table = DataTable::create('staffCoverage')->setRenderer($gridRenderer);
 
         if (!empty($groupBy)) {
@@ -151,7 +151,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_planner.php
                     return $coverage['contextName'].'<br/>'.Format::small(Format::timeRange($coverage['timeStart'], $coverage['timeEnd']));
                 };
 
-                $url = $coverage['context'] == 'Class' 
+                $url = $coverage['context'] == 'Class'
                     ? './index.php?q=/modules/Departments/department_course_class.php&gibbonDepartmentID='.$coverage['gibbonDepartmentID'].'&gibbonCourseID='.$coverage['gibbonCourseID'].'&gibbonCourseClassID='.$coverage['gibbonCourseClassID']
                     : '';
                 return Format::link($url, $coverage['contextName']).'<br/>'.Format::small($coverage['space']);
@@ -172,7 +172,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_planner.php
                 }
                 return AbsenceFormats::substituteDetails($coverage);
         });
-        
+
         // ACTIONS
         $table->addActionColumn()
             ->addParam('gibbonStaffCoverageID')

--- a/modules/Staff/coverage_planner_assign.php
+++ b/modules/Staff/coverage_planner_assign.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage.php'
     // DETAILS
     $table = DataTable::createDetails('coverage');
 
-    $table->addColumn('date', __('Date'))->format(Format::using('dateReadable', ['date', '%A, %b %e']));
+    $table->addColumn('date', __('Date'))->format(Format::using('dateIntlReadable', ['date', 'EEEE, MMM d']));
     $table->addColumn('period', __('Period'));
     $table->addColumn('time', __('Time'))->format(Format::using('timeRange', ['timeStart', 'timeEnd']));
 

--- a/modules/Staff/coverage_planner_assign.php
+++ b/modules/Staff/coverage_planner_assign.php
@@ -41,7 +41,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage.php'
     // Proceed!
     $gibbonSchoolYearID = $session->get('gibbonSchoolYearID');
     $gibbonStaffCoverageDateID = $_REQUEST['gibbonStaffCoverageDateID'] ?? '';
-    
+
     $staffCoverageGateway = $container->get(StaffCoverageGateway::class);
     $staffCoverageDateGateway = $container->get(StaffCoverageDateGateway::class);
     $subGateway = $container->get(SubstituteGateway::class);
@@ -92,7 +92,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage.php'
                 $url = './index.php?q=/modules/Departments/department_course_class.php&gibbonDepartmentID='.$coverage['gibbonDepartmentID'].'&gibbonCourseID='.$coverage['gibbonCourseID'].'&gibbonCourseClassID='.$coverage['gibbonCourseClassID'];
                 return Format::link($url, Format::courseClassName($coverage['courseNameShort'], $coverage['nameShort']), ['target' => '_blank']);
             });
-        
+
         $table->addColumn('studentsTotal', __('Students'));
 
         $table->addColumn('spaceName', __('Room'))
@@ -148,7 +148,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage.php'
 
     $subs = $subGateway->queryAvailableSubsByDate($criteria, $coverage['date'], $coverage['timeStart'], $coverage['timeEnd']);
     $availability = $subGateway->selectUnavailableDatesByDateRange($coverage['date'], $coverage['date'])->fetchGrouped();
-    
+
     // Check for special days for these classes
     $specialDayGateway = $container->get(SchoolYearSpecialDayGateway::class);
     $specialDay = $specialDayGateway->getSpecialDayByDate($coverage['date']);
@@ -171,7 +171,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage.php'
             return $item['status'] == 'Absent' && $item['allDay'] == 'Y';
         }));
     });
-    
+
     // Sort by highest availability to lowest availability
     $subList = $subs->toArray();
     usort($subList, function ($a, $b) {

--- a/modules/Staff/report_absences_summary.php
+++ b/modules/Staff/report_absences_summary.php
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
 
     // Translated array of months in the current school year
     foreach ($dateRange as $monthDate) {
-        $months[$monthDate->format('Y-m-d')] = Format::dateReadable($monthDate->format('Y-m-d'), '%B %Y');
+        $months[$monthDate->format('Y-m-d')] = Format::dateIntlReadable($monthDate->format('Y-m-d'), 'MMMM yyyy');
     }
 
     // Setup the date range used for this report
@@ -143,7 +143,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
             }
 
             $calendar[] = [
-                'name'  => Format::dateReadable($monthDate->format('Y-m-d'), '%b'),
+                'name'  => Format::dateIntlReadable($monthDate->format('Y-m-d'), 'MMM'),
                 'days'  => $days,
             ];
         }
@@ -173,8 +173,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
                     if (empty($day)) return '';
                     $dateText = $day['date']->format($dateFormat);
                     $url = $baseURL.'&dateStart='.$dateText.'&dateEnd='.$dateText.'&gibbonStaffAbsenceTypeID='.$gibbonStaffAbsenceTypeID;
-                    $title =  Format::dateReadable($day['date'], '%A');
-                    $title .= '<br/>'.Format::dateReadable($day['date'], '%b %e, %Y');
+                    $title =  Format::dateIntlReadable($day['date'], 'EEEE');
+                    $title .= '<br/>'.Format::dateIntlReadable($day['date'], 'MMM d, yyyy');
                     if ($day['count'] > 0) {
                         $title .= '<br/>'.__n('{count} Absence', '{count} Absences', $day['count']);
                     }

--- a/modules/Staff/report_absences_weekly.php
+++ b/modules/Staff/report_absences_weekly.php
@@ -70,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_week
     // SETUP DAYS OF WEEK
     $sql = "SELECT name, nameShort FROM gibbonDaysOfWeek WHERE schoolDay='Y' ORDER BY sequenceNumber";
     $result = $pdo->select($sql)->fetchAll();
-    
+
     $currentWeekday = $date->format('l');
     $weekdays = array_map(function ($weekday) use ($date, $currentWeekday) {
         $weekday['date'] = $currentWeekday == 'Sunday'
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_week
             ],
         ],
     ];
-    
+
     // QUERY
     $criteria = $staffAbsenceGateway->newQueryCriteria()
         ->sortBy('date')
@@ -149,17 +149,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_week
         }
 
         if (!isSchoolOpen($guid, $date->format('Y-m-d'), $connection2)) {
-            echo '<h2>'.__(Format::dateReadable($date->format('Y-m-d'), '%A')).'</h2>';
+            echo '<h2>'.__(Format::dateIntlReadable($date->format('Y-m-d'), 'EEEE')).'</h2>';
             echo Format::alert(__('School is closed on the specified day.'));
             continue;
         }
 
         $table = DataTable::create('staffAbsences'.$date->format('D'));
-        $table->setTitle(__(Format::dateReadable($date->format('Y-m-d'), '%A')));
-        $table->setDescription(Format::dateReadable($date->format('Y-m-d')));
+        $table->setTitle(__(Format::dateIntlReadable($date->format('Y-m-d'), 'EEEE')));
+        $table->setDescription(Format::dateIntlReadable($date->format('Y-m-d')));
 
         $canView = isActionAccessible($guid, $connection2, '/modules/Staff/absences_view_byPerson.php', 'View Absences_any');
-        
+
         // COLUMNS
         $table->addColumn('fullName', __('Name'))
             ->width('30%')

--- a/modules/Staff/report_coverage_summary.php
+++ b/modules/Staff/report_coverage_summary.php
@@ -47,7 +47,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
     $schoolYearGateway = $container->get(SchoolYearGateway::class);
     $staffCoverageGateway = $container->get(StaffCoverageGateway::class);
     $substituteGateway = $container->get(SubstituteGateway::class);
-    
+
     // COVERAGE DATA
     $schoolYear = $schoolYearGateway->getSchoolYearByID($gibbonSchoolYearID);
 
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
 
     // Translated array of months in the current school year
     foreach ($dateRange as $monthDate) {
-        $months[$monthDate->format('Y-m-d')] = Format::dateReadable($monthDate->format('Y-m-d'), '%B %Y');
+        $months[$monthDate->format('Y-m-d')] = Format::dateIntlReadable($monthDate->format('Y-m-d'), 'MMMM yyyy');
     }
 
     // Setup the date range used for this report
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
     } else {
         $dateStart = new DateTime($schoolYear['firstDay']);
     }
-    
+
     // Get all substitutes
     $status = $_GET['status'] ?? 'Full';
     $criteria = $substituteGateway->newQueryCriteria()
@@ -98,7 +98,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
         $subsByID = array_map(function ($sub) {
             return $sub['gibbonPersonID'];
         }, $substitutes->toArray());
-        
+
         $row = $form->addRow()->addClass('substitutes');
             $row->addLabel('gibbonPersonID', __('Substitute'));
             $row->addSelectUsersFromList('gibbonPersonID', $subsByID)
@@ -118,7 +118,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
 
         echo $form->getOutput();
     }
-    
+
 
     if (!empty($gibbonPersonID)) {
         // COVERAGE SUMMARY BY SUBSTITUTE
@@ -153,7 +153,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
             ->width('20%')
             ->sortable(['absence.surname', 'absence.preferredName'])
             ->format([AbsenceFormats::class, 'personDetails']);
-            
+
         $table->addColumn('notesStatus', __('Comment'))
             ->format(function ($coverage) {
                 return Format::truncate($coverage['notesStatus'], 60);
@@ -208,7 +208,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
 
         $count = 0;
         foreach ($dateRange as $monthDate) {
-            $table->addColumn('month'.$count, Format::dateReadable($monthDate, '%b'))->description(Format::dateReadable($monthDate, '%Y'))
+            $table->addColumn('month'.$count, Format::dateIntlReadable($monthDate, 'MMM'))->description(Format::dateIntlReadable($monthDate, 'yyyy'))
                 ->notSortable()
                 ->format(function ($sub) use ($monthDate) {
                     $sum =  array_sum($sub['coverage'][$monthDate->format('Y-m')] ?? []);

--- a/modules/Staff/report_subs_availability.php
+++ b/modules/Staff/report_subs_availability.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     $timeStart = $_GET['timeStart'] ?? null;
     $timeEnd = $_GET['timeEnd'] ?? null;
     $allStaff = $_GET['allStaff'] ?? $settingGateway->getSettingByScope('Staff', 'coverageInternal');
-    
+
     // CRITERIA
     $criteria = $subGateway->newQueryCriteria(true)
         ->sortBy('gibbonSubstitute.priority', 'DESC')
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     $row = $form->addRow();
         $row->addLabel('allDay', __('When'));
         $row->addSelect('allDay')->fromArray($allDayOptions)->selected($allDay);
-    
+
     $form->toggleVisibilityByClass('timeOptions')->onSelect('allDay')->when('N');
 
     $row = $form->addRow()->addClass('timeOptions');
@@ -117,11 +117,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     });
 
     $dayOfWeek = $container->get(DaysOfWeekGateway::class)->getDayOfWeekByDate($date);
-    
+
     // DATA TABLE
     $table = DataTable::createPaginated('subsManage', $criteria);
     $table->setTitle(__('Substitute Availability'));
-    $table->setDescription(Format::dateReadable($dateObject->format('Y-m-d'), '%A, %b %e'));
+    $table->setDescription(Format::dateIntlReadable($dateObject->format('Y-m-d'), 'EEEE, MMM d'));
 
     $table->addHeaderAction('calendar', __('Weekly').' '.__('View'))
         ->setIcon('planner')
@@ -189,9 +189,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
                 $output .= '<br/>';
                 $output .= CoverageMiniCalendar::renderTimeRange($dayOfWeek, $person['dates'] ?? [], $dateObject);
             }
-            
-            
-            
+
+
+
             return $output;
         });
 

--- a/modules/Staff/report_subs_availabilityWeekly.php
+++ b/modules/Staff/report_subs_availabilityWeekly.php
@@ -135,14 +135,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
 
     $dateRange = new DatePeriod($dateStart, new DateInterval('P1D'), $dateEnd);
     $daysOfWeekGateway = $container->get(DaysOfWeekGateway::class);
-    
+
     foreach ($dateRange as $weekday) {
         if (!isSchoolOpen($guid, $weekday->format('Y-m-d'), $connection2)) continue;
 
         $dayOfWeek = $daysOfWeekGateway->getDayOfWeekByDate($weekday->format('Y-m-d'));
 
         $url = './index.php?q=/modules/Staff/report_subs_availability.php&date='.Format::date($weekday->format('Y-m-d'));
-        $columnTitle = Format::link($url, Format::dateReadable($weekday->format('Y-m-d'), '%a, %b %e'));
+        $columnTitle = Format::link($url, Format::dateIntlReadable($weekday->format('Y-m-d'), 'EEE, MMM d'));
 
         $table->addColumn($weekday->format('D'), $columnTitle)
             ->context('primary')

--- a/modules/Staff/src/Forms/CoverageRequestForm.php
+++ b/modules/Staff/src/Forms/CoverageRequestForm.php
@@ -65,7 +65,7 @@ class CoverageRequestForm
     {
         $canSelectSubstitutes = $this->coverageMode == 'Requested'; // TODO: && $values['status'] == 'Approved'
         $classesNeedingCover = 0;
-        
+
         // Get timetabled classes and non-class records that need coverage (activities and duty)
         $classes = $this->staffCoverageDateGateway->selectPotentialCoverageByPersonAndDate($this->session->get('gibbonSchoolYearID'), $gibbonPersonID, $dateStart, $dateEnd)->fetchAll();
         $classes = array_map(function ($item) {
@@ -176,12 +176,12 @@ class CoverageRequestForm
 
             $form->toggleVisibilityByClass('individualOptions')->onSelect('requestType')->when('Individual');
             $form->toggleVisibilityByClass('broadcastOptions')->onSelect('requestType')->when('Broadcast');
-                
+
             // Broadcast
             if (!empty($availableSubs)) {
                 $col = $form->addRow()->addClass('broadcastOptions')->addColumn();
                 $col->addAlert(__("This option sends a request out to all available substitutes. There are currently {count} substitutes with availability for this time period. You'll receive a notification once your request is accepted.", ['count' => Format::bold(count($availableSubs))]), 'message');
-                
+
                 if ($coverageByTimetable && $classesNeedingCover > $availabilityCount) {
                     $col->addAlert(__("There are currently no available substitutes for {count} of the following classes.", ['count' => Format::bold($classesNeedingCover - $availabilityCount)]).' '.__('A notification will be sent to administration.'), 'warning');
                 }
@@ -223,7 +223,7 @@ class CoverageRequestForm
         $table->addColumn('dateLabel', __('Date'))
             ->format(Format::using('dateReadable', 'date'))
             ->formatDetails(function ($coverage) {
-                return Format::small(Format::dateReadable($coverage['date'], '%A'));
+                return Format::small(Format::dateIntlReadable($coverage['date'], 'EEEE'));
             });
 
         if ($coverageByTimetable) {
@@ -248,7 +248,7 @@ class CoverageRequestForm
                 ->width('15%')
                 ->checked(function ($class) use ($allDay, $timeStart, $timeEnd) {
                     if ($class['offTimetable']) return false;
-                    
+
                     $insideTimeRange = $class['timeStart'] < $timeEnd.':00' && $class['timeEnd'] > $timeStart.':00';
 
                     return $allDay == 'Y' || $insideTimeRange ? $class['contextCheckboxID'] : false;
@@ -273,9 +273,9 @@ class CoverageRequestForm
                         $times = $unavailable[$date['date']];
 
                         foreach ($times as $time) {
-                        
+
                             // Handle full day and partial day unavailability
-                            if ($time['allDay'] == 'Y' 
+                            if ($time['allDay'] == 'Y'
                             || ($time['allDay'] == 'N' && $request['allDay'] == 'Y')
                             || ($time['allDay'] == 'N' && $request['allDay'] == 'N'
                                 && $time['timeStart'] < $request['timeEnd']

--- a/modules/Staff/src/Forms/CoverageRequestForm.php
+++ b/modules/Staff/src/Forms/CoverageRequestForm.php
@@ -221,7 +221,7 @@ class CoverageRequestForm
         });
 
         $table->addColumn('dateLabel', __('Date'))
-            ->format(Format::using('dateReadable', 'date'))
+            ->format(Format::using('dateIntlReadable', 'date'))
             ->formatDetails(function ($coverage) {
                 return Format::small(Format::dateIntlReadable($coverage['date'], 'EEEE'));
             });

--- a/modules/Staff/src/Messages/AbsenceApproval.php
+++ b/modules/Staff/src/Messages/AbsenceApproval.php
@@ -60,7 +60,7 @@ class AbsenceApproval extends Message
     public function getDetails() : array
     {
         return [
-            __($this->absence['status'])  => Format::dateTimeReadable($this->absence['timestampApproval']),
+            __($this->absence['status'])  => Format::dateTimeIntlReadable($this->absence['timestampApproval']),
             __('Reply') => $this->absence['notesApproval'],
         ];
     }

--- a/modules/Staff/src/Messages/CoveragePartial.php
+++ b/modules/Staff/src/Messages/CoveragePartial.php
@@ -34,7 +34,7 @@ class CoveragePartial extends Message
         $this->coverage = $coverage;
 
         $this->uncoveredDates = array_map(function ($date) {
-            return Format::dateReadable($date, '%b %e');
+            return Format::dateIntlReadable($date, 'MMM d');
         }, $uncoveredDates);
     }
 

--- a/modules/Staff/src/Messages/NewAbsenceWithCoverage.php
+++ b/modules/Staff/src/Messages/NewAbsenceWithCoverage.php
@@ -70,7 +70,7 @@ class NewAbsenceWithCoverage extends Message
             if (!empty($date['period']) && !empty($date['contextName'])) {
                 $coverageDetails[$date['period']] = $date['contextName'].$notes;
             } else {
-                $dateReadable = Format::dateReadable($date['date']);
+                $dateReadable = Format::dateIntlReadable($date['date']);
                 $coverageDetails[$dateReadable] = (!empty($date['surnameCoverage']) ? Format::name($date['titleCoverage'], $date['preferredNameCoverage'], $date['surnameCoverage'], 'Staff', false, true) : __('Any available substitute')).$notes;
             }
         }

--- a/modules/Staff/src/Tables/AbsenceCalendar.php
+++ b/modules/Staff/src/Tables/AbsenceCalendar.php
@@ -30,9 +30,9 @@ use DatePeriod;
 
 /**
  * AbsenceCalendar
- * 
+ *
  * A reusable DataTable class for displaying absences in a colour-coded calendar view.
- * 
+ *
  * @version v18
  * @since   v18
  */
@@ -64,7 +64,7 @@ class AbsenceCalendar
             }
 
             $calendar[] = [
-                'name'  => Format::dateReadable($month ,'%b'),
+                'name'  => Format::dateIntlReadable($month ,'MMM'),
                 'days'  => $days,
             ];
         }
@@ -88,7 +88,7 @@ class AbsenceCalendar
                     if (empty($day) || $day['count'] <= 0) return '';
 
                     $url = 'fullscreen.php?q=/modules/Staff/absences_view_details.php&gibbonStaffAbsenceID='.$day['absence']['gibbonStaffAbsenceID'].'&width=800&height=550';
-                    $title = Format::dateReadable($day['date'], '%A').'<br/>'.Format::dateReadable($day['date'], '%b %e, %Y');
+                    $title = Format::dateIntlReadable($day['date'], 'EEEE').'<br/>'.Format::dateIntlReadable($day['date'], 'MMM d, yyyy');
                     $title .= '<br/>'.$day['absence']['type'];
                     $classes = ['thickbox'];
                     if ($day['absence']['allDay'] == 'N') {
@@ -102,7 +102,7 @@ class AbsenceCalendar
                     if (empty($day)) return '';
 
                     $cell->addClass($day['date']->format('Y-m-d') == date('Y-m-d') ? 'border-2 border-gray-700' : 'border');
-                    
+
                     if ($day['count'] > 0) $cell->addClass('bg-chart'.($day['absence']['sequenceNumber'] % 10));
                     elseif ($day['weekend']) $cell->addClass('bg-gray-200');
                     else $cell->addClass('bg-white');

--- a/modules/Staff/src/Tables/AbsenceDates.php
+++ b/modules/Staff/src/Tables/AbsenceDates.php
@@ -64,7 +64,7 @@ class AbsenceDates
         $connection2 = $this->db->getConnection();
 
         $absence = $this->staffAbsenceGateway->getAbsenceDetailsByID($gibbonStaffAbsenceID);
-        $dates = $includeCoverage 
+        $dates = $includeCoverage
             ? $this->staffAbsenceDateGateway->selectDatesByAbsenceWithCoverage($gibbonStaffAbsenceID)->toDataSet()
             : $this->staffAbsenceDateGateway->selectDatesByAbsence($gibbonStaffAbsenceID)->toDataSet();
 
@@ -94,7 +94,7 @@ class AbsenceDates
         }
 
         $table->addColumn('date', $dateLabel)
-            ->format(Format::using('dateReadable', 'date'));
+            ->format(Format::using('dateIntlReadable', 'date'));
 
         $table->addColumn('timeStart', $timeLabel)
             ->format([AbsenceFormats::class, 'timeDetails']);

--- a/modules/Staff/src/Tables/CoverageDates.php
+++ b/modules/Staff/src/Tables/CoverageDates.php
@@ -99,9 +99,9 @@ class CoverageDates
         $table->addMetaData('blankSlate', __('Coverage is required but has not been requested yet.'));
 
         $table->addColumn('date', __('Date'))
-            ->format(Format::using('dateReadable', 'date'))
+            ->format(Format::using('dateIntlReadable', 'date'))
             ->formatDetails(function ($coverage) {
-                return Format::small(Format::dateReadable($coverage['date'], '%A'));
+                return Format::small(Format::dateIntlReadable($coverage['date'], 'EEEE'));
             });
 
         if ($coverageByTimetable) {
@@ -166,7 +166,7 @@ class CoverageDates
                             ->setURL('/modules/Staff/coverage_manage_edit_deleteProcess.php')
                             ->addConfirmation(__('Are you sure you wish to delete this record?'));
                     }
-                
+
                 });
         }
 

--- a/modules/Students/firstAidRecord.php
+++ b/modules/Students/firstAidRecord.php
@@ -102,10 +102,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.ph
         $output = '';
         if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2br($person['description']).'<br/><br/>';
         if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2br($person['actionTaken']).'<br/><br/>';
-        if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeReadable($person['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
+        if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateIntlReadable($person['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
         $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
         foreach ($resultLog AS $rowLog) {
-            $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeReadable($rowLog['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
+            $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateIntlReadable($rowLog['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
         }
 
         return $output;

--- a/modules/Students/firstAidRecord_edit.php
+++ b/modules/Students/firstAidRecord_edit.php
@@ -53,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
     if ($gibbonFirstAidID == '') {
         $page->addError(__('You have not specified one or more required parameters.'));
     } else {
-        
+
             $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonFirstAidID' => $gibbonFirstAidID);
             $sql = "SELECT gibbonFirstAid.*, patient.gibbonPersonID AS gibbonPersonIDPatient, patient.surname AS surnamePatient, patient.preferredName AS preferredNamePatient, firstAider.title, firstAider.surname AS surnameFirstAider, firstAider.preferredName AS preferredNameFirstAider
                 FROM gibbonFirstAid
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
             if (!empty($values['followUp'])) {
                 $row = $form->addRow();
                     $column = $row->addColumn();
-                    $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider']), 'date' => Format::dateTimeReadable($values['timestamp'], '%H:%M, %b %d %Y')]));
+                    $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider']), 'date' => Format::dateIntlReadable($values['timestamp'], 'HH:mm, MMM dd yyyy')]));
                     $column->addContent($values['followUp'])->setClass('fullWidth');
             }
 

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -712,7 +712,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         $col->addColumn('departureReason', __('Departure Reason'));
 
                         $container->get(CustomFieldHandler::class)->addCustomFieldsToTable($table, 'Student Enrolment', [], $student['fields'] ?? '');
-                        
+
                         $col = $table->addColumn('Background Information', __('Background Information'));
                         $country = $session->get('country');
 
@@ -1168,7 +1168,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         // Follow-up Contacts
                         $contacts = [];
                         $emergencyFollowUpGroup = $settingGateway->getSettingByScope('Students', 'emergencyFollowUpGroup');
-                        
+
                         if (!empty($emergencyFollowUpGroup)) {
                             $contactsList = explode(',', $emergencyFollowUpGroup) ?? [];
                             $contacts = $container->get(UserGateway::class)->selectNotificationDetailsByPerson($contactsList)->fetchAll();
@@ -1184,7 +1184,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         $table = DataTable::create('followupMedicalContacts');
                         $table->setTitle(__('Follow-up Contacts'));
                         $table->setDescription(__('These contacts can be used when following up on an emergency, or for less serious issues, when parents and staff need to be notified by email.'));
-                        
+
                         $table->addColumn('fullName', __('Name'))
                                 ->notSortable()
                                 ->format(function ($person) {
@@ -1315,7 +1315,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.php') == false) {
                             echo Format::alert(__('Your request failed because you do not have access to this action.'));
                         } else {
-                            
+
                             $firstAidGateway = $container->get(FirstAidGateway::class);
                             $criteria = $firstAidGateway->newQueryCriteria()
                                 ->sortBy(['date', 'timeIn'], 'DESC')
@@ -1330,10 +1330,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                 $output = '';
                                 if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2br($person['description']).'<br/><br/>';
                                 if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2br($person['actionTaken']).'<br/><br/>';
-                                if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeReadable($person['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
+                                if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeIntlReadable($person['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
                                 $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
                                 foreach ($resultLog AS $rowLog) {
-                                    $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeReadable($rowLog['timestamp'], '%H:%M, %b %d %Y')]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
+                                    $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeIntlReadable($rowLog['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
                                 }
 
                                 return $output;
@@ -1613,7 +1613,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                         ->fromArray(array('*' => __('All Years')))
                                         ->fromQuery($pdo, $sqlSelect, $dataSelect)
                                         ->selected($gibbonSchoolYearID);
-                                
+
                                 if ($enableGroupByTerm == "Y") {
                                     $dataSelect = [];
                                     $sqlSelect = "SELECT gibbonSchoolYear.gibbonSchoolYearID as chainedTo, gibbonSchoolYearTerm.gibbonSchoolYearTermID as value, gibbonSchoolYearTerm.name FROM gibbonSchoolYearTerm JOIN gibbonSchoolYear ON (gibbonSchoolYearTerm.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID) ORDER BY gibbonSchoolYearTerm.sequenceNumber";
@@ -2114,7 +2114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                 $table->addColumn('timestampModified', __('Date'))
                                     ->width('30%')
                                     ->format(function ($report) {
-                                        $output = Format::dateReadable($report['timestampModified']);
+                                        $output = Format::dateIntlReadable($report['timestampModified']);
                                         if ($report['status'] == 'Draft') {
                                             $output .= '<span class="tag ml-2 dull">'.__($report['status']).'</span>';
                                         }

--- a/modules/System Admin/import_manage.php
+++ b/modules/System Admin/import_manage.php
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_manage
             ->width('25%')
             ->format(function ($importType) use ($session) {
                 if ($log = $importType['log']) {
-                    $text = Format::dateReadable($log['timestamp']);
+                    $text = Format::dateIntlReadable($log['timestamp']);
                     $url = $session->get('absoluteURL').'/fullscreen.php?q=/modules/System Admin/import_history_view.php&gibbonLogID='.$log['gibbonLogID'].'&width=800&height=550';
                     $title = Format::dateTime($log['timestamp']).' - '.Format::nameList([$log]);
                     return Format::link($url, $text, ['title' => $title, 'class' => 'thickbox']);

--- a/modules/Timetable/report_viewAvailableSpace_view.php
+++ b/modules/Timetable/report_viewAvailableSpace_view.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    
+
     $date = $_GET['date'] ?? '';
     $period = $_GET['period'] ?? '';
     $facilityNameList = $_GET['ids'] ?? [];
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     // DATA TABLE
     $table = DataTable::create('facilityList');
-    $table->setTitle(Format::dateReadable($date). ' - '. $period);
+    $table->setTitle(Format::dateIntlReadable($date). ' - '. $period);
     $table->setDescription(__('View Available Facilities'));
 
     $table->addColumn('name', __('Name'))

--- a/modules/Timetable/report_viewAvailableTeachers_view.php
+++ b/modules/Timetable/report_viewAvailableTeachers_view.php
@@ -30,7 +30,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-    
+
     $date = $_GET['date'] ?? '';
     $period = $_GET['period'] ?? '';
     $gibbonPersonIDList = $_GET['ids'] ?? [];
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     // DATA TABLE
     $table = DataTable::create('teacherList');
-    $table->setTitle(Format::dateReadable($date). ' - '. $period);
+    $table->setTitle(Format::dateIntlReadable($date). ' - '. $period);
     $table->setDescription(__('View Available Teachers'));
 
     // COLUMNS

--- a/modules/User Admin/user_manage_password.php
+++ b/modules/User Admin/user_manage_password.php
@@ -150,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
 
             $row = $form->addRow();
                 $row->addLabel('lastTimestampLabel', __('Last Login: Time'));
-                $row->addTextField('lastTimestamp')->setValue(Format::dateTimeReadable($values['lastTimestamp']))->setClass('w-64')->readonly();
+                $row->addTextField('lastTimestamp')->setValue(Format::dateTimeIntlReadable($values['lastTimestamp']))->setClass('w-64')->readonly();
                 $row->addContent(!empty($values['lastTimestamp'])? $trueIcon : $falseIcon);
 
             $row = $form->addRow();

--- a/src/Forms/Builder/View/ApplicationCheckView.php
+++ b/src/Forms/Builder/View/ApplicationCheckView.php
@@ -30,7 +30,7 @@ use Gibbon\Forms\Builder\Storage\FormDataInterface;
 class ApplicationCheckView extends AbstractFormView
 {
     protected $session;
-    
+
     public function __construct(Session $session)
     {
         $this->session = $session;
@@ -43,7 +43,7 @@ class ApplicationCheckView extends AbstractFormView
 
     public function configure(Form $form)
     {
-        
+
     }
 
     public function display(Form $form, FormDataInterface $data)
@@ -52,7 +52,7 @@ class ApplicationCheckView extends AbstractFormView
         $col->addSubheading($this->getName());
 
         $list[__('Status')] = $data->getStatus();
-        $list[__('Date')] = Format::dateTimeReadable($data->getResult('statusDate'));
+        $list[__('Date')] = Format::dateTimeIntlReadable($data->getResult('statusDate'));
 
         $col->addContent(Format::listDetails($list));
 

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -103,6 +103,7 @@ class x extends TestCase
 
         // modules/Attendance/attendance.php
         // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
         // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
         // modules/Attendance/report_formGroupsNotRegistered_byDate.php
         // modules/Attendance/src/AttendanceView.php
@@ -111,6 +112,7 @@ class x extends TestCase
 
         // modules/Attendance/attendance.php
         // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
         // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
         // modules/Attendance/report_formGroupsNotRegistered_byDate.php
         // modules/Attendance/src/AttendanceView.php

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -121,6 +121,10 @@ class x extends TestCase
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('February  3, 2018', Format::dateReadable($dateString, '%B %e, %Y'));
         $this->assertEquals('February 3, 2018', Format::dateIntlReadable($dateString, 'MMMM d, yyyy'));
+
+        // modules/Attendance/report_graph_byType.php
+        $this->assertEquals('Feb 03', Format::dateReadable($dateString, '%b %d'));
+        $this->assertEquals('Feb 03', Format::dateIntlReadable($dateString, 'MMM dd'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -118,6 +118,7 @@ class x extends TestCase
         // modules/Attendance/src/AttendanceView.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
         // modules/Staff/src/Tables/CoverageCalendar.php
+        // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
         $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
         $this->assertEquals('Feb', Format::dateIntlReadable($dateString, 'MMM'));
@@ -150,11 +151,14 @@ class x extends TestCase
         // modules/Staff/src/Tables/CoverageCalendar.php
         // modules/Staff/coverage_my.php
         // modules/Staff/coverage_planner.php
+        // modules/Staff/report_absences_summary.php
         // modules/Staff/report_absences_weekly.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
 
         // modules/Staff/src/Tables/AbsenceCalendar.php
+        // modules/Staff/report_absences_summary.php
+        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
         $this->assertEquals('Feb 3, 2018', Format::dateIntlReadable($dateString, 'MMM d, yyyy'));
 
@@ -163,6 +167,7 @@ class x extends TestCase
         $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
         $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'EEEE, MMM d'));
 
+        // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
         $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
         $this->assertEquals('February 2018', Format::dateIntlReadable($dateString, 'MMMM yyyy'));

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -137,6 +137,10 @@ class x extends TestCase
         // modules/Activities/report_attendance.php
         $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
         $this->assertEquals('Sat', Format::dateIntlReadable($dateString, 'EEE'));
+
+        // modules/Staff/src/Forms/CoverageRequestForm.php
+        $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
+        $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Format
  */
-class FormatTest extends TestCase
+class x extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -147,6 +147,7 @@ class x extends TestCase
         // modules/Staff/src/Tables/AbsenceCalendar.php
         // modules/Staff/src/Tables/CoverageDates.php
         // modules/Staff/src/Tables/CoverageCalendar.php
+        // modules/Staff/coverage_my.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
 

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -127,6 +127,16 @@ class x extends TestCase
         // modules/Attendance/report_graph_byType.php
         $this->assertEquals('Feb 03', Format::dateReadable($dateString, '%b %d'));
         $this->assertEquals('Feb 03', Format::dateIntlReadable($dateString, 'MMM dd'));
+
+        // modules/Reports/reporting_my.php
+        // modules/Activities/report_attendance.php
+        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
+        $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
+        $this->assertEquals('Feb 3', Format::dateIntlReadable($dateString, 'MMM d'));
+
+        // modules/Activities/report_attendance.php
+        $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
+        $this->assertEquals('Sat', Format::dateIntlReadable($dateString, 'EEE'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -118,6 +118,7 @@ class x extends TestCase
         // modules/Attendance/src/AttendanceView.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
         // modules/Staff/src/Tables/CoverageCalendar.php
+        // modules/Staff/report_coverage_summary.php
         $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
         $this->assertEquals('Feb', Format::dateIntlReadable($dateString, 'MMM'));
 
@@ -159,6 +160,10 @@ class x extends TestCase
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
         $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'EEEE, MMM d'));
+
+        // modules/Staff/report_coverage_summary.php
+        $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%B %Y'));
+        $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'MMMM yyyy'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -117,6 +117,7 @@ class x extends TestCase
         // modules/Attendance/report_formGroupsNotRegistered_byDate.php
         // modules/Attendance/src/AttendanceView.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
+        // modules/Staff/src/Tables/CoverageCalendar.php
         $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
         $this->assertEquals('Feb', Format::dateIntlReadable($dateString, 'MMM'));
 
@@ -144,6 +145,7 @@ class x extends TestCase
         // modules/Staff/src/Forms/CoverageRequestForm.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
         // modules/Staff/src/Tables/CoverageDates.php
+        // modules/Staff/src/Tables/CoverageCalendar.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
 

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -171,6 +171,12 @@ class x extends TestCase
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat, Feb  3', Format::dateReadable($dateString, '%a, %b %e'));
         $this->assertEquals('Sat, Feb 3', Format::dateIntlReadable($dateString, 'EEE, MMM d'));
+
+        // modules/Staff/report_absences_summary.php
+        // modules/Planner/units_edit_working.php
+        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
+        $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
+        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntlReadable($dateString, 'EEE d MMM, yyyy'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -141,8 +141,13 @@ class x extends TestCase
         $this->assertEquals('Sat', Format::dateIntlReadable($dateString, 'EEE'));
 
         // modules/Staff/src/Forms/CoverageRequestForm.php
+        // modules/Staff/src/Tables/AbsenceCalendar.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
+
+        // modules/Staff/src/Tables/AbsenceCalendar.php
+        $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
+        $this->assertEquals('Feb 3, 2018', Format::dateIntlReadable($dateString, 'MMM d, yyyy'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -116,6 +116,7 @@ class x extends TestCase
         // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
         // modules/Attendance/report_formGroupsNotRegistered_byDate.php
         // modules/Attendance/src/AttendanceView.php
+        // modules/Staff/src/Tables/AbsenceCalendar.php
         $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
         $this->assertEquals('Feb', Format::dateIntlReadable($dateString, 'MMM'));
 
@@ -142,6 +143,7 @@ class x extends TestCase
 
         // modules/Staff/src/Forms/CoverageRequestForm.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
+        // modules/Staff/src/Tables/CoverageDates.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
 

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -184,6 +184,21 @@ class x extends TestCase
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
         $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntlReadable($dateString, 'EEE d MMM, yyyy'));
+
+        // modules/Attendance/attendance_future_byPerson.php
+        // modules/Attendance/attendance_take_byPerson.php
+        $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%R, %b %d'));
+        $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%H:%M, %b %d'));
+        $this->assertEquals('13:24, Feb 03', Format::dateIntlReadable($dateString, 'HH:mm, MMM dd'));
+
+        // modules/Students/firstAidRecord_edit.php
+        // modules/Students/firstAidRecord.php
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateTimeReadable($dateString, '%H:%M, %b %d %Y'));
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntlReadable($dateString, 'HH:mm, MMM dd yyyy'));
+
+        // modules/Attendance/attendance_take_byPerson.php
+        $this->assertEquals('13:24', Format::dateTimeReadable($dateString, '%H:%M'));
+        $this->assertEquals('13:24', Format::dateIntlReadable($dateString, 'HH:mm'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -130,11 +130,13 @@ class x extends TestCase
 
         // modules/Reports/reporting_my.php
         // modules/Activities/report_attendance.php
+        // modules/Activities/activities_attendance.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
         $this->assertEquals('Feb 3', Format::dateIntlReadable($dateString, 'MMM d'));
 
         // modules/Activities/report_attendance.php
+        // modules/Activities/activities_attendance.php
         $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
         $this->assertEquals('Sat', Format::dateIntlReadable($dateString, 'EEE'));
 

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -149,6 +149,7 @@ class x extends TestCase
         // modules/Staff/src/Tables/CoverageDates.php
         // modules/Staff/src/Tables/CoverageCalendar.php
         // modules/Staff/coverage_my.php
+        // modules/Staff/coverage_planner.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
 
@@ -162,8 +163,8 @@ class x extends TestCase
         $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'EEEE, MMM d'));
 
         // modules/Staff/report_coverage_summary.php
-        $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%B %Y'));
-        $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'MMMM yyyy'));
+        $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
+        $this->assertEquals('February 2018', Format::dateIntlReadable($dateString, 'MMMM yyyy'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -100,6 +100,27 @@ class x extends TestCase
         // modules/Students/student_view_details.php
         $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, '%H:%M, %b %d %Y'));
         $this->assertEquals('13:24, Feb 03 2018', Format::dateIntlReadable($dateString, 'HH:mm, MMM dd yyyy'));
+
+        // modules/Attendance/attendance.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
+        // modules/Attendance/src/AttendanceView.php
+        $this->assertEquals('03', Format::dateReadable($dateString, '%d'));
+        $this->assertEquals('03', Format::dateIntlReadable($dateString, 'dd'));
+
+        // modules/Attendance/attendance.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
+        // modules/Attendance/src/AttendanceView.php
+        $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
+        $this->assertEquals('Feb', Format::dateIntlReadable($dateString, 'MMM'));
+
+        // modules/Attendance/attendance_future_byPerson.php
+        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
+        $this->assertEquals('February  3, 2018', Format::dateReadable($dateString, '%B %e, %Y'));
+        $this->assertEquals('February 3, 2018', Format::dateIntlReadable($dateString, 'MMMM d, yyyy'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -150,6 +150,7 @@ class x extends TestCase
         // modules/Staff/src/Tables/CoverageCalendar.php
         // modules/Staff/coverage_my.php
         // modules/Staff/coverage_planner.php
+        // modules/Staff/report_absences_weekly.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
 

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -85,6 +85,21 @@ class x extends TestCase
         $this->assertEquals('May 18, 2018', Format::dateIntlReadable('2018-05-18'));
         $this->assertEquals('May 18, 2018 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
         $this->assertEquals('May 18, 2018 13:24', Format::dateTimeIntlReadable('2018-05-18 13:24'));
+
+        //
+        // Verify fidelity of formatting output before and after dateIntlReadable refactor.
+        //
+
+        $dateString = '2018-02-03 13:24';
+
+        // modules/Planner/units_edit_deploy.php
+        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
+        $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
+        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntlReadable($dateString, 'E d MMM, yyyy'));
+
+        // modules/Students/student_view_details.php
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, '%H:%M, %b %d %Y'));
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntlReadable($dateString, 'HH:mm, MMM dd yyyy'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -166,6 +166,11 @@ class x extends TestCase
         // modules/Staff/report_coverage_summary.php
         $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
         $this->assertEquals('February 2018', Format::dateIntlReadable($dateString, 'MMMM yyyy'));
+
+        // modules/Staff/report_subs_availabilityWeekly.php
+        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
+        $this->assertEquals('Sat, Feb  3', Format::dateReadable($dateString, '%a, %b %e'));
+        $this->assertEquals('Sat, Feb 3', Format::dateIntlReadable($dateString, 'EEE, MMM d'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -133,6 +133,7 @@ class x extends TestCase
         // modules/Reports/reporting_my.php
         // modules/Activities/report_attendance.php
         // modules/Activities/activities_attendance.php
+        // modules/Staff/src/Messages/CoveragePartial.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
         $this->assertEquals('Feb 3', Format::dateIntlReadable($dateString, 'MMM d'));
@@ -152,6 +153,11 @@ class x extends TestCase
         // modules/Staff/src/Tables/AbsenceCalendar.php
         $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
         $this->assertEquals('Feb 3, 2018', Format::dateIntlReadable($dateString, 'MMM d, yyyy'));
+
+        // modules/Staff/report_subs_availability.php
+        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
+        $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
+        $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'EEEE, MMM d'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -136,6 +136,7 @@ class x extends TestCase
         // modules/Activities/report_attendance.php
         // modules/Activities/activities_attendance.php
         // modules/Staff/src/Messages/CoveragePartial.php
+        // modules/Reports/templates/ui/reportingCycleHeader.twig.html
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
         $this->assertEquals('Feb 3', Format::dateIntlReadable($dateString, 'MMM d'));
@@ -163,6 +164,7 @@ class x extends TestCase
         $this->assertEquals('Feb 3, 2018', Format::dateIntlReadable($dateString, 'MMM d, yyyy'));
 
         // modules/Staff/report_subs_availability.php
+        // modules/Staff/coverage_planner_assign.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
         $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'EEEE, MMM d'));


### PR DESCRIPTION
**Description**
- Follow up to #1758, refactor existing use if Format::dateReadable with Format::dateIntlReadable.
- Depends on #1759.

Note that the formatting strign '%e' (day of month with leading space) has no equivlant in intl module. They are all rewritten with 'd' formatter, which is only the digit without leading space. These are all the occurrence of such '%e' refactors:
- modules/Activities/activities_attendance.php
- modules/Activities/report_attendance.php
- modules/Attendance/attendance_future_byPerson.php
- modules/Planner/units_edit_deploy.php
- modules/Planner/units_edit_working.php
- modules/Reports/reporting_my.php
- modules/Reports/templates/ui/reportingCycleHeader.twig.html
- modules/Staff/coverage_planner_assign.php
- modules/Staff/report_absences_summary.php
- modules/Staff/report_subs_availability.php
- modules/Staff/report_subs_availabilityWeekly.php
- modules/Staff/src/Messages/CoveragePartial.php
- modules/Staff/src/Tables/AbsenceCalendar.php
- modules/Staff/src/Tables/CoverageCalendar.php

**Motivation and Context**
* See #1643

**How Has This Been Tested?**
* Locally
* CI environment (with the newly written tests)