### PR TITLE
GitHub Actions: CI always check server logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         run: composer test:phpstan
 
       - name: Check PHP warning and deprecated messages in server_log
+        if: success() || failure()
         run: |
           # Check number of uncaught exceptions.
           export NUM_EXCEPTION=$(grep --perl-regexp 'Uncaught Exception: ' ./tests/_logs/server_log | wc -l)
@@ -138,6 +139,7 @@ jobs:
         continue-on-error: ${{ matrix.experimental }}
 
       - name: Check PHP notice in server_log
+        if: success() || failure()
         run: |
           # Check number of notice.
           export NUM_NOTICE=$(grep --perl-regexp 'Notice: ' ./tests/_logs/server_log | wc -l)


### PR DESCRIPTION
**Description**
* Always run log checks, even if previous step has failed. Provide better information for debugging and code review.
* Do not run when the job is canceled.

**Motivation and Context**
* Provides log analysis even when the test has failed.
* Improve errors visibility to developer on test failure.

**How Has This Been Tested?**
On local branch:
https://github.com/yookoala/GibbonEduCore/actions/runs/7955748397/job/21715239643

![圖片](https://github.com/GibbonEdu/core/assets/91274/72cca17d-a353-440b-a791-ad3f6930b77a)