### PR TITLE
github: fix issue link to feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://ask.gibbonedu.org/
     about: Have problem using Gibbon? Please ask in our support forum.
   - name: Feature Request
-    url: https://ask.gibbonedu.org/categories/feature-requests
+    url: https://ask.gibbonedu.org/c/feature-requests/12
     about: To request new features, please use the Feature Requests category in our support forums.


### PR DESCRIPTION
**Description**
* Fix GitHub's issue config to correct "feature request" link.

**Motivation and Context**
* The URL pattern of categories seem to have changed. The [old "Feature Request" page URL](https://ask.gibbonedu.org/categories/feature-requests) no longer works.
* That makes the current link in the [New Issue](https://github.com/GibbonEdu/core/issues/new/choose) page unusable.

**How Has This Been Tested?**
* On browser.