### PR TITLE
Search on basis of age in Library

### DIFF
--- a/modules/Library/library_browse.php
+++ b/modules/Library/library_browse.php
@@ -121,14 +121,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
         
     $col = $row->addColumn()->setClass('fullWidth');
         $col->addLabel('readerAge', __('Readers Age'));
-        $ageArray=[2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21];
+        $ageArray=range(2,21);
         $col->addSelect('readerAge')->fromArray($ageArray)->setClass('fullWidth')->selected($readerAge)->placeholder();
 
     $col = $row->addColumn()->setClass('quarterWidth');
         $col->addCheckBox('locationToggle')->description('Include Books Outside of Library?')->checked(($locationToggle == 'on'))->setValue('on');
 
-    //$row = $form->addRow();
-    //$row->setClass('advancedOptions hidden grid grid-cols-6 gap-4');
 
 
     $row = $form->addRow();
@@ -193,7 +191,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
 
         $sql = "SELECT gibbonLibraryTypeID as groupBy, gibbonLibraryType.* FROM gibbonLibraryType";
         $typeFields = $pdo->select($sql)->fetchGroupedUnique();
-        //var_dump($typeFields);
         $locationName = ['name' => ''];
         
         if(!empty($location)) {

--- a/modules/Library/library_browse.php
+++ b/modules/Library/library_browse.php
@@ -85,7 +85,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
         $row->addSearchSubmit($session, __('Clear Search'))->addClass('sm:col-start-3 md:col-start-5 lg:col-start-7');
 
     $row = $form->addRow();
-        $row->setClass('advancedOptions hidden grid grid-cols-6 gap-4');
+        $row->setClass('advancedOptions hidden grid grid-cols-7 gap-4');
 
     $col = $row->addColumn()->setClass('quarterWidth');
         $col->addLabel('name', __('Title'));
@@ -119,15 +119,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
         ->selected($collection)
         ->placeholder();
         
+    $col = $row->addColumn()->setClass('fullWidth');
+        $col->addLabel('readerAge', __('Readers Age'));
+        $ageArray=[2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21];
+        $col->addSelect('readerAge')->fromArray($ageArray)->setClass('fullWidth')->selected($readerAge)->placeholder();
+
     $col = $row->addColumn()->setClass('quarterWidth');
         $col->addCheckBox('locationToggle')->description('Include Books Outside of Library?')->checked(($locationToggle == 'on'))->setValue('on');
 
-    $row = $form->addRow();
-        $row->setClass('advancedOptions hidden grid grid-cols-6 gap-4');
-    $col = $row->addColumn()->setClass('fullwidth');
-        $col->addLabel('readerAge', __('Readers Age'));
-        $ageArray=[2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21];
-        $col->addSelect('readerAge')->fromArray($ageArray)->selected($readerAge)->placeholder();
+    //$row = $form->addRow();
+    //$row->setClass('advancedOptions hidden grid grid-cols-6 gap-4');
+
 
     $row = $form->addRow();
         $row->addAdvancedOptionsToggle()->addClass('pt-2');

--- a/src/Domain/Library/LibraryGateway.php
+++ b/src/Domain/Library/LibraryGateway.php
@@ -193,6 +193,15 @@ class LibraryGateway extends QueryableGateway
                     ->where('gibbonSpace.name LIKE :location')
                     ->bindValue('location', $location);
             },
+            'agecheck' => function ($query, $readerAge) {
+                //var_dump($readerAge);
+                return $query
+                    ->where('gibbonLibraryItem.fields->\'$."Reader Age (Youngest)"\' != "" 
+                            AND gibbonLibraryItem.fields->\'$."Reader Age (Oldest)"\' != "" 
+                            AND gibbonLibraryItem.fields->\'$."Reader Age (Youngest)"\'+0 <= :readerAge 
+                            AND gibbonLibraryItem.fields->\'$."Reader Age (Oldest)"\'+0 >= :readerAge')
+                    ->bindValue('readerAge', $readerAge);
+            },
             'everything' => function ($query, $needle) {
                 $globalSearch = "(";
                 foreach ($query->getCols() as $col) {

--- a/src/Domain/Library/LibraryGateway.php
+++ b/src/Domain/Library/LibraryGateway.php
@@ -194,7 +194,6 @@ class LibraryGateway extends QueryableGateway
                     ->bindValue('location', $location);
             },
             'agecheck' => function ($query, $readerAge) {
-                //var_dump($readerAge);
                 return $query
                     ->where('gibbonLibraryItem.fields->\'$."Reader Age (Youngest)"\' != "" 
                             AND gibbonLibraryItem.fields->\'$."Reader Age (Oldest)"\' != "" 


### PR DESCRIPTION
added the functionality to search on basis of age in "Browse the Library" part.


Added a field for age entry in "advanced search" in "Browse the Library" part. On basis of this information only those books are shown as a result of search that are appropriate for a given age.

**Description**
Interface of "advanced search" in "browse the library section" has one additional field for age entry. If the entered age is not null then only those books that fulfill this criteria: 
- Books that have non-null information in the fields "Reader Age (Youngest)", "Reader Age (Oldest)", AND
- "Reader Age (Youngest)" <= Entered Age <= "Reader Age (Oldest)" 
DB structure is not changed.
(Just a heads up, this is my first try with PHP, so make sure to give it a good look before merging. Cheers!)

**Motivation and Context**
An example: the books that are readable by a 5 y.o. are very different than those that are readable by a 9 y.o. Also vice versa.
Since in our school, we have children from 5 all the way to 20, so it made sense to be able to efficiently filter on this basis. 


**How Has This Been Tested?**
tested on sample data included in the gibbon


**Screenshots**
![image](https://github.com/GibbonEdu/core/assets/73481556/2ff52ddc-2004-4ba8-bb0b-2a416c4b57cb)

