### PR TITLE
System: remove raw exception message output from the interface

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ v27.0.00
 
     Tweaks & Additions
         System: automatically hyperlink any urls included in Custom Field descriptions
+        System: removed raw exception message output from the interface
         Activities: added notification events for activity enrolment changes
         Activities: added a Left status to activity enrolment
         Activities: added bulk actions to the activity enrolment page

--- a/index.php
+++ b/index.php
@@ -169,7 +169,6 @@ if ($session->get('pageLoads') == 0 && !$session->has('address')) { // First pag
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);
                             } catch (PDOException $e) {
-                                $page->addError($e->getMessage());
                             }
 
                             if ($result->rowCount() == 0) {

--- a/modules/Activities/activities_view_full.php
+++ b/modules/Activities/activities_view_full.php
@@ -75,7 +75,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($result->rowCount() != 1) {

--- a/modules/Activities/activities_view_register.php
+++ b/modules/Activities/activities_view_register.php
@@ -159,7 +159,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);
                             } catch (PDOException $e) {
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                             }
 
                             if ($result->rowCount() != 1) {
@@ -326,7 +325,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);
                             } catch (PDOException $e) {
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                             }
 
                             if ($result->rowCount() != 1) {

--- a/modules/Activities/report_attendanceExport.php
+++ b/modules/Activities/report_attendanceExport.php
@@ -66,7 +66,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
             $activityResult = $connection2->prepare($sql);
             $activityResult->execute($data);
         } catch (PDOException $e) {
-            echo $e->getMessage();
         }
         $activity = $activityResult->fetch();
 
@@ -77,7 +76,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
             $studentResult = $connection2->prepare($sql);
             $studentResult->execute($data);
         } catch (PDOException $e) {
-            echo $e->getMessage();
         }
         $students = $studentResult->fetchAll();
 
@@ -88,7 +86,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
             $resultAttendance = $connection2->prepare($sql);
             $resultAttendance->execute($data);
         } catch (PDOException $e) {
-            echo $e->getMessage();
         }
         $sessions = $resultAttendance->fetchAll();
 
@@ -99,7 +96,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
             $resultSlots = $connection2->prepare($sql);
             $resultSlots->execute($data);
         } catch (PDOException $e) {
-            echo $e->getMessage();
         }
 
         // Get the activity staff members
@@ -108,9 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
             $sqlStaff = "SELECT title, preferredName, surname, role FROM gibbonActivityStaff JOIN gibbonPerson ON (gibbonActivityStaff.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonActivityID=:gibbonActivityID AND gibbonPerson.status='Full' AND (dateStart IS NULL OR dateStart<='".date('Y-m-d')."') AND (dateEnd IS NULL  OR dateEnd>='".date('Y-m-d')."') ORDER BY surname, preferredName";
             $resultStaff = $connection2->prepare($sqlStaff);
             $resultStaff->execute($dataStaff);
-        } catch (PDOException $e) {
-            $e->getMessage();
-        }
+        } catch (PDOException $e) {}
 
         $columnStart = 1;
         $columnEnd = count($students) + 1;

--- a/modules/Attendance/attendance.php
+++ b/modules/Attendance/attendance.php
@@ -208,7 +208,6 @@ if ($session->has('username')) {
                 'gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'),
             ]);
         } catch (PDOException $e) {
-            $page->addError($e->getMessage());
         }
 
         if ($result->rowCount() > 0) {
@@ -223,7 +222,6 @@ if ($session->has('username')) {
                         'dateEnd' => $lastNSchoolDays[0],
                     ]);
                 } catch (PDOException $e) {
-                    $page->addError($e->getMessage());
                 }
                 $logHistory = array();
                 while ($rowAttendance = $resultAttendance->fetch()) {
@@ -248,7 +246,6 @@ if ($session->has('username')) {
                         'date' => $currentDate . '%'
                     ]);
                 } catch (PDOException $e) {
-                    $page->addError($e->getMessage());
                 }
 
                 $log = $resultLog->fetch();
@@ -309,7 +306,6 @@ if ($session->has('username')) {
                 'dateEnd' => $lastNSchoolDays[0],
             ]);
         } catch (PDOException $e) {
-            $page->addError($e->getMessage());
         }
         $logHistory = array();
         while ($row = $result->fetch()) {
@@ -324,7 +320,6 @@ if ($session->has('username')) {
                 'dateEnd' => $lastNSchoolDays[0],
             ]);
         } catch (PDOException $e) {
-            $page->addError($e->getMessage());
         }
         $ttHistory = array();
         while ($row = $result->fetch()) {
@@ -377,7 +372,6 @@ if ($session->has('username')) {
                         'date' => $currentDate . '%',
                     ]);
                 } catch (PDOException $e) {
-                    $page->addError($e->getMessage());
                 }
 
                 $log = $resultLog->fetch();

--- a/modules/Attendance/attendance_take_byCourseClass.php
+++ b/modules/Attendance/attendance_take_byCourseClass.php
@@ -66,7 +66,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>" . $e->getMessage() . "</div>";
         }
 
         if ($result->rowCount() > 0) {
@@ -139,7 +138,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>" . $e->getMessage() . "</div>";
                 }
 
                 if ($result->rowCount() == 0) {
@@ -175,7 +173,6 @@ if (isActionAccessible($guid, $connection2, "/modules/Attendance/attendance_take
                         $resultLog = $connection2->prepare($sqlLog);
                         $resultLog->execute($dataLog);
                     } catch (PDOException $e) {
-                        echo "<div class='error'>" . $e->getMessage() . "</div>";
                     }
                     if ($resultLog->rowCount() < 1) {
                         echo "<div class='error'>";

--- a/modules/Attendance/report_summary_byDate.php
+++ b/modules/Attendance/report_summary_byDate.php
@@ -134,7 +134,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_summary_
 
         $resultCodes = $pdo->select($sqlCodes, $dataCodes);
     } catch (PDOException $e) {
-        echo "<div class='error'>".$e->getMessage().'</div>';
     }
 
     $attendanceCodes = $resultCodes->fetchGrouped();
@@ -208,7 +207,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_summary_
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() < 1) {

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -73,7 +73,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Behaviour/behaviour_view_details.php
+++ b/modules/Behaviour/behaviour_view_details.php
@@ -66,7 +66,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_view_d
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() != 1) {

--- a/modules/Data Updater/data_family.php
+++ b/modules/Data Updater/data_family.php
@@ -112,7 +112,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_family.p
                     $resultCheck = $connection2->prepare($sqlCheck);
                     $resultCheck->execute($dataCheck);
                 } catch (PDOException $e) {
-                    echo $e->getMessage();
                 }
             }
 

--- a/modules/Data Updater/data_medical_manage_editProcess.php
+++ b/modules/Data Updater/data_medical_manage_editProcess.php
@@ -297,7 +297,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_medical_
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                     $URL .= '&return=error2';
                     header("Location: {$URL}");
                     exit();

