### PR TITLE
Improvement in Generic OAuth

### DIFF
--- a/modules/System Admin/thirdPartySettings_ssoEdit.php
+++ b/modules/System Admin/thirdPartySettings_ssoEdit.php
@@ -139,6 +139,20 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
         $row = $form->addRow()->addClass('settingActive');
             $row->addLabel('userEndpoint', __('API User Endpoint'));
             $row->addURL('userEndpoint')->required();
+    
+        $row = $form->addRow()->addHeading('Additional Parameters', __('Additional Parameters'))
+                    ->addClass('settingActive')
+                    ->append(__('Some systems require additional parameters for a login request in order to read the user\'s basic profile.'));
+            
+        $row = $form->addRow()->addClass('settingActive');
+            $row->addLabel('scopes', __('Scopes'))
+                ->description(__('Scope is a mechanism in OAuth 2.0 to limit an application\'s access to a user\'s account. An application can request one or more scopes. The standard scopes for an OpenID Connect compliant system are: openid profile email.'));
+            $row->addTextField('scopes');
+
+        $row = $form->addRow()->addClass('settingActive');
+            $row->addLabel('usernameAttribute', __('Username attribute'))
+                ->description(__('Name of the attribute containing usernames in the OAuth service.'));
+            $row->addTextField('usernameAttribute')->required();                       
     }
 
     $row = $form->addRow();

--- a/modules/System Admin/thirdPartySettings_ssoEditProcess.php
+++ b/modules/System Admin/thirdPartySettings_ssoEditProcess.php
@@ -47,14 +47,16 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/thirdPartySet
     $values = json_decode($values, true) ?? [];
 
     $data = [
-        'enabled'           => $_POST['enabled'] ?? 'N',
-        'clientName'        => $_POST['clientName'] ?? '',
-        'clientID'          => $_POST['clientID'] ?? '',
-        'clientSecret'      => $_POST['clientSecret'] ?? '',
-        'developerKey'      => $_POST['developerKey'] ?? '',
-        'authorizeEndpoint' => $_POST['authorizeEndpoint'] ?? '',
-        'tokenEndpoint'     => $_POST['tokenEndpoint'] ?? '',
-        'userEndpoint'      => $_POST['userEndpoint'] ?? '',
+        'enabled'            => $_POST['enabled'] ?? 'N',
+        'clientName'         => $_POST['clientName'] ?? '',
+        'clientID'           => $_POST['clientID'] ?? '',
+        'clientSecret'       => $_POST['clientSecret'] ?? '',
+        'developerKey'       => $_POST['developerKey'] ?? '',
+        'authorizeEndpoint'  => $_POST['authorizeEndpoint'] ?? '',
+        'tokenEndpoint'      => $_POST['tokenEndpoint'] ?? '',
+        'userEndpoint'       => $_POST['userEndpoint'] ?? '',
+        'scopes'             => $_POST['scopes'] ?? '',
+        'usernameAttribute'      => $_POST['usernameAttribute'] ?? '',
     ];
 
     $calendarFeed = $_POST['calendarFeed'] ?? '';

--- a/src/Auth/Adapter/OAuthGenericAdapter.php
+++ b/src/Auth/Adapter/OAuthGenericAdapter.php
@@ -26,6 +26,7 @@ use Gibbon\Auth\Exception;
 use Gibbon\Auth\Adapter\AuthenticationAdapter;
 use Gibbon\Contracts\Services\Session;
 use Gibbon\Domain\User\UserGateway;
+use Gibbon\Domain\System\SettingGateway;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 
 /**
@@ -96,17 +97,28 @@ class OAuthGenericAdapter extends AuthenticationAdapter implements OAuthAdapterI
         $resourceOwner = $oauthProvider->getResourceOwner($accessToken);
 
         $user = $resourceOwner->toArray();
-        $email = $user['email'] ?? $user['emailAddress'] ?? $user['email-address'] ?? $user['email_address'];
-        $_POST['usernameOAuth'] = $email;
+        $settingGateway = $this->getContainer()->get(SettingGateway::class);
 
-        if (empty($email)) {
+        $ssoSettings = $settingGateway->getSettingByScope('System Admin', 'ssoOther');
+        $ssoSettings = json_decode($ssoSettings, true);
+        
+        // If usernameAttribute is empty the Gibbon version less than v27
+        if (empty($ssoSettings['usernameAttribute'])) {
+            $usernameOAuth = $user['email'] ?? $user['emailAddress'] ?? $user['email-address'] ?? $user['email_address'];
+        } else {
+            $usernameOAuth = $user[$ssoSettings['usernameAttribute']];
+        }
+        
+        $_POST['usernameOAuth'] = $usernameOAuth;
+
+        if (empty($usernameOAuth)) {
             $session->forget('genericAPIAccessToken');
             throw new Exception\OAuthLoginError;
         }
 
         // Get basic user data needed to verify login access
         $this->userGateway = $this->getContainer()->get(UserGateway::class);
-        $userData = $this->getUserData(['username' => $email]);
+        $userData = $this->getUserData(['username' => $usernameOAuth]);
 
         if (empty($userData)) {
             $session->forget('genericAPIAccessToken');

--- a/src/Services/AuthServiceProvider.php
+++ b/src/Services/AuthServiceProvider.php
@@ -203,6 +203,7 @@ class AuthServiceProvider extends AbstractServiceProvider
                     'urlAuthorize'              => $ssoSettings['authorizeEndpoint'],
                     'urlAccessToken'            => $ssoSettings['tokenEndpoint'],
                     'urlResourceOwnerDetails'   => $ssoSettings['userEndpoint'],
+                    'scopes'                    => $ssoSettings['scopes'] ?? 'openid profile offline_access email groups'
                 ]);
             } catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
                 throw new OAuthLoginError($e->getMessage());


### PR DESCRIPTION
**Description**
Some systems require additional parameters for a login request in order to read the user's basic profile.

**Motivation and Context**
I needed to do SSO and the institution did not use the email field as a username. With this PR, the user can configure it without changing the code. Now it is more generic and flexible.


**How Has This Been Tested?**
Locally and Travis

**Screenshots**
![image](https://github.com/GibbonEdu/core/assets/1969911/c91aaf70-891e-4d50-9f65-63e9ccf5927e)
