### PR TITLE
Activities: add a Left status for activity enrolment and notification events for enrolment changes

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -784,8 +784,8 @@ CREATE INDEX `gibbonPersonID` ON gibbonNotification(gibbonPersonID);end
 ++$count;
 $sql[$count][0] = '27.0.00';
 $sql[$count][1] = "
-INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Student Added', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
-INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Student Removed', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Enrolment Added', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Enrolment Removed', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
 INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Status Changed', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
 ALTER TABLE `gibbonActivityStudent` CHANGE `status` `status` ENUM('Accepted','Pending','Waiting List','Not Accepted','Left') NOT NULL DEFAULT 'Pending';end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -784,4 +784,8 @@ CREATE INDEX `gibbonPersonID` ON gibbonNotification(gibbonPersonID);end
 ++$count;
 $sql[$count][0] = '27.0.00';
 $sql[$count][1] = "
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Student Added', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Student Removed', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
+INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `type`, `scopes`, `active`) VALUES ('Activity Status Changed', 'Activities', 'View Activities', 'Core', 'All', 'Y');end
+ALTER TABLE `gibbonActivityStudent` CHANGE `status` `status` ENUM('Accepted','Pending','Waiting List','Not Accepted','Left') NOT NULL DEFAULT 'Pending';end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,9 @@ v27.0.00
 
     Tweaks & Additions
         System: automatically hyperlink any urls included in Custom Field descriptions
+        Activities: added notification events for activity enrolment changes
+        Activities: added a Left status to activity enrolment
+        Activities: added bulk actions to the activity enrolment page
 
     Bug Fixes
 

