### PR TITLE
GitHub Actions: CI to check PHP Notice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,21 @@ jobs:
           fi
         continue-on-error: ${{ matrix.experimental }}
 
+      - name: Check PHP notice in server_log
+        run: |
+          # Check number of notice.
+          export NUM_NOTICE=$(grep --perl-regexp 'Notice: ' ./tests/_logs/server_log | wc -l)
+          if [ "$NUM_NOTICE" -eq 0 ]; then
+            echo -e '\e[32mNo Notice.\e[0m'
+            echo
+          else
+            echo -e "\e[1m\e[33mGot $NUM_NOTICE notice(s):\e[0m"
+            grep --line-number --color=always --perl-regexp 'Notice: ' ./tests/_logs/server_log
+            echo
+            (exit 1)
+          fi
+        continue-on-error: true
+
       - name: Export Database if Test Failed
         if: ${{ failure() }}
         run: |


### PR DESCRIPTION
**Description**
* CI to check and output all php "Notice" in server_log generated in test. More hint to improve code with.
* Allow the step to fail at the moment. Only provide verbose hint but not enforcing developer to clear all notices.

**Motivation and Context**
Sometimes changes in code would generate notice that are expose incorrect assumption and hence potential problem, for example:

![圖片](https://github.com/GibbonEdu/core/assets/91274/6811590f-2fa2-495d-b78c-3f5cb427fb0a)

(from: https://github.com/GibbonEdu/core/actions/runs/7955085821)

Extracting and showing verbose log about it can provide vital hints for code improvements.

**How Has This Been Tested?**

Tested the base script locally against the log with notice:
![圖片](https://github.com/GibbonEdu/core/assets/91274/1b7c443d-443f-4eee-87f8-2b4f894dec08)