--- a/modules/Data Updater/data_personalProcess.php
+++ b/modules/Data Updater/data_personalProcess.php
@@ -81,7 +81,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Data Updater/data_personal
                     $resultCheck = $connection2->prepare($sqlCheck);
                     $resultCheck->execute($dataCheck);
                 } catch (PDOException $e) {
-                    echo $e->getMessage();
                 }
                 while ($rowCheck = $resultCheck->fetch()) {
 

--- a/modules/Departments/department_course_class.php
+++ b/modules/Departments/department_course_class.php
@@ -184,7 +184,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Departments/department_cou
                     $resultCourse = $connection2->prepare($sqlCourse);
                     $resultCourse->execute($dataCourse);
                 } catch (PDOException $e) {
-                    $sidebarExtra .= "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($resultCourse->rowCount() > 0) {

--- a/modules/Finance/budgetCycles_manage_addProcess.php
+++ b/modules/Finance/budgetCycles_manage_addProcess.php
@@ -68,7 +68,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/budgetCycles_manag
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo $e->getMessage();
                 exit();
                 $URL .= '&return=error2';
                 header("Location: {$URL}");

--- a/modules/Finance/expenseRequest_manage.php
+++ b/modules/Finance/expenseRequest_manage.php
@@ -69,7 +69,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo $e->getMessage();
             }
 
             if ($result->rowCount() < 1) {
@@ -200,7 +199,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo "<div class='error'>".$e->getMessage().'</div>';
                     }
 
                     if ($result->rowCount() < 1) {

--- a/modules/Finance/expenseRequest_manage_add.php
+++ b/modules/Finance/expenseRequest_manage_add.php
@@ -80,7 +80,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo $e->getMessage();
                 }
 
                 if ($result->rowCount() < 1) {

--- a/modules/Finance/expenseRequest_manage_addProcess.php
+++ b/modules/Finance/expenseRequest_manage_addProcess.php
@@ -94,7 +94,6 @@ if ($gibbonFinanceBudgetCycleID == '' or $gibbonFinanceBudgetID == '' or $status
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo $e->getMessage();
                 $URL .= '&return=error2';
                 header("Location: {$URL}");
                 exit();

--- a/modules/Finance/expenseRequest_manage_reimburse.php
+++ b/modules/Finance/expenseRequest_manage_reimburse.php
@@ -65,7 +65,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo $e->getMessage();
             }
 
             if ($result->rowCount() < 1) {

--- a/modules/Finance/expenseRequest_manage_view.php
+++ b/modules/Finance/expenseRequest_manage_view.php
@@ -82,7 +82,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenseRequest_man
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo $e->getMessage();
                 }
 
                 if ($result->rowCount() < 1) {

--- a/modules/Finance/expenseRequest_manage_viewProcess.php
+++ b/modules/Finance/expenseRequest_manage_viewProcess.php
@@ -88,7 +88,6 @@ if ($gibbonFinanceBudgetCycleID == '') { echo 'Fatal error loading this page!';
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo $e->getMessage();
                         }
 
                         if ($result->rowCount() < 1) {

--- a/modules/Finance/expenses_manage.php
+++ b/modules/Finance/expenses_manage.php
@@ -96,7 +96,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage.ph
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo $e->getMessage();
                 }
 
                 if ($result->rowCount() < 1) {
@@ -252,7 +251,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage.ph
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         echo '<h3>';

--- a/modules/Finance/expenses_manage_approve.php
+++ b/modules/Finance/expenses_manage_approve.php
@@ -94,7 +94,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                     }
 
                     if ($result->rowCount() < 1) {
@@ -127,7 +126,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ap
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         if ($result->rowCount() != 1) {

--- a/modules/Finance/expenses_manage_approveProcess.php
+++ b/modules/Finance/expenses_manage_approveProcess.php
@@ -91,7 +91,6 @@ if ($gibbonFinanceBudgetCycleID == '' or $gibbonFinanceBudgetID == '') { echo 'F
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo $e->getMessage();
                         }
 
                         if ($result->rowCount() < 1) {

--- a/modules/Finance/expenses_manage_edit.php
+++ b/modules/Finance/expenses_manage_edit.php
@@ -96,7 +96,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_ed
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                     }
 
                     if ($result->rowCount() < 1) {

--- a/modules/Finance/expenses_manage_editProcess.php
+++ b/modules/Finance/expenses_manage_editProcess.php
@@ -71,7 +71,6 @@ if ($gibbonFinanceBudgetCycleID == '') { echo 'Fatal error loading this page!';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                     }
 
                     if ($result->rowCount() < 1) {

--- a/modules/Finance/expenses_manage_print.php
+++ b/modules/Finance/expenses_manage_print.php
@@ -93,7 +93,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                     }
 
                     if ($result->rowCount() < 1) {
@@ -126,7 +125,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         if ($result->rowCount() != 1) {
@@ -290,7 +288,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
 													$resultCheck = $connection2->prepare($sqlCheck);
 													$resultCheck->execute($dataCheck);
 												} catch (PDOException $e) {
-													echo "<div class='error'>".$e->getMessage().'</div>';
 													$budgetAllocationFail = true;
 												}
 												if ($resultCheck->rowCount() != 1) {
@@ -336,7 +333,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
 													$resultCheck = $connection2->prepare($sqlCheck);
 													$resultCheck->execute($dataCheck);
 												} catch (PDOException $e) {
-													echo "<div class='error'>".$e->getMessage().'</div>';
 													$budgetAllocatedFail = true;
 												}
 												if ($budgetAllocatedFail == false) {

--- a/modules/Finance/expenses_manage_print_print.php
+++ b/modules/Finance/expenses_manage_print_print.php
@@ -81,7 +81,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                     }
 
                     if ($result->rowCount() < 1) {
@@ -114,7 +113,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         if ($result->rowCount() != 1) {
@@ -275,7 +273,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
 													$resultCheck = $connection2->prepare($sqlCheck);
 													$resultCheck->execute($dataCheck);
 												} catch (PDOException $e) {
-													echo "<div class='error'>".$e->getMessage().'</div>';
 													$budgetAllocationFail = true;
 												}
 												if ($resultCheck->rowCount() != 1) {
@@ -321,7 +318,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_pr
 													$resultCheck = $connection2->prepare($sqlCheck);
 													$resultCheck->execute($dataCheck);
 												} catch (PDOException $e) {
-													echo "<div class='error'>".$e->getMessage().'</div>';
 													$budgetAllocatedFail = true;
 												}
 												if ($budgetAllocatedFail == false) {

--- a/modules/Finance/expenses_manage_processBulkExportContents.php
+++ b/modules/Finance/expenses_manage_processBulkExportContents.php
@@ -60,7 +60,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage.ph
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
 

--- a/modules/Finance/expenses_manage_view.php
+++ b/modules/Finance/expenses_manage_view.php
@@ -95,7 +95,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_vi
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                     }
 
                     if ($result->rowCount() < 1) {
@@ -128,7 +127,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/expenses_manage_vi
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         if ($result->rowCount() != 1) {

--- a/modules/Finance/fees_manage_add.php
+++ b/modules/Finance/fees_manage_add.php
@@ -63,9 +63,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/fees_manage_add.ph
             $sqlYear = 'SELECT name AS schoolYear FROM gibbonSchoolYear WHERE gibbonSchoolYearID=:gibbonSchoolYearID';
             $resultYear = $connection2->prepare($sqlYear);
             $resultYear->execute($dataYear);
-        } catch (PDOException $e) {
-            $form->addRow()->addAlert($e->getMessage(), 'error');
-        }
+        } catch (PDOException $e) {}
         if ($resultYear->rowCount() == 1) {
             $values = $resultYear->fetch();
             $row = $form->addRow();

--- a/modules/Finance/invoices_manage_addProcess.php
+++ b/modules/Finance/invoices_manage_addProcess.php
@@ -203,7 +203,6 @@ if ($gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
                                         $resultInvoiceAdd = $connection2->prepare($sqlInvoiceAdd);
                                         $resultInvoiceAdd->execute($dataInvoiceAdd);
                                     } catch (PDOException $e) {
-                                        echo $e->getMessage();
                                         ++$invoiceFailCount;
                                         $thisInvoiceFailed = true;
                                     }
@@ -334,7 +333,6 @@ if ($gibbonSchoolYearID == '') { echo 'Fatal error loading this page!';
                                         $resultInvoiceAdd = $connection2->prepare($sqlInvoiceAdd);
                                         $resultInvoiceAdd->execute($dataInvoiceAdd);
                                     } catch (PDOException $e) {
-                                        echo $e->getMessage();
                                         ++$invoiceFailCount;
                                         $thisInvoiceFailed = true;
                                     }

--- a/modules/Finance/invoices_manage_print.php
+++ b/modules/Finance/invoices_manage_print.php
@@ -168,7 +168,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_manage_pr
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            $return .= "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                     if ($result->rowCount() < 1) {

--- a/modules/Finance/invoices_view.php
+++ b/modules/Finance/invoices_view.php
@@ -112,7 +112,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_view.php'
                 $resultChild = $connection2->prepare($sqlChild);
                 $resultChild->execute($dataChild);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($resultChild->rowCount() < 1) {
                 echo "<div class='error'>";
@@ -237,7 +236,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_view.php'
                                 $resultTotal = $connection2->prepare($sqlTotal);
                                 $resultTotal->execute($dataTotal);
                             } catch (PDOException $e) {
-                                echo $e->getMessage();
                                 echo '<i>Error calculating total</i>';
                                 $feeError = true;
                             }

--- a/modules/Finance/invoices_view_print.php
+++ b/modules/Finance/invoices_view_print.php
@@ -58,7 +58,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Finance/invoices_view_prin
                 $resultChild = $connection2->prepare($sqlChild);
                 $resultChild->execute($dataChild);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($resultChild->rowCount() < 1) {
                 echo "<div class='error'>";

--- a/modules/Finance/moduleFunctions.php
+++ b/modules/Finance/moduleFunctions.php
@@ -59,7 +59,6 @@ function getPaymentLog($connection2, $guid, $foreignTable, $foreignTableID, $gib
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        $return .= "<div class='error'>".$e->getMessage().'</div>';
     }
 
     if ($result->rowCount() < 1) {
@@ -541,7 +540,6 @@ function getBudgetsByPerson($connection2, $gibbonPersonID, $gibbonFinanceBudgetI
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        echo $e->getMessage();
     }
 
     $count = 0;
@@ -569,7 +567,6 @@ function getBudgets($connection2)
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        echo $e->getMessage();
     }
 
     $count = 0;
@@ -842,7 +839,6 @@ function invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
                 $resultParents = $connection2->prepare($sqlParents);
                 $resultParents->execute($dataParents);
             } catch (PDOException $e) {
-                $return .= "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($resultParents->rowCount() < 1) {
                 $return .= "<div class='warning'>".__('There are no family members available to send this receipt to.').'</div>';
@@ -909,7 +905,6 @@ function invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
                 $resultSched = $connection2->prepare($sqlSched);
                 $resultSched->execute($dataSched);
             } catch (PDOException $e) {
-                $return .= "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($resultSched->rowCount() == 1) {
                 $rowSched = $resultSched->fetch();
@@ -967,7 +962,6 @@ function invoiceContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
             $resultFees = $connection2->prepare($sqlFees);
             $resultFees->execute($dataFees);
         } catch (PDOException $e) {
-            $return .= "<div class='error'>".$e->getMessage().'</div>';
         }
         if ($resultFees->rowCount() < 1) {
             $return .= "<div class='error'>";
@@ -1178,7 +1172,6 @@ function receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
                 $resultParents = $connection2->prepare($sqlParents);
                 $resultParents->execute($dataParents);
             } catch (PDOException $e) {
-                $return .= "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($resultParents->rowCount() < 1) {
                 $return .= "<div class='warning'>".__('There are no family members available to send this receipt to.').'</div>';
@@ -1246,7 +1239,6 @@ function receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
                     $resultPayment->execute($dataPayment);
                 } catch (PDOException $e) {
                     $paymentFail = true;
-                    $return .= "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($resultPayment->rowCount() != 1) {
@@ -1272,7 +1264,6 @@ function receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
                 $resultSched = $connection2->prepare($sqlSched);
                 $resultSched->execute($dataSched);
             } catch (PDOException $e) {
-                $return .= "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($resultSched->rowCount() == 1) {
                 $rowSched = $resultSched->fetch();
@@ -1326,7 +1317,6 @@ function receiptContents($guid, $connection2, $gibbonFinanceInvoiceID, $gibbonSc
             $resultFees = $connection2->prepare($sqlFees);
             $resultFees->execute($dataFees);
         } catch (PDOException $e) {
-            $return .= "<div class='error'>".$e->getMessage().'</div>';
         }
         if ($resultFees->rowCount() < 1) {
             $return .= "<div class='error'>";

--- a/modules/Form Groups/formGroups_details.php
+++ b/modules/Form Groups/formGroups_details.php
@@ -78,7 +78,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Form Groups/formGroups_det
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Formal Assessment/externalAssessment_details.php
+++ b/modules/Formal Assessment/externalAssessment_details.php
@@ -58,7 +58,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() != 1) {

--- a/modules/Formal Assessment/externalAssessment_manage_details_add.php
+++ b/modules/Formal Assessment/externalAssessment_manage_details_add.php
@@ -58,7 +58,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() != 1) {
@@ -174,7 +173,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
                             $sqlCopy = "SELECT * FROM gibbonExternalAssessment JOIN gibbonExternalAssessmentStudent ON (gibbonExternalAssessmentStudent.gibbonExternalAssessmentID=gibbonExternalAssessment.gibbonExternalAssessmentID) WHERE name='GCSE/iGCSE' AND gibbonPersonID=:gibbonPersonID ORDER BY date DESC";
                             $resultCopy = $connection2->prepare($sqlCopy);
                             $resultCopy->execute($dataCopy);
-                        } catch (PDOException $e) { echo $e->getMessage();
+                        } catch (PDOException $e) {
                         }
 
                         if ($resultCopy->rowCount() > 0) {
@@ -189,7 +188,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/external
                                 $resultCopy2 = $connection2->prepare($sqlCopy2);
                                 $resultCopy2->execute($dataCopy2);
                             } catch (PDOException $e) {
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                             }
                             while ($rowCopy2 = $resultCopy2->fetch()) {
                                 //Conert grade to numeric value

--- a/modules/Formal Assessment/internalAssessment_manage_addProcess.php
+++ b/modules/Formal Assessment/internalAssessment_manage_addProcess.php
@@ -144,7 +144,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo $e->getMessage();
                     exit();
                     $partialFail = true;
                 }

--- a/modules/Formal Assessment/internalAssessment_write.php
+++ b/modules/Formal Assessment/internalAssessment_write.php
@@ -88,7 +88,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($result->rowCount() != 1) {
                 $page->breadcrumbs->add(__('Write Internal Assessments'));
@@ -209,7 +208,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                                         $resultExternalAssessment = $connection2->prepare($sqlExternalAssessment);
                                         $resultExternalAssessment->execute($dataExternalAssessment);
                                     } catch (PDOException $e) {
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
                                     if ($resultExternalAssessment->rowCount() >= 1) {
                                         $rowExternalAssessment = $resultExternalAssessment->fetch();

--- a/modules/Formal Assessment/internalAssessment_write_data.php
+++ b/modules/Formal Assessment/internalAssessment_write_data.php
@@ -72,7 +72,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Formal Assessment/moduleFunctions.php
+++ b/modules/Formal Assessment/moduleFunctions.php
@@ -42,7 +42,6 @@ function getInternalAssessmentRecord($guid, $connection2, $gibbonPersonID, $role
         $resultYears = $connection2->prepare($sqlYears);
         $resultYears->execute($dataYears);
     } catch (PDOException $e) {
-        $output .= "<div class='error'>".$e->getMessage().'</div>';
     }
 
     if ($resultYears->rowCount() < 1) {
@@ -65,7 +64,6 @@ function getInternalAssessmentRecord($guid, $connection2, $gibbonPersonID, $role
                 $resultInternalAssessment = $connection2->prepare($sqlInternalAssessment);
                 $resultInternalAssessment->execute($dataInternalAssessment);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($resultInternalAssessment->rowCount() > 0) {
@@ -140,7 +138,6 @@ function getInternalAssessmentRecord($guid, $connection2, $gibbonPersonID, $role
                             $resultAttainment = $connection2->prepare($sqlAttainment);
                             $resultAttainment->execute($dataAttainment);
                         } catch (PDOException $e) {
-                            $output .= "<div class='error'>".$e->getMessage().'</div>';
                         }
                         if ($resultAttainment->rowCount() == 1) {
                             $rowAttainment = $resultAttainment->fetch();
@@ -167,7 +164,6 @@ function getInternalAssessmentRecord($guid, $connection2, $gibbonPersonID, $role
                             $resultEffort = $connection2->prepare($sqlEffort);
                             $resultEffort->execute($dataEffort);
                         } catch (PDOException $e) {
-                            $output .= "<div class='error'>".$e->getMessage().'</div>';
                         }
                         if ($resultEffort->rowCount() == 1) {
                             $rowEffort = $resultEffort->fetch();

--- a/modules/Library/library_browse.php
+++ b/modules/Library/library_browse.php
@@ -72,7 +72,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
         $resultTop = $connection2->prepare($sqlTop);
         $resultTop->execute($dataTop);
     } catch (PDOException $e) {
-        echo "<div class='error'>" . $e->getMessage() . '</div>';
     }
     if ($resultTop->rowCount() < 1) {
         echo "<div class='warning'>";
@@ -107,7 +106,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
         $resultTop = $connection2->prepare($sqlTop);
         $resultTop->execute($dataTop);
     } catch (PDOException $e) {
-        echo "<div class='error'>" . $e->getMessage() . '</div>';
     }
     if ($resultTop->rowCount() < 1) {
         echo "<div class='warning'>";

--- a/modules/Library/library_lending_item_editProcess.php
+++ b/modules/Library/library_lending_item_editProcess.php
@@ -89,7 +89,7 @@ if ($gibbonLibraryItemID == '') { echo 'Fatal error loading this page!';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2'.$e->getMessage();
+                    $URL .= '&return=error2';
                     header("Location: {$URL}");
                     exit();
                 }

--- a/modules/Library/library_lending_item_renewProcess.php
+++ b/modules/Library/library_lending_item_renewProcess.php
@@ -73,7 +73,7 @@ if ($gibbonLibraryItemID == '') { echo 'Fatal error loading this page!';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    $URL .= '&return=error2'.$e->getMessage();
+                    $URL .= '&return=error2';
                     header("Location: {$URL}");
                     exit();
                 }

--- a/modules/Library/library_lending_item_returnProcess.php
+++ b/modules/Library/library_lending_item_returnProcess.php
@@ -107,7 +107,7 @@ if ($gibbonLibraryItemID == '') { echo 'Fatal error loading this page!';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        $URL .= '&return=error2'.$e->getMessage();
+                        $URL .= '&return=error2';
                         header("Location: {$URL}");
                         exit();
                     }

--- a/modules/Library/library_lending_item_signoutProcess.php
+++ b/modules/Library/library_lending_item_signoutProcess.php
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_lending_it
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $URL .= '&return=error2'.$e->getMessage();
+                $URL .= '&return=error2';
                 header("Location: {$URL}");
                 exit();
             }

--- a/modules/Library/report_catalogSummaryExport.php
+++ b/modules/Library/report_catalogSummaryExport.php
@@ -80,7 +80,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/report_catalogSumm
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        echo "<div class='error'>".$e->getMessage().'</div>';
     }
 
     if ($result->rowCount() < 1) {

--- a/modules/Markbook/markbook_edit.php
+++ b/modules/Markbook/markbook_edit.php
@@ -78,7 +78,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit.php
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/markbook_edit_add.php
+++ b/modules/Markbook/markbook_edit_add.php
@@ -84,7 +84,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_add
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($result->rowCount() != 1) {
                 echo "<div class='error'>";

--- a/modules/Markbook/markbook_edit_copy.php
+++ b/modules/Markbook/markbook_edit_copy.php
@@ -58,7 +58,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_cop
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -162,7 +162,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/markbook_edit_delete.php
+++ b/modules/Markbook/markbook_edit_delete.php
@@ -65,7 +65,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_del
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/markbook_edit_edit.php
+++ b/modules/Markbook/markbook_edit_edit.php
@@ -82,7 +82,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_edi
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/markbook_edit_targets.php
+++ b/modules/Markbook/markbook_edit_targets.php
@@ -65,7 +65,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_tar
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/markbook_edit_targetsProcess.php
+++ b/modules/Markbook/markbook_edit_targetsProcess.php
@@ -79,7 +79,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_tar
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                         $partialFail = true;
                     }
                 } else {

--- a/modules/Markbook/markbook_view_allClassesAllData.php
+++ b/modules/Markbook/markbook_view_allClassesAllData.php
@@ -652,7 +652,6 @@ require_once __DIR__ . '/src/MarkbookColumn.php';
             $resultStudents = $connection2->prepare($sqlStudents);
             $resultStudents->execute($dataStudents);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         $count = 0;

--- a/modules/Markbook/markbook_view_rubric.php
+++ b/modules/Markbook/markbook_view_rubric.php
@@ -63,7 +63,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_view.php
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() != 1) {

--- a/modules/Markbook/markbook_view_viewMyChildrensClasses.php
+++ b/modules/Markbook/markbook_view_viewMyChildrensClasses.php
@@ -241,7 +241,6 @@ if ($result->rowCount() < 1) {
                         $resultEntry = $connection2->prepare($sqlEntry);
                         $resultEntry->execute($dataEntry);
                     } catch (PDOException $e) {
-                        echo "<div class='error'>".print_r($dataEntry).'<br/>'.$e->getMessage().'</div>';
                     }
                     if ($resultEntry->rowCount() > 0) {
                         echo '<h4>'.$rowList['course'].'.'.$rowList['class']." <span style='font-size:85%; font-style: italic'>(".$rowList['name'].')</span></h4>';

--- a/modules/Markbook/src/MarkbookView.php
+++ b/modules/Markbook/src/MarkbookView.php
@@ -772,7 +772,6 @@ class MarkbookView
             $sql = 'SELECT type, description, weighting, reportable, calculate FROM gibbonMarkbookWeight WHERE gibbonCourseClassID=:gibbonCourseClassID ORDER BY calculate, type';
             $resultWeights = $this->pdo->select($sql, $data);
         } catch (\PDOException $e) {
-            echo "<div class='error'>" . $e->getMessage() . '</div>';
         }
 
         if ($resultWeights->rowCount() > 0) {

--- a/modules/Markbook/weighting_manage.php
+++ b/modules/Markbook/weighting_manage.php
@@ -81,7 +81,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage.
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/weighting_manage_add.php
+++ b/modules/Markbook/weighting_manage_add.php
@@ -73,7 +73,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/weighting_manage_delete.php
+++ b/modules/Markbook/weighting_manage_delete.php
@@ -72,7 +72,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Markbook/weighting_manage_edit.php
+++ b/modules/Markbook/weighting_manage_edit.php
@@ -72,7 +72,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/weighting_manage_
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Messenger/messenger_manage_delete.php
+++ b/modules/Messenger/messenger_manage_delete.php
@@ -53,7 +53,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_manage
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Messenger/messenger_postQuickWallProcess.php
+++ b/modules/Messenger/messenger_postQuickWallProcess.php
@@ -84,7 +84,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_postQu
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo $e->getMessage();
                 exit();
                 $URL .= '&return=error2';
                 header("Location: {$URL}");

--- a/modules/Messenger/src/MessageTargets.php
+++ b/modules/Messenger/src/MessageTargets.php
@@ -544,7 +544,7 @@ class MessageTargets
                                     $resultEmail=$connection2->prepare($sqlEmail);
                                     $resultEmail->execute($dataEmail);
                                 }
-                                catch(\PDOException $e) { print $e->getMessage() ;}
+                                catch(\PDOException $e) {}
                                 while ($rowEmail=$resultEmail->fetch()) {
                                     $countryCodeTemp = $countryCode;
                                     if ($rowEmail["countryCode"]=="")
@@ -1422,7 +1422,7 @@ class MessageTargets
                                             $resultEmail=$connection2->prepare($sqlEmail);
                                             $resultEmail->execute($dataEmail);
                                         }
-                                        catch(\PDOException $e) { print $e->getMessage() ;}
+                                        catch(\PDOException $e) {}
                                         while ($rowEmail=$resultEmail->fetch()) {
                                             $countryCodeTemp = $countryCode;
                                             if ($rowEmail["countryCode"]=="")
@@ -1909,7 +1909,7 @@ class MessageTargets
                                 $resultEmail=$connection2->prepare($sqlEmail);
                                 $resultEmail->execute($dataEmail);
                             }
-                            catch(\PDOException $e) { echo $e->getMessage();}
+                            catch(\PDOException $e) {}
 
                             while ($rowEmail=$resultEmail->fetch()) { //Add emails to list of receivers
                                 $this->reportAdd($emailReceipt, $rowEmail['gibbonPersonID'], 'Attendance', $t, 'Email', $rowEmail["email"], $rowEmail['gibbonPersonIDStudent'], Format::name('', $rowEmail['preferredName'], $rowEmail['surname'], 'Student'));
@@ -2096,7 +2096,7 @@ class MessageTargets
                                     $resultEmail=$connection2->prepare($sqlEmail);
                                     $resultEmail->execute($dataEmail);
                                 }
-                                catch(\PDOException $e) { echo $e->getMessage(); }
+                                catch(\PDOException $e) { }
                                 while ($rowEmail=$resultEmail->fetch()) {
                                     $countryCodeTemp = $countryCode;
                                     if ($rowEmail["countryCode"]=="")

--- a/modules/Planner/conceptExplorer.php
+++ b/modules/Planner/conceptExplorer.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/conceptExplorer.ph
                 $sqlSelect = "SELECT gibbonDepartment.gibbonDepartmentID FROM gibbonDepartment JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)') ORDER BY gibbonDepartment.name";
                 $resultSelect = $connection2->prepare($sqlSelect);
                 $resultSelect->execute($dataSelect);
-            } catch (PDOException $e) { echo $e->getMessage(); }
+            } catch (PDOException $e) { }
             while ($rowSelect = $resultSelect->fetch()) {
                 $departments[$departmentCount] = $rowSelect['gibbonDepartmentID'];
                 $departmentCount ++;
@@ -122,7 +122,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/conceptExplorer.ph
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
 

--- a/modules/Planner/curriculumMapping_outcomesByCourse.php
+++ b/modules/Planner/curriculumMapping_outcomesByCourse.php
@@ -153,7 +153,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/curriculumMapping_
                 } catch (PDOException $e) {
                     echo '<tr>';
                     echo '<td colspan='.(($classCount * 2) + 2).'>';
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                     echo '</td>';
                     echo '</tr>';
                 }
@@ -231,7 +230,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/curriculumMapping_
 					} catch (PDOException $e) {
 						echo '<tr>';
 						echo '<td colspan='.(($classCount * 2) + 2).'>';
-						echo "<div class='error'>".$e->getMessage().'</div>';
 						echo '</td>';
 						echo '</tr>';
 					}

--- a/modules/Planner/moduleFunctions.php
+++ b/modules/Planner/moduleFunctions.php
@@ -218,7 +218,6 @@ function getThread($guid, $connection2, $gibbonPlannerEntryID, $parent, $level, 
         $resultDiscuss = $connection2->prepare($sqlDiscuss);
         $resultDiscuss->execute($dataDiscuss);
     } catch (PDOException $e) {
-        $output .= "<div class='error'>".$e->getMessage().'</div>';
     }
 
     if ($level == 0 and $resultDiscuss->rowCount() == 0) {
@@ -271,7 +270,6 @@ function getThread($guid, $connection2, $gibbonPlannerEntryID, $parent, $level, 
                 $resultReplies->execute($dataReplies);
             } catch (PDOException $e) {
                 $replies = false;
-                $output .= print "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($replies) {

--- a/modules/Planner/outcomes_delete.php
+++ b/modules/Planner/outcomes_delete.php
@@ -62,7 +62,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_delete.ph
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($result->rowCount() != 1) {

--- a/modules/Planner/outcomes_edit.php
+++ b/modules/Planner/outcomes_edit.php
@@ -72,7 +72,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/outcomes_edit.php'
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($result->rowCount() != 1) {

--- a/modules/Planner/planner.php
+++ b/modules/Planner/planner.php
@@ -505,7 +505,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == f
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo "<div class='error'>".$e->getMessage().'</div>';
                     }
 
                     //Only show add if user has edit rights
@@ -686,7 +685,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner.php') == f
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         //Only show add if user has edit rights

--- a/modules/Planner/planner_add.php
+++ b/modules/Planner/planner_add.php
@@ -112,7 +112,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_add.php') 
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($result->rowCount() != 1) {

--- a/modules/Planner/planner_bump.php
+++ b/modules/Planner/planner_bump.php
@@ -94,7 +94,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_bump.php')
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($result->rowCount() != 1) {

--- a/modules/Planner/planner_deadlines.php
+++ b/modules/Planner/planner_deadlines.php
@@ -249,7 +249,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_deadlines.
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
                 if ($result->rowCount() != 1) {
                     $proceed = false;

--- a/modules/Planner/planner_delete.php
+++ b/modules/Planner/planner_delete.php
@@ -120,7 +120,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_delete.php
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Planner/planner_duplicate.php
+++ b/modules/Planner/planner_duplicate.php
@@ -110,7 +110,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {
@@ -233,7 +232,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_duplicate.
                             $resultSelect = $connection2->prepare($sqlSelect);
                             $resultSelect->execute($dataSelect);
                         } catch (PDOException $e) {
-                            echo $e->getMEssage();
                         }
                         if ($resultSelect->rowCount() == 1) {
                             $rowSelect = $resultSelect->fetch();

--- a/modules/Planner/planner_edit.php
+++ b/modules/Planner/planner_edit.php
@@ -125,7 +125,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_edit.php')
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Planner/planner_unitOverview.php
+++ b/modules/Planner/planner_unitOverview.php
@@ -453,7 +453,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_unitOvervi
                                         $sqlDiscuss = 'SELECT gibbonPlannerEntryDiscuss.*, title, surname, preferredName, category FROM gibbonPlannerEntryDiscuss JOIN gibbonPerson ON (gibbonPlannerEntryDiscuss.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID ORDER BY timestamp';
                                         $resultDiscuss = $connection2->prepare($sqlDiscuss);
                                         $resultDiscuss->execute($dataDiscuss);
-                                    } catch (PDOException $e) { print $e->getMessage();}
+                                    } catch (PDOException $e) {}
 
                                     if ($resultDiscuss->rowCount() > 0) {
                                         echo "<h5 style='font-size: 85%'>".__('Chat').'</h5>';

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -267,7 +267,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                                 $resultPrevious = $connection2->prepare($sqlPrevious);
                                 $resultPrevious->execute($dataPrevious);
                             } catch (PDOException $e) {
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                             }
                             if ($resultPrevious->rowCount() > 0) {
                                 $rowPrevious = $resultPrevious->fetch();
@@ -294,7 +293,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                                 $resultNext = $connection2->prepare($sqlNext);
                                 $resultNext->execute($dataNext);
                             } catch (PDOException $e) {
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                             }
                             if ($resultNext->rowCount() > 0) {
                                 $rowNext = $resultNext->fetch();

--- a/modules/Planner/planner_view_full_smartProcess.php
+++ b/modules/Planner/planner_view_full_smartProcess.php
@@ -85,7 +85,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                                 $result->execute($data);
                             } catch (PDOException $e) {
                                 echo 'Here';
-                                echo $e->getMessage();
                                 $partialFail = true;
                             }
                         }

--- a/modules/Planner/planner_view_full_submit_edit.php
+++ b/modules/Planner/planner_view_full_submit_edit.php
@@ -82,7 +82,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full_
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Planner/resources_add_ajaxProcess.php
+++ b/modules/Planner/resources_add_ajaxProcess.php
@@ -131,7 +131,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_a
                 $result->execute($data);
             } catch (PDOException $e) {
                 echo "<span style='font-weight: bold; color: #ff0000'>";
-                echo $e->getMessage();
                 echo '</span>';
                 exit();
             }

--- a/modules/Planner/resources_insert_ajax.php
+++ b/modules/Planner/resources_insert_ajax.php
@@ -149,7 +149,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_view.php
 		$result = $connection2->prepare($sql);
 		$result->execute($data);
 	} catch (PDOException $e) {
-		echo "<div class='error'>".$e->getMessage().'</div>';
 	}
 
     if ($result->rowCount() < 1) {

--- a/modules/Planner/resources_manage_edit.php
+++ b/modules/Planner/resources_manage_edit.php
@@ -61,7 +61,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/resources_manage_e
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Planner/scopeAndSequence.php
+++ b/modules/Planner/scopeAndSequence.php
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/scopeAndSequence.p
                 $sqlSelect = "SELECT gibbonDepartment.gibbonDepartmentID FROM gibbonDepartment JOIN gibbonDepartmentStaff ON (gibbonDepartmentStaff.gibbonDepartmentID=gibbonDepartment.gibbonDepartmentID) WHERE gibbonDepartmentStaff.gibbonPersonID=:gibbonPersonID AND (role='Coordinator' OR role='Assistant Coordinator' OR role='Teacher (Curriculum)') ORDER BY gibbonDepartment.name";
                 $resultSelect = $connection2->prepare($sqlSelect);
                 $resultSelect->execute($dataSelect);
-            } catch (PDOException $e) { echo $e->getMessage(); }
+            } catch (PDOException $e) { }
             while ($rowSelect = $resultSelect->fetch()) {
                 $departments[$departmentCount] = $rowSelect['gibbonDepartmentID'];
                 $departmentCount ++;
@@ -116,7 +116,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/scopeAndSequence.p
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() == 1) {

--- a/modules/Planner/units.php
+++ b/modules/Planner/units.php
@@ -74,7 +74,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units.php') == fal
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
         if ($result->rowCount() > 0) {
             $row = $result->fetch();
@@ -137,7 +136,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units.php') == fal
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        echo "<div class='error'>".$e->getMessage().'</div>';
     }
 
     if ($result->rowCount() < 1) {

--- a/modules/Planner/units_addProcess.php
+++ b/modules/Planner/units_addProcess.php
@@ -97,8 +97,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_add.php') ==
                         $sql = 'INSERT INTO gibbonUnit SET gibbonCourseID=:gibbonCourseID, name=:name, description=:description, tags=:tags, active=:active, map=:map, ordering=:ordering, license=:license, sharedPublic=:sharedPublic, attachment=:attachment, details=:details, gibbonPersonIDCreator=:gibbonPersonIDCreator, gibbonPersonIDLastEdit=:gibbonPersonIDLastEdit';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
-                    } catch (PDOException $e) {
-                        echo $e->getMessage();exit;
+                    } catch (PDOException $e) {exit;
                         $URL .= '&return=error2';
                         header("Location: {$URL}");
                         exit();

--- a/modules/Planner/units_editProcess.php
+++ b/modules/Planner/units_editProcess.php
@@ -197,7 +197,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                                             $resultBlock = $connection2->prepare($sqlBlock);
                                             $resultBlock->execute($dataBlock);
                                         } catch (PDOException $e) {
-                                            echo $e->getMessage();
                                             $partialFail = true;
                                         }
                                         $dataRemove["gibbonUnitBlockID$sequenceNumber"] = $connection2->lastInsertId();
@@ -217,7 +216,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit.php') =
                                 $resultRemove = $connection2->prepare($sqlRemove);
                                 $resultRemove->execute($dataRemove);
                             } catch (PDOException $e) {
-                                echo $e->getMessage();
                                 $partialFail = true;
                             }
                         }

--- a/modules/Rubrics/rubrics_delete.php
+++ b/modules/Rubrics/rubrics_delete.php
@@ -67,7 +67,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Rubrics/rubrics_delete.php
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($result->rowCount() != 1) {

--- a/modules/Staff/applicationFormProcess.php
+++ b/modules/Staff/applicationFormProcess.php
@@ -181,7 +181,6 @@ if ($proceed == false) {
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo $e->getMessage();
                         exit();
                         $partialFail = true;
                         $thisFail = true;

--- a/modules/Staff/applicationForm_jobOpenings_view.php
+++ b/modules/Staff/applicationForm_jobOpenings_view.php
@@ -55,9 +55,6 @@ if ($proceed == false) {
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        echo "<div class='error'>";
-        echo __('Your request failed due to a database error.');
-        echo '</div>';
     }
 
     if ($result->rowCount() < 1) {

--- a/modules/Staff/applicationForm_manage_accept.php
+++ b/modules/Staff/applicationForm_manage_accept.php
@@ -218,7 +218,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                             $result->execute($data);
                         } catch (PDOException $e) {
                             $insertOK = false;
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
                         if ($insertOK == true) {
                             $gibbonPersonID = $connection2->lastInsertID();
@@ -265,7 +264,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                             $result->execute($data);
                         } catch (PDOException $e) {
                             $enrolmentOK = false;
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         //Report back
@@ -334,7 +332,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                         $result->execute($data);
                     } catch (PDOException $e) {
                         $enrolmentCheckFail = true;
-                        echo "<div class='error'>".$e->getMessage().'</div>';
                     }
                     if ($result->rowCount() == 1) {
                         $alreadyEnrolled = true;
@@ -357,7 +354,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                             $result->execute($data);
                         } catch (PDOException $e) {
                             $enrolmentOK = false;
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         //Report back
@@ -382,7 +378,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/applicationForm_mana
                     $result->execute($data);
                 } catch (PDOException $e) {
                     $failStatus = true;
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($failStatus == true) {

--- a/modules/Staff/staff_view_details.php
+++ b/modules/Staff/staff_view_details.php
@@ -114,7 +114,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/staff_view_details.p
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($result->rowCount() != 1) {

--- a/modules/Students/applicationForm_manage_accept.php
+++ b/modules/Students/applicationForm_manage_accept.php
@@ -404,7 +404,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                         $result->execute($data);
                     } catch (PDOException $e) {
                         $insertOK = false;
-                        echo "<div class='error'>".$e->getMessage().'</div>';
                         $partialFailures[] = 'insertOK';
                     }
                     if ($insertOK == true) {
@@ -480,7 +479,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                 $result->execute($data);
                             } catch (PDOException $e) {
                                 $enrolmentOK = false;
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                             }
                         } else {
                             $enrolmentOK = false;
@@ -556,7 +554,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                         $result->execute($data);
                     } catch (PDOException $e) {
                         $paymentOK = false;
-                        echo "<div class='error'>".$e->getMessage().'</div>';
                         $partialFailures[] = 'paymentOK';
                     }
 
@@ -592,7 +589,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                     $result->execute($data);
                                 } catch (PDOException $e) {
                                     $insertFail == true;
-                                    echo "<div class='error'>".$e->getMessage().'</div>';
                                     $partialFailures[] = 'failFamily1';
                                 }
                                 if ($insertFail == false) {
@@ -612,7 +608,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                         $sqlParent = 'SELECT gibbonPerson.gibbonPersonID FROM gibbonFamilyAdult JOIN gibbonPerson ON (gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonFamilyID=:gibbonFamilyID AND surname=:parentSurname AND preferredName=:parentPreferredName';
                                         $resultParent = $pdo->executeQuery($dataParent, $sqlParent);
                                     } catch (PDOException $e) {
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
 
                                     if (isset($resultParent) && $resultParent->rowCount() == 1) {
@@ -625,7 +620,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                             $sqlParent = 'INSERT INTO gibbonFamilyRelationship SET gibbonFamilyID=:gibbonFamilyID, gibbonPersonID1=:gibbonPersonID1, gibbonPersonID2=:gibbonPersonID2, relationship=:relationship';
                                             $resultParentRelationship = $pdo->executeQuery($dataParent, $sqlParent);
                                         } catch (PDOException $e) {
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
                                         }
                                     }
                                 }
@@ -678,7 +672,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                             $result->execute($data);
                                     }
                                 } else {
-                                    echo "<div class='error'>".$e->getMessage().'</div>';
                                 }
                             }
                         }
@@ -730,7 +723,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                             $result->execute($data);
                         } catch (PDOException $e) {
                             $insertOK = false;
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                             $partialFailures[] = 'failFamily3';
                         }
 
@@ -775,7 +767,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                             $result->execute($data);
                                         } catch (PDOException $e) {
                                             $insertOK = false;
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
                                             $partialFailures[] = 'failFamily4';
                                         }
                                         if ($insertOK == true) {
@@ -829,7 +820,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                                 $result->execute($data);
                                             } catch (PDOException $e) {
                                                 $insertOK = false;
-                                                echo "<div class='error'>".$e->getMessage().'</div>';
                                             }
                                             if ($insertOK == true) {
                                                 $failFamily = false;
@@ -877,7 +867,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                         $result->execute($data);
                                     } catch (PDOException $e) {
                                         $insertOK = false;
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
                                     if ($insertOK == true) {
                                         $failParent1 = false;
@@ -934,7 +923,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                                     $result->execute($data);
                                                 } catch (PDOException $e) {
                                                     $insertOK = false;
-                                                    echo "<div class='error'>".$e->getMessage().'</div>';
                                                 }
                                                 if ($insertOK == true) {
                                                     $failFamily = false;
@@ -988,7 +976,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                         $result->execute($data);
                                     } catch (PDOException $e) {
                                         $insertOK = false;
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
                                     if ($insertOK == true) {
                                         $failParent2 = false;
@@ -1045,7 +1032,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                                                     $result->execute($data);
                                                 } catch (PDOException $e) {
                                                     $insertOK = false;
-                                                    echo "<div class='error'>".$e->getMessage().'</div>';
                                                 }
                                                 if ($insertOK == true) {
                                                     $failFamily = false;
@@ -1208,7 +1194,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/applicationForm_m
                         $result->execute($data);
                     } catch (PDOException $e) {
                         $failStatus = true;
-                        echo "<div class='error'>".$e->getMessage().'</div>';
                         $partialFailures[] = 'failStatus';
                     }
 

--- a/modules/Students/report_emergencySMS_byTransport.php
+++ b/modules/Students/report_emergencySMS_byTransport.php
@@ -102,7 +102,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_emergencyS
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         echo "<table cellspacing='0' style='width: 100%'>";

--- a/modules/Students/report_emergencySMS_byYearGroup.php
+++ b/modules/Students/report_emergencySMS_byYearGroup.php
@@ -102,7 +102,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_emergencyS
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         echo "<table cellspacing='0' style='width: 100%'>";

--- a/modules/Students/report_students_IDCards.php
+++ b/modules/Students/report_students_IDCards.php
@@ -81,7 +81,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_I
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() < 1) {

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -236,7 +236,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                     return;
                 }
 
@@ -1443,7 +1442,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                     $result = $connection2->prepare($sql);
                                     $result->execute($data);
                                 } catch (PDOException $e) {
-                                    echo "<div class='error'>".$e->getMessage().'</div>';
                                 }
 
                                 $notes = $pdo->select($sql, $data);
@@ -1740,7 +1738,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                             $resultEntry = $connection2->prepare($sqlEntry);
                                             $resultEntry->execute($dataEntry);
                                         } catch (PDOException $e) {
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
                                         }
 
                                         if ($resultEntry->rowCount() > 0) {
@@ -2408,7 +2405,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                         $result->execute($data);
                                         $resultData = $result->fetchAll();
                                     } catch (PDOException $e) {
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                         exit;
                                     }
 

--- a/modules/Students/student_view_details_notes_addProcess.php
+++ b/modules/Students/student_view_details_notes_addProcess.php
@@ -123,7 +123,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
     								WHERE gibbonStudentEnrolment.gibbonPersonID=:gibbonPersonID AND gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID";
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);
-                            } catch (PDOException $e) { print $e->getMessage(); }
+                            } catch (PDOException $e) {}
                             while ($rowTutors = $result->fetch()) {
                                 $event->addRecipient($rowTutors['gibbonPersonID']);
                             }

--- a/modules/Students/student_view_details_notes_edit.php
+++ b/modules/Students/student_view_details_notes_edit.php
@@ -85,7 +85,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                             $result = $connection2->prepare($sql);
                             $result->execute($data);
                         } catch (PDOException $e) {
-                            echo "<div class='error'>".$e->getMessage().'</div>';
                         }
 
                         if ($result->rowCount() != 1) {

--- a/modules/System Admin/moduleFunctions.php
+++ b/modules/System Admin/moduleFunctions.php
@@ -44,7 +44,6 @@ function setFirstDayOfTheWeek($connection2, $fdotw, $databaseName)
                 $resultIndex->execute($dataIndex);
             }
         } catch (PDOException $e) {
-            echo $e->getMessage();
             exit();
             $return = false;
         }
@@ -89,7 +88,6 @@ function setFirstDayOfTheWeek($connection2, $fdotw, $databaseName)
                 $resultDOTW = $connection2->prepare($sqlDOTW);
                 $resultDOTW->execute($dataDOTW);
             } catch (PDOException $e) {
-                echo $e->getMessage();
                 exit();
                 $return = false;
             }
@@ -102,7 +100,6 @@ function setFirstDayOfTheWeek($connection2, $fdotw, $databaseName)
             $resultIndex = $connection2->prepare($sqlIndex);
             $resultIndex->execute($dataIndex);
         } catch (PDOException $e) {
-            echo $e->getMessage();
             exit();
             $return = false;
         }

--- a/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
+++ b/modules/Timetable Admin/courseEnrolment_manage_byPerson_edit.php
@@ -65,7 +65,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/courseEnro
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() != 1) {

--- a/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
+++ b/modules/Timetable Admin/tt_edit_day_edit_class_exception_add.php
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_edit_da
                     ORDER BY surname, preferredName";
                 $resultSelect = $connection2->prepare($sqlSelect);
                 $resultSelect->execute($dataSelect);
-            } catch (PDOException $e) { echo $e->getMessage();}
+            } catch (PDOException $e) {}
             while ($rowSelect = $resultSelect->fetch()) {
                 $participants[$rowSelect['gibbonPersonID']] = Format::name('', htmlPrep($rowSelect['preferredName']), htmlPrep($rowSelect['surname']), 'Student', true).' ('.__($rowSelect['role'].')');
             }