--- a/modules/Activities/activities_manage_enrolment.php
+++ b/modules/Activities/activities_manage_enrolment.php
@@ -19,11 +19,16 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\School\SchoolYearTermGateway;
-use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Http\Url;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
-use Gibbon\Http\Url;
+use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Domain\School\SchoolYearTermGateway;
+use Gibbon\Domain\Activities\ActivityStudentGateway;
+use Gibbon\Domain\Activities\ActivityStaffGateway;
+use Gibbon\Domain\Activities\ActivityGateway;
+use Gibbon\Tables\DataTable;
+use Gibbon\Forms\Prefab\BulkActionForm;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -33,18 +38,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     $page->addError(__('You do not have access to this action.'));
 } else {
     //Proceed!
-    $gibbonActivityID = (isset($_GET['gibbonActivityID']))? $_GET['gibbonActivityID'] : null;
+    $gibbonActivityID = $_GET['gibbonActivityID'] ?? '';
+    $params = [
+        'search' => $_GET['search'] ?? '',
+        'gibbonSchoolYearTermID' => $_GET['gibbonSchoolYearTermID'] ?? null
+    ];
 
+    if (empty($gibbonActivityID)) {
+        $page->addError(__('You have not specified one or more required parameters.'));
+        return;
+    }
+
+    $settingGateway = $container->get(SettingGateway::class);
+    $activityStudentGateway = $container->get(ActivityStudentGateway::class);
+    $activityStaffGateway = $container->get(ActivityStaffGateway::class);
+    
     $highestAction = getHighestGroupedAction($guid, '/modules/Activities/activities_manage_enrolment.php', $connection2);
     if ($highestAction == 'My Activities_viewEditEnrolment') {
-
-            $data = array('gibbonPersonID' => $gibbon->session->get('gibbonPersonID'), 'gibbonSchoolYearID' => $gibbon->session->get('gibbonSchoolYearID'), 'gibbonActivityID' => $gibbonActivityID);
-            $sql = "SELECT gibbonActivity.*, NULL as status, gibbonActivityStaff.role FROM gibbonActivity JOIN gibbonActivityStaff ON (gibbonActivity.gibbonActivityID=gibbonActivityStaff.gibbonActivityID) WHERE gibbonActivity.gibbonActivityID=:gibbonActivityID AND gibbonActivityStaff.gibbonPersonID=:gibbonPersonID AND gibbonActivityStaff.role='Organiser' AND gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' ORDER BY name";
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-
-        if (!$result || $result->rowCount() == 0) {
-            //Acess denied
+        $organiser = $activityStaffGateway->selectActivityOrganiserByPerson($gibbonActivityID, $session->get('gibbonPersonID'));
+        if (empty($organiser)) {
             $page->addError(__('You do not have access to this action.'));
             return;
         }
@@ -54,148 +66,185 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         ->add(__('Manage Activities'), 'activities_manage.php')
         ->add(__('Activity Enrolment'));
 
-    //Check if gibbonActivityID specified
-    if ($gibbonActivityID == '') {
-        $page->addError(__('You have not specified one or more required parameters.'));
-    } else {
+    $activity = $container->get(ActivityGateway::class)->getActivityDetailsByID($gibbonActivityID);
 
-            $data = array('gibbonActivityID' => $gibbonActivityID);
-            $sql = 'SELECT gibbonActivity.*, gibbonActivityType.access, gibbonActivityType.maxPerStudent, gibbonActivityType.enrolmentType, gibbonActivityType.backupChoice FROM gibbonActivity LEFT JOIN gibbonActivityType ON (gibbonActivity.type=gibbonActivityType.name) WHERE gibbonActivityID=:gibbonActivityID';
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-
-        if ($result->rowCount() != 1) {
-            echo "<div class='error'>";
-            echo __('The selected record does not exist, or you do not have access to it.');
-            echo '</div>';
-        } else {
-            //Let's go!
-            $values = $result->fetch();
-            $settingGateway = $container->get(SettingGateway::class);
-            $dateType = $settingGateway->getSettingByScope('Activities', 'dateType');
-            if ($_GET['search'] != '' || $_GET['gibbonSchoolYearTermID'] != '') {
-                $params = [
-                    "search" => $_GET['search'] ?? '',
-                    "gibbonSchoolYearTermID" => $_GET['gibbonSchoolYearTermID'] ?? null
-                ];
-                $page->navigator->addSearchResultsAction(Url::fromModuleRoute('Activities', 'activities_manage.php')->withQueryParams($params));
-            }
-
-            $form = Form::create('activityEnrolment', $gibbon->session->get('absoluteURL').'/index.php');
-
-            $row = $form->addRow();
-                $row->addLabel('nameLabel', __('Name'));
-                $row->addTextField('name')->readOnly()->setValue($values['name']);
-
-            if ($dateType == 'Date') {
-                $row = $form->addRow();
-                $row->addLabel('listingDatesLabel', __('Listing Dates'));
-                $row->addTextField('listingDates')->readOnly()->setValue(Format::date($values['listingStart']).'-'.Format::date($values['listingEnd']));
-
-                $row = $form->addRow();
-                $row->addLabel('programDatesLabel', __('Program Dates'));
-                $row->addTextField('programDates')->readOnly()->setValue(Format::date($values['programStart']).'-'.Format::date($values['programEnd']));
-            } else {
-                /**
-                 * @var SchoolYearTermGateway
-                 */
-                $schoolYearTermGateway = $container->get(SchoolYearTermGateway::class);
-                $termList = $schoolYearTermGateway->getTermNamesByID($values['gibbonSchoolYearTermIDList']);
-
-                $row = $form->addRow();
-                $row->addLabel('termsLabel', __('Terms'));
-                $row->addTextField('terms')->readOnly()->setValue(!empty($termList)? implode(', ', $termList) : '-');
-            }
-            echo $form->getOutput();
-
-
-            $enrolment = $settingGateway->getSettingByScope('Activities', 'enrolmentType');
-            $enrolment = !empty($values['enrolmentType'])? $values['enrolmentType'] : $enrolment;
-
-                $data = array('gibbonActivityID' => $gibbonActivityID, 'today' => date('Y-m-d'), 'statusCheck' => ($enrolment == 'Competitive'? 'Pending' : 'Waiting List'));
-                $sql = "SELECT gibbonActivityStudent.*, surname, preferredName, gibbonFormGroup.nameShort as formGroupNameShort
-                        FROM gibbonActivityStudent
-                        JOIN gibbonPerson ON (gibbonActivityStudent.gibbonPersonID=gibbonPerson.gibbonPersonID)
-                        LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current'))
-                        LEFT JOIN gibbonFormGroup ON (gibbonFormGroup.gibbonFormGroupID=gibbonStudentEnrolment.gibbonFormGroupID)
-                        WHERE gibbonActivityID=:gibbonActivityID
-                        AND NOT gibbonActivityStudent.status=:statusCheck
-                        AND gibbonPerson.status='Full'
-                        AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL OR dateEnd>=:today)
-                        ORDER BY gibbonActivityStudent.status, timestamp";
-                $result = $connection2->prepare($sql);
-                $result->execute($data);
-
-            echo "<div class='linkTop'>";
-            echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.$gibbon->session->get('module')."/activities_manage_enrolment_add.php&gibbonActivityID=$gibbonActivityID&search=".$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']."'>".__('Add')."<img style='margin-left: 5px' title='".__('Add')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/page_new.png'/></a>";
-            echo '</div>';
-
-            if ($result->rowCount() < 1) {
-                echo "<div class='error'>";
-                echo __('There are no records to display.');
-                echo '</div>';
-            } else {
-                echo "<table cellspacing='0' style='width: 100%'>";
-                echo "<tr class='head'>";
-                echo '<th>';
-                echo __('Student');
-                echo '</th>';
-                echo '<th>';
-                echo __('Form Group');
-                echo '</th>';
-                echo '<th>';
-                echo __('Status');
-                echo '</th>';
-                echo '<th>';
-                echo __('Timestamp');
-                echo '</th>';
-                echo '<th>';
-                echo __('Actions');
-                echo '</th>';
-                echo '</tr>';
-
-                $canViewStudentDetails = isActionAccessible($guid, $connection2, '/modules/Students/student_view_details.php');
-
-                $count = 0;
-                $rowNum = 'odd';
-                while ($values = $result->fetch()) {
-                    if ($count % 2 == 0) {
-                        $rowNum = 'even';
-                    } else {
-                        $rowNum = 'odd';
-                    }
-                    ++$count;
-
-                    //COLOR ROW BY STATUS!
-                    echo "<tr class=$rowNum>";
-                    echo '<td>';
-                    $studentName = Format::name('', $values['preferredName'], $values['surname'], 'Student', true);
-                    if ($canViewStudentDetails) {
-                        echo sprintf('<a href="%2$s">%1$s</a>', $studentName, $gibbon->session->get('absoluteURL').'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$values['gibbonPersonID'].'&subpage=Activities');
-                    } else {
-                        echo $studentName;
-                    }
-                    echo '</td>';
-                    echo '<td>';
-                    echo $values['formGroupNameShort'];
-                    echo '</td>';
-                    echo '<td>';
-                    echo __($values['status']);
-                    echo '</td>';
-                    echo '<td>';
-                    echo __('{date} at {time}',
-                            ['date' => Format::date(substr($values['timestamp'], 0, 10)),
-                            'time' => substr($values['timestamp'], 11, 5)]);
-                    echo '</td>';
-                    echo '<td>';
-                    echo "<a href='".$gibbon->session->get('absoluteURL').'/index.php?q=/modules/'.$gibbon->session->get('module').'/activities_manage_enrolment_edit.php&gibbonActivityID='.$values['gibbonActivityID'].'&gibbonPersonID='.$values['gibbonPersonID'].'&search='.$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']."'><img title='".__('Edit')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/config.png'/></a> ";
-                    echo "<a class='thickbox' href='".$gibbon->session->get('absoluteURL').'/fullscreen.php?q=/modules/'.$gibbon->session->get('module').'/activities_manage_enrolment_delete.php&gibbonActivityID='.$values['gibbonActivityID'].'&gibbonPersonID='.$values['gibbonPersonID'].'&search='.$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']."&width=650&height=135'><img title='".__('Delete')."' src='./themes/".$gibbon->session->get('gibbonThemeName')."/img/garbage.png'/></a> ";
-                    echo '</td>';
-                    echo '</tr>';
-                }
-                echo '</table>';
-            }
-        }
+    if (empty($activity)) {
+        $page->addError(__('The selected record does not exist, or you do not have access to it.'));
+        return;
     }
+
+    //Let's go!
+    $dateType = $settingGateway->getSettingByScope('Activities', 'dateType');
+    if (!empty($params['search']) || !empty($params['gibbonSchoolYearTermID'])) {
+        
+        $page->navigator->addSearchResultsAction(Url::fromModuleRoute('Activities', 'activities_manage.php')->withQueryParams($params));
+    }
+
+    // FORM
+    $form = Form::create('activityEnrolment', $session->get('absoluteURL').'/index.php');
+
+    $row = $form->addRow();
+        $row->addLabel('nameLabel', __('Name'));
+        $row->addTextField('name')->readOnly()->setValue($activity['name']);
+
+    if ($dateType == 'Date') {
+        $row = $form->addRow();
+        $row->addLabel('listingDatesLabel', __('Listing Dates'));
+        $row->addTextField('listingDates')->readOnly()->setValue(Format::date($activity['listingStart']).'-'.Format::date($activity['listingEnd']));
+
+        $row = $form->addRow();
+        $row->addLabel('programDatesLabel', __('Program Dates'));
+        $row->addTextField('programDates')->readOnly()->setValue(Format::date($activity['programStart']).'-'.Format::date($activity['programEnd']));
+    } else {
+        $schoolYearTermGateway = $container->get(SchoolYearTermGateway::class);
+        $termList = $schoolYearTermGateway->getTermNamesByID($activity['gibbonSchoolYearTermIDList']);
+
+        $row = $form->addRow();
+        $row->addLabel('termsLabel', __('Terms'));
+        $row->addTextField('terms')->readOnly()->setValue(!empty($termList)? implode(', ', $termList) : '-');
+    }
+    echo $form->getOutput();
+
+
+    $enrolmentType = $settingGateway->getSettingByScope('Activities', 'enrolmentType');
+    $enrolmentType = !empty($activity['enrolmentType'])? $activity['enrolmentType'] : $enrolmentType;
+
+    // FORM
+    $form = BulkActionForm::create('bulkAction', $session->get('absoluteURL').'/modules/'.$session->get('module').'/activities_manageProcessBulk.php');
+    $form->addHiddenValue('search', $search);
+
+    $table = $form->addRow()->addDataTable('activities', $criteria)->withData($enrolment);
+
+    // DATA TABLE
+    $table = DataTable::create('enrolment');
+    $table->setTitle(__('Participants'));
+
+    $table->addHeaderAction('add', __('Add'))
+        ->setURL('/modules/Activities/activities_manage_enrolment_add.php')
+        ->addParam('gibbonActivityID', $gibbonActivityID)
+        ->addParam('search', $params['search'])
+        ->addParam('gibbonSchoolYearTermID', $params['gibbonSchoolYearTermID'])
+        ->displayLabel();
+
+    $table->modifyRows(function ($values, $row) {
+        if ($values['status'] == 'Left') $row->addClass('error');
+        return $row;
+    });
+
+    $table->addColumn('student', __('Student'))
+        ->sortable(['surname', 'preferredName'])
+        ->format(function ($person)  {
+            return Format::name('', $person['preferredName'], $person['surname'], 'Student', true, true);
+        });
+
+    $table->addColumn('formGroup', __('Form Group'));
+
+    $table->addColumn('status', __('Status'));
+
+    $table->addColumn('timestamp', __('Timestamp'))->format(Format::using('timestamp', 'timestamp'));
+
+
+    // ACTIONS
+    $table->addActionColumn()
+        ->addParam('gibbonActivityID')
+        ->addParam('gibbonPersonID')
+        ->format(function ($activity, $actions) {
+            $actions->addAction('edit', __('Edit'))
+                    ->setURL('/modules/Activities/activities_manage_enrolment_edit.php');
+
+            $actions->addAction('delete', __('Delete'))
+                    ->setURL('/modules/Activities/activities_manage_enrolment_delete.php');
+        });
+
+    $table->addCheckboxColumn('gibbonActivityStudentID');
+
+    echo $form->getOutput();
+
+
+    return;
+
+        $data = array('gibbonActivityID' => $gibbonActivityID, 'today' => date('Y-m-d'), 'statusCheck' => ($enrolment == 'Competitive'? 'Pending' : 'Waiting List'));
+        $sql = "SELECT gibbonActivityStudent.*, surname, preferredName, gibbonFormGroup.nameShort as formGroupNameShort
+                FROM gibbonActivityStudent
+                JOIN gibbonPerson ON (gibbonActivityStudent.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current'))
+                LEFT JOIN gibbonFormGroup ON (gibbonFormGroup.gibbonFormGroupID=gibbonStudentEnrolment.gibbonFormGroupID)
+                WHERE gibbonActivityID=:gibbonActivityID
+                AND NOT gibbonActivityStudent.status=:statusCheck
+                AND gibbonPerson.status='Full'
+                AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL OR dateEnd>=:today)
+                ORDER BY gibbonActivityStudent.status, timestamp";
+        $result = $connection2->prepare($sql);
+        $result->execute($data);
+
+    echo "<div class='linkTop'>";
+    echo "<a href='".$session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module')."/activities_manage_enrolment_add.php&gibbonActivityID=$gibbonActivityID&search=".$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']."'>".__('Add')."<img style='margin-left: 5px' title='".__('Add')."' src='./themes/".$session->get('gibbonThemeName')."/img/page_new.png'/></a>";
+    echo '</div>';
+
+    if ($result->rowCount() < 1) {
+        echo "<div class='error'>";
+        echo __('There are no records to display.');
+        echo '</div>';
+    } else {
+        echo "<table cellspacing='0' style='width: 100%'>";
+        echo "<tr class='head'>";
+        echo '<th>';
+        echo __('Student');
+        echo '</th>';
+        echo '<th>';
+        echo __('Form Group');
+        echo '</th>';
+        echo '<th>';
+        echo __('Status');
+        echo '</th>';
+        echo '<th>';
+        echo __('Timestamp');
+        echo '</th>';
+        echo '<th>';
+        echo __('Actions');
+        echo '</th>';
+        echo '</tr>';
+
+        $canViewStudentDetails = isActionAccessible($guid, $connection2, '/modules/Students/student_view_details.php');
+
+        $count = 0;
+        $rowNum = 'odd';
+        while ($activity = $result->fetch()) {
+            if ($count % 2 == 0) {
+                $rowNum = 'even';
+            } else {
+                $rowNum = 'odd';
+            }
+            ++$count;
+
+            //COLOR ROW BY STATUS!
+            echo "<tr class=$rowNum>";
+            echo '<td>';
+            $studentName = Format::name('', $activity['preferredName'], $activity['surname'], 'Student', true);
+            if ($canViewStudentDetails) {
+                echo sprintf('<a href="%2$s">%1$s</a>', $studentName, $session->get('absoluteURL').'/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$activity['gibbonPersonID'].'&subpage=Activities');
+            } else {
+                echo $studentName;
+            }
+            echo '</td>';
+            echo '<td>';
+            echo $activity['formGroupNameShort'];
+            echo '</td>';
+            echo '<td>';
+            echo __($activity['status']);
+            echo '</td>';
+            echo '<td>';
+            echo __('{date} at {time}',
+                    ['date' => Format::date(substr($activity['timestamp'], 0, 10)),
+                    'time' => substr($activity['timestamp'], 11, 5)]);
+            echo '</td>';
+            echo '<td>';
+            echo "<a href='".$session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/activities_manage_enrolment_edit.php&gibbonActivityID='.$activity['gibbonActivityID'].'&gibbonPersonID='.$activity['gibbonPersonID'].'&search='.$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']."'><img title='".__('Edit')."' src='./themes/".$session->get('gibbonThemeName')."/img/config.png'/></a> ";
+            echo "<a class='thickbox' href='".$session->get('absoluteURL').'/fullscreen.php?q=/modules/'.$session->get('module').'/activities_manage_enrolment_delete.php&gibbonActivityID='.$activity['gibbonActivityID'].'&gibbonPersonID='.$activity['gibbonPersonID'].'&search='.$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']."&width=650&height=135'><img title='".__('Delete')."' src='./themes/".$session->get('gibbonThemeName')."/img/garbage.png'/></a> ";
+            echo '</td>';
+            echo '</tr>';
+        }
+        echo '</table>';
+    }
+
 }
-?>

--- a/modules/Activities/activities_manage_enrolmentProcessBulk.php
+++ b/modules/Activities/activities_manage_enrolmentProcessBulk.php
@@ -1,0 +1,124 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\Activities\ActivityGateway;
+use Gibbon\Domain\Activities\ActivityStudentGateway;
+use Gibbon\Domain\Activities\ActivityStaffGateway;
+use Gibbon\Domain\User\UserGateway;
+use Gibbon\Comms\NotificationEvent;
+use Gibbon\Services\Format;
+use Gibbon\Domain\System\LogGateway;
+
+include '../../gibbon.php';
+
+$action = $_POST['action'] ?? '';
+$gibbonActivityID = $_POST['gibbonActivityID'] ?? '';
+
+$URL = $session->get('absoluteURL')."/index.php?q=/modules/Activities/activities_manage_enrolment.php&gibbonActivityID=$gibbonActivityID";
+
+if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_enrolment.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    //Proceed!
+    $enrolments = $_POST['gibbonActivityStudentID'] ?? [];
+
+    if (empty($action) || ($action != 'Mark as Left' && $action != 'Mark as Accepted' && $action != 'Delete')) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    } 
+    
+    // Check if person specified
+    if (empty($enrolments)) {
+        $URL .= '&return=error3';
+        header("Location: {$URL}");
+        exit;
+    } 
+
+    $activity = $container->get(ActivityGateway::class)->getByID($gibbonActivityID);
+    if (empty($activity)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    } 
+
+    $activityStudentGateway = $container->get(ActivityStudentGateway::class);
+    $activityStaffGateway = $container->get(ActivityStaffGateway::class);
+    $userGateway = $container->get(UserGateway::class);
+    $logGateway = $container->get(LogGateway::class);
+
+    $partialFail = false;
+    $students = [];
+    
+    foreach ($enrolments AS $gibbonActivityStudentID) {
+        $activityStudent = $activityStudentGateway->getByID($gibbonActivityStudentID);
+        $student = $userGateway->getUserDetails($activityStudent['gibbonPersonID'] ?? '', $session->get('gibbonSchoolYearID'));
+
+        if (empty($activityStudent) || empty($student)) {
+            $partialFail = true;
+            continue;
+        }
+
+        $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, false).' ('.$student['formGroup'].')';
+        $students[] = $studentName;
+
+        if ($action == 'Mark as Accepted') {
+            $data = ['gibbonActivityID' => $gibbonActivityID, 'gibbonPersonID' => $activityStudent['gibbonPersonID'], 'status' => 'Accepted'];
+            $activityStudentGateway->update($activityStudent['gibbonActivityStudentID'], $data);
+        } elseif ($action == 'Mark as Left') {
+            $data = ['gibbonActivityID' => $gibbonActivityID, 'gibbonPersonID' => $activityStudent['gibbonPersonID'], 'status' => 'Left'];
+            $activityStudentGateway->update($activityStudent['gibbonActivityStudentID'], $data);
+        } else if ($action == 'Delete') {
+            $activityStudentGateway->delete($activityStudent['gibbonActivityStudentID']);
+        }
+    }
+
+    // Raise a new notification event
+    $event = new NotificationEvent('Activities', 'Activity Enrolment Removed');
+    
+    if ($action == 'Mark as Accepted') {
+        $notificationText =  __('The following participants have been set to {status} in {name}', ['name' => $activity['name'], 'status' => __('Accepted') ]).':<br/>'.Format::list($students);
+    } elseif ($action == 'Mark as Left') {
+        $notificationText =  __('The following participants have been set to {status} in {name}', ['name' => $activity['name'], 'status' => __('Left') ]).':<br/>'.Format::list($students);
+    } else if ($action == 'Delete') {
+        $notificationText = __('The following participants have been removed from the activity {name}', ['name' => $activity['name']]).':<br/>'.Format::list($students);
+    }
+    
+    $event->setNotificationText($notificationText);
+    $event->setActionLink('/index.php?q=/modules/Activities/activities_manage_enrolment.php&gibbonActivityID='.$gibbonActivityID.'&search=&gibbonSchoolYearTermID=');
+
+    $activityStaff = $activityStaffGateway->selectActivityStaff($gibbonActivityID)->fetchAll();
+    foreach ($activityStaff as $staff) {
+        $event->addRecipient($staff['gibbonPersonID']);
+    }
+
+    $event->sendNotifications($pdo, $session);
+    
+    // Set log
+    $gibbonModuleID = getModuleIDFromName($connection2, 'Activities') ;
+    $logGateway->addLog($session->get('gibbonSchoolYearIDCurrent'), $gibbonModuleID, $session->get('gibbonPersonID'), $action == 'Delete' ? 'Activities - Student Deleted' : 'Activities - Student Status Changed', ['students' => implode(',', $students)]);
+
+    $URL .= $partialFail
+        ? '&return=warning1'
+        : '&return=success0';
+    header("Location: {$URL}");
+}

