### PR TITLE
Added 'active' column to gibbonSpace table and changed pages to only show active facilities.

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -790,5 +790,5 @@ INSERT INTO `gibbonNotificationEvent` (`event`, `moduleName`, `actionName`, `typ
 ALTER TABLE `gibbonActivityStudent` CHANGE `status` `status` ENUM('Accepted','Pending','Waiting List','Not Accepted','Left') NOT NULL DEFAULT 'Pending';end
 INSERT INTO `gibbonSetting` (`scope`, `name`, `nameDisplay`, `description`, `value`) VALUES ('User Admin', 'privacyOptionVisibility', 'Display privacy options?', 'If enabled, privacy options can be selected by users through the Data Updater and Application Form. If not enabled, privacy options can only be changed by staff through Manage Users.', 'Y');end
 UPDATE `gibbonSetting` SET description='Comma-separated list of choices to make available if privacy options are turned on.' WHERE scope='User Admin' AND name='privacyOptions';end
-
+ALTER TABLE `gibbonSpace` ADD `active` ENUM('N','Y') NOT NULL DEFAULT 'Y' AFTER `type`;end
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ v27.0.00
         Fast Finder: added facilities as one of the searchable options with the fast finder.
         Messenger: Added search form and school year navigator to Manage Groups page for quicker group browsing.
         System: Replaced session call through $gibbon->session to $session. "$gibbon->session" is now deprecated.
+        Facilities: Added an 'active' column in the gibbonSpace table and changed pages to only show active Facilities.
 
     Bug Fixes
         System: fixed PHP 8+ compatibility in CustomFieldIDs migration file

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,7 +38,7 @@ v27.0.00
         Fast Finder: added facilities as one of the searchable options with the fast finder.
         Messenger: Added search form and school year navigator to Manage Groups page for quicker group browsing.
         System: Replaced session call through $gibbon->session to $session. "$gibbon->session" is now deprecated.
-        Facilities: Added an 'active' column in the gibbonSpace table and changed pages to only show active Facilities.
+        Facilities: added the ability to toggle facilities between active and inactive, removing inactive facilities from general use
 
     Bug Fixes
         System: fixed PHP 8+ compatibility in CustomFieldIDs migration file

--- a/index_fastFinder_ajax.php
+++ b/index_fastFinder_ajax.php
@@ -143,7 +143,8 @@ if (!isset($_SESSION[$guid]) or !$session->exists('gibbonPersonID')) {
                     gibbonSpace.name AS name,
                     NULL as type
                     FROM gibbonSpace
-                    WHERE gibbonSpace.name LIKE :search
+                    WHERE gibbonSpace.name LIKE :search 
+                    AND gibbonSpace.active='Y'
                     ORDER BY name";
             $resultList = $connection2->prepare($sql);
             $resultList->execute($data);

--- a/modules/School Admin/space_manage.php
+++ b/modules/School Admin/space_manage.php
@@ -73,6 +73,11 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage.
         ->addParam('search', $search)
         ->displayLabel();
 
+    $table->modifyRows(function ($value, $row) {
+        if ($value['active'] == 'N') $row->addClass('error');
+        return $row;
+    });
+
     $table->addColumn('name', __('Name'));
     $table->addColumn('type', __('Type'));
     $table->addColumn('capacity', __('Capacity'));

--- a/modules/School Admin/space_manage_add.php
+++ b/modules/School Admin/space_manage_add.php
@@ -50,6 +50,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
     $row = $form->addRow();
         $row->addLabel('type', __('Type'));
         $row->addSelect('type')->fromString($types)->required()->placeholder();
+    
+    $row = $form->addRow();
+        $row->addLabel('active', __('Active'));
+        $row->addYesNo('active')->selected('Y');
 
     $row = $form->addRow();
         $row->addLabel('capacity', __('Capacity'));

--- a/modules/School Admin/space_manage_addProcess.php
+++ b/modules/School Admin/space_manage_addProcess.php
@@ -33,6 +33,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
     //Proceed!
     $name = $_POST['name'] ?? '';
     $type = $_POST['type'] ?? '';
+    $active = $_POST['active'] ?? '';
     $capacity = $_POST['capacity'] ?? '';
     $computer = $_POST['computer'] ?? '';
     $computerStudent = $_POST['computerStudent'] ?? '';
@@ -47,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
     $comment = $_POST['comment'] ?? '';
 
     //Validate Inputs
-    if ($name == '' or $type == '' or $computer == '' or $computerStudent == '' or $projector == '' or $tv == '' or $dvd == '' or $hifi == '' or $speakers == '' or $iwb == '') {
+    if ($name == '' or $type == '' or $active == '' or $computer == '' or $computerStudent == '' or $projector == '' or $tv == '' or $dvd == '' or $hifi == '' or $speakers == '' or $iwb == '') {
         $URL .= '&return=error1';
         header("Location: {$URL}");
     } else {
@@ -69,8 +70,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
         } else {
             //Write to database
             try {
-                $data = array('name' => $name, 'type' => $type, 'capacity' => $capacity, 'computer' => $computer, 'computerStudent' => $computerStudent, 'projector' => $projector, 'tv' => $tv, 'dvd' => $dvd, 'hifi' => $hifi, 'speakers' => $speakers, 'iwb' => $iwb, 'phoneInternal' => $phoneInternal, 'phoneExternal' => $phoneExternal, 'comment' => $comment);
-                $sql = 'INSERT INTO gibbonSpace SET name=:name, type=:type, capacity=:capacity, computer=:computer, computerStudent=:computerStudent, projector=:projector, tv=:tv, dvd=:dvd, hifi=:hifi, speakers=:speakers, iwb=:iwb, phoneInternal=:phoneInternal, phoneExternal=:phoneExternal, comment=:comment';
+                $data = array('name' => $name, 'type' => $type, 'active' => $active, 'capacity' => $capacity, 'computer' => $computer, 'computerStudent' => $computerStudent, 'projector' => $projector, 'tv' => $tv, 'dvd' => $dvd, 'hifi' => $hifi, 'speakers' => $speakers, 'iwb' => $iwb, 'phoneInternal' => $phoneInternal, 'phoneExternal' => $phoneExternal, 'comment' => $comment);
+                $sql = 'INSERT INTO gibbonSpace SET name=:name, type=:type, active=:active, capacity=:capacity, computer=:computer, computerStudent=:computerStudent, projector=:projector, tv=:tv, dvd=:dvd, hifi=:hifi, speakers=:speakers, iwb=:iwb, phoneInternal=:phoneInternal, phoneExternal=:phoneExternal, comment=:comment';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {

--- a/modules/School Admin/space_manage_edit.php
+++ b/modules/School Admin/space_manage_edit.php
@@ -63,6 +63,10 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
                 $row->addSelect('type')->fromString($types)->required()->placeholder();
 
             $row = $form->addRow();
+                $row->addLabel('active', __('Active'));
+                $row->addYesNo('active')->selected('Y');
+
+            $row = $form->addRow();
                 $row->addLabel('capacity', __('Capacity'));
                 $row->addNumber('capacity')->maxLength(5)->setValue('0');
 

--- a/modules/School Admin/space_manage_editProcess.php
+++ b/modules/School Admin/space_manage_editProcess.php
@@ -54,6 +54,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
         } else {
             $name = $_POST['name'] ?? '';
             $type = $_POST['type'] ?? '';
+            $active = $_POST['active'] ?? '';
             $capacity = $_POST['capacity'] ?? '';
             $computer = $_POST['computer'] ?? '';
             $computerStudent = $_POST['computerStudent'] ?? '';
@@ -68,7 +69,7 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
             $comment = $_POST['comment'] ?? '';
 
             //Validate Inputs
-            if ($name == '' or $type == '' or $computer == '' or $computerStudent == '' or $projector == '' or $tv == '' or $dvd == '' or $hifi == '' or $speakers == '' or $iwb == '') {
+            if ($name == '' or $type == '' or $active == '' or $computer == '' or $computerStudent == '' or $projector == '' or $tv == '' or $dvd == '' or $hifi == '' or $speakers == '' or $iwb == '') {
                 $URL .= '&return=error3';
                 header("Location: {$URL}");
             } else {
@@ -90,8 +91,8 @@ if (isActionAccessible($guid, $connection2, '/modules/School Admin/space_manage_
                 } else {
                     //Write to database
                     try {
-                        $data = array('name' => $name, 'type' => $type, 'capacity' => $capacity, 'computer' => $computer, 'computerStudent' => $computerStudent, 'projector' => $projector, 'tv' => $tv, 'dvd' => $dvd, 'hifi' => $hifi, 'speakers' => $speakers, 'iwb' => $iwb, 'phoneInternal' => $phoneInternal, 'phoneExternal' => $phoneExternal, 'comment' => $comment, 'gibbonSpaceID' => $gibbonSpaceID);
-                        $sql = 'UPDATE gibbonSpace SET name=:name, type=:type, capacity=:capacity, computer=:computer, computerStudent=:computerStudent, projector=:projector, tv=:tv, dvd=:dvd , hifi=:hifi, speakers=:speakers, iwb=:iwb, phoneInternal=:phoneInternal, phoneExternal=:phoneExternal, comment=:comment WHERE gibbonSpaceID=:gibbonSpaceID';
+                        $data = array('name' => $name, 'type' => $type, 'active' => $active, 'capacity' => $capacity, 'computer' => $computer, 'computerStudent' => $computerStudent, 'projector' => $projector, 'tv' => $tv, 'dvd' => $dvd, 'hifi' => $hifi, 'speakers' => $speakers, 'iwb' => $iwb, 'phoneInternal' => $phoneInternal, 'phoneExternal' => $phoneExternal, 'comment' => $comment, 'gibbonSpaceID' => $gibbonSpaceID);
+                        $sql = 'UPDATE gibbonSpace SET name=:name, type=:type, active=:active, capacity=:capacity, computer=:computer, computerStudent=:computerStudent, projector=:projector, tv=:tv, dvd=:dvd , hifi=:hifi, speakers=:speakers, iwb=:iwb, phoneInternal=:phoneInternal, phoneExternal=:phoneExternal, comment=:comment WHERE gibbonSpaceID=:gibbonSpaceID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {

--- a/modules/Timetable/report_viewAvailableSpaces.php
+++ b/modules/Timetable/report_viewAvailableSpaces.php
@@ -361,7 +361,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
                                         $vacancies = '';
                                         if ($rowPeriods['type'] != 'Break') {
                                             
-                                            $sqlSelect = 'SELECT * FROM gibbonSpace ORDER BY name';
+                                            $sqlSelect = 'SELECT * FROM gibbonSpace WHERE active="Y" ORDER BY name';
                                             $resultSelect = $pdo->select($sqlSelect);
 
                                             $removers = [];

--- a/modules/Timetable/spaceBooking_manage_add.php
+++ b/modules/Timetable/spaceBooking_manage_add.php
@@ -70,7 +70,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/spaceBooking_man
             $timeEnd = isset($_GET['timeEnd'])? $_GET['timeEnd'] : '';
 
             // Collect facilities
-            $sql = "SELECT CONCAT('gibbonSpaceID-', gibbonSpaceID) as value, name FROM gibbonSpace ORDER BY name";
+            $sql = "SELECT CONCAT('gibbonSpaceID-', gibbonSpaceID) as value, name FROM gibbonSpace WHERE active='Y' ORDER BY name";
             $results = $pdo->executeQuery(array(), $sql);
             if ($results->rowCOunt() > 0) {
                 $facilities['--'.__('Facilities').'--'] = $results->fetchAll(\PDO::FETCH_KEY_PAIR);

--- a/modules/Timetable/tt_space.php
+++ b/modules/Timetable/tt_space.php
@@ -47,6 +47,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space.php') =
         // CRITERIA
         $criteria = $facilityGateway->newQueryCriteria(true)
             ->searchBy($facilityGateway->getSearchableColumns(), $search)
+            ->filterBy('active', 'Y')
             ->sortBy('name')
             ->fromPOST();
 

--- a/src/Domain/School/FacilityGateway.php
+++ b/src/Domain/School/FacilityGateway.php
@@ -50,6 +50,13 @@ class FacilityGateway extends QueryableGateway
             ->cols([
                 'gibbonSpaceID', 'name', 'type', 'active', 'capacity', 'computer', 'computerStudent', 'projector', 'tv', 'dvd', 'hifi', 'speakers', 'iwb', 'phoneInternal', 'phoneExternal'
             ]);
+        $criteria->addFilterRules([
+            'active' => function ($query, $active) {
+                return $query
+                    ->where('gibbonSpace.active = :active')
+                    ->bindValue('active', $active);
+            },
+        ]);
 
         return $this->runQuery($query, $criteria);
     }

--- a/src/Domain/School/FacilityGateway.php
+++ b/src/Domain/School/FacilityGateway.php
@@ -48,7 +48,7 @@ class FacilityGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonSpaceID', 'name', 'type', 'capacity', 'computer', 'computerStudent', 'projector', 'tv', 'dvd', 'hifi', 'speakers', 'iwb', 'phoneInternal', 'phoneExternal'
+                'gibbonSpaceID', 'name', 'type', 'active', 'capacity', 'computer', 'computerStudent', 'projector', 'tv', 'dvd', 'hifi', 'speakers', 'iwb', 'phoneInternal', 'phoneExternal'
             ]);
 
         return $this->runQuery($query, $criteria);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
Added 'active' column to gibbonSpace table and changed pages to only show active facilities. This involved changing the FacilityGateway, FastFinder, Manage Facilities (including add and edit pages), Manage Space Booking, and Facilities TimeTable pages.

Important to note the the CHANGEDB file has been updated too to add the 'active' field to the gibbonSpace table.

**Motivation and Context**
As new classes get developed and exist in the school, or as old ones close down, it's important to be able to declare them as active or inactive such that no one mistakenly uses the inactive rooms before they are ready.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
In all of these cases, the room: "B001" has had its 'active' field set to 'N' (inactive). Leaving "B001A" as the next in the list.
<img width="399" alt="Screenshot 2024-01-15 at 10 43 11" src="https://github.com/GibbonEdu/core/assets/74660787/a71780c9-8292-42bc-9db2-e6cd15c433fd">
<img width="1031" alt="Screenshot 2024-01-15 at 10 43 36" src="https://github.com/GibbonEdu/core/assets/74660787/874b6fb3-eb18-41dc-8234-dda17ea8994a">
<img width="1036" alt="Screenshot 2024-01-15 at 10 43 53" src="https://github.com/GibbonEdu/core/assets/74660787/ad739741-6cfd-41ee-8b43-107b4f64c992">
<img width="1040" alt="Screenshot 2024-01-15 at 10 44 04" src="https://github.com/GibbonEdu/core/assets/74660787/bf4e2e51-1a4d-4b7c-9b65-f70e731f640b">
<img width="795" alt="Screenshot 2024-01-15 at 10 44 26" src="https://github.com/GibbonEdu/core/assets/74660787/61b1c7e7-e320-4c55-b7fb-3d1ad873dcfc">

