### PR TITLE
Staff: added anchor links for job openings page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ v27.0.00
         Activities: added notification events for activity enrolment changes
         Activities: added a Left status to activity enrolment
         Activities: added bulk actions to the activity enrolment page
+        Staff: added anchor links for job openings page
         User Admin: added an option to disable the display of privacy options, so they can be managed internally
 
     Bug Fixes

--- a/modules/Staff/templates/jobOpenings.twig.html
+++ b/modules/Staff/templates/jobOpenings.twig.html
@@ -1,5 +1,7 @@
 {% for jobOpening in jobOpenings %}
+    <a id="{{ jobOpening.gibbonStaffJobOpeningID }}" ></a>
     <h3>{{ jobOpening.jobTitle }}</h3>
     <p><b>{{ __('Job Type: %1$s')|format(jobOpening.type) }}</b></p>
     {{ jobOpening.description|raw }}<br/>
+    <hr/>
 {% endfor %}


### PR DESCRIPTION
**Description**
Added anchor links to staff job openings page for individual links to each opening.

**How Has This Been Tested?**
Local testing.
