### PR TITLE
Messenger: added search form and school year nav to Manage Groups Page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ v27.0.00
         Timetable: added timetable iCal Export buttons to staff and student profiles
         User Admin: added an option to disable the display of privacy options, so they can be managed internally
         Fast Finder: added facilities as one of the searchable options with the fast finder.
+        Messenger: Added search form and school year navigator to Manage Groups page for quicker group browsing.
 
     Bug Fixes
 


### PR DESCRIPTION
**Description**
Messenger: Added search form and school year navigator to Manage Groups page for quicker group browsing. 
"modules/Data Updater/data_personal_manage.php" was used as an example for implementing the search form and navigator.

**Motivation and Context**
Implementing the search allows for quicker filtering through groups, therefore improving scalability with increasing numbers of groups.

**How Has This Been Tested?**
Tested Locally.

**Screenshots**
<img width="1046" alt="Screenshot 2024-01-08 at 15 05 07" src="https://github.com/GibbonEdu/core/assets/74660787/41f43028-d8a1-4a70-a4f0-db9d7f089524">
<img width="1063" alt="Screenshot 2024-01-08 at 15 05 25" src="https://github.com/GibbonEdu/core/assets/74660787/976a3f37-8c8f-43c2-bdce-e3718fe63d07">

