### PR TITLE
Updated Format file to remove in-baked styling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ v27.0.00
         School Admin: added the ability to toggle facilities between active and inactive, removing inactive facilities from general use
         Students: add an Upcoming Students option to the Students by House report
         Timetable: added basic information table to the View Timetable by Facility report
+        System: Updated Format file to remove in-baked styling
 
     Bug Fixes
         System: fixed PHP 8+ compatibility in CustomFieldIDs migration file

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -817,9 +817,8 @@ class Format
      * @param string $class
      * @return string
      */
-    public static function photo($path, $size = 75, $class = '')
+    public static function photo($path, $size = 75, $class = 'inline-block shadow bg-white border border-gray-600')
     {
-        $class .= ' inline-block shadow bg-white border border-gray-600 ';
         switch ($size) {
             case 240:
             case 'lg':


### PR DESCRIPTION
**Description**
Updated Format file to remove in-baked styling of Format::photo uses. The styling will now only be used as a default param.

**Motivation and Context**
This change allows for more modular usage of the Format::photo method stylistically.

**How Has This Been Tested?**
Tested Locally