--- a/modules/Timetable Admin/tt_import.php
+++ b/modules/Timetable Admin/tt_import.php
@@ -218,7 +218,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);
                             } catch (PDOException $e) {
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                                 $importFail = true;
                                 $proceed = false;
                             }
@@ -835,7 +834,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/tt_delete.
                                     $resultSpace = $connection2->prepare($sqlSpace);
                                     $resultSpace->execute($dataSpace);
                                 } catch (PDOException $e) {
-                                    echo $e->getMessage();
                                     $ttSyncFail = true;
                                     $proceed = false;
                                     $addFail = true;

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -395,7 +395,6 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                     $resultDisplay = $connection2->prepare($sqlDisplay);
                     $resultDisplay->execute($dataDisplay);
                 } catch (PDOException $e) {
-                    $output .= "<div class='error'>".$e->getMessage().'</div>';
                 }
             }
         } else {
@@ -420,7 +419,6 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
 
         //If I am not involved in any timetables display all within the year
@@ -431,7 +429,6 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
         }
 
@@ -557,7 +554,6 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                 $resultDays = $connection2->prepare($sqlDays);
                 $resultDays->execute($dataDays);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
             $days = $resultDays->fetchAll();
             $daysInWeek = $resultDays->rowCount();
@@ -583,7 +579,7 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                     $sqlDays = "SELECT nameShort FROM gibbonDaysOfWeek WHERE nameShort='Sun' AND schoolDay='N'";
                     $resultDays = $connection2->prepare($sqlDays);
                     $resultDays->execute($dataDays);
