### PR TITLE
Added Status Filter to Coverage and Absence Summary Forms

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ v27.0.00
         Students: add an Upcoming Students option to the Students by House report
         Timetable: added basic information table to the View Timetable by Facility report
         System: Updated Format file to remove in-baked styling
+        Staff: Added status filter to Staff Absence and Coverage Summaries to display only 'Full' status staff by default
 
     Bug Fixes
         System: fixed PHP 8+ compatibility in CustomFieldIDs migration file

--- a/modules/Staff/report_absences_summary.php
+++ b/modules/Staff/report_absences_summary.php
@@ -44,7 +44,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
     $staffAbsenceTypeGateway = $container->get(StaffAbsenceTypeGateway::class);
 
     // ABSENCE DATA
+    $status = $_GET['status'] ?? 'Full';
+    echo $status;
     $criteria = $staffAbsenceGateway->newQueryCriteria()
+        ->filterBy('status', $status == 'Full' ? $status : '')
         ->filterBy('type', $gibbonStaffAbsenceTypeID)
         ->fromPOST();
 
@@ -102,6 +105,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
         $row = $form->addRow();
             $row->addLabel('month', __('Month'));
             $row->addSelect('month')->fromArray(['' => __('All')])->fromArray($months)->selected($month);
+        
+        $row = $form->addRow();
+            $row->addLabel('Status', __('All Staff'))->description(__('Include all staff, regardless of status and current employment.'));
+            $row->addCheckbox('status')->setValue('on')->checked($status);
 
         $row = $form->addRow();
         $row->addFooter();
@@ -202,6 +209,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
     // DATA TABLE
     $staffGateway = $container->get(StaffGateway::class);
     $criteria = $staffGateway->newQueryCriteria()
+        ->filterBy('all', $status == 'on' ? $status : '')
         ->sortBy(['surname', 'preferredName'])
         ->fromPOST();
 

--- a/modules/Staff/report_absences_summary.php
+++ b/modules/Staff/report_absences_summary.php
@@ -45,10 +45,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
 
     // ABSENCE DATA
     $status = $_GET['status'] ?? 'Full';
-    echo $status;
     $criteria = $staffAbsenceGateway->newQueryCriteria()
-        ->filterBy('status', $status == 'Full' ? $status : '')
         ->filterBy('type', $gibbonStaffAbsenceTypeID)
+        ->filterBy('all', $status == 'on')
         ->fromPOST();
 
     $schoolYear = $schoolYearGateway->getSchoolYearByID($gibbonSchoolYearID);
@@ -209,7 +208,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
     // DATA TABLE
     $staffGateway = $container->get(StaffGateway::class);
     $criteria = $staffGateway->newQueryCriteria()
-        ->filterBy('all', $status == 'on' ? $status : '')
+        ->filterBy('all', $status == 'on')
         ->sortBy(['surname', 'preferredName'])
         ->fromPOST();
 

--- a/modules/Staff/report_absences_summary.php
+++ b/modules/Staff/report_absences_summary.php
@@ -269,6 +269,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
             ->width('10%');
     }
 
+    $table->modifyRows(function ($values, $row) {
+        if ($values['status'] == 'Left') $row->addClass('error');
+        return $row;
+    });
+
     $table->addColumn('total', __('Total'))->notSortable();
 
 

--- a/modules/Staff/report_coverage_summary.php
+++ b/modules/Staff/report_coverage_summary.php
@@ -75,8 +75,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
     }
     
     // Get all substitutes
+    $status = $_GET['status'] ?? 'Full';
     $criteria = $substituteGateway->newQueryCriteria()
         ->filterBy('allStaff', $internalCoverage == 'Y')
+        ->filterBy('status', $status == 'Full' ? $status : '')
         ->sortBy(['active', 'surname', 'preferredName'])
         ->fromPOST();
 
@@ -106,6 +108,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
         $row = $form->addRow();
             $row->addLabel('month', __('Month'));
             $row->addSelect('month')->fromArray(['' => __('All')])->fromArray($months)->selected($month);
+
+        $row = $form->addRow();
+                $row->addLabel('Status', __('All Staff'))->description(__('Include all staff, regardless of status and current employment.'));
+                $row->addCheckbox('status')->setValue('Left')->checked($status);
 
         $row = $form->addRow();
             $row->addSearchSubmit($session);

