### PR TITLE
GitHub Actions: update workflow actions for node20 transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           ini-values: date.timezone="Etc/UTC", xdebug.max_nesting_level=-1, opcache.jit="off"
 
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: "recursive"
           fetch-depth: 0
@@ -63,7 +63,7 @@ jobs:
             >/dev/null 2>./tests/_logs/server_log &
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/composer-cache
           key: ${{ runner.os }}-php${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
**Description**

* Update workflow actions used to transit to node20.

**Motivation and Context**
* See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

**How Has This Been Tested?**
On GitHub:

Before:
![圖片](https://github.com/GibbonEdu/core/assets/91274/a2d414fb-0270-4c0a-82d6-a823e2d6c352)
(https://github.com/GibbonEdu/core/actions/runs/7956226859)

After:
![圖片](https://github.com/GibbonEdu/core/assets/91274/e2021b8d-d6a9-4655-9bb4-7601ee4451b6)
(https://github.com/yookoala/GibbonEduCore/actions/runs/7956286647)