### PR TITLE
Bug Fix: Fixed view all option in Students > Students by Form Group

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ v27.0.00
 
     Bug Fixes
         System: fixed PHP 8+ compatibility in CustomFieldIDs migration file
+        Students: fixed view all option in report_students_byFormGroup 
 
 v26.0.00
 --------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,7 +41,7 @@ v27.0.00
 
     Bug Fixes
         System: fixed PHP 8+ compatibility in CustomFieldIDs migration file
-        Students: fixed view all option in report_students_byFormGroup 
+        Students: fixed view all option in Students > Students by Form Group. 
 
 v26.0.00
 --------

--- a/modules/Students/report_students_byFormGroup.php
+++ b/modules/Students/report_students_byFormGroup.php
@@ -64,9 +64,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/report_students_b
 
         echo $form->getOutput();
     }
-
+    
     // Cancel out early if there's no form group selected
-    if (empty($gibbonFormGroupID)) return;
+    if (!isset($gibbonFormGroupID)) return;
 
     $formGroupGateway = $container->get(FormGroupGateway::class);
     $studentGateway = $container->get(StudentGateway::class);


### PR DESCRIPTION
**Description**
Fixed view all option in report_students_byFormGroup.php:
The solution involved switching the usage of the `empty()` method to `!isset()` in a line of the form validation to allow for the '*' to still get picked up post-sanitisation.

**Motivation and Context**
The bug involved involved selecting the 'All' option in the topmost dropdown in Students, Students by Form Group. After selecting it and clicking 'Go', the data table does not get displayed.

**How Has This Been Tested?**
Tested Locally