--- a/modules/Staff/report_coverage_summary.php
+++ b/modules/Staff/report_coverage_summary.php
@@ -111,7 +111,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
 
         $row = $form->addRow();
                 $row->addLabel('Status', __('All Staff'))->description(__('Include all staff, regardless of status and current employment.'));
-                $row->addCheckbox('status')->setValue('Left')->checked($status);
+                $row->addCheckbox('status')->setValue('on')->checked($status);
 
         $row = $form->addRow();
             $row->addSearchSubmit($session);

--- a/src/Domain/Staff/StaffAbsenceGateway.php
+++ b/src/Domain/Staff/StaffAbsenceGateway.php
@@ -173,7 +173,6 @@ class StaffAbsenceGateway extends QueryableGateway implements ScrubbableGateway
             ->leftJoin('gibbonPerson AS coverage', 'gibbonStaffCoverage.gibbonPersonIDCoverage=coverage.gibbonPersonID')
             ->where('gibbonStaffAbsenceDate.date BETWEEN :dateStart AND :dateEnd')
             ->where("gibbonStaffAbsence.status = 'Approved'")
-            //->where("gibbonPerson.status = 'Full'")
             ->bindValue('dateStart', $dateStart)
             ->bindValue('dateEnd', $dateEnd)
             ->groupBy(['gibbonStaffAbsence.gibbonStaffAbsenceID', 'gibbonStaffCoverageDate.gibbonStaffCoverageDateID']);

--- a/src/Domain/Staff/StaffAbsenceGateway.php
+++ b/src/Domain/Staff/StaffAbsenceGateway.php
@@ -173,7 +173,7 @@ class StaffAbsenceGateway extends QueryableGateway implements ScrubbableGateway
             ->leftJoin('gibbonPerson AS coverage', 'gibbonStaffCoverage.gibbonPersonIDCoverage=coverage.gibbonPersonID')
             ->where('gibbonStaffAbsenceDate.date BETWEEN :dateStart AND :dateEnd')
             ->where("gibbonStaffAbsence.status = 'Approved'")
-            ->where("gibbonPerson.status = 'Full'")
+            //->where("gibbonPerson.status = 'Full'")
             ->bindValue('dateStart', $dateStart)
             ->bindValue('dateEnd', $dateEnd)
             ->groupBy(['gibbonStaffAbsence.gibbonStaffAbsenceID', 'gibbonStaffCoverageDate.gibbonStaffCoverageDateID']);
@@ -184,6 +184,10 @@ class StaffAbsenceGateway extends QueryableGateway implements ScrubbableGateway
         } else {
             $query->cols(['1 as days', 'gibbonStaffAbsenceDate.date as dateStart', 'gibbonStaffAbsenceDate.date as dateEnd', 'gibbonStaffAbsenceDate.value as value'])
                 ->groupBy(['gibbonStaffAbsenceDate.gibbonStaffAbsenceDateID']);
+        }
+
+        if (!$criteria->hasFilter('all')) {
+            $query->where('gibbonPerson.status = "Full"');
         }
 
         $criteria->addFilterRules($this->getSharedFilterRules());


### PR DESCRIPTION
**Description**
Added status filter to Staff Absence and Coverage Summaries to display only 'Full' status staff by default. This was done by implementing a `$status` variable that get's changed by a checkbox form input. The filter then gets applied by the value the checkbox sets the `$status` variable to.

**Motivation and Context**
This fix was required to de-clutter the default viewing experience for the tables in each summary page.

**How Has This Been Tested?**
Tested Locally

**Screenshots**
<img width="1045" alt="Screenshot 2024-01-24 at 10 48 12" src="https://github.com/GibbonEdu/core/assets/74660787/c5637e33-070e-4db5-bb5e-d1be67e2858c">
<img width="1039" alt="Screenshot 2024-01-24 at 10 48 22" src="https://github.com/GibbonEdu/core/assets/74660787/f561d5b4-9dd0-46d0-a2b4-e79f2676983a">
<img width="1155" alt="Screenshot 2024-01-24 at 12 57 15" src="https://github.com/GibbonEdu/core/assets/74660787/6fd1d018-d26e-4a9d-a746-c18814e8009b">
<img width="1174" alt="Screenshot 2024-01-24 at 12 57 27" src="https://github.com/GibbonEdu/core/assets/74660787/3cd4138f-ec6d-4be5-b89d-b6f0f5419d26">
