### PR TITLE
Fix error that generates page breaks when adding a new adult to the f…

### DIFF
--- a/modules/User Admin/family_manage_edit_addAdultProcess.php
+++ b/modules/User Admin/family_manage_edit_addAdultProcess.php
@@ -84,7 +84,7 @@ if ($gibbonFamilyID == '') { echo 'Fatal error loading this page!';
                         $contactMail = 'Y';
                     } else {
                         $contactCall = $_POST['contactCall'] ?? 'N';
-                        $contactSMS = $_POST['contactSMS'] ?? 'N;
+                        $contactSMS = $_POST['contactSMS'] ?? 'N';
                         $contactEmail = $_POST['contactEmail'] ?? 'N';
                         $contactMail = $_POST['contactMail'] ?? 'N';
                     }


### PR DESCRIPTION
**Description**
When adding a new adult to the family with Contact Priority != 1 it generates a page break error


**How Has This Been Tested?**
Local and travis

**Screenshots**

![Captura de Tela 2024-05-03 às 16 06 21](https://github.com/GibbonEdu/core/assets/1969911/209dff4d-640e-40ac-855e-4654fee50e07)
