### PR TITLE
Adding the Study Year beside the form group in student history details

### DIFF
--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -408,25 +408,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                         $table->addColumn('email', __('Email'))
                                 ->format(Format::using('link', ['email']));
 
-                        $table->addColumn('schoolHistory', __('School History'))
-                                ->format(function($row) use ($connection2) {
+                                $studentGateway = $container->get(StudentGateway::class);
+                                $table->addColumn('schoolHistory', __('School History'))
+                                ->format(function($row) use ($connection2, $studentGateway ) {
                                     if ($row['dateStart'] != '') {
                                         echo '<u>'.__('Start Date').'</u>: '.Format::date($row['dateStart']).'</br>';
                                     }
 
-                                    $dataSelect = array('gibbonPersonID' => $row['gibbonPersonID']);
-                                    $sqlSelect = "SELECT gibbonFormGroup.name AS formGroup, gibbonSchoolYear.name AS schoolYear
-                                        FROM gibbonStudentEnrolment
-                                        JOIN gibbonFormGroup ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID)
-                                        JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
-                                        WHERE gibbonPersonID=:gibbonPersonID
-                                        AND (gibbonSchoolYear.status = 'Current' OR gibbonSchoolYear.status='Past')
-                                        ORDER BY gibbonStudentEnrolment.gibbonSchoolYearID";
-                                    $resultSelect = $connection2->prepare($sqlSelect);
-                                    $resultSelect->execute($dataSelect);
-
+                                    $resultSelect = $studentGateway->selectStudentEnrolmentHistory($row['gibbonPersonID']);
+                                    
                                     while ($rowSelect = $resultSelect->fetch()) {
-                                        echo '<u>'.$rowSelect['schoolYear'].'</u>: '.$rowSelect['formGroup'].'<br/>';
+                                        echo '<u>'.$rowSelect['schoolYear'].'</u>: '.$rowSelect['formGroup'].' ('.$rowSelect['studyYear'].')'.'<br/>';
                                     }
 
                                     if ($row['dateEnd'] != '') {

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -406,8 +406,8 @@ class StudentGateway extends QueryableGateway
 
     public function selectStudentEnrolmentHistory($gibbonPersonID)
     {
-        $dataSelect = ['gibbonPersonID' => $gibbonPersonID];
-        $sqlSelect = "SELECT gibbonFormGroup.name AS formGroup, gibbonSchoolYear.name AS schoolYear, gibbonYearGroup.nameShort as studyYear
+        $data = ['gibbonPersonID' => $gibbonPersonID];
+        $sql = "SELECT gibbonFormGroup.name AS formGroup, gibbonSchoolYear.name AS schoolYear, gibbonYearGroup.nameShort as studyYear
             FROM gibbonStudentEnrolment
             JOIN gibbonFormGroup ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID)
             JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
@@ -416,6 +416,6 @@ class StudentGateway extends QueryableGateway
             AND (gibbonSchoolYear.status = 'Current' OR gibbonSchoolYear.status='Past')
             ORDER BY gibbonStudentEnrolment.gibbonSchoolYearID";
           
-          return $this->db()->select($sqlSelect, $dataSelect);
+          return $this->db()->select($sql, $data);
     }
 }

--- a/src/Domain/Students/StudentGateway.php
+++ b/src/Domain/Students/StudentGateway.php
@@ -403,4 +403,19 @@ class StudentGateway extends QueryableGateway
 
         return $this->db()->select($sql, $data);
     }
+
+    public function selectStudentEnrolmentHistory($gibbonPersonID)
+    {
+        $dataSelect = ['gibbonPersonID' => $gibbonPersonID];
+        $sqlSelect = "SELECT gibbonFormGroup.name AS formGroup, gibbonSchoolYear.name AS schoolYear, gibbonYearGroup.nameShort as studyYear
+            FROM gibbonStudentEnrolment
+            JOIN gibbonFormGroup ON (gibbonStudentEnrolment.gibbonFormGroupID=gibbonFormGroup.gibbonFormGroupID)
+            JOIN gibbonSchoolYear ON (gibbonStudentEnrolment.gibbonSchoolYearID=gibbonSchoolYear.gibbonSchoolYearID)
+            JOIN gibbonYearGroup ON (gibbonStudentEnrolment.gibbonYearGroupID=gibbonYearGroup.gibbonYearGroupID)
+            WHERE gibbonPersonID=:gibbonPersonID
+            AND (gibbonSchoolYear.status = 'Current' OR gibbonSchoolYear.status='Past')
+            ORDER BY gibbonStudentEnrolment.gibbonSchoolYearID";
+          
+          return $this->db()->select($sqlSelect, $dataSelect);
+    }
 }


### PR DESCRIPTION
**Description**

Updated the Student History list to show the form group and Study Year, especially important for students in mixed form groups, as before it didn’t tell which year they were in.