--- a/modules/Activities/activities_manage_enrolment_add.php
+++ b/modules/Activities/activities_manage_enrolment_add.php
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             $enrolment = $settingGateway->getSettingByScope('Activities', 'enrolmentType');
             $enrolment = !empty($values['enrolmentType'])? $values['enrolmentType'] : $enrolment;
 
-			$statuses = array('Accepted' => __('Accepted'));
+			$statuses = ['Accepted' => __('Accepted')];
 			if ($enrolment == 'Competitive') {
                 if (!empty($values['waitingList']) && $values['waitingList'] == 'Y') {
                     $statuses['Waiting List'] = __('Waiting List');
@@ -162,6 +162,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 			} else {
 				$statuses['Pending'] = __('Pending');
 			}
+            $statuses['Left'] = __('Left');
 
 			$row = $form->addRow();
                 $row->addLabel('status', __('Status'));

--- a/modules/Activities/activities_manage_enrolment_add.php
+++ b/modules/Activities/activities_manage_enrolment_add.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         }
     }
 
-    $urlParams = ['gibbonActivityID' => $_GET['gibbonActivityID'], 'search' => $_GET['search'], 'gibbonSchoolYearTermID' => $_GET['gibbonSchoolYearTermID']];
+    $urlParams = ['gibbonActivityID' => $_GET['gibbonActivityID'], 'search' => $_GET['search'] ?? '', 'gibbonSchoolYearTermID' => $_GET['gibbonSchoolYearTermID'] ?? ''];
 
     $page->breadcrumbs
         ->add(__('Manage Activities'), 'activities_manage.php')

