### PR TITLE
Behaviour: add notifications for positive behaviour records

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,8 +38,9 @@ v27.0.00
         Activities: added notification events for activity enrolment changes
         Activities: added a Left status to activity enrolment, to retain a history of previous enrolments
         Activities: added bulk actions to the activity enrolment page
+        Behaviour: added notifications for positive behaviour records
         Behaviour: added the ability to view other students involved in multiple behaviour records
-        Behaviour: updated the viee so that followups are displayed as conversational logs and stored in a separate table
+        Behaviour: updated the view so that followups are displayed as conversational logs and stored in a separate table
         Behaviour: added the ability to able to link a behaviour record to some other existing behaviour record
         Library: added ui changes to Library module browsing through library shelves and improved search page
         Library: added automatic shelf generation by search term, automatic shelf updates, and auto-shuffling

--- a/modules/Behaviour/behaviour_manage_addProcess.php
+++ b/modules/Behaviour/behaviour_manage_addProcess.php
@@ -123,80 +123,96 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                 } 
 
                 // Attempt to notify tutor(s) and EA(s) of negative behaviour
-                if ($type == 'Negative') {
+                $dataDetail = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbonPersonID);
+                $sqlDetail = 'SELECT gibbonPersonIDTutor, gibbonPersonIDTutor2, gibbonPersonIDTutor3, surname, preferredName, gibbonStudentEnrolment.gibbonYearGroupID FROM gibbonFormGroup JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID) JOIN gibbonPerson ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonPersonID=:gibbonPersonID';
+                $resultDetail = $connection2->prepare($sqlDetail);
+                $resultDetail->execute($dataDetail);
 