-                } catch (PDOException $e) { echo $e->getMessage(); }
+                } catch (PDOException $e) { }
                 if ($resultDays->rowCount() == 1) {
                     $homeSunday = false ;
                 }
@@ -826,7 +822,6 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                 $resultDiff = $connection2->prepare($sqlDiff);
                 $resultDiff->execute($dataDiff);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
             while ($rowDiff = $resultDiff->fetch()) {
                 try {
@@ -835,7 +830,6 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                     $resultDiffDay = $connection2->prepare($sqlDiffDay);
                     $resultDiffDay->execute($dataDiffDay);
                 } catch (PDOException $e) {
-                    $output .= "<div class='error'>".$e->getMessage().'</div>';
                 }
                 while ($rowDiffDay = $resultDiffDay->fetch()) {
                     if ($rowDiffDay['timeStart'] < $timeStart) {
@@ -1069,7 +1063,6 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                         $resultTerm = $connection2->prepare($sqlTerm);
                         $resultTerm->execute($dataTerm);
                     } catch (PDOException $e) {
-                        $output .= "<div class='error'>".$e->getMessage().'</div>';
                     }
                     while ($rowTerm = $resultTerm->fetch()) {
                         if (date('Y-m-d', ($startDayStamp + (86400 * $dateCorrection))) >= $rowTerm['firstDay'] and date('Y-m-d', ($startDayStamp + (86400 * $dateCorrection))) <= $rowTerm['lastDay']) {
@@ -1343,7 +1336,6 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
             $resultDiff = $connection2->prepare($sqlDiff);
             $resultDiff->execute($dataDiff);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
         while ($rowDiff = $resultDiff->fetch()) {
             if ($dayTimeStart == '') {
@@ -1385,7 +1377,6 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                 $resultPeriods = $connection2->prepare($sqlPeriods);
                 $resultPeriods->execute($dataPeriods);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
             while ($rowPeriods = $resultPeriods->fetch()) {
                 $isSlotInTime = false;
@@ -1459,7 +1450,6 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                 $resultPeriods = $connection2->prepare($sqlPeriods);
                 $resultPeriods->execute($dataPeriods);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
 
             $periods = $resultPeriods->rowCount() > 0 ? $resultPeriods->fetchAll() : [];
@@ -1510,7 +1500,6 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                             $resultClassCheck = $connection2->prepare($sqlClassCheck);
                             $resultClassCheck->execute($dataClassCheck);
                         } catch (PDOException $e) {
-                            $output .= "<div class='error'>".$e->getMessage().'</div>';
                         }
                         
                         // See if there are no students left in the class after year groups and form groups are checked
@@ -1527,7 +1516,6 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                         $resultException = $connection2->prepare($sqlException);
                         $resultException->execute($dataException);
                     } catch (PDOException $e) {
-                        $output .= "<div class='error'>".$e->getMessage().'</div>';
                     }
                     if ($resultException->rowCount() < 1 || $isCovering) {
                         $className = !empty($rowPeriods['gibbonCourseClassID'])? $rowPeriods['course'].'.'.$rowPeriods['class'] : ($rowPeriods['contextName'] ?? '');
@@ -1726,7 +1714,6 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                                                     $resultPlan = $connection2->prepare($sqlPlan);
                                                     $resultPlan->execute($dataPlan);
                                                 } catch (PDOException $e) {
-                                                    $output .= "<div class='error'>".$e->getMessage().'</div>';
                                                 }
 
                                                 if ($resultPlan->rowCount() == 1) {
@@ -1756,7 +1743,6 @@ function renderTTDay($guid, $connection2, $gibbonTTID, $schoolOpen, $startDaySta
                                                 $resultPlan = $connection2->prepare($sqlPlan);
                                                 $resultPlan->execute($dataPlan);
                                             } catch (PDOException $e) {
-                                                $output .= "<div class='error'>".$e->getMessage().'</div>';
                                             }
                                             if ($resultPlan->rowCount() == 1) {
                                                 $rowPlan = $resultPlan->fetch();
@@ -2032,7 +2018,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        $output .= "<div class='error'>".$e->getMessage().'</div>';
     }
 
     //If I am not involved in any timetables display all within the year
@@ -2043,7 +2028,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
     }
 
@@ -2175,7 +2159,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
             $resultDays = $connection2->prepare($sqlDays);
             $resultDays->execute($dataDays);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
         $days = $resultDays->fetchAll();
         $daysInWeek = $resultDays->rowCount();
@@ -2215,7 +2198,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
             $resultDiff = $connection2->prepare($sqlDiff);
             $resultDiff->execute($dataDiff);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
         while ($rowDiff = $resultDiff->fetch()) {
             try {
@@ -2224,7 +2206,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
                 $resultDiffDay = $connection2->prepare($sqlDiffDay);
                 $resultDiffDay->execute($dataDiffDay);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
             while ($rowDiffDay = $resultDiffDay->fetch()) {
                 if ($rowDiffDay['timeStart'] < $timeStart) {
@@ -2243,7 +2224,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
             $resultDiff = $connection2->prepare($sqlDiff);
             $resultDiff->execute($dataDiff);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
 
         while ($rowDiff = $resultDiff->fetch()) {
@@ -2349,7 +2329,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
                         $resultSpecial = $connection2->prepare($sqlSpecial);
                         $resultSpecial->execute($dataSpecial);
                     } catch (PDOException $e) {
-                        $output .= "<div class='error'>".$e->getMessage().'</div>';
                     }
                     if ($resultSpecial->rowcount() == 1) {
                         $rowSpecial = $resultSpecial->fetch();
@@ -2391,7 +2370,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
                 $resultTerm = $connection2->prepare($sqlTerm);
                 $resultTerm->execute($dataTerm);
             } catch (PDOException $e) {
-                $output .= "<div class='error'>".$e->getMessage().'</div>';
             }
             $weekStart = date('Y-m-d', ($startDayStamp + (86400 * 0)));
             $weekEnd = date('Y-m-d', ($startDayStamp + (86400 * 6)));
@@ -2422,7 +2400,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
                         $resultTerm = $connection2->prepare($sqlTerm);
                         $resultTerm->execute($dataTerm);
                     } catch (PDOException $e) {
-                        $output .= "<div class='error'>".$e->getMessage().'</div>';
                     }
                     while ($rowTerm = $resultTerm->fetch()) {
                         if (date('Y-m-d', ($startDayStamp + (86400 * $dateCorrection))) >= $rowTerm['firstDay'] and date('Y-m-d', ($startDayStamp + (86400 * $dateCorrection))) <= $rowTerm['lastDay']) {
@@ -2438,7 +2415,6 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
                             $resultClosure = $connection2->prepare($sqlClosure);
                             $resultClosure->execute($dataClosure);
                         } catch (PDOException $e) {
-                            $output .= "<div class='error'>".$e->getMessage().'</div>';
                         }
                         if ($resultClosure->rowCount() == 1) {
 
@@ -2522,7 +2498,6 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
         $resultDiff = $connection2->prepare($sqlDiff);
         $resultDiff->execute($dataDiff);
     } catch (PDOException $e) {
-        $output .= "<div class='error'>".$e->getMessage().'</div>';
     }
     while ($rowDiff = $resultDiff->fetch()) {
         if ($dayTimeStart == '') {
@@ -2564,7 +2539,6 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
         $resultDay = $connection2->prepare($sqlDay);
         $resultDay->execute($dataDay);
     } catch (PDOException $e) {
-        $output .= "<div class='error'>".$e->getMessage().'</div>';
     }
 
     if ($resultDay->rowCount() == 1) {
@@ -2579,7 +2553,6 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
             $resultPeriods = $connection2->prepare($sqlPeriods);
             $resultPeriods->execute($dataPeriods);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
         while ($rowPeriods = $resultPeriods->fetch()) {
             $isSlotInTime = false;
@@ -2670,7 +2643,6 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
             $resultPeriods = $connection2->prepare($sqlPeriods);
             $resultPeriods->execute($dataPeriods);
         } catch (PDOException $e) {
-            $output .= "<div class='error'>".$e->getMessage().'</div>';
         }
 
         $periodCount = [];
@@ -2708,7 +2680,6 @@ function renderTTSpaceDay($guid, $connection2, $gibbonTTID, $startDayStamp, $cou
                             $resultClassCheck = $connection2->prepare($sqlClassCheck);
                             $resultClassCheck->execute($dataClassCheck);
                         } catch (PDOException $e) {
-                            $output .= "<div class='error'>".$e->getMessage().'</div>';
                         }
                         
                         // See if there are no students left in the class after year groups and form groups are checked

--- a/modules/Timetable/spaceBooking_manage_delete.php
+++ b/modules/Timetable/spaceBooking_manage_delete.php
@@ -51,7 +51,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($result->rowCount() != 1) {

--- a/modules/Timetable/tt_view.php
+++ b/modules/Timetable/tt_view.php
@@ -73,7 +73,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_view.php') ==
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {
-            echo "<div class='error'>".$e->getMessage().'</div>';
         }
 
         if ($result->rowCount() != 1) {

--- a/modules/Tracking/dataPoints_contents.php
+++ b/modules/Tracking/dataPoints_contents.php
@@ -93,7 +93,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Tracking/dataPoints.php') 
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
-                echo $e->getMessage();
             }
             while ($row = $result->fetch()) {
                 $externalIndex = $row['assessment'].'-'.$row['category'].'-'.$row['field'].'-'.$row['gibbonPersonID'];

--- a/modules/Tracking/graphing.php
+++ b/modules/Tracking/graphing.php
@@ -162,7 +162,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') ==
                     $resultDepartments = $connection2->prepare($sqlDepartments);
                     $resultDepartments->execute($dataDepartments);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
                 while ($rowDepartments = $resultDepartments->fetch()) {
                     $departments[$departmentCount]['department'] = $rowDepartments['department'];
@@ -226,7 +225,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') ==
                     $resultGrades = $connection2->prepare($sqlGrades);
                     $resultGrades->execute($dataGrades);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>".$e->getMessage().'</div>';
                 }
 
                 if ($resultGrades->rowCount() < 1) {

--- a/modules/User Admin/permission_manage.php
+++ b/modules/User Admin/permission_manage.php
@@ -77,7 +77,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/permission_mana
         $resultModules = $connection2->prepare($sqlModules);
         $resultModules->execute($dataModules);
     } catch (PDOException $e) {
-        echo "<div class='error'>".$e->getMessage().'</div>';
     }
 
     try {
@@ -91,7 +90,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/permission_mana
         $resultRoles = $connection2->prepare($sqlRoles);
         $resultRoles->execute($dataRoles);
     } catch (PDOException $e) {
-        echo "<div class='error'>".$e->getMessage().'</div>';
     }
 
     

--- a/modules/User Admin/role_manage_duplicateProcess.php
+++ b/modules/User Admin/role_manage_duplicateProcess.php
@@ -83,7 +83,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/role_manage_dup
                 $resultPermissions->execute($dataPermissions);
             } catch (PDOException $e) {
                 $partialFail = true;
-                echo $e->getMessage();
             }
 
             while ($rowPermissions = $resultPermissions->fetch()) {

--- a/modules/User Admin/rollover.php
+++ b/modules/User Admin/rollover.php
@@ -60,16 +60,12 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
         $nextYearBySession = $schoolYearGateway->getNextSchoolYearByID($session->get('gibbonSchoolYearID'));
         if ($nextYearBySession === false) {
-            echo "<div class='error'>";
-            echo __('The next school year cannot be determined, so this action cannot be performed.');
-            echo '</div>';
+            echo Format::alert(__('The next school year cannot be determined, so this action cannot be performed.'), 'error');
         } else {
 
 
             if (empty($nextYearBySession)) {
-                echo "<div class='error'>";
-                echo __('The next school year cannot be determined, so this action cannot be performed.');
-                echo '</div>';
+                echo Format::alert(__('The next school year cannot be determined, so this action cannot be performed.'), 'error');
             } else {
                 $form = Form::create('action', $session->get('absoluteURL').'/index.php?q=/modules/'.$session->get('module').'/rollover.php&step=2');
 
@@ -94,9 +90,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
         $nextYearID = $_POST['nextYear'];
         $nextYearBySession = $schoolYearGateway->getNextSchoolYearByID($session->get('gibbonSchoolYearID'));
         if (empty($nextYearID) or $nextYearBySession === false or $nextYearID != $nextYearBySession['gibbonSchoolYearID']) {
-            echo "<div class='error'>";
-            echo __('The next school year cannot be determined, so this action cannot be performed.');
-            echo '</div>';
+            echo Format::alert(__('The next school year cannot be determined, so this action cannot be performed.'), 'error');
         } else {
 
                 $dataNext = array('gibbonSchoolYearID' => $nextYearID);
@@ -109,9 +103,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
             $nameNext = $rowNext['name'];
             $sequenceNext = $rowNext['sequenceNumber'];
             if ($nameNext == '' or $sequenceNext == '') {
-                echo "<div class='error'>";
-                echo __('The next school year cannot be determined, so this action cannot be performed.');
-                echo '</div>';
+                echo Format::alert(__('The next school year cannot be determined, so this action cannot be performed.'), 'error');
             } else {
                 echo '<p>';
                 echo sprintf(__('In rolling over to %1$s, the following actions will take place. You may need to adjust some fields below to get the result you desire.'), $nameNext);
@@ -514,9 +506,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
         $nextYearID = $_POST['nextYear'] ?? '';
         $nextYearBySession = $schoolYearGateway->getNextSchoolYearByID($session->get('gibbonSchoolYearID'));
         if (empty($nextYearID) or $nextYearBySession === false or $nextYearID != $nextYearBySession['gibbonSchoolYearID']) {
-            echo "<div class='error'>";
-            echo __('The next school year cannot be determined, so this action cannot be performed.');
-            echo '</div>';
+            echo Format::alert(__('The next school year cannot be determined, so this action cannot be performed.'), 'error');
         } else {
 
                 $dataNext = array('gibbonSchoolYearID' => $nextYearID);
@@ -529,9 +519,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
             $nameNext = $rowNext['name'] ?? '';
             $sequenceNext = $rowNext['sequenceNumber'] ?? '';
             if ($nameNext == '' or $sequenceNext == '') {
-                echo "<div class='error'>";
-                echo __('The next school year cannot be determined, so this action cannot be performed.');
-                echo '</div>';
+                echo Format::alert(__('The next school year cannot be determined, so this action cannot be performed.'), 'error');
             } else {
                 echo '<h3>';
                 echo __('Step 3');
@@ -551,9 +539,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                     $lastDay = Format::dateConvert($_POST['nextlastDay'] ?? '');
 
                     if ($name == '' or $status == '' or $sequenceNumber == '' or is_numeric($sequenceNumber) == false or $firstDay == '' or $lastDay == '') {
-                        echo "<div class='error'>";
-                        echo __('Your request failed because your inputs were invalid.');
-                        echo '</div>';
+                        echo Format::alert(__('Your request failed because your inputs were invalid.'), 'error');
                     } else {
                         //Check unique inputs for uniqueness
 
@@ -563,9 +549,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                             $result->execute($data);
 
                         if ($result->rowCount() > 0) {
-                            echo "<div class='error'>";
-                            echo __('Your request failed because your inputs were invalid.');
-                            echo '</div>';
+                            echo Format::alert(__('Your request failed because your inputs were invalid.'), 'error');
                         } else {
                             //Write to database
                             $fail = false;
@@ -575,13 +559,10 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                 $result = $connection2->prepare($sql);
                                 $result->execute($data);
                             } catch (PDOException $e) {
-                                echo "<div class='error'>".$e->getMessage().'</div>';
                                 $fail = true;
                             }
                             if ($fail == false) {
-                                echo "<div class='success'>";
-                                echo __('Your request was completed successfully.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request was completed successfully.'), 'success');
                             }
                         }
                     }
@@ -603,9 +584,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {
-                    echo "<div class='error'>";
-                    echo __('Your request failed due to a database error.');
-                    echo '</div>';
+                    echo Format::alert(__('Your request failed due to a database error.'), 'error');
                     $advance = false;
                 }
                 if ($advance) {
@@ -616,18 +595,14 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
-                        echo "<div class='error'>";
-                        echo __('Your request failed due to a database error.');
-                        echo '</div>';
+                        echo Format::alert(__('Your request failed due to a database error.'), 'error');
                         $advance2 = false;
                     }
                     if ($advance2) {
                         $session->forget('gibbonSchoolYearIDCurrent');
                         SessionFactory::setCurrentSchoolYear($session, $nextYearBySession);
 
-                        echo "<div class='success'>";
-                        echo __('Advance was successful, you are now in a new academic year!');
-                        echo '</div>';
+                        echo Format::alert(__('Advance was successful, you are now in a new academic year!'), 'success');
 
                         //SET EXPECTED USERS TO FULL
                         echo '<h4>';
@@ -636,9 +611,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                         $count = $_POST['expect-count'] ?? 0;
                         if (empty($count)) {
-                            echo "<div class='warning'>";
-                            echo __('No actions were selected in Step 2, and so no changes have been made.');
-                            echo '</div>';
+                            echo Format::alert(__('No actions were selected in Step 2, and so no changes have been made.'), 'warning');
                         } else {
                             $success = 0;
                             for ($i = 1; $i <= $count; ++$i) {
@@ -667,17 +640,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                             //Feedback result!
                             if ($success == 0) {
-                                echo "<div class='error'>";
-                                echo __('Your request failed.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request failed.'), 'error');
                             } elseif ($success < $count) {
-                                echo "<div class='warning'>";
-                                echo sprintf(__('%1$s updates failed.'), ($count - $success));
-                                echo '</div>';
+                                echo Format::alert(sprintf(__('%1$s updates failed.'), ($count - $success)), 'warning');
                             } else {
-                                echo "<div class='success'>";
-                                echo __('Your request was completed successfully.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request was completed successfully.'), 'success');
                             }
                         }
 
@@ -688,9 +655,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                         $count = $_POST['enrol-count'] ?? 0;
                         if (empty($count)) {
-                            echo "<div class='warning'>";
-                            echo __('No actions were selected in Step 2, and so no changes have been made.');
-                            echo '</div>';
+                            echo Format::alert(__('No actions were selected in Step 2, and so no changes have been made.'), 'warning');
                         } else {
                             $success = 0;
                             for ($i = 1; $i <= $count; ++$i) {
@@ -757,17 +722,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                             //Feedback result!
                             if ($success == 0) {
-                                echo "<div class='error'>";
-                                echo __('Your request failed.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request failed.'), 'error');
                             } elseif ($success < $count) {
-                                echo "<div class='warning'>";
-                                echo sprintf(__('%1$s adds failed.'), ($count - $success));
-                                echo '</div>';
+                                echo Format::alert(sprintf(__('%1$s adds failed.'), ($count - $success)), 'warning');
                             } else {
-                                echo "<div class='success'>";
-                                echo __('Your request was completed successfully.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request was completed successfully.'), 'success');
                             }
                         }
 
@@ -781,9 +740,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                             $count = $_POST['enrolFull-count'];
                         }
                         if ($count == '') {
-                            echo "<div class='warning'>";
-                            echo __('No actions were selected in Step 2, and so no changes have been made.');
-                            echo '</div>';
+                            echo Format::alert(__('No actions were selected in Step 2, and so no changes have been made.'), 'warning');
                         } else {
                             $success = 0;
                             for ($i = 1; $i <= $count; ++$i) {
@@ -875,17 +832,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                             //Feedback result!
                             if ($success == 0) {
-                                echo "<div class='error'>";
-                                echo __('Your request failed.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request failed.'), 'error');
                             } elseif ($success < $count) {
-                                echo "<div class='warning'>";
-                                echo  sprintf(__('%1$s adds failed.'), ($count - $success));
-                                echo '</div>';
+                                echo Format::alert( sprintf(__('%1$s adds failed.'), ($count - $success)), 'warning');
                             } else {
-                                echo "<div class='success'>";
-                                echo __('Your request was completed successfully.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request was completed successfully.'), 'success');
                             }
                         }
 
@@ -899,9 +850,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                             $count = $_POST['reenrol-count'];
                         }
                         if ($count == '') {
-                            echo "<div class='warning'>";
-                            echo __('No actions were selected in Step 2, and so no changes have been made.');
-                            echo '</div>';
+                            echo Format::alert(__('No actions were selected in Step 2, and so no changes have been made.'), 'warning');
                         } else {
                             $success = 0;
 
@@ -922,7 +871,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                         $result->execute($data);
                                     } catch (PDOException $e) {
                                         $reenrolled = false;
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
 
                                     if ($result->rowCount() != 1 and $result->rowCount() != 0) {
@@ -936,7 +884,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                             $result2->execute($data2);
                                         } catch (PDOException $e) {
                                             $reenrolled = false;
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
                                         }
                                         if ($reenrolled) {
                                             ++$success;
@@ -950,7 +897,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                             $result2->execute($data2);
                                         } catch (PDOException $e) {
                                             $reenrolled = false;
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
                                         }
                                         if ($reenrolled) {
                                             ++$success;
@@ -965,7 +911,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                         $result->execute($data);
                                     } catch (PDOException $e) {
                                         $reenrolled = false;
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
                                     if ($reenrolled) {
                                         ++$success;
@@ -977,17 +922,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                             //Feedback result!
                             if ($success == 0) {
-                                echo "<div class='error'>";
-                                echo __('Your request failed.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request failed.'), 'error');
                             } elseif ($success < $count) {
-                                echo "<div class='warning'>";
-                                echo sprintf(__('%1$s adds failed.'), ($count - $success));
-                                echo '</div>';
+                                echo Format::alert(sprintf(__('%1$s adds failed.'), ($count - $success)), 'warning');
                             } else {
-                                echo "<div class='success'>";
-                                echo __('Your request was completed successfully.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request was completed successfully.'), 'success');
                             }
                         }
 
@@ -999,9 +938,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                         $count = $_POST['final-count'] ?? 0;
 
                         if (empty($count)) {
-                            echo "<div class='warning'>";
-                            echo __('No actions were selected in Step 2, and so no changes have been made.');
-                            echo '</div>';
+                            echo Format::alert(__('No actions were selected in Step 2, and so no changes have been made.'), 'warning');
                         } else {
                             $success = 0;
                             for ($i = 1; $i <= $count; ++$i) {
@@ -1018,7 +955,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                     $result->execute($data);
                                 } catch (PDOException $e) {
                                     $left = false;
-                                    echo "<div class='error'>".$e->getMessage().'</div>';
                                 }
                                 if ($left) {
                                     ++$success;
@@ -1029,17 +965,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                             //Feedback result!
                             if ($success == 0) {
-                                echo "<div class='error'>";
-                                echo __('Your request failed.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request failed.'), 'error');
                             } elseif ($success < $count) {
-                                echo "<div class='warning'>";
-                                echo sprintf(__('%1$s updates failed.'), ($count - $success));
-                                echo '</div>';
+                                echo Format::alert(sprintf(__('%1$s updates failed.'), ($count - $success)), 'warning');
                             } else {
-                                echo "<div class='success'>";
-                                echo __('Your request was completed successfully.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request was completed successfully.'), 'success');
                             }
                         }
 
@@ -1050,9 +980,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                         $count = $_POST['register-count'] ?? 0;
                         if (empty($count)) {
-                            echo "<div class='warning'>";
-                            echo __('No actions were selected in Step 2, and so no changes have been made.');
-                            echo '</div>';
+                            echo Format::alert(__('No actions were selected in Step 2, and so no changes have been made.'), 'warning');
                         } else {
                             $success = 0;
                             for ($i = 1; $i <= $count; ++$i) {
@@ -1072,7 +1000,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                         $resultCheck->execute($dataCheck);
                                     } catch (PDOException $e) {
                                         $enrolled = false;
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
                                     if ($resultCheck->rowCount() == 0) {
                                         try {
@@ -1082,7 +1009,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                             $result->execute($data);
                                         } catch (PDOException $e) {
                                             $enrolled = false;
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
                                         }
                                         if ($enrolled) {
                                             ++$success;
@@ -1095,7 +1021,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                             $result->execute($data);
                                         } catch (PDOException $e) {
                                             $enrolled = false;
-                                            echo "<div class='error'>".$e->getMessage().'</div>';
                                         }
                                         if ($enrolled) {
                                             ++$success;
@@ -1110,7 +1035,6 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
                                         $result->execute($data);
                                     } catch (PDOException $e) {
                                         $left = false;
-                                        echo "<div class='error'>".$e->getMessage().'</div>';
                                     }
                                     if ($left) {
                                         ++$success;
@@ -1122,17 +1046,11 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/rollover.php') 
 
                             //Feedback result!
                             if ($success == 0) {
-                                echo "<div class='error'>";
-                                echo __('Your request failed.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request failed.'), 'error');
                             } elseif ($success < $count) {
-                                echo "<div class='warning'>";
-                                echo sprintf(__('%1$s adds failed.'), ($count - $success));
-                                echo '</div>';
+                                echo Format::alert(sprintf(__('%1$s adds failed.'), ($count - $success)), 'warning');
                             } else {
-                                echo "<div class='success'>";
-                                echo __('Your request was completed successfully.');
-                                echo '</div>';
+                                echo Format::alert(__('Your request was completed successfully.'), 'success');
                             }
                         }
                     }

--- a/notificationsDeleteProcess.php
+++ b/notificationsDeleteProcess.php
@@ -38,7 +38,6 @@ if (!isset($_GET['gibbonNotificationID'])) {
         $result = $connection2->prepare($sql);
         $result->execute($data);
     } catch (PDOException $e) {
-        echo $e->getMessage();
         header("Location: {$URL->withReturn('error2')}");
         exit();
     }

--- a/src/Domain/Messenger/MessengerGateway.php
+++ b/src/Domain/Messenger/MessengerGateway.php
@@ -259,7 +259,6 @@ class MessengerGateway extends QueryableGateway
             $resultRoleCategory = $connection2->prepare($sqlRoleCategory);
             $resultRoleCategory->execute($dataRoleCategory);
         } catch (\PDOException $e) {
-            echo $e->getMessage();
         }
         $sqlWhere = '(';
         if ($resultRoleCategory->rowCount() > 0) {
@@ -712,7 +711,6 @@ class MessengerGateway extends QueryableGateway
                 $resultPosts = $connection2->prepare($sqlPosts);
                 $resultPosts->execute($dataPosts);
             } catch (\PDOException $e) {
-                echo $e->getMessage();
             }
 
             $arrayPosts = $resultPosts->rowCount() > 0 ? $resultPosts->fetchAll() : [];
@@ -733,7 +731,6 @@ class MessengerGateway extends QueryableGateway
                 $resultPosts = $connection2->prepare($sqlPosts);
                 $resultPosts->execute($dataPosts);
             } catch (\PDOException $e) {
-                echo $e->getMessage();
             }
 
             if ($resultPosts->rowCount() < 1) {

--- a/src/UI/Dashboard/ParentDashboard.php
+++ b/src/UI/Dashboard/ParentDashboard.php
@@ -179,7 +179,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (\PDOException $e) {
-                    $plannerOutput .= "<div class='error'>".$e->getMessage().'</div>';
                 }
                 if ($result->rowCount() > 0) {
                     $classes = true;
@@ -294,7 +293,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                 $resultEntry = $connection2->prepare($sqlEntry);
                 $resultEntry->execute($dataEntry);
             } catch (\PDOException $e) {
-                $gradesOutput .= "<div class='error'>".$e->getMessage().'</div>';
             }
             if ($resultEntry->rowCount() > 0) {
                 $showParentAttainmentWarning = $this->settingGateway->getSettingByScope('Markbook', 'showParentAttainmentWarning');
@@ -477,7 +475,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                             $resultSub = $connection2->prepare($sqlSub);
                             $resultSub->execute($dataSub);
                         } catch (\PDOException $e) {
-                            $gradesOutput .= "<div class='error'>".$e->getMessage().'</div>';
                         }
                         if ($resultSub->rowCount() != 1) {
                             $gradesOutput .= "<td class='dull' style='color: #bbb; text-align: left'>";
@@ -493,7 +490,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                                 $resultWork = $connection2->prepare($sqlWork);
                                 $resultWork->execute($dataWork);
                             } catch (\PDOException $e) {
-                                $gradesOutput .= "<div class='error'>".$e->getMessage().'</div>';
                             }
                             if ($resultWork->rowCount() > 0) {
                                 $rowWork = $resultWork->fetch();
@@ -621,7 +617,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                 $resultYears = $connection2->prepare($sqlYears);
                 $resultYears->execute($dataYears);
             } catch (\PDOException $e) {
-                $activitiesOutput .= "<div class='error'>".$e->getMessage().'</div>';
             }
 
             if ($resultYears->rowCount() < 1) {
@@ -638,7 +633,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (\PDOException $e) {
-                        $activitiesOutput .= "<div class='error'>".$e->getMessage().'</div>';
                     }
 
                     if ($result->rowCount() < 1) {
@@ -714,7 +708,6 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
                                     $resultSlots = $connection2->prepare($sqlSlots);
                                     $resultSlots->execute($dataSlots);
                                 } catch (\PDOException $e) {
-                                    $activitiesOutput .= "<div class='error'>".$e->getMessage().'</div>';
                                 }
                                 $count = 0;
                                 while ($rowSlots = $resultSlots->fetch()) {

--- a/src/UI/Dashboard/StaffDashboard.php
+++ b/src/UI/Dashboard/StaffDashboard.php
@@ -150,7 +150,6 @@ class StaffDashboard implements OutputableInterface, ContainerAwareInterface
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (\PDOException $e) {
-            $planner .= "<div class='error'>".$e->getMessage().'</div>';
         }
         $planner .= '<h2>';
         $planner .= __("Today's Lessons");
@@ -332,9 +331,7 @@ class StaffDashboard implements OutputableInterface, ContainerAwareInterface
                     $sqlBehaviour = 'SELECT gibbonBehaviour.*, student.surname AS surnameStudent, student.preferredName AS preferredNameStudent, creator.surname AS surnameCreator, creator.preferredName AS preferredNameCreator, creator.title FROM gibbonBehaviour JOIN gibbonPerson AS student ON (gibbonBehaviour.gibbonPersonID=student.gibbonPersonID) JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonPersonID=student.gibbonPersonID) JOIN gibbonPerson AS creator ON (gibbonBehaviour.gibbonPersonIDCreator=creator.gibbonPersonID) WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonBehaviour.gibbonSchoolYearID=:gibbonSchoolYearID2 AND gibbonFormGroupID=:gibbonFormGroupID ORDER BY timestamp DESC';
                     $resultBehaviour = $connection2->prepare($sqlBehaviour);
                     $resultBehaviour->execute($dataBehaviour);
-                } catch (\PDOException $e) {
-                    $formGroups[$count][3] .= "<div class='error'>".$e->getMessage().'</div>';
-                }
+                } catch (\PDOException $e) {}
 
                 if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage_add.php')) {
                     $formGroups[$count][3] .= "<div class='linkTop'>";

--- a/src/UI/Dashboard/StudentDashboard.php
+++ b/src/UI/Dashboard/StudentDashboard.php
@@ -115,7 +115,6 @@ class StudentDashboard implements OutputableInterface, ContainerAwareInterface
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (\PDOException $e) {
-                $planner .= "<div class='error'>".$e->getMessage().'</div>';
             }
             $planner .= '<h2>';
             $planner .= __("Today's Lessons");


### PR DESCRIPTION
Currently, there's many areas of the code where exception messages are output directly to the user-facing interface. In particular, when handling SQL queries. This is problematic for two reasons, one in that the Connection class already internally handles exceptions so this is a duplication of code, and another because exception messages shouldn't be displayed raw to the user except when in Development mode. Instead, in Production systems they should be logged, which is another set of refactoring we have planned for the future.

**Description**
Removes all raw $e->getMessage() output from try/catch blocks. Scripts that use $e->getMessage() internally and properly handle the exception message have not been changed.

**Motivation and Context**
Refactoring and security.

**How Has This Been Tested?**
Locally and CI.