--- a/modules/Activities/activities_manage_enrolment_addProcess.php
+++ b/modules/Activities/activities_manage_enrolment_addProcess.php
@@ -81,7 +81,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
                     ];
 
                     $inserted = $activityStudentGateway->insert($data);
-                    $student = $userGateway->getUserDetails($gibbonPersonID);
+                    $student = $userGateway->getUserDetails($gibbonPersonID, $session->get('gibbonSchoolYearID'));
 
                     if (!empty($inserted) && !empty($student)) {
                         $added[] = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, false).' ('.$student['formGroup'].') '.$status;
@@ -95,9 +95,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
             if (!empty($added)) {
                 // Raise a new notification event
-                $event = new NotificationEvent('Activities', 'Activity Student Added');
+                $event = new NotificationEvent('Activities', 'Activity Enrolment Added');
 
-                $notificationText = __('One or more students have been added to the activity {name}', ['name' => $activity['name']]).'<br/>'.Format::list($added);
+                $notificationText = __('The following participants have been added to the activity {name}', ['name' => $activity['name']]).':<br/>'.Format::list($added);
 
                 $event->setNotificationText($notificationText);
                 $event->setActionLink('/index.php?q=/modules/Activities/activities_manage_enrolment.php&gibbonActivityID='.$gibbonActivityID.'&search=&gibbonSchoolYearTermID=');

--- a/modules/Activities/activities_manage_enrolment_addProcess.php
+++ b/modules/Activities/activities_manage_enrolment_addProcess.php
@@ -21,6 +21,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Domain\System\LogGateway;
 use Gibbon\Data\Validator;
+use Gibbon\Domain\User\UserGateway;
+use Gibbon\Services\Format;
+use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\Activities\ActivityStudentGateway;
+use Gibbon\Domain\Activities\ActivityStaffGateway;
+use Gibbon\Domain\Activities\ActivityGateway;
 
 include '../../gibbon.php';
 
@@ -54,30 +60,56 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             $URL .= '&return=error1';
             header("Location: {$URL}");
         } else {
-            foreach ($choices as $t) {
-                //Check to see if student is already registered in this activity
+            $activity = $container->get(ActivityGateway::class)->getByID($gibbonActivityID);
 
-                    $data = array('gibbonPersonID' => $t, 'gibbonActivityID' => $gibbonActivityID);
-                    $sql = 'SELECT * FROM gibbonActivityStudent WHERE gibbonPersonID=:gibbonPersonID AND gibbonActivityID=:gibbonActivityID';
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
+            $activityStudentGateway = $container->get(ActivityStudentGateway::class);
+            $activityStaffGateway = $container->get(ActivityStaffGateway::class);
+            $userGateway = $container->get(UserGateway::class);
+            $added = [];
 
-                //If student not in activity, add them
-                if ($result->rowCount() == 0) {
-                    try {
-                        $data = array('gibbonPersonID' => $t, 'gibbonActivityID' => $gibbonActivityID, 'status' => $status, 'timestamp' => date('Y-m-d H:i:s', time()));
-                        $sql = 'INSERT INTO gibbonActivityStudent SET gibbonPersonID=:gibbonPersonID, gibbonActivityID=:gibbonActivityID, status=:status, timestamp=:timestamp';
-                        $result = $connection2->prepare($sql);
-                        $result->execute($data);
-                    } catch (PDOException $e) {
-                        $update = false;
+            foreach ($choices as $gibbonPersonID) {
+                // Check to see if student is already registered in this activity
+                $activityStudent = $activityStudentGateway->selectBy(['gibbonPersonID' => $gibbonPersonID, 'gibbonActivityID' => $gibbonActivityID])->fetch();
+
+                // If student not in activity, add them
+                if (empty($activityStudent)) {
+                    $data = [
+                        'gibbonPersonID' => $gibbonPersonID,
+                        'gibbonActivityID' => $gibbonActivityID,
+                        'status' => $status,
+                        'timestamp' => date('Y-m-d H:i:s', time()),
+                    ];
+
+                    $inserted = $activityStudentGateway->insert($data);
+                    $student = $userGateway->getUserDetails($gibbonPersonID);
+
+                    if (!empty($inserted) && !empty($student)) {
+                        $added[] = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, false).' ('.$student['formGroup'].') '.$status;
                     }
 
-                    //Set log
+                    // Set log
                     $gibbonModuleID = getModuleIDFromName($connection2, 'Activities') ;
-                    $logGateway->addLog($session->get('gibbonSchoolYearIDCurrent'), $gibbonModuleID, $session->get('gibbonPersonID'), 'Activities - Student Added', array('gibbonPersonIDStudent' => $t));
+                    $logGateway->addLog($session->get('gibbonSchoolYearIDCurrent'), $gibbonModuleID, $session->get('gibbonPersonID'), 'Activities - Student Added', ['gibbonPersonIDStudent' => $gibbonPersonID]);
                 }
             }
+
+            if (!empty($added)) {
+                // Raise a new notification event
+                $event = new NotificationEvent('Activities', 'Activity Student Added');
+
+                $notificationText = __('One or more students have been added to the activity {name}', ['name' => $activity['name']]).'<br/>'.Format::list($added);
+
+                $event->setNotificationText($notificationText);
+                $event->setActionLink('/index.php?q=/modules/Activities/activities_manage_enrolment.php&gibbonActivityID='.$gibbonActivityID.'&search=&gibbonSchoolYearTermID=');
+
+                $activityStaff = $activityStaffGateway->selectActivityStaff($gibbonActivityID)->fetchAll();
+                foreach ($activityStaff as $staff) {
+                    $event->addRecipient($staff['gibbonPersonID']);
+                }
+
+                $event->sendNotifications($pdo, $session);
+            }
+
             //Write to database
             if ($update == false) {
                 $URL .= '&return=error2';

--- a/modules/Activities/activities_manage_enrolment_deleteProcess.php
+++ b/modules/Activities/activities_manage_enrolment_deleteProcess.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         exit;
     }
     
-    $student = $container->get(UserGateway::class)->getUserDetails($gibbonPersonID);
+    $student = $container->get(UserGateway::class)->getUserDetails($gibbonPersonID, $session->get('gibbonSchoolYearID'));
     if (empty($student)) {
         $URL .= '&return=error2';
         header("Location: {$URL}");
@@ -73,10 +73,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     $activityStudentGateway->delete($activityStudent['gibbonActivityStudentID']);
 
     // Raise a new notification event
-    $event = new NotificationEvent('Activities', 'Activity Student Removed');
+    $event = new NotificationEvent('Activities', 'Activity Enrolment Removed');
     $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, false).' ('.$student['formGroup'].')';
     
-    $notificationText = __('{student} has been removed from the activity {name}', ['name' => $activity['name'], 'student' => $studentName ]);
+    $notificationText = __('The following participants have been removed from the activity {name}', ['name' => $activity['name']]).':<br/>'.Format::list([$studentName]);
     
     $event->setNotificationText($notificationText);
     $event->setActionLink('/index.php?q=/modules/Activities/activities_manage_enrolment.php&gibbonActivityID='.$gibbonActivityID.'&search=&gibbonSchoolYearTermID=');
@@ -90,7 +90,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     
     // Set log
     $gibbonModuleID = getModuleIDFromName($connection2, 'Activities') ;
-    $logGateway->addLog($session->get('gibbonSchoolYearIDCurrent'), $gibbonModuleID, $session->get('gibbonPersonID'), 'Activities - Student Deleted', array('gibbonPersonIDStudent' => $gibbonPersonID));
+    $logGateway->addLog($session->get('gibbonSchoolYearIDCurrent'), $gibbonModuleID, $session->get('gibbonPersonID'), 'Activities - Student Deleted', ['gibbonPersonIDStudent' => $gibbonPersonID]);
 
     $URLDelete = $URLDelete.'&return=success0';
     header("Location: {$URLDelete}");

--- a/modules/Activities/activities_manage_enrolment_edit.php
+++ b/modules/Activities/activities_manage_enrolment_edit.php
@@ -50,7 +50,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         }
     }
 
-    $urlParams = ['gibbonActivityID' => $_GET['gibbonActivityID'], 'search' => $_GET['search'], 'gibbonSchoolYearTermID' => $_GET['gibbonSchoolYearTermID']];
+    $urlParams = ['gibbonActivityID' => $_GET['gibbonActivityID'], 'search' => $_GET['search'] ?? '', 'gibbonSchoolYearTermID' => $_GET['gibbonSchoolYearTermID'] ?? ''];
 
     $page->breadcrumbs
         ->add(__('Manage Activities'), 'activities_manage.php')

--- a/modules/Activities/activities_manage_enrolment_edit.php
+++ b/modules/Activities/activities_manage_enrolment_edit.php
@@ -126,13 +126,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             $enrolment = $settingGateway->getSettingByScope('Activities', 'enrolmentType');
             $enrolment = !empty($values['enrolmentType'])? $values['enrolmentType'] : $enrolment;
 
-            $statuses = array('Accepted' => __('Accepted'));
+            $statuses = ['Accepted' => __('Accepted')];
             if ($enrolment == 'Competitive') {
                 $statuses['Waiting List'] = __('Waiting List');
             } else {
                 $statuses['Pending'] = __('Pending');
             }
             $statuses['Not Accepted'] = __('Not Accepted');
+            $statuses['Left'] = __('Left');
 
             $row = $form->addRow();
             $row->addLabel('status', __('Status'));

--- a/modules/Activities/activities_manage_enrolment_editProcess.php
+++ b/modules/Activities/activities_manage_enrolment_editProcess.php
@@ -21,6 +21,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Domain\System\LogGateway;
 use Gibbon\Data\Validator;
+use Gibbon\Domain\Activities\ActivityGateway;
+use Gibbon\Domain\Activities\ActivityStudentGateway;
+use Gibbon\Domain\Activities\ActivityStaffGateway;
+use Gibbon\Domain\User\UserGateway;
+use Gibbon\Comms\NotificationEvent;
+use Gibbon\Services\Format;
 
 require_once '../../gibbon.php';
 
@@ -34,58 +40,71 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     $URL .= '&return=error0';
     header("Location: {$URL}");
 } else {
+    //Proceed!
     $URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address'])."/activities_manage_enrolment_edit.php&gibbonPersonID=$gibbonPersonID&gibbonActivityID=$gibbonActivityID&search=".$_GET['search']."&gibbonSchoolYearTermID=".$_GET['gibbonSchoolYearTermID'];
 
     if ($gibbonActivityID == '' or $gibbonPersonID == '') {
         $URL .= '&return=error0';
         header("Location: {$URL}");
-    } else {
-        //Proceed!
-        //Check if status specified
-        $status = $_POST['status'] ?? '';
-        if ($status == '') {
-            $URL .= '&return=error1';
-            header("Location: {$URL}");
-        } else {
-            try {
-                $data = array('gibbonActivityID' => $gibbonActivityID, 'gibbonPersonID' => $gibbonPersonID);
-                $sql = 'SELECT gibbonActivity.*, gibbonActivityStudent.*, surname, preferredName FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivity.gibbonActivityID=gibbonActivityStudent.gibbonActivityID) JOIN gibbonPerson ON (gibbonActivityStudent.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonActivityStudent.gibbonActivityID=:gibbonActivityID AND gibbonActivityStudent.gibbonPersonID=:gibbonPersonID';
-                $result = $connection2->prepare($sql);
-                $result->execute($data);
-            } catch (PDOException $e) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
-                exit();
-            }
+        exit;
+    } 
 
-            if ($result->rowCount() != 1) {
-                $URL .= '&return=error2';
-                header("Location: {$URL}");
-            } else {
-                $row = $result->fetch();
-                $statusOld = $row['status'];
-
-                //Write to database
-                try {
-                    $data = array('gibbonActivityID' => $gibbonActivityID, 'gibbonPersonID' => $gibbonPersonID, 'status' => $status);
-                    $sql = 'UPDATE gibbonActivityStudent SET status=:status WHERE gibbonActivityID=:gibbonActivityID AND gibbonPersonID=:gibbonPersonID';
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    $URL .= '&return=error2';
-                    header("Location: {$URL}");
-                    exit();
-                }
-
-                //Set log
-                if ($statusOld != $status) {
-                    $gibbonModuleID = getModuleIDFromName($connection2, 'Activities') ;
-                    $logGateway->addLog($session->get('gibbonSchoolYearIDCurrent'), $gibbonModuleID, $session->get('gibbonPersonID'), 'Activities - Student Status Changed', array('gibbonPersonIDStudent' => $gibbonPersonID, 'statusOld' => $statusOld, 'statusNew' => $status));
-                }
-
-                $URL .= '&return=success0';
-                header("Location: {$URL}");
-            }
-        }
+    $student = $container->get(UserGateway::class)->getUserDetails($gibbonPersonID);
+    if (empty($student)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
     }
