### PR TITLE
gitlab-ci: PHP 8.3 testing update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,5 +145,5 @@ php:8.2:
   extends: .tests
 
 php:8.3:
-  image: php:8.3-rc
+  image: php:8.3
   extends: .tests


### PR DESCRIPTION
**Description**
* Use "php-8.3" docker instead of "php-8.3-rc" for GitLab CI testing.

**Motivation and Context**
* PHP 8.3 has been released in Nov. Docker hub has the official image tag for php-8.3. The "-rc" suffix is no longer needed.

**How Has This Been Tested?**
* GitLab CI pipeline [here](https://gitlab.com/yookoala/gibboneducore/-/pipelines/1122921570)

**Screenshots**
![圖片](https://github.com/GibbonEdu/core/assets/91274/8eea19ca-9781-454f-95fd-db056ea6fac9)
