### PR TITLE
Added departments as one of the searchable options with the fast finder

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,7 @@ v27.0.00
         User Admin: added an option to disable the display of privacy options, so they can be managed internally
         User Admin: increased the field length for Departure Reason to 100 characters
         System Admin: added an importer for Behaviour Records
+        System: added departments as one of the searchable options with the fast finder
 
     Bug Fixes
         System: fixed PHP 8+ compatibility in CustomFieldIDs migration file

--- a/indexFindRedirect.php
+++ b/indexFindRedirect.php
@@ -19,6 +19,8 @@ if ($session->has('absoluteURL')) {
         $URL = Url::fromModuleRoute('Departments', 'department_course_class')->withQueryParam('gibbonCourseClassID', $id);
     } elseif ($type == 'Fac') {
         $URL = Url::fromModuleRoute('Timetable', 'tt_space_view')->withQueryParam('gibbonSpaceID', $id);
+    } elseif ($type == 'Dep') {
+        $URL = Url::fromModuleRoute('Departments', 'department')->withQueryParam('gibbonDepartmentID', $id);
     }
 }
 

--- a/index_fastFinder_ajax.php
+++ b/index_fastFinder_ajax.php
@@ -43,6 +43,7 @@ if (!isset($_SESSION[$guid]) or !$session->exists('gibbonPersonID')) {
     $studentIsAccessible = isActionAccessible($guid, $connection2, '/modules/students/student_view.php');
     $highestActionStudent = getHighestGroupedAction($guid, '/modules/students/student_view.php', $connection2);
 
+    $departmentIsAccessible = isActionAccessible($guid, $connection2, '/modules/Departments/department.php');
     $facilityIsAccessible = isActionAccessible($guid, $connection2, '/modules/Timetable/tt_space_view.php');
     $staffIsAccessible = isActionAccessible($guid, $connection2, '/modules/Staff/staff_view.php');
     $classIsAccessible = false;
@@ -151,6 +152,23 @@ if (!isset($_SESSION[$guid]) or !$session->exists('gibbonPersonID')) {
         } catch (PDOException $e) { die($resultError); }
 
         if ($resultList->rowCount() > 0) $resultSet['Facility'] = $resultList->fetchAll();
+    }
+
+    // DEPARTMENT
+    if ($departmentIsAccessible == true) {
+        try {
+            $data = array('search' => '%'.$searchTerm.'%');
+            $sql = "SELECT gibbonDepartment.gibbonDepartmentID AS id,
+                    gibbonDepartment.name AS name,
+                    gibbonDepartment.type as type
+                    FROM gibbonDepartment
+                    WHERE gibbonDepartment.name LIKE :search 
+                    ORDER BY name";
+            $resultList = $connection2->prepare($sql);
+            $resultList->execute($data);
+        } catch (PDOException $e) { die($resultError); }
+
+        if ($resultList->rowCount() > 0) $resultSet['Department'] = $resultList->fetchAll();
     }
 
     // STUDENTS


### PR DESCRIPTION
**Description**
Added departments as one of the searchable options with the fast finder by editing the index_fastFinder_ajax.php and indexFindRedirect.php files to be able to navigate to specific department pages from the fast finder.

**Motivation and Context**
For streamlining navigation to specific departments from the home page.

**How Has This Been Tested?**
Tested Locally.

**Screenshots**
<img width="458" alt="Screenshot 2024-02-22 at 15 24 04" src="https://github.com/GibbonEdu/core/assets/74660787/f2b595d3-a5f4-415e-91ab-dbefeb12a271">