+    
+    // Check if status specified
+    $status = $_POST['status'] ?? '';
+    if (empty($status)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $activityStudentGateway = $container->get(ActivityStudentGateway::class);
+    $activityStaffGateway = $container->get(ActivityStaffGateway::class);
+
+    $activity = $container->get(ActivityGateway::class)->getByID($gibbonActivityID);
+    $activityStudent = $activityStudentGateway->selectBy(['gibbonPersonID' => $gibbonPersonID, 'gibbonActivityID' => $gibbonActivityID])->fetch();
+
+    if (empty($activity) || empty($activityStudent)) {
+        $URL .= '&return=error2';
+        header("Location: {$URL}");
+        exit;
+    }
+    
+    $statusOld = $activity['status'];
+
+    // Write to database
+    $data = ['gibbonActivityID' => $gibbonActivityID, 'gibbonPersonID' => $gibbonPersonID, 'status' => $status];
+    $activityStudentGateway->update($activityStudent['gibbonActivityStudentID'], $data);
+
+    
+    if ($statusOld != $status) {
+        // Raise a new notification event
+        $event = new NotificationEvent('Activities', 'Activity Status Changed');
+        $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, false).' ('.$student['formGroup'].')';
+        
+        $notificationText = __('The activity status for {student} has been set to {status} in {name}', ['name' => $activity['name'], 'student' => $studentName, 'status' => $status ]);
+        
+        $event->setNotificationText($notificationText);
+        $event->setActionLink('/index.php?q=/modules/Activities/activities_manage_enrolment.php&gibbonActivityID='.$gibbonActivityID.'&search=&gibbonSchoolYearTermID=');
+
+        $activityStaff = $activityStaffGateway->selectActivityStaff($gibbonActivityID)->fetchAll();
+        foreach ($activityStaff as $staff) {
+            $event->addRecipient($staff['gibbonPersonID']);
+        }
+
+        $event->sendNotifications($pdo, $session);
+        
+        // Set log
+        $gibbonModuleID = getModuleIDFromName($connection2, 'Activities') ;
+        $logGateway->addLog($session->get('gibbonSchoolYearIDCurrent'), $gibbonModuleID, $session->get('gibbonPersonID'), 'Activities - Student Status Changed', array('gibbonPersonIDStudent' => $gibbonPersonID, 'statusOld' => $statusOld, 'statusNew' => $status));
+    }
+
+    $URL .= '&return=success0';
+    header("Location: {$URL}");
 }

