### PR TITLE
Adding comment log to behaviour incidents

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -800,6 +800,7 @@ INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001',
 CREATE TABLE `gibbonLibraryShelfItem` ( `gibbonLibraryShelfItemID` INT(6) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT , `gibbonLibraryItemID` INT(10) UNSIGNED ZEROFILL NOT NULL, `gibbonLibraryShelfID` INT(6) UNSIGNED ZEROFILL NOT NULL, PRIMARY KEY (`gibbonLibraryShelfItemID`)) ENGINE = InnoDB CHARSET=utf8;end
 ALTER TABLE `gibbonLibraryShelf` ADD `shuffle` ENUM('N','Y') NOT NULL DEFAULT 'N' AFTER `active`;end
 CREATE INDEX `gibbonMessengerID` ON gibbonMessengerTarget(`gibbonMessengerID`,`gibbonMessengerTargetID`);end
-";
 ALTER TABLE `gibbonBehaviour` ADD `gibbonMultiIncidentID` varchar(64) DEFAULT NULL;end
+CREATE TABLE `gibbonBehaviourFollowUp` ( `gibbonBehaviourFollowUpID` int(11) unsigned zerofill NOT NULL AUTO_INCREMENT,
+ `gibbonBehaviourID` int(10) unsigned zerofill NOT NULL, `gibbonPersonID` int(10) unsigned zerofill NOT NULL, `followUp` text, `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonBehaviourFollowUpID`), KEY `gibbonBehaviourID` (`gibbonBehaviourID`));end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -803,5 +803,4 @@ CREATE INDEX `gibbonMessengerID` ON gibbonMessengerTarget(`gibbonMessengerID`,`g
 ALTER TABLE `gibbonBehaviour` ADD `gibbonMultiIncidentID` varchar(64) DEFAULT NULL;end
 CREATE TABLE `gibbonBehaviourFollowUp` ( `gibbonBehaviourFollowUpID` INT(11) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT,
  `gibbonBehaviourID` INT(12) UNSIGNED ZEROFILL NOT NULL, `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL, `followUp` TEXT, `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonBehaviourFollowUpID`), KEY `gibbonBehaviourID` (`gibbonBehaviourID`));end
-ALTER TABLE `gibbonBehaviour` DROP COLUMN `followup`;end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -803,4 +803,5 @@ CREATE INDEX `gibbonMessengerID` ON gibbonMessengerTarget(`gibbonMessengerID`,`g
 ALTER TABLE `gibbonBehaviour` ADD `gibbonMultiIncidentID` varchar(64) DEFAULT NULL;end
 CREATE TABLE `gibbonBehaviourFollowUp` ( `gibbonBehaviourFollowUpID` INT(11) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT,
  `gibbonBehaviourID` INT(12) UNSIGNED ZEROFILL NOT NULL, `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL, `followUp` TEXT, `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonBehaviourFollowUpID`), KEY `gibbonBehaviourID` (`gibbonBehaviourID`));end