-                        $dataDetail = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'gibbonPersonID' => $gibbonPersonID);
-                        $sqlDetail = 'SELECT gibbonPersonIDTutor, gibbonPersonIDTutor2, gibbonPersonIDTutor3, surname, preferredName, gibbonStudentEnrolment.gibbonYearGroupID FROM gibbonFormGroup JOIN gibbonStudentEnrolment ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID) JOIN gibbonPerson ON (gibbonStudentEnrolment.gibbonPersonID=gibbonPerson.gibbonPersonID) WHERE gibbonStudentEnrolment.gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonStudentEnrolment.gibbonPersonID=:gibbonPersonID';
-                        $resultDetail = $connection2->prepare($sqlDetail);
-                        $resultDetail->execute($dataDetail);
-                    if ($resultDetail->rowCount() == 1) {
-                        $rowDetail = $resultDetail->fetch();
+                if ($resultDetail->rowCount() == 1) {
+                    $rowDetail = $resultDetail->fetch();
 
-                        // Initialize the notification sender & gateway objects
-                        $notificationGateway = $container->get(NotificationGateway::class);
-                        $notificationSender = $container->get(NotificationSender::class);;
+                    // Initialize the notification sender & gateway objects
+                    $notificationGateway = $container->get(NotificationGateway::class);
+                    $notificationSender = $container->get(NotificationSender::class);;
 
-                        $studentName = Format::name('', $rowDetail['preferredName'], $rowDetail['surname'], 'Student', false);
-                        $actionLink = "/index.php?q=/modules/Behaviour/behaviour_view_details.php&gibbonPersonID=$gibbonPersonID&search=";
+                    $studentName = Format::name('', $rowDetail['preferredName'], $rowDetail['surname'], 'Student', false);
+                    $staffName = Format::name('', $session->get('preferredName'), $session->get('surname'), 'Staff', false, true);
+                    $actionLink = "/index.php?q=/modules/Behaviour/behaviour_view_details.php&gibbonPersonID=$gibbonPersonID&search=";
 
-                        // Raise a new notification event
-                        $event = new NotificationEvent('Behaviour', 'New Negative Record');
+                    // Raise a new notification event
+                    $event = new NotificationEvent('Behaviour', $type == 'Positive' ? 'New Positive Record' : 'New Negative Record');
+                    $event->setNotificationText(__('{person} has created a {type} behaviour record for {student}.', [
+                        'type' => strtolower($type),
+                        'person' => $staffName,
+                        'student' => $studentName,
+                    ]));
+                    
+                    $event->setActionLink($actionLink);
+                    $event->addScope('gibbonPersonIDStudent', $gibbonPersonID);
+                    $event->addScope('gibbonYearGroupID', $rowDetail['gibbonYearGroupID']);
 
-                        $personName = Format::name('', $session->get('preferredName'), $session->get('surname'), 'Staff', false, true);
+                    // Add notifications for Educational Assistants
+                    if ($settingGateway->getSettingByScope('Behaviour', 'notifyEducationalAssistants') == 'Y') {
+                        $educationalAssistants = $container->get(INAssistantGateway::class)->selectINAssistantsByStudent($gibbonPersonID)->fetchAll();
+                        foreach ($educationalAssistants as $ea) {
+                            $event->addRecipient($ea['gibbonPersonID']);
+                        }
+                    }
 
-                        $event->setNotificationText(__('{person} has created a negative behaviour record for {student}.', ['person' => $personName, 'student' => $studentName]));
-                        $event->setActionLink($actionLink);
+                    // Add event listeners to the notification sender
+                    $event->pushNotifications($notificationGateway, $notificationSender);
 
-                        $event->addScope('gibbonPersonIDStudent', $gibbonPersonID);
-                        $event->addScope('gibbonYearGroupID', $rowDetail['gibbonYearGroupID']);
+                    // Add direct notifications to form group tutors
+                    if ($event->getEventDetails($notificationGateway, 'active') == 'Y') {
+                        if ($settingGateway->getSettingByScope('Behaviour', 'notifyTutors') == 'Y') {
 
-                        // Add notifications for Educational Assistants
-                        if ($settingGateway->getSettingByScope('Behaviour', 'notifyEducationalAssistants') == 'Y') {
-                            $educationalAssistants = $container->get(INAssistantGateway::class)->selectINAssistantsByStudent($gibbonPersonID)->fetchAll();
-                            foreach ($educationalAssistants as $ea) {
-                                $event->addRecipient($ea['gibbonPersonID']);
+                            $notificationText = __('{person} has created a {type} behaviour record for your tutee, {student}.', [
+                                'type' => strtolower($type),
+                                'person' => $staffName,
+                                'student' => $studentName,
+                            ]);
+
+                            if ($rowDetail['gibbonPersonIDTutor'] != null and $rowDetail['gibbonPersonIDTutor'] != $session->get('gibbonPersonID')) {
+                                $notificationSender->addNotification($rowDetail['gibbonPersonIDTutor'], $notificationText, 'Behaviour', $actionLink);
+                            }
+                            if ($rowDetail['gibbonPersonIDTutor2'] != null and $rowDetail['gibbonPersonIDTutor2'] != $session->get('gibbonPersonID')) {
+                                $notificationSender->addNotification($rowDetail['gibbonPersonIDTutor2'], $notificationText, 'Behaviour', $actionLink);
+                            }
+                            if ($rowDetail['gibbonPersonIDTutor3'] != null and $rowDetail['gibbonPersonIDTutor3'] != $session->get('gibbonPersonID')) {
+                                $notificationSender->addNotification($rowDetail['gibbonPersonIDTutor3'], $notificationText, 'Behaviour', $actionLink);
                             }
                         }
+                    }
+
+                    // Check if this is an IN student
+                    $studentIN = $container->get(INGateway::class)->selectIndividualNeedsDescriptorsByStudent($gibbonPersonID)->fetchAll();
+                    if (!empty($studentIN)) {
+                        // Raise a notification event for IN students
+                        $eventIN = new NotificationEvent('Behaviour', 'Behaviour Record for IN Student');
+                        
+                        $eventIN->setNotificationText(__('{person} has created a {type} behaviour record for {student}.', [
+                            'type' => strtolower($type),
+                            'person' => $staffName, 
+                            'student' => $studentName,
+                        ]));
+                        $eventIN->setActionLink($actionLink);
+
+                        $eventIN->addScope('gibbonPersonIDStudent', $gibbonPersonID);
+                        $eventIN->addScope('gibbonYearGroupID', $rowDetail['gibbonYearGroupID']);
 
                         // Add event listeners to the notification sender
-                        $event->pushNotifications($notificationGateway, $notificationSender);
-
-                        // Add direct notifications to form group tutors
-                        if ($event->getEventDetails($notificationGateway, 'active') == 'Y') {
-                            if ($settingGateway->getSettingByScope('Behaviour', 'notifyTutors') == 'Y') {
-                                $notificationText = __('{person} has created a negative behaviour record for your tutee, {student}.', ['person' => $personName, 'student' => $studentName]);
-
-                                if ($rowDetail['gibbonPersonIDTutor'] != null and $rowDetail['gibbonPersonIDTutor'] != $session->get('gibbonPersonID')) {
-                                    $notificationSender->addNotification($rowDetail['gibbonPersonIDTutor'], $notificationText, 'Behaviour', $actionLink);
-                                }
-                                if ($rowDetail['gibbonPersonIDTutor2'] != null and $rowDetail['gibbonPersonIDTutor2'] != $session->get('gibbonPersonID')) {
-                                    $notificationSender->addNotification($rowDetail['gibbonPersonIDTutor2'], $notificationText, 'Behaviour', $actionLink);
-                                }
-                                if ($rowDetail['gibbonPersonIDTutor3'] != null and $rowDetail['gibbonPersonIDTutor3'] != $session->get('gibbonPersonID')) {
-                                    $notificationSender->addNotification($rowDetail['gibbonPersonIDTutor3'], $notificationText, 'Behaviour', $actionLink);
-                                }
-                            }
-                        }
-
-                        // Check if this is an IN student
-                        $studentIN = $container->get(INGateway::class)->selectIndividualNeedsDescriptorsByStudent($gibbonPersonID)->fetchAll();
-                        if (!empty($studentIN)) {
-                            // Raise a notification event for IN students
-                            $eventIN = new NotificationEvent('Behaviour', 'Behaviour Record for IN Student');
-                            
-                            $eventIN->setNotificationText(__('{person} has created a negative behaviour record for {student}.', ['person' => $personName, 'student' => $studentName]));
-                            $eventIN->setActionLink($actionLink);
-    
-                            $eventIN->addScope('gibbonPersonIDStudent', $gibbonPersonID);
-                            $eventIN->addScope('gibbonYearGroupID', $rowDetail['gibbonYearGroupID']);
-
-                            // Add event listeners to the notification sender
-                            $eventIN->pushNotifications($notificationGateway, $notificationSender);
-                        }
-
-                        // Send all notifications
-                        $notificationSender->sendNotifications();
+                        $eventIN->pushNotifications($notificationGateway, $notificationSender);
                     }
+                    $eventIN->setActionLink($actionLink);
+
+                    $eventIN->addScope('gibbonPersonIDStudent', $gibbonPersonID);
+                    $eventIN->addScope('gibbonYearGroupID', $rowDetail['gibbonYearGroupID']);
+
+                    // Add event listeners to the notification sender
+                    $eventIN->pushNotifications($notificationGateway, $notificationSender);
+                    
+                    // Send all notifications
+                    $notificationSender->sendNotifications();
                 }
 
                 if ($copyToNotes == 'on') {

--- a/modules/Behaviour/behaviour_manage_addProcess.php
+++ b/modules/Behaviour/behaviour_manage_addProcess.php
@@ -203,13 +203,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Behaviour/behaviour_manage
                         // Add event listeners to the notification sender
                         $eventIN->pushNotifications($notificationGateway, $notificationSender);
                     }
-                    $eventIN->setActionLink($actionLink);
-
-                    $eventIN->addScope('gibbonPersonIDStudent', $gibbonPersonID);
-                    $eventIN->addScope('gibbonYearGroupID', $rowDetail['gibbonYearGroupID']);
-
-                    // Add event listeners to the notification sender
-                    $eventIN->pushNotifications($notificationGateway, $notificationSender);
                     
                     // Send all notifications
                     $notificationSender->sendNotifications();


### PR DESCRIPTION
Currently, behaviour notifications are only sent for negative records. However, it would be good to draw attention to those times where students receive positive behaviour notes, so this PR enables notifications for both positive and negative records.

Thanks @Fongngtis for contributing these code changes to the core.

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="920" alt="Screen Shot 2024-03-22 at 9 49 52 AM" src="https://github.com/GibbonEdu/core/assets/897700/ae4103b9-5f73-416e-98fd-4b23ddff8a88">