--- a/modules/Activities/activities_manage_enrolment_editProcess.php
+++ b/modules/Activities/activities_manage_enrolment_editProcess.php
@@ -49,7 +49,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         exit;
     } 
 
-    $student = $container->get(UserGateway::class)->getUserDetails($gibbonPersonID);
+    $student = $container->get(UserGateway::class)->getUserDetails($gibbonPersonID, $session->get('gibbonSchoolYearID'));
     if (empty($student)) {
         $URL .= '&return=error2';
         header("Location: {$URL}");
@@ -88,7 +88,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         $event = new NotificationEvent('Activities', 'Activity Status Changed');
         $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, false).' ('.$student['formGroup'].')';
         
-        $notificationText = __('The activity status for {student} has been set to {status} in {name}', ['name' => $activity['name'], 'student' => $studentName, 'status' => $status ]);
+        $notificationText = __('The following participants have been set to {status} in {name}', ['name' => $activity['name'], 'status' => __($status) ]).':<br/>'.Format::list([$studentName]);
         
         $event->setNotificationText($notificationText);
         $event->setActionLink('/index.php?q=/modules/Activities/activities_manage_enrolment.php&gibbonActivityID='.$gibbonActivityID.'&search=&gibbonSchoolYearTermID=');

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -2403,7 +2403,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     ++$yearCount;
                                     try {
                                         $data = array('gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $rowYears['gibbonSchoolYearID']);
-                                        $sql = "SELECT gibbonActivity.gibbonActivityID, gibbonActivity.name, gibbonActivity.type, gibbonActivity.programStart, gibbonActivity.programEnd, GROUP_CONCAT(gibbonSchoolYearTerm.nameShort ORDER BY gibbonSchoolYearTerm.sequenceNumber SEPARATOR ', ') as terms, gibbonActivityStudent.status, NULL AS role FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivity.gibbonActivityID=gibbonActivityStudent.gibbonActivityID) LEFT JOIN gibbonSchoolYearTerm ON (FIND_IN_SET(gibbonSchoolYearTerm.gibbonSchoolYearTermID, gibbonActivity.gibbonSchoolYearTermIDList)) WHERE gibbonActivityStudent.gibbonPersonID=:gibbonPersonID AND gibbonActivity.gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' GROUP BY gibbonActivity.gibbonActivityID, gibbonActivityStudent.status ORDER BY gibbonActivity.name";
+                                        $sql = "SELECT gibbonActivity.gibbonActivityID, gibbonActivity.name, gibbonActivity.type, gibbonActivity.programStart, gibbonActivity.programEnd, GROUP_CONCAT(gibbonSchoolYearTerm.nameShort ORDER BY gibbonSchoolYearTerm.sequenceNumber SEPARATOR ', ') as terms, gibbonActivityStudent.status, NULL AS role FROM gibbonActivity JOIN gibbonActivityStudent ON (gibbonActivity.gibbonActivityID=gibbonActivityStudent.gibbonActivityID) LEFT JOIN gibbonSchoolYearTerm ON (FIND_IN_SET(gibbonSchoolYearTerm.gibbonSchoolYearTermID, gibbonActivity.gibbonSchoolYearTermIDList)) WHERE gibbonActivityStudent.gibbonPersonID=:gibbonPersonID AND gibbonActivity.gibbonSchoolYearID=:gibbonSchoolYearID AND active='Y' AND gibbonActivityStudent.status <> 'Not Accepted' GROUP BY gibbonActivity.gibbonActivityID, gibbonActivityStudent.status ORDER BY gibbonActivityStudent.status, gibbonActivity.name";
                                         $result = $connection2->prepare($sql);
                                         $result->execute($data);
                                         $resultData = $result->fetchAll();
@@ -2414,6 +2414,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
 
                                     $table = DataTable::create('activities');
                                     $table->setTitle($rowYears['name']);
+
+                                    $table->modifyRows(function ($values, $row) {
+                                        if ($values['status'] == 'Pending') $row->addClass('warning');
+                                        if ($values['status'] == 'Waiting List') $row->addClass('warning');
+                                        if ($values['status'] == 'Not Accepted') $row->addClass('dull');
+                                        if ($values['status'] == 'Left') $row->addClass('dull');
+                                        return $row;
+                                    });
+
                                     $table->addColumn('name', __('Activity'));
                                     $table->addColumn('type', __('Type'));
                                     $table->addColumn('date', $dateType == "Date" ? __('Dates') : __('Term'))

--- a/src/Domain/Activities/ActivityGateway.php
+++ b/src/Domain/Activities/ActivityGateway.php
@@ -250,6 +250,14 @@ class ActivityGateway extends QueryableGateway
         return $this->db()->select($sql, $data);
     }
 
+    public function getActivityDetailsByID($gibbonActivityID)
+    {
+        $data = ['gibbonActivityID' => $gibbonActivityID];
+        $sql = 'SELECT gibbonActivity.*, gibbonActivityType.access, gibbonActivityType.maxPerStudent, gibbonActivityType.enrolmentType, gibbonActivityType.backupChoice FROM gibbonActivity LEFT JOIN gibbonActivityType ON (gibbonActivity.type=gibbonActivityType.name) WHERE gibbonActivityID=:gibbonActivityID';
+
+        return $this->db()->selectOne($sql, $data);
+    }
+
     function getStudentActivityCountByType($type, $gibbonPersonID)
     {
         $data = array('gibbonPersonID' => $gibbonPersonID, 'type' => $type, 'date' => date('Y-m-d'));

--- a/src/Domain/Activities/ActivityStaffGateway.php
+++ b/src/Domain/Activities/ActivityStaffGateway.php
@@ -41,31 +41,38 @@ class ActivityStaffGateway extends QueryableGateway
     private static $searchableColumns = [];
 
     public function selectActivityStaff($gibbonActivityID) {
-    	$select = $this
-    		->newSelect()
-    		->cols(['preferredName, surname, gibbonActivityStaff.*'])
-    		->from($this->getTableName())
-    		->leftJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonActivityStaff.gibbonPersonID')
-    		->where('gibbonActivityStaff.gibbonActivityID = :gibbonActivityID')
-    		->bindValue('gibbonActivityID', $gibbonActivityID)
-    		->where('gibbonPerson.status="Full"')
-    		->orderBy(['surname', 'preferredName']);
+        $select = $this
+            ->newSelect()
+            ->cols(['preferredName, surname, gibbonActivityStaff.*'])
+            ->from($this->getTableName())
+            ->leftJoin('gibbonPerson', 'gibbonPerson.gibbonPersonID=gibbonActivityStaff.gibbonPersonID')
+            ->where('gibbonActivityStaff.gibbonActivityID = :gibbonActivityID')
+            ->bindValue('gibbonActivityID', $gibbonActivityID)
+            ->where('gibbonPerson.status="Full"')
+            ->orderBy(['surname', 'preferredName']);
 
-    	return $this->runSelect($select);
+        return $this->runSelect($select);
+    }
+
+    public function selectActivityOrganiserByPerson($gibbonActivityID, $gibbonPersonID) {
+        $data = ['gibbonPersonID' => $gibbonPersonID, 'gibbonActivityID' => $gibbonActivityID];
+        $sql = "SELECT gibbonActivity.*, NULL as status, gibbonActivityStaff.role FROM gibbonActivity JOIN gibbonActivityStaff ON (gibbonActivity.gibbonActivityID=gibbonActivityStaff.gibbonActivityID) WHERE gibbonActivity.gibbonActivityID=:gibbonActivityID AND gibbonActivityStaff.gibbonPersonID=:gibbonPersonID AND gibbonActivityStaff.role='Organiser' AND active='Y' ORDER BY name";
+
+        return $this->db()->select($sql, $data);
     }
 
     public function selectActivityStaffByID($gibbonActivityID, $gibbonPersonID) {
-    	return $this->selectBy([
-    		'gibbonPersonID' 	=> $gibbonPersonID,
-    		'gibbonActivityID' 	=> $gibbonActivityID
-    	]);
+        return $this->selectBy([
+            'gibbonPersonID' 	=> $gibbonPersonID,
+            'gibbonActivityID' 	=> $gibbonActivityID
+        ]);
     }
 
     public function insertActivityStaff($gibbonActivityID, $gibbonPersonID, $role) {
-    	return $this->insert([
-    		'gibbonPersonID' 	=> $gibbonPersonID,
-    		'gibbonActivityID' 	=> $gibbonActivityID,
-    		'role'				=> $role
-    	]);
+        return $this->insert([
+            'gibbonPersonID' 	=> $gibbonPersonID,
+            'gibbonActivityID' 	=> $gibbonActivityID,
+            'role'				=> $role
+        ]);
     }
 }

--- a/src/Domain/Activities/ActivityStudentGateway.php
+++ b/src/Domain/Activities/ActivityStudentGateway.php
@@ -1,0 +1,54 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Activities;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * Activity Student Gateway
+ *
+ * @version v27
+ * @since   v27
+ */
+class ActivityStudentGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonActivityStudent';
+    private static $primaryKey = 'gibbonActivityStudentID';
+
+    private static $searchableColumns = [];
+
+    // $data = array('gibbonActivityID' => $gibbonActivityID, 'today' => date('Y-m-d'), 'statusCheck' => ($enrolment == 'Competitive'? 'Pending' : 'Waiting List'));
+    //     $sql = "SELECT gibbonActivityStudent.*, surname, preferredName, gibbonFormGroup.nameShort as formGroupNameShort
+    //             FROM gibbonActivityStudent
+    //             JOIN gibbonPerson ON (gibbonActivityStudent.gibbonPersonID=gibbonPerson.gibbonPersonID)
+    //             LEFT JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=(SELECT gibbonSchoolYearID FROM gibbonSchoolYear WHERE status='Current'))
+    //             LEFT JOIN gibbonFormGroup ON (gibbonFormGroup.gibbonFormGroupID=gibbonStudentEnrolment.gibbonFormGroupID)
+    //             WHERE gibbonActivityID=:gibbonActivityID
+    //             AND NOT gibbonActivityStudent.status=:statusCheck
+    //             AND gibbonPerson.status='Full'
+    //             AND (dateStart IS NULL OR dateStart<=:today) AND (dateEnd IS NULL OR dateEnd>=:today)
+    //             ORDER BY gibbonActivityStudent.status, timestamp";
+}