+ALTER TABLE `gibbonBehaviour` DROP COLUMN `followup`;end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -801,6 +801,6 @@ CREATE TABLE `gibbonLibraryShelfItem` ( `gibbonLibraryShelfItemID` INT(6) UNSIGN
 ALTER TABLE `gibbonLibraryShelf` ADD `shuffle` ENUM('N','Y') NOT NULL DEFAULT 'N' AFTER `active`;end
 CREATE INDEX `gibbonMessengerID` ON gibbonMessengerTarget(`gibbonMessengerID`,`gibbonMessengerTargetID`);end
 ALTER TABLE `gibbonBehaviour` ADD `gibbonMultiIncidentID` varchar(64) DEFAULT NULL;end
-CREATE TABLE `gibbonBehaviourFollowUp` ( `gibbonBehaviourFollowUpID` int(11) unsigned zerofill NOT NULL AUTO_INCREMENT,
- `gibbonBehaviourID` int(10) unsigned zerofill NOT NULL, `gibbonPersonID` int(10) unsigned zerofill NOT NULL, `followUp` text, `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonBehaviourFollowUpID`), KEY `gibbonBehaviourID` (`gibbonBehaviourID`));end
+CREATE TABLE `gibbonBehaviourFollowUp` ( `gibbonBehaviourFollowUpID` INT(11) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT,
+ `gibbonBehaviourID` INT(10) UNSIGNED ZEROFILL NOT NULL, `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL, `followUp` TEXT, `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonBehaviourFollowUpID`), KEY `gibbonBehaviourID` (`gibbonBehaviourID`));end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -802,5 +802,5 @@ ALTER TABLE `gibbonLibraryShelf` ADD `shuffle` ENUM('N','Y') NOT NULL DEFAULT 'N
 CREATE INDEX `gibbonMessengerID` ON gibbonMessengerTarget(`gibbonMessengerID`,`gibbonMessengerTargetID`);end
 ALTER TABLE `gibbonBehaviour` ADD `gibbonMultiIncidentID` varchar(64) DEFAULT NULL;end
 CREATE TABLE `gibbonBehaviourFollowUp` ( `gibbonBehaviourFollowUpID` INT(11) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT,
- `gibbonBehaviourID` INT(10) UNSIGNED ZEROFILL NOT NULL, `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL, `followUp` TEXT, `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonBehaviourFollowUpID`), KEY `gibbonBehaviourID` (`gibbonBehaviourID`));end
+ `gibbonBehaviourID` INT(12) UNSIGNED ZEROFILL NOT NULL, `gibbonPersonID` INT(10) UNSIGNED ZEROFILL NOT NULL, `followUp` TEXT, `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`gibbonBehaviourFollowUpID`), KEY `gibbonBehaviourID` (`gibbonBehaviourID`));end
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -800,5 +800,6 @@ INSERT INTO `gibbonPermission` (`gibbonRoleID` ,`gibbonActionID`) VALUES ('001',
 CREATE TABLE `gibbonLibraryShelfItem` ( `gibbonLibraryShelfItemID` INT(6) UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT , `gibbonLibraryItemID` INT(10) UNSIGNED ZEROFILL NOT NULL, `gibbonLibraryShelfID` INT(6) UNSIGNED ZEROFILL NOT NULL, PRIMARY KEY (`gibbonLibraryShelfItemID`)) ENGINE = InnoDB CHARSET=utf8;end
 ALTER TABLE `gibbonLibraryShelf` ADD `shuffle` ENUM('N','Y') NOT NULL DEFAULT 'N' AFTER `active`;end
 CREATE INDEX `gibbonMessengerID` ON gibbonMessengerTarget(`gibbonMessengerID`,`gibbonMessengerTargetID`);end
+";
 ALTER TABLE `gibbonBehaviour` ADD `gibbonMultiIncidentID` varchar(64) DEFAULT NULL;end
 ";

--- a/modules/Behaviour/behaviour_manage.php
+++ b/modules/Behaviour/behaviour_manage.php
@@ -132,6 +132,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 ->prepend('&nbsp|&nbsp');
         }
 
+        // $dataSet = $BehaviourGateway->queryAllUsers();
+        // $gibbonBehaviourIDs = $dataSet->getColumn('gibbonBehaviourID');
+        // $folowUpData = $BehaviourFollowUpGateway->selectFollowUpDetailsByBehaviourID($gibbonBehaviorIDs)->fetchGrouped();
+        
         $table->addExpandableColumn('comment')
             ->format(function($beahviour) {
                 $output = '';

--- a/modules/Behaviour/behaviour_manage_add.php
+++ b/modules/Behaviour/behaviour_manage_add.php
@@ -154,7 +154,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             $row = $form->addRow();
             	$column = $row->addColumn();
             	$column->addLabel('followup', __('Follow Up'));
-            	$column->addTextArea('followup')->setRows(5)->setClass('fullWidth');
+            	$column->addTextArea('followUp')->setRows(5)->setClass('fullWidth');
 
             // CUSTOM FIELDS
             $container->get(CustomFieldHandler::class)->addCustomFieldsToForm($form, 'Behaviour', []);

--- a/modules/Behaviour/behaviour_manage_addMulti.php
+++ b/modules/Behaviour/behaviour_manage_addMulti.php
@@ -152,7 +152,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
     $row = $form->addRow();
         $col = $row->addColumn();
         $col->addLabel('followup', __('Follow Up'));
-        $col->addTextArea('followup')
+        $col->addTextArea('followUp')
             ->setRows(5)
             ->setClass('fullWidth');
 

--- a/modules/Behaviour/behaviour_manage_addMultiProcess.php
+++ b/modules/Behaviour/behaviour_manage_addMultiProcess.php
@@ -19,16 +19,17 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Data\Validator;
 use Gibbon\Services\Format;
 use Gibbon\Comms\NotificationEvent;
 use Gibbon\Comms\NotificationSender;
 use Gibbon\Forms\CustomFieldHandler;
+use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Domain\IndividualNeeds\INGateway;
 use Gibbon\Domain\System\NotificationGateway;
 use Gibbon\Domain\Students\StudentNoteGateway;
+use Gibbon\Domain\Behaviour\BehaviourFollowUpGateway;
 use Gibbon\Domain\IndividualNeeds\INAssistantGateway;
-use Gibbon\Data\Validator;
-use Gibbon\Domain\IndividualNeeds\INGateway;
 
 require_once '../../gibbon.php';
 
@@ -61,7 +62,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
     $descriptor = $_POST['descriptor'] ?? null;
     $level = $_POST['level'] ?? null;
     $comment = $_POST['comment'] ?? '';
-    $followup = $_POST['followup'] ?? '';
+    $followUp = $_POST['followUp'] ?? '';
     $copyToNotes = $_POST['copyToNotes'] ?? null;
 
     $customRequireFail = false;
@@ -80,8 +81,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
         foreach ($gibbonPersonIDMulti as $gibbonPersonID) {
             //Write to database
             try {
-                $data = array('gibbonPersonID' => $gibbonPersonID, 'date' => Format::dateConvert($date),'gibbonMultiIncidentID' => $gibbonMultiIncidentID, 'type' => $type, 'descriptor' => $descriptor, 'level' => $level, 'comment' => $comment, 'followup' => $followup, 'fields' => $fields, 'gibbonPersonIDCreator' => $session->get('gibbonPersonID'), 'gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
-                $sql = 'INSERT INTO gibbonBehaviour SET gibbonPersonID=:gibbonPersonID, date=:date, type=:type, gibbonMultiIncidentID=:gibbonMultiIncidentID, descriptor=:descriptor, level=:level, comment=:comment, followup=:followup, fields=:fields, gibbonPersonIDCreator=:gibbonPersonIDCreator, gibbonSchoolYearID=:gibbonSchoolYearID';
+                $data = array('gibbonPersonID' => $gibbonPersonID, 'date' => Format::dateConvert($date),'gibbonMultiIncidentID' => $gibbonMultiIncidentID, 'type' => $type, 'descriptor' => $descriptor, 'level' => $level, 'comment' => $comment, 'fields' => $fields, 'gibbonPersonIDCreator' => $session->get('gibbonPersonID'), 'gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
+                $sql = 'INSERT INTO gibbonBehaviour SET gibbonPersonID=:gibbonPersonID, date=:date, type=:type, gibbonMultiIncidentID=:gibbonMultiIncidentID, descriptor=:descriptor, level=:level, comment=:comment, fields=:fields, gibbonPersonIDCreator=:gibbonPersonIDCreator, gibbonSchoolYearID=:gibbonSchoolYearID';
                 $result = $connection2->prepare($sql);
                 $result->execute($data);
             } catch (PDOException $e) {
@@ -89,6 +90,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             }
 
             $gibbonBehaviourID = $connection2->lastInsertID();
+
+            // Add a follow up log
+            if (!empty($followUp)) {
+                $behaviourFollowUpGateway = $container->get(BehaviourFollowUpGateway::class);
+                $data = [
+                            'gibbonBehaviourID' => $gibbonBehaviourID,
+                            'gibbonPersonID' => $session->get('gibbonPersonID'),
+                            'followUp' => $followUp,
+                        ];
+
+                $inserted = $behaviourFollowUpGateway->insert($data);
+
+                if (!$inserted) {
+                    $URL .= '&return=error2';
+                    header("Location: {$URL}");
+                    exit;
+                }
+            } 
 
             // Attempt to notify tutor(s) and EA(s) of negative behaviour
             if ($type == 'Negative') {

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -19,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\Behaviour\BehaviourFollowupGateway;
 use Gibbon\Http\Url;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
@@ -182,7 +183,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
 
                 //Print new-style follow-up as log
                 $behaviourGateway = $container->get(BehaviourGateway::class);
-                $logs = $behaviourGateway->queryFollowUpByBehaviourID($gibbonBehaviourID)->fetchAll();
+                $behaviourFollowUpGateway = $container->get(BehaviourFollowupGateway::class);
+                $logs = $behaviourFollowUpGateway->selectFollowUpByBehaviourID($gibbonBehaviourID)->fetchAll();
 
                 if (!empty($logs)) {
                     $form->addRow()->addContent($page->fetchFromTemplate('ui/discussion.twig.html', [

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -173,15 +173,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
 
                 $row = $form->addRow()->addHeading('Follow Up', __('Follow Up'));
 
-                //Print old-style followup as first log entry
-                if (!empty($values['followup'])) {
-                    $row = $form->addRow();
-                        $column = $row->addColumn();
-                        $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameCreator'], $values['surnameCreator']), 'date' => Format::dateTimeReadable($values['timestamp'], '%H:%M, %b %d %Y')]));
-                        $column->addContent($values['followup'])->setClass('fullWidth');
-                }
-
-                //Print new-style follow-up as log
+                //Print follow-up as log
                 $behaviourGateway = $container->get(BehaviourGateway::class);
                 $behaviourFollowUpGateway = $container->get(BehaviourFollowupGateway::class);
                 $logs = $behaviourFollowUpGateway->selectFollowUpByBehaviourID($gibbonBehaviourID)->fetchAll();
@@ -197,7 +189,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                     $column = $row->addColumn();
                     $column->addLabel('followUp', (empty($logs) ? __('Follow Up') : __('Further Follow Up')));
                     $column->addTextArea('followUp')->setRows(8)->setClass('fullWidth');
-                
                 
                 //Lesson link
                 $lessons = array();

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -193,7 +193,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 //Allow entry of fresh followup
                 $row = $form->addRow();
                     $column = $row->addColumn();
-                    $column->addLabel('followUp', (empty($logs) ? __('Follow Up') : __('Further Follow Up')) .' / '.__('Notes'))->description(__('If you are the student\'s teacher, please include details such as: the location & lesson, what was the incident, what did you do.'));
+                    $column->addLabel('followUp', (empty($logs) ? __('Follow Up') : __('Further Follow Up')));
                     $column->addTextArea('followUp')->setRows(8)->setClass('fullWidth');
                 
                 

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -19,7 +19,6 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 use Gibbon\Http\Url;
 use Gibbon\Forms\Form;
 use Gibbon\Services\Format;
@@ -73,7 +72,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
             } else {
                 //Let's go!
                 $form = Form::create('addform', $session->get('absoluteURL').'/modules/Behaviour/behaviour_manage_editProcess.php?gibbonBehaviourID='.$gibbonBehaviourID.'&gibbonPersonID='.$_GET['gibbonPersonID'].'&gibbonFormGroupID='.$_GET['gibbonFormGroupID'].'&gibbonYearGroupID='.$_GET['gibbonYearGroupID'].'&type='.$_GET['type']);
-                
                 $form->setFactory(DatabaseFormFactory::create($pdo));
                 
                 $policyLink = $settingGateway->getSettingByScope('Behaviour', 'policyLink');
@@ -99,7 +97,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
 
                 //To show other students involved in the incident
                 if(!empty($values['gibbonMultiIncidentID'])) {
-
                     $students = $behaviourGateway->selectMultipleStudentsOfOneIncident($values['gibbonMultiIncidentID'])->fetchAll();
                 }
             }
@@ -173,12 +170,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                     $column->addLabel('comment', __('Incident'));
                     $column->addTextArea('comment')->setRows(5)->setClass('fullWidth')->setValue($values['comment']);
 
-                //Follow Up
-                // $row = $form->addRow();
-                //     $column = $row->addColumn();
-                //     $column->addLabel('followup', __('Follow Up'));
-                //     $column->addTextArea('followup')->setRows(5)->setClass('fullWidth')->setValue($values['followup']);
-
                 $row = $form->addRow()->addHeading('Follow Up', __('Follow Up'));
 
                 //Print old-style followup as first log entry
@@ -214,7 +205,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                     $sqlSelect = "SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID, gibbonCourseClass.gibbonCourseClassID, gibbonPlannerEntry.name AS lesson, gibbonPlannerEntryID, date, homework, homeworkSubmission FROM gibbonCourse JOIN gibbonCourseClass ON (gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID) JOIN gibbonCourseClassPerson ON (gibbonCourseClass.gibbonCourseClassID=gibbonCourseClassPerson.gibbonCourseClassID) JOIN gibbonPlannerEntry ON (gibbonCourseClass.gibbonCourseClassID=gibbonPlannerEntry.gibbonCourseClassID) WHERE (date<=:date AND date>=:minDate) AND gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClassPerson.gibbonPersonID=:gibbonPersonID AND role='Student' ORDER BY course, class, date, timeStart";
                     $resultSelect = $connection2->prepare($sqlSelect);
                     $resultSelect->execute($dataSelect);
-                while ($rowSelect = $resultSelect->fetch()) {
+                    while ($rowSelect = $resultSelect->fetch()) {
                     $show = true;
                     if ($highestAction == 'Manage Behaviour Records_my') {
 

--- a/modules/Behaviour/behaviour_manage_edit.php
+++ b/modules/Behaviour/behaviour_manage_edit.php
@@ -173,6 +173,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
 
                 $row = $form->addRow()->addHeading('Follow Up', __('Follow Up'));
 
+                //Print old-style followup as first log entry
+                if (!empty($values['followup'])) {
+                    $row = $form->addRow();
+                        $column = $row->addColumn();
+                        $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameCreator'], $values['surnameCreator']), 'date' => Format::dateTimeReadable($values['timestamp'], '%H:%M, %b %d %Y')]));
+                        $column->addContent($values['followup'])->setClass('fullWidth');
+                }
+
                 //Print follow-up as log
                 $behaviourGateway = $container->get(BehaviourGateway::class);
                 $behaviourFollowUpGateway = $container->get(BehaviourFollowupGateway::class);

--- a/modules/Behaviour/behaviour_manage_editProcess.php
+++ b/modules/Behaviour/behaviour_manage_editProcess.php
@@ -102,26 +102,25 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                         header("Location: {$URL}");
                         exit();
                     }
-                    
 
                 // Add a new follow up log, if needed
-                if (!empty($followUp)) {
-                    $behaviourFollowUpGateway = $container->get(BehaviourFollowUpGateway::class);
+                    if (!empty($followUp)) {
+                        $behaviourFollowUpGateway = $container->get(BehaviourFollowUpGateway::class);
 
-                    $data = [
-                        'gibbonBehaviourID' => $gibbonBehaviourID,
-                        'gibbonPersonID' => $session->get('gibbonPersonID'),
-                        'followUp' => $followUp,
-                    ];
+                        $data = [
+                            'gibbonBehaviourID' => $gibbonBehaviourID,
+                            'gibbonPersonID' => $session->get('gibbonPersonID'),
+                            'followUp' => $followUp,
+                        ];
 
-                    $inserted = $behaviourFollowUpGateway->insert($data);
+                        $inserted = $behaviourFollowUpGateway->insert($data);
 
-                    if (!$inserted) {
-                        $URL .= '&return=error2';
-                        header("Location: {$URL}");
-                        exit;
-                    }
-                }
+                        if (!$inserted) {
+                            $URL .= '&return=error2';
+                            header("Location: {$URL}");
+                            exit;
+                        }
+                    }   
 
                     // Send a notification to student's tutors and anyone subscribed to the notification event
                     $studentGateway = $container->get(StudentGateway::class);

--- a/modules/Behaviour/behaviour_manage_editProcess.php
+++ b/modules/Behaviour/behaviour_manage_editProcess.php
@@ -28,6 +28,7 @@ use Gibbon\Domain\Students\StudentGateway;
 use Gibbon\Domain\IndividualNeeds\INGateway;
 use Gibbon\Domain\Behaviour\BehaviourGateway;
 use Gibbon\Domain\FormGroups\FormGroupGateway;
+use Gibbon\Domain\Behaviour\BehaviourFollowUpGateway;
 use Gibbon\Domain\IndividualNeeds\INAssistantGateway;
 
 require_once '../../gibbon.php';
@@ -81,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 $descriptor = $_POST['descriptor'] ?? null;
                 $level = $_POST['level'] ?? null;
                 $comment = $_POST['comment'] ?? '';
-                $followup = $_POST['followup'] ?? '';
+                $followUp = $_POST['followUp'] ?? '';
                 $gibbonPlannerEntryID = !empty($_POST['gibbonPlannerEntryID']) ? $_POST['gibbonPlannerEntryID'] : null;
 
                 $customRequireFail = false;
@@ -92,8 +93,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                     header("Location: {$URL}");
                 } else {
                     try {
-                        $data = array('gibbonPersonID' => $gibbonPersonID, 'date' => Format::dateConvert($date), 'type' => $type, 'descriptor' => $descriptor, 'level' => $level, 'comment' => $comment, 'followup' => $followup, 'fields' => $fields, 'gibbonPlannerEntryID' => $gibbonPlannerEntryID, 'gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonBehaviourID' => $gibbonBehaviourID);
-                        $sql = 'UPDATE gibbonBehaviour SET gibbonPersonID=:gibbonPersonID, date=:date, type=:type, descriptor=:descriptor, level=:level, comment=:comment, followup=:followup, fields=:fields, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonSchoolYearID=:gibbonSchoolYearID WHERE gibbonBehaviourID=:gibbonBehaviourID';
+                        $data = array('gibbonPersonID' => $gibbonPersonID, 'date' => Format::dateConvert($date), 'type' => $type, 'descriptor' => $descriptor, 'level' => $level, 'comment' => $comment, 'fields' => $fields, 'gibbonPlannerEntryID' => $gibbonPlannerEntryID, 'gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonBehaviourID' => $gibbonBehaviourID);
+                        $sql = 'UPDATE gibbonBehaviour SET gibbonPersonID=:gibbonPersonID, date=:date, type=:type, descriptor=:descriptor, level=:level, comment=:comment, fields=:fields, gibbonPlannerEntryID=:gibbonPlannerEntryID, gibbonSchoolYearID=:gibbonSchoolYearID WHERE gibbonBehaviourID=:gibbonBehaviourID';
                         $result = $connection2->prepare($sql);
                         $result->execute($data);
                     } catch (PDOException $e) {
@@ -101,6 +102,26 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                         header("Location: {$URL}");
                         exit();
                     }
+                    
+
+                // Add a new follow up log, if needed
+                if (!empty($followUp)) {
+                    $behaviourFollowUpGateway = $container->get(BehaviourFollowUpGateway::class);
+
+                    $data = [
+                        'gibbonBehaviourID' => $gibbonBehaviourID,
+                        'gibbonPersonID' => $session->get('gibbonPersonID'),
+                        'followUp' => $followUp,
+                    ];
+
+                    $inserted = $behaviourFollowUpGateway->insert($data);
+
+                    if (!$inserted) {
+                        $URL .= '&return=error2';
+                        header("Location: {$URL}");
+                        exit;
+                    }
+                }
 
                     // Send a notification to student's tutors and anyone subscribed to the notification event
                     $studentGateway = $container->get(StudentGateway::class);

--- a/modules/Behaviour/behaviour_manage_editProcess.php
+++ b/modules/Behaviour/behaviour_manage_editProcess.php
@@ -114,7 +114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                         ];
 
                         $inserted = $behaviourFollowUpGateway->insert($data);
-
+                        
                         if (!$inserted) {
                             $URL .= '&return=error2';
                             header("Location: {$URL}");

--- a/src/Domain/Behaviour/BehaviourFollowUpGateway.php
+++ b/src/Domain/Behaviour/BehaviourFollowUpGateway.php
@@ -46,4 +46,23 @@ class BehaviourFollowupGateway extends QueryableGateway implements ScrubbableGat
     private static $scrubbableKey = ['gibbonPersonID', 'gibbonBehaviourFollowUpID', 'gibbonBehaviourID'];
     private static $scrubbableColumns = ['followUp' => ''];
 
+    public function selectFollowUpByBehaviourID($gibbonBehaviourID)
+    {
+        $query = $this
+            ->newSelect()
+            ->from($this->getTableName())
+            ->cols([
+                'gibbonBehaviourFollowUp.*',
+                'gibbonBehaviourFollowUp.followUp as comment',
+                'gibbonPerson.surname',
+                'gibbonPerson.preferredName',
+                'gibbonPerson.image_240'
+            ])
+            ->innerJoin('gibbonBehaviour', 'gibbonBehaviourFollowUp.gibbonBehaviourID=gibbonBehaviour.gibbonBehaviourID')
+            ->innerJoin('gibbonPerson', 'gibbonBehaviourFollowUp.gibbonPersonID=gibbonPerson.gibbonPersonID')
+            ->where('gibbonBehaviourFollowUp.gibbonBehaviourID=:gibbonBehaviourID')
+            ->bindValue('gibbonBehaviourID', $gibbonBehaviourID);
+
+        return $this->runSelect($query);
+    }
 }

--- a/src/Domain/Behaviour/BehaviourFollowUpGateway.php
+++ b/src/Domain/Behaviour/BehaviourFollowUpGateway.php
@@ -1,0 +1,49 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Behaviour;
+
+use Gibbon\Domain\QueryCriteria;
+use Gibbon\Domain\QueryableGateway;
+use Gibbon\Domain\ScrubbableGateway;
+use Gibbon\Domain\Traits\Scrubbable;
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\Traits\ScrubByPerson;
+
+/**
+ * @version v27
+ * @since   v27
+ */
+class BehaviourFollowupGateway extends QueryableGateway implements ScrubbableGateway
+{
+    use TableAware;
+    use Scrubbable;
+    use ScrubByPerson;
+
+    private static $tableName = 'gibbonBehaviourFollowUp';
+    private static $primaryKey = 'gibbonBehaviourFollowUpID';
+
+    private static $searchableColumns = [''];
+    
+    private static $scrubbableKey = ['gibbonPersonID', 'gibbonBehaviourFollowUpID', 'gibbonBehaviourID'];
+    private static $scrubbableColumns = ['followUp' => ''];
+
+}

--- a/src/Domain/Behaviour/BehaviourFollowUpGateway.php
+++ b/src/Domain/Behaviour/BehaviourFollowUpGateway.php
@@ -65,4 +65,16 @@ class BehaviourFollowupGateway extends QueryableGateway implements ScrubbableGat
 
         return $this->runSelect($query);
     }
+
+    public function selectFollowUpsByBehaviorID($gibbonBehaviourIDList)
+    {
+        $idList = is_array($gibbonBehaviourIDList) ? implode(',', $gibbonBehaviourIDList) : $gibbonBehaviourIDList;
+        $data = array('idList' => $idList);
+        $sql = "SELECT gibbonBehaviourFollowUp.gibbonBehaviourID, gibbonBehaviourFollowUp.gibbonPersonID, gibbonBehaviourFollowUp.followUp, gibbonPerson.firstName, gibbonPerson.surname
+        FROM gibbonBehaviourFollowUp
+        JOIN gibbonPerson ON (gibbonBehaviourFollowUp.gibbonPersonID=gibbonPerson.gibbonPersonID)
+        WHERE FIND_IN_SET(gibbonBehaviourFollowUp.gibbonBehaviourID, :idList)";
+
+        return $this->db()->select($sql, $data);
+    }
 }

--- a/src/Domain/Behaviour/BehaviourGateway.php
+++ b/src/Domain/Behaviour/BehaviourGateway.php
@@ -65,7 +65,6 @@ class BehaviourGateway extends QueryableGateway implements ScrubbableGateway
                 'gibbonBehaviour.date',
                 'gibbonBehaviour.timestamp',
                 'gibbonBehaviour.comment',
-                'gibbonBehaviour.followup',
                 'student.gibbonPersonID',
                 'student.surname',
                 'student.preferredName',

--- a/src/Domain/Behaviour/BehaviourGateway.php
+++ b/src/Domain/Behaviour/BehaviourGateway.php
@@ -254,4 +254,23 @@ class BehaviourGateway extends QueryableGateway implements ScrubbableGateway
 
         return $this->db()->select($sql, $data);
     }
+    public function queryFollowUpByBehaviourID($gibbonBehaviourID)
+    {
+        $query = $this
+            ->newSelect()
+            ->from($this->getTableName())
+            ->cols([
+                'gibbonBehaviourFollowUp.*',
+                'gibbonBehaviourFollowUp.followUp as comment',
+                'gibbonPerson.surname',
+                'gibbonPerson.preferredName',
+                'gibbonPerson.image_240'
+            ])
+            ->innerJoin('gibbonBehaviourFollowUp', 'gibbonBehaviourFollowUp.gibbonBehaviourID=gibbonBehaviour.gibbonBehaviourID')
+            ->innerJoin('gibbonPerson', 'gibbonBehaviourFollowUp.gibbonPersonID=gibbonPerson.gibbonPersonID')
+            ->where('gibbonBehaviourFollowUp.gibbonBehaviourID=:gibbonBehaviourID')
+            ->bindValue('gibbonBehaviourID', $gibbonBehaviourID);
+
+        return $this->runSelect($query);
+    }
 }

--- a/src/Domain/Behaviour/BehaviourGateway.php
+++ b/src/Domain/Behaviour/BehaviourGateway.php
@@ -46,7 +46,7 @@ class BehaviourGateway extends QueryableGateway implements ScrubbableGateway
     private static $searchableColumns = [];
 
     private static $scrubbableKey = 'gibbonPersonID';
-    private static $scrubbableColumns = ['descriptor' => null, 'level' => null, 'comment' => '', 'followup' => ''];
+    private static $scrubbableColumns = ['descriptor' => null, 'level' => null, 'comment' => ''];
     
     /**
      * @param QueryCriteria $criteria
@@ -253,24 +253,5 @@ class BehaviourGateway extends QueryableGateway implements ScrubbableGateway
         $sql = 'SELECT gibbonBehaviour.gibbonPersonID AS gibbonPersonID, student.preferredName AS preferredNameStudent, student.surname AS surnameStudent FROM gibbonBehaviour JOIN gibbonPerson AS student ON (gibbonBehaviour.gibbonPersonID=student.gibbonPersonID)WHERE gibbonMultiIncidentID = :gibbonMultiIncidentID ORDER BY preferredNameStudent';
 
         return $this->db()->select($sql, $data);
-    }
-    public function queryFollowUpByBehaviourID($gibbonBehaviourID)
-    {
-        $query = $this
-            ->newSelect()
-            ->from($this->getTableName())
-            ->cols([
-                'gibbonBehaviourFollowUp.*',
-                'gibbonBehaviourFollowUp.followUp as comment',
-                'gibbonPerson.surname',
-                'gibbonPerson.preferredName',
-                'gibbonPerson.image_240'
-            ])
-            ->innerJoin('gibbonBehaviourFollowUp', 'gibbonBehaviourFollowUp.gibbonBehaviourID=gibbonBehaviour.gibbonBehaviourID')
-            ->innerJoin('gibbonPerson', 'gibbonBehaviourFollowUp.gibbonPersonID=gibbonPerson.gibbonPersonID')
-            ->where('gibbonBehaviourFollowUp.gibbonBehaviourID=:gibbonBehaviourID')
-            ->bindValue('gibbonBehaviourID', $gibbonBehaviourID);
-
-        return $this->runSelect($query);
     }
 }

--- a/src/Domain/Behaviour/BehaviourGateway.php
+++ b/src/Domain/Behaviour/BehaviourGateway.php
@@ -65,6 +65,7 @@ class BehaviourGateway extends QueryableGateway implements ScrubbableGateway
                 'gibbonBehaviour.date',
                 'gibbonBehaviour.timestamp',
                 'gibbonBehaviour.comment',
+                'gibbonBehaviour.followup',
                 'student.gibbonPersonID',
                 'student.surname',
                 'student.preferredName',


### PR DESCRIPTION
**Description**

Behaviour: Added a follow-up log to behaviour incidents so that any staff member can add their comment, and all comments are displayed in a chronological order with names and timestamps. Also created a new table in the DB called - gibbonBehaviourFollowUp to store all the follow-up comments for respective behaviour reports. 