--- a/src/Domain/User/UserGateway.php
+++ b/src/Domain/User/UserGateway.php
@@ -121,6 +121,28 @@ class UserGateway extends QueryableGateway implements ScrubbableGateway
     }
 
     /**
+     * Returns basic user details, including name and user photo, and also returns 
+     * form group information if this user is a student.
+     *
+     * @param string $gibbonPersonID
+     * @return array
+     */
+    public function getUserDetails($gibbonPersonID)
+    {
+        $data = ['gibbonPersonID' => $gibbonPersonID];
+        $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, email, image_240, gender, dateStart, dateEnd, gibbonStudentEnrolment.gibbonStudentEnrolmentID, gibbonStudentEnrolment.gibbonSchoolYearID, gibbonYearGroup.gibbonYearGroupID, gibbonYearGroup.nameShort AS yearGroup, gibbonYearGroup.name AS yearGroupName, gibbonFormGroup.gibbonFormGroupID, gibbonFormGroup.nameShort AS formGroup, gibbonFormGroup.name AS formGroupName, gibbonRole.category as roleCategory
+                FROM gibbonPerson
+                JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary)
+                LEFT JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
+                LEFT JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonSchoolYear.status='Current')
+                LEFT JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
+                LEFT JOIN gibbonFormGroup ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID)
+                WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID";
+
+        return $this->db()->selectOne($sql, $data);
+    }
+
+    /**
      * Selects the family info for a subset of users. Primarily used to join family data to the queryAllUsers results.
      *
      * @param string|array $gibbonPersonIDList

--- a/src/Domain/User/UserGateway.php
+++ b/src/Domain/User/UserGateway.php
@@ -127,14 +127,13 @@ class UserGateway extends QueryableGateway implements ScrubbableGateway
      * @param string $gibbonPersonID
      * @return array
      */
-    public function getUserDetails($gibbonPersonID)
+    public function getUserDetails($gibbonPersonID, $gibbonSchoolYearID)
     {
-        $data = ['gibbonPersonID' => $gibbonPersonID];
+        $data = ['gibbonPersonID' => $gibbonPersonID, 'gibbonSchoolYearID' => $gibbonSchoolYearID];
         $sql = "SELECT gibbonPerson.gibbonPersonID, title, surname, preferredName, email, image_240, gender, dateStart, dateEnd, gibbonStudentEnrolment.gibbonStudentEnrolmentID, gibbonStudentEnrolment.gibbonSchoolYearID, gibbonYearGroup.gibbonYearGroupID, gibbonYearGroup.nameShort AS yearGroup, gibbonYearGroup.name AS yearGroupName, gibbonFormGroup.gibbonFormGroupID, gibbonFormGroup.nameShort AS formGroup, gibbonFormGroup.name AS formGroupName, gibbonRole.category as roleCategory
                 FROM gibbonPerson
                 JOIN gibbonRole ON (gibbonRole.gibbonRoleID=gibbonPerson.gibbonRoleIDPrimary)
-                LEFT JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID)
-                LEFT JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID AND gibbonSchoolYear.status='Current')
+                LEFT JOIN gibbonStudentEnrolment ON (gibbonPerson.gibbonPersonID=gibbonStudentEnrolment.gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID)
                 LEFT JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
                 LEFT JOIN gibbonFormGroup ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID)
                 WHERE gibbonPerson.gibbonPersonID=:gibbonPersonID";


### PR DESCRIPTION
This PR improved the activity enrolment process with the following changes:

 - Notification events for activity enrolment changes (add, edit, delete)
 - Adds a Left status to activity enrolment to track past students in activities
 - Refactors several scripts and adds bulk actions to the activity enrolment page

**Motivation and Context**
Makes it easier to track changes and historical data in activity enrolment.

**How Has This Been Tested?**
Tested locally.