### PR TITLE
System: update handling of readable dates in Format class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: gettext, gd, zip, pdo-mysql
+          extensions: gettext, gd, zip, pdo-mysql, intl
           tools: composer:v2
           ini-values: date.timezone="Etc/UTC", xdebug.max_nesting_level=-1, opcache.jit="off"
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ v27.0.00
     Changes With Important Notices
         System: updated Google OAuth Client SSO to handle granular permissions (required by Google for June 17, 2024)
         System: updated JQuery(2.2.4 -> 3.7.1) and JQuery Migrate(1.4.1 -> 3.4.0) files to latest versions
+        System: updated date localisation to use the PHP Intl library, removed deprecated strftime
         System: in you use Gmail SMTP relay, be sure to update your settings to use an App Password
 
     Security

--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -215,7 +215,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
             $col = $row->addColumn()->addClass('h-24 px-2 text-center');
             $dateLabel = $col->addContent(
                 Format::dayOfWeekName($sessionDate, true) . '<br>' .
-                Format::dateIntl($sessionDate, Format::MEDIUM_NO_YEAR)
+                Format::dateReadable($sessionDate, Format::MEDIUM_NO_YEAR)
             )->addClass('w-10 mx-auto whitespace-nowrap');
 
             if (isset($sessionAttendanceData[$sessionDate]['data'])) {

--- a/modules/Activities/activities_attendance.php
+++ b/modules/Activities/activities_attendance.php
@@ -215,7 +215,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_atte
             $col = $row->addColumn()->addClass('h-24 px-2 text-center');
             $dateLabel = $col->addContent(
                 Format::dayOfWeekName($sessionDate, true) . '<br>' .
-                Format::dateIntlReadable($sessionDate, 'MMM d')
+                Format::dateIntl($sessionDate, Format::MEDIUM_NO_YEAR)
             )->addClass('w-10 mx-auto whitespace-nowrap');
 
             if (isset($sessionAttendanceData[$sessionDate]['data'])) {

--- a/modules/Activities/report_attendance.php
+++ b/modules/Activities/report_attendance.php
@@ -220,12 +220,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
                 printf("<span title='%s'>%s <br/> %s</span><br/>&nbsp;<br/>",
                     $sessionAttendanceData[$sessionDate]['info'],
                     Format::dayOfWeekName($sessionDate, true),
-                    Format::dateIntl($sessionDate, Format::MEDIUM_NO_YEAR)
+                    Format::dateReadable($sessionDate, Format::MEDIUM_NO_YEAR)
                 );
             } else {
                 echo "<td style='color: #bbb; vertical-align:top; width: 50px; white-space: nowrap;'>";
                 echo Format::dayOfWeekName($sessionDate).' <br/> '.
-                    Format::dateIntl($sessionDate, Format::MEDIUM_NO_YEAR).'<br/>&nbsp;<br/>';
+                    Format::dateReadable($sessionDate, Format::MEDIUM_NO_YEAR).'<br/>&nbsp;<br/>';
             }
             echo '</td>';
         }

--- a/modules/Activities/report_attendance.php
+++ b/modules/Activities/report_attendance.php
@@ -220,12 +220,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/report_attendan
                 printf("<span title='%s'>%s <br/> %s</span><br/>&nbsp;<br/>",
                     $sessionAttendanceData[$sessionDate]['info'],
                     Format::dayOfWeekName($sessionDate, true),
-                    Format::dateIntlReadable($sessionDate, 'MMM d')
+                    Format::dateIntl($sessionDate, Format::MEDIUM_NO_YEAR)
                 );
             } else {
                 echo "<td style='color: #bbb; vertical-align:top; width: 50px; white-space: nowrap;'>";
                 echo Format::dayOfWeekName($sessionDate).' <br/> '.
-                    Format::dateIntlReadable($sessionDate, 'MMM d').'<br/>&nbsp;<br/>';
+                    Format::dateIntl($sessionDate, Format::MEDIUM_NO_YEAR).'<br/>&nbsp;<br/>';
             }
             echo '</td>';
         }

--- a/modules/Admissions/admissions_manage_edit.php
+++ b/modules/Admissions/admissions_manage_edit.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Admissions/admissions_mana
                 : __('This account is not linked to a family.');
         });
 
-    $table->addColumn('created', __('Created'))->format(Format::using('dateIntlReadable', 'timestampCreated'));
+    $table->addColumn('created', __('Created'))->format(Format::using('dateIntl', 'timestampCreated'));
 
     $table->addColumn('active', __('Last Active'))->format(Format::using('relativeTime', 'timestampActive'));
 

--- a/modules/Admissions/admissions_manage_edit.php
+++ b/modules/Admissions/admissions_manage_edit.php
@@ -72,7 +72,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Admissions/admissions_mana
                 : __('This account is not linked to a family.');
         });
 
-    $table->addColumn('created', __('Created'))->format(Format::using('dateIntl', 'timestampCreated'));
+    $table->addColumn('created', __('Created'))->format(Format::using('dateReadable', 'timestampCreated'));
 
     $table->addColumn('active', __('Last Active'))->format(Format::using('relativeTime', 'timestampActive'));
 

--- a/modules/Admissions/applicationFormView.php
+++ b/modules/Admissions/applicationFormView.php
@@ -129,7 +129,7 @@ if (!$proceed) {
         });
         $table->addColumn('formName', __('Application Form'));
         $table->addColumn('status', __('Status'))->translatable();
-        $table->addColumn('timestampCreated', __('Date'))->width('20%')->format(Format::using('dateTimeIntlReadable', 'timestampCreated'));
+        $table->addColumn('timestampCreated', __('Date'))->width('20%')->format(Format::using('dateTimeIntl', 'timestampCreated'));
 
         $table->modifyRows(function ($values, $row) {
             if ($values['status'] == 'Incomplete') $row->addClass('warning');

--- a/modules/Admissions/applicationFormView.php
+++ b/modules/Admissions/applicationFormView.php
@@ -129,7 +129,7 @@ if (!$proceed) {
         });
         $table->addColumn('formName', __('Application Form'));
         $table->addColumn('status', __('Status'))->translatable();
-        $table->addColumn('timestampCreated', __('Date'))->width('20%')->format(Format::using('dateTimeIntl', 'timestampCreated'));
+        $table->addColumn('timestampCreated', __('Date'))->width('20%')->format(Format::using('dateTimeReadable', 'timestampCreated'));
 
         $table->modifyRows(function ($values, $row) {
             if ($values['status'] == 'Incomplete') $row->addClass('warning');

--- a/modules/Admissions/applicationForm_payFee.php
+++ b/modules/Admissions/applicationForm_payFee.php
@@ -135,7 +135,7 @@ if (!$proceed) {
 
             $row = $form->addRow();
             $row->addLabel('timestampLabel', __('Date Paid'));
-            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntl($payment['timestamp'] ?? ''));
+            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeReadable($payment['timestamp'] ?? ''));
 
             $row = $form->addRow();
             $row->addLabel('gatewayLabel', __('Payment Gateway'));
@@ -180,7 +180,7 @@ if (!$proceed) {
 
             $row = $form->addRow();
             $row->addLabel('timestampLabel', __('Date Paid'));
-            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntl($payment['timestamp'] ?? ''));
+            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeReadable($payment['timestamp'] ?? ''));
 
             $row = $form->addRow();
             $row->addLabel('gatewayLabel', __('Payment Gateway'));

--- a/modules/Admissions/applicationForm_payFee.php
+++ b/modules/Admissions/applicationForm_payFee.php
@@ -135,7 +135,7 @@ if (!$proceed) {
 
             $row = $form->addRow();
             $row->addLabel('timestampLabel', __('Date Paid'));
-            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntlReadable($payment['timestamp'] ?? ''));
+            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntl($payment['timestamp'] ?? ''));
 
             $row = $form->addRow();
             $row->addLabel('gatewayLabel', __('Payment Gateway'));
@@ -180,7 +180,7 @@ if (!$proceed) {
 
             $row = $form->addRow();
             $row->addLabel('timestampLabel', __('Date Paid'));
-            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntlReadable($payment['timestamp'] ?? ''));
+            $row->addTextField('timestamp')->readOnly()->setValue(Format::dateTimeIntl($payment['timestamp'] ?? ''));
 
             $row = $form->addRow();
             $row->addLabel('gatewayLabel', __('Payment Gateway'));

--- a/modules/Admissions/src/Forms/ApplicationMilestonesForm.php
+++ b/modules/Admissions/src/Forms/ApplicationMilestonesForm.php
@@ -79,7 +79,7 @@ class ApplicationMilestonesForm extends Form
             $dateInfo = '';
             if ($checked) {
                 $user = $this->userGateway->getByID($milestonesData[$milestone]['user'], ['preferredName', 'surname']);
-                $dateInfo = Format::dateIntl($milestonesData[$milestone]['date']).' '.__('By').' '.Format::name('', $user['preferredName'], $user['surname'], 'Staff', false, true);
+                $dateInfo = Format::dateReadable($milestonesData[$milestone]['date']).' '.__('By').' '.Format::name('', $user['preferredName'], $user['surname'], 'Staff', false, true);
             }
 
             $description = '<div class="milestone flex-1 text-left"><span class="milestoneCheck '.($checked ? '' : 'hidden').'">'.$checkIcon.'</span><span class="milestoneCross '.($checked ? 'hidden' : '').'">'.$crossIcon.'</span><span class="text-base leading-normal">'.__($milestone).'</span></div><div class="flex-1 text-left">'.$dateInfo.'</div>';

--- a/modules/Admissions/src/Forms/ApplicationMilestonesForm.php
+++ b/modules/Admissions/src/Forms/ApplicationMilestonesForm.php
@@ -79,7 +79,7 @@ class ApplicationMilestonesForm extends Form
             $dateInfo = '';
             if ($checked) {
                 $user = $this->userGateway->getByID($milestonesData[$milestone]['user'], ['preferredName', 'surname']);
-                $dateInfo = Format::dateIntlReadable($milestonesData[$milestone]['date']).' '.__('By').' '.Format::name('', $user['preferredName'], $user['surname'], 'Staff', false, true);
+                $dateInfo = Format::dateIntl($milestonesData[$milestone]['date']).' '.__('By').' '.Format::name('', $user['preferredName'], $user['surname'], 'Staff', false, true);
             }
 
             $description = '<div class="milestone flex-1 text-left"><span class="milestoneCheck '.($checked ? '' : 'hidden').'">'.$checkIcon.'</span><span class="milestoneCross '.($checked ? 'hidden' : '').'">'.$crossIcon.'</span><span class="text-base leading-normal">'.__($milestone).'</span></div><div class="flex-1 text-left">'.$dateInfo.'</div>';

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -387,7 +387,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                 $row->addLabel('periodSelectContainer', __('Periods Absent'));
 
                 $table = $row->addTable('periodSelectContainer')->setClass('standardWidth');
-                $table->addHeaderRow()->addHeading(Format::dateReadable(Format::dateConvert($date),'MMMM d, yyyy'));
+                $table->addHeaderRow()->addHeading(Format::dateReadable(Format::dateConvert($date), Format::LONG));
 
                 foreach ($classes as $class) {
                     $name = $class['columnName'] . ' - ' . $class['courseNameShort'] . '.' . $class['classNameShort'];

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -252,7 +252,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                     }
                 });
                 $table->addColumn('staff', __('Recorded By'))->format(Format::using('name', ['', 'preferredName', 'surname', 'Staff', false, true]));
-                $table->addColumn('timestamp', __('On'))->format(Format::using('dateIntlReadable', 'timestampTaken', 'HH:mm, MMM dd'));
+                $table->addColumn('timestamp', __('On'))->format(Format::using('dateTimeIntl', 'timestampTaken'));
 
                 $table->addActionColumn()
                     ->addParam('gibbonPersonID', $gibbonPersonIDList[0] ?? '')
@@ -387,7 +387,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                 $row->addLabel('periodSelectContainer', __('Periods Absent'));
 
                 $table = $row->addTable('periodSelectContainer')->setClass('standardWidth');
-                $table->addHeaderRow()->addHeading(Format::dateIntlReadable(Format::dateConvert($date),'MMMM d, yyyy'));
+                $table->addHeaderRow()->addHeading(Format::dateIntl(Format::dateConvert($date),'MMMM d, yyyy'));
 
                 foreach ($classes as $class) {
                     $name = $class['columnName'] . ' - ' . $class['courseNameShort'] . '.' . $class['classNameShort'];

--- a/modules/Attendance/attendance_future_byPerson.php
+++ b/modules/Attendance/attendance_future_byPerson.php
@@ -252,7 +252,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                     }
                 });
                 $table->addColumn('staff', __('Recorded By'))->format(Format::using('name', ['', 'preferredName', 'surname', 'Staff', false, true]));
-                $table->addColumn('timestamp', __('On'))->format(Format::using('dateTimeIntl', 'timestampTaken'));
+                $table->addColumn('timestamp', __('On'))->format(Format::using('dateTimeReadable', 'timestampTaken'));
 
                 $table->addActionColumn()
                     ->addParam('gibbonPersonID', $gibbonPersonIDList[0] ?? '')
@@ -387,7 +387,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_futu
                 $row->addLabel('periodSelectContainer', __('Periods Absent'));
 
                 $table = $row->addTable('periodSelectContainer')->setClass('standardWidth');
-                $table->addHeaderRow()->addHeading(Format::dateIntl(Format::dateConvert($date),'MMMM d, yyyy'));
+                $table->addHeaderRow()->addHeading(Format::dateReadable(Format::dateConvert($date),'MMMM d, yyyy'));
 
                 foreach ($classes as $class) {
                     $name = $class['columnName'] . ' - ' . $class['courseNameShort'] . '.' . $class['classNameShort'];

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -129,8 +129,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                         if (empty($log['timestampTaken'])) return Format::small(__('N/A'));
 
                         return $currentDate != substr($log['timestampTaken'], 0, 10)
-                            ? Format::dateTimeIntl($log['timestampTaken'])
-                            : Format::dateTimeIntl($log['timestampTaken'], Format::NONE, Format::SHORT);
+                            ? Format::dateReadable($log['timestampTaken'], Format::MEDIUM, Format::SHORT)
+                            : Format::dateReadable($log['timestampTaken'], Format::NONE, Format::SHORT);
                     });
 
                 $table->addColumn('direction', __('Attendance'))

--- a/modules/Attendance/attendance_take_byPerson.php
+++ b/modules/Attendance/attendance_take_byPerson.php
@@ -129,8 +129,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/attendance_take
                         if (empty($log['timestampTaken'])) return Format::small(__('N/A'));
 
                         return $currentDate != substr($log['timestampTaken'], 0, 10)
-                            ? Format::dateIntlReadable($log['timestampTaken'], 'HH:mm, MMM dd')
-                            : Format::dateIntlReadable($log['timestampTaken'], 'HH:mm');
+                            ? Format::dateTimeIntl($log['timestampTaken'])
+                            : Format::dateTimeIntl($log['timestampTaken'], Format::NONE, Format::SHORT);
                     });
 
                 $table->addColumn('direction', __('Attendance'))

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -203,7 +203,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_graph_by
                     ],
                 ])
                 ->setLabels(array_map(function ($date) {
-                    return Format::dateIntlReadable($date, 'MMM dd');
+                    return Format::dateIntl($date, Format::MEDIUM_NO_YEAR);
                 }, $days));
 
             foreach ($data as $typeName => $dates) {

--- a/modules/Attendance/report_graph_byType.php
+++ b/modules/Attendance/report_graph_byType.php
@@ -203,7 +203,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Attendance/report_graph_by
                     ],
                 ])
                 ->setLabels(array_map(function ($date) {
-                    return Format::dateIntl($date, Format::MEDIUM_NO_YEAR);
+                    return Format::dateReadable($date, Format::MEDIUM_NO_YEAR);
                 }, $days));
 
             foreach ($data as $typeName => $dates) {

--- a/modules/Planner/units_edit_deploy.php
+++ b/modules/Planner/units_edit_deploy.php
@@ -218,7 +218,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
 
         foreach ($lessons as $index => $lesson) {
 
-            $form->addRow()->addHeading(($index+1).'. '.Format::dateIntlReadable($lesson['date'], 'E d MMM, yyyy'))
+            $form->addRow()->addHeading(($index+1).'. '.Format::dateIntl($lesson['date'], Format::FULL))
                 ->append(Format::small($lesson['period'].' ('.Format::timeRange($lesson['timeStart'], $lesson['timeEnd']).')'));
 
             $col = $form->addRow()->addClass('')->addColumn()->addClass('blockLesson');

--- a/modules/Planner/units_edit_deploy.php
+++ b/modules/Planner/units_edit_deploy.php
@@ -218,7 +218,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_deploy.
 
         foreach ($lessons as $index => $lesson) {
 
-            $form->addRow()->addHeading(($index+1).'. '.Format::dateIntl($lesson['date'], Format::FULL))
+            $form->addRow()->addHeading(($index+1).'. '.Format::dateReadable($lesson['date'], Format::FULL))
                 ->append(Format::small($lesson['period'].' ('.Format::timeRange($lesson['timeStart'], $lesson['timeEnd']).')'));
 
             $col = $form->addRow()->addClass('')->addColumn()->addClass('blockLesson');

--- a/modules/Planner/units_edit_working.php
+++ b/modules/Planner/units_edit_working.php
@@ -155,7 +155,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
 
         // Display the heading
         $heading = $form->addRow()->addHeading($lessonLink . $deleteLink)
-            ->append(Format::small(Format::dateIntl($lesson['date'], Format::FULL)).'<br/>')
+            ->append(Format::small(Format::dateReadable($lesson['date'], Format::FULL)).'<br/>')
             ->append($lessonTiming.'<br/>')
             ->append(Format::small($times['spaceName'] ?? ''));
 

--- a/modules/Planner/units_edit_working.php
+++ b/modules/Planner/units_edit_working.php
@@ -155,7 +155,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/units_edit_working
 
         // Display the heading
         $heading = $form->addRow()->addHeading($lessonLink . $deleteLink)
-            ->append(Format::small(Format::dateIntlReadable($lesson['date'], 'EEE d MMM, yyyy')).'<br/>')
+            ->append(Format::small(Format::dateIntl($lesson['date'], Format::FULL)).'<br/>')
             ->append($lessonTiming.'<br/>')
             ->append(Format::small($times['spaceName'] ?? ''));
 

--- a/modules/Reports/archive_byReport.php
+++ b/modules/Reports/archive_byReport.php
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport.p
     $table->setTitle(__('View'));
 
     $table->addColumn('reportIdentifier', __('Report'));
-    $table->addColumn('timestampModified', __('Date'))->format(Format::using('dateIntl', 'timestampModified'));
+    $table->addColumn('timestampModified', __('Date'))->format(Format::using('dateReadable', 'timestampModified'));
     $table->addColumn('readCount', __('Read'))
         ->width('30%')
         ->format(function ($report) use (&$page) {

--- a/modules/Reports/archive_byReport.php
+++ b/modules/Reports/archive_byReport.php
@@ -58,7 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport.p
     $table->setTitle(__('View'));
 
     $table->addColumn('reportIdentifier', __('Report'));
-    $table->addColumn('timestampModified', __('Date'))->format(Format::using('dateIntlReadable', 'timestampModified'));
+    $table->addColumn('timestampModified', __('Date'))->format(Format::using('dateIntl', 'timestampModified'));
     $table->addColumn('readCount', __('Read'))
         ->width('30%')
         ->format(function ($report) use (&$page) {

--- a/modules/Reports/archive_byReport_view.php
+++ b/modules/Reports/archive_byReport_view.php
@@ -129,7 +129,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport_v
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                     $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
-                    $title = Format::dateTimeIntlReadable($archive['timestampModified']);
+                    $title = Format::dateTimeIntl($archive['timestampModified']);
                     $output .= Format::link($url, $title).$tag;
                 }
 
@@ -169,7 +169,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport_v
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                     $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                    $title = Format::dateTimeIntlReadable($archive['timestampModified']);
+                    $title = Format::dateTimeIntl($archive['timestampModified']);
                     return Format::link($url, $title).$tag;
                 }
 

--- a/modules/Reports/archive_byReport_view.php
+++ b/modules/Reports/archive_byReport_view.php
@@ -129,7 +129,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport_v
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                     $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
-                    $title = Format::dateTimeIntl($archive['timestampModified']);
+                    $title = Format::dateTimeReadable($archive['timestampModified']);
                     $output .= Format::link($url, $title).$tag;
                 }
 
@@ -169,7 +169,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byReport_v
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                     $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                    $title = Format::dateTimeIntl($archive['timestampModified']);
+                    $title = Format::dateTimeReadable($archive['timestampModified']);
                     return Format::link($url, $title).$tag;
                 }
 

--- a/modules/Reports/archive_byStudent_view.php
+++ b/modules/Reports/archive_byStudent_view.php
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byStudent_
         $table->addColumn('timestampModified', __('Date'))
             ->width('30%')
             ->format(function ($report) {
-                $output = Format::dateIntl($report['timestampModified']);
+                $output = Format::dateReadable($report['timestampModified']);
                 if ($report['status'] == 'Draft') {
                     $output .= '<span class="tag ml-2 dull">'.__($report['status']).'</span>';
                 }

--- a/modules/Reports/archive_byStudent_view.php
+++ b/modules/Reports/archive_byStudent_view.php
@@ -136,7 +136,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_byStudent_
         $table->addColumn('timestampModified', __('Date'))
             ->width('30%')
             ->format(function ($report) {
-                $output = Format::dateIntlReadable($report['timestampModified']);
+                $output = Format::dateIntl($report['timestampModified']);
                 if ($report['status'] == 'Draft') {
                     $output .= '<span class="tag ml-2 dull">'.__($report['status']).'</span>';
                 }

--- a/modules/Reports/reporting_access_manage.php
+++ b/modules/Reports/reporting_access_manage.php
@@ -93,10 +93,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_access_m
         });
     $table->addColumn('roleName', __('Role'))->translatable();
     $table->addColumn('scopeName', __('Scope'));
-    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntl', 'dateStart'));
-    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntl', 'dateEnd'))
+    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateReadable', 'dateStart'));
+    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateReadable', 'dateEnd'))
         ->format(function ($values) {
-            $output = Format::dateIntl($values['dateEnd']);
+            $output = Format::dateReadable($values['dateEnd']);
             if (date('Y-m-d') > $values['dateEnd']) {
                 $output .= Format::tag(__('Ended'), 'dull ml-2');
             }

--- a/modules/Reports/reporting_access_manage.php
+++ b/modules/Reports/reporting_access_manage.php
@@ -93,10 +93,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_access_m
         });
     $table->addColumn('roleName', __('Role'))->translatable();
     $table->addColumn('scopeName', __('Scope'));
-    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntlReadable', 'dateStart'));
-    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntlReadable', 'dateEnd'))
+    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntl', 'dateStart'));
+    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntl', 'dateEnd'))
         ->format(function ($values) {
-            $output = Format::dateIntlReadable($values['dateEnd']);
+            $output = Format::dateIntl($values['dateEnd']);
             if (date('Y-m-d') > $values['dateEnd']) {
                 $output .= Format::tag(__('Ended'), 'dull ml-2');
             }

--- a/modules/Reports/reporting_cycles_manage.php
+++ b/modules/Reports/reporting_cycles_manage.php
@@ -53,8 +53,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_cycles_m
     $table->addColumn('name', __('Name'))->width('30%');
     $table->addColumn('cycleNumber', __('Cycle'))->width('8%');
     $table->addColumn('yearGroups', __('Year Groups'))->width('15%');
-    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntl', 'dateStart'))->width('15%');
-    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntl', 'dateEnd'))->width('15%');
+    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateReadable', 'dateStart'))->width('15%');
+    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateReadable', 'dateEnd'))->width('15%');
 
     $table->addActionColumn()
         ->addParam('gibbonReportingCycleID')

--- a/modules/Reports/reporting_cycles_manage.php
+++ b/modules/Reports/reporting_cycles_manage.php
@@ -53,8 +53,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_cycles_m
     $table->addColumn('name', __('Name'))->width('30%');
     $table->addColumn('cycleNumber', __('Cycle'))->width('8%');
     $table->addColumn('yearGroups', __('Year Groups'))->width('15%');
-    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntlReadable', 'dateStart'))->width('15%');
-    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntlReadable', 'dateEnd'))->width('15%');
+    $table->addColumn('dateStart', __('Start Date'))->format(Format::using('dateIntl', 'dateStart'))->width('15%');
+    $table->addColumn('dateEnd', __('End Date'))->format(Format::using('dateIntl', 'dateEnd'))->width('15%');
 
     $table->addActionColumn()
         ->addParam('gibbonReportingCycleID')

--- a/modules/Reports/reporting_my.php
+++ b/modules/Reports/reporting_my.php
@@ -142,8 +142,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_my.php')
             $table = DataTable::create('reportsMy');
             $table->setTitle($scope['name']);
             $table->setDescription(__('You have access from {dateStart} to {dateEnd}.', [
-                'dateStart' => Format::dateIntlReadable($scope['dateStart'], 'MMM d'),
-                'dateEnd' => Format::dateIntlReadable($scope['dateEnd'], 'MMM d'),
+                'dateStart' => Format::dateIntl($scope['dateStart'], Format::MEDIUM_NO_YEAR),
+                'dateEnd' => Format::dateIntl($scope['dateEnd'], Format::MEDIUM_NO_YEAR),
             ]));
 
             $table->addColumn('criteriaName', __('Name'))->width('35%');

--- a/modules/Reports/reporting_my.php
+++ b/modules/Reports/reporting_my.php
@@ -142,8 +142,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_my.php')
             $table = DataTable::create('reportsMy');
             $table->setTitle($scope['name']);
             $table->setDescription(__('You have access from {dateStart} to {dateEnd}.', [
-                'dateStart' => Format::dateIntl($scope['dateStart'], Format::MEDIUM_NO_YEAR),
-                'dateEnd' => Format::dateIntl($scope['dateEnd'], Format::MEDIUM_NO_YEAR),
+                'dateStart' => Format::dateReadable($scope['dateStart'], Format::MEDIUM_NO_YEAR),
+                'dateEnd' => Format::dateReadable($scope['dateEnd'], Format::MEDIUM_NO_YEAR),
             ]));
 
             $table->addColumn('criteriaName', __('Name'))->width('35%');

--- a/modules/Reports/reports_generate.php
+++ b/modules/Reports/reports_generate.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
                       .'<span class="tag ml-2 message">'.__('Running').'</span></div>';
             }
 
-            return !empty($report['timestampGenerated'])? Format::dateTimeIntl($report['timestampGenerated']) : '';
+            return !empty($report['timestampGenerated'])? Format::dateTimeReadable($report['timestampGenerated']) : '';
         });
 
     $table->addActionColumn()

--- a/modules/Reports/reports_generate.php
+++ b/modules/Reports/reports_generate.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
                       .'<span class="tag ml-2 message">'.__('Running').'</span></div>';
             }
 
-            return !empty($report['timestampGenerated'])? Format::dateTimeIntlReadable($report['timestampGenerated']) : '';
+            return !empty($report['timestampGenerated'])? Format::dateTimeIntl($report['timestampGenerated']) : '';
         });
 
     $table->addActionColumn()

--- a/modules/Reports/reports_generate_ajax.php
+++ b/modules/Reports/reports_generate_ajax.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
                 $tag = '<span class="tag success ml-2">'.__('Complete').'</span>';
                 $tag .= '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                 $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                $title = Format::dateTimeIntlReadable($archive['timestampModified']);
+                $title = Format::dateTimeIntl($archive['timestampModified']);
                 echo Format::link($url, $title).$tag;
             }
 

--- a/modules/Reports/reports_generate_ajax.php
+++ b/modules/Reports/reports_generate_ajax.php
@@ -55,7 +55,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
                 $tag = '<span class="tag success ml-2">'.__('Complete').'</span>';
                 $tag .= '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                 $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                $title = Format::dateTimeIntl($archive['timestampModified']);
+                $title = Format::dateTimeReadable($archive['timestampModified']);
                 echo Format::link($url, $title).$tag;
             }
 

--- a/modules/Reports/reports_generate_batch.php
+++ b/modules/Reports/reports_generate_batch.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
             if ($archive) {
                 $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                 $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                $title = Format::dateTimeIntlReadable($archive['timestampModified']);
+                $title = Format::dateTimeIntl($archive['timestampModified']);
                 return Format::link($url, $title).$tag;
             }
 

--- a/modules/Reports/reports_generate_batch.php
+++ b/modules/Reports/reports_generate_batch.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate.p
             if ($archive) {
                 $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
                 $url = './modules/Reports/archive_byReport_download.php?gibbonReportArchiveEntryID='.$archive['gibbonReportArchiveEntryID'];
-                $title = Format::dateTimeIntl($archive['timestampModified']);
+                $title = Format::dateTimeReadable($archive['timestampModified']);
                 return Format::link($url, $title).$tag;
             }
 

--- a/modules/Reports/reports_generate_single.php
+++ b/modules/Reports/reports_generate_single.php
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
         ->format(function ($report) use ($gibbonReportID, &$reportArchiveEntryGateway) {
             if ($report['archive']) {
                 $tag = '<span class="tag ml-2 '.($report['archive']['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['archive']['status']).'</span>';
-                $title = Format::dateTimeIntlReadable($report['archive']['timestampModified']);
+                $title = Format::dateTimeIntl($report['archive']['timestampModified']);
                 $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$report['archive']['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
                 return Format::link($url, $title).$tag;
             }

--- a/modules/Reports/reports_generate_single.php
+++ b/modules/Reports/reports_generate_single.php
@@ -106,7 +106,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
         ->format(function ($report) use ($gibbonReportID, &$reportArchiveEntryGateway) {
             if ($report['archive']) {
                 $tag = '<span class="tag ml-2 '.($report['archive']['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['archive']['status']).'</span>';
-                $title = Format::dateTimeIntl($report['archive']['timestampModified']);
+                $title = Format::dateTimeReadable($report['archive']['timestampModified']);
                 $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$report['archive']['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
                 return Format::link($url, $title).$tag;
             }

--- a/modules/Reports/reports_manage.php
+++ b/modules/Reports/reports_manage.php
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage.php
         });
 
     $table->addColumn('accessDate', __('Go Live'))
-        ->format(Format::using('dateTimeIntl', 'accessDate'));
+        ->format(Format::using('dateTimeReadable', 'accessDate'));
 
     $table->addActionColumn()
         ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)

--- a/modules/Reports/reports_manage.php
+++ b/modules/Reports/reports_manage.php
@@ -73,7 +73,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_manage.php
         });
 
     $table->addColumn('accessDate', __('Go Live'))
-        ->format(Format::using('dateTimeIntlReadable', 'accessDate'));
+        ->format(Format::using('dateTimeIntl', 'accessDate'));
 
     $table->addActionColumn()
         ->addParam('gibbonSchoolYearID', $gibbonSchoolYearID)

--- a/modules/Reports/reports_send.php
+++ b/modules/Reports/reports_send.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send.php')
         $table->addColumn('timestampModified', __('Last Created'))
             ->format(function ($report) {
                 $tag = '<span class="tag ml-2 success">'.__('Final').'</span>';
-                return Format::dateTimeIntlReadable($report['timestampModified']).$tag;
+                return Format::dateTimeIntl($report['timestampModified']).$tag;
             });
 
         $table->addActionColumn()
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send.php')
 
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
-                    return Format::dateTimeIntlReadable($archive['timestampModified']).$tag;
+                    return Format::dateTimeIntl($archive['timestampModified']).$tag;
                 }
 
                 return '';

--- a/modules/Reports/reports_send.php
+++ b/modules/Reports/reports_send.php
@@ -61,7 +61,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send.php')
         $table->addColumn('timestampModified', __('Last Created'))
             ->format(function ($report) {
                 $tag = '<span class="tag ml-2 success">'.__('Final').'</span>';
-                return Format::dateTimeIntl($report['timestampModified']).$tag;
+                return Format::dateTimeReadable($report['timestampModified']).$tag;
             });
 
         $table->addActionColumn()
@@ -107,7 +107,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send.php')
 
                 if ($archive) {
                     $tag = '<span class="tag ml-2 '.($archive['status'] == 'Final' ? 'success' : 'dull').'">'.__($archive['status']).'</span>';
-                    return Format::dateTimeIntl($archive['timestampModified']).$tag;
+                    return Format::dateTimeReadable($archive['timestampModified']).$tag;
                 }
 
                 return '';

--- a/modules/Reports/reports_send_batch.php
+++ b/modules/Reports/reports_send_batch.php
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send_batch
         ->format(function ($report) {
 
             $tag = '<span class="tag ml-2 '.($report['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['status']).'</span>';
-            $title = Format::dateTimeIntl($report['timestampModified']);
+            $title = Format::dateTimeReadable($report['timestampModified']);
             $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$report['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
             return Format::link($url, $title).$tag;
         });

--- a/modules/Reports/reports_send_batch.php
+++ b/modules/Reports/reports_send_batch.php
@@ -113,7 +113,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_send_batch
         ->format(function ($report) {
 
             $tag = '<span class="tag ml-2 '.($report['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['status']).'</span>';
-            $title = Format::dateTimeIntlReadable($report['timestampModified']);
+            $title = Format::dateTimeIntl($report['timestampModified']);
             $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$report['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
             return Format::link($url, $title).$tag;
         });

--- a/modules/Reports/templates/reports/coverPage.twig.html
+++ b/modules/Reports/templates/reports/coverPage.twig.html
@@ -46,7 +46,7 @@ config:
     </tr>
     <tr>
         <td colspan=3 style="text-align:center; line-height: 1.1; font-size: 14px; font-weight: normal; color: #888888;">
-            {{- formatUsing('dateIntl', report.date) -}}
+            {{- formatUsing('dateReadable', report.date) -}}
         </td>
     </tr>
     <tr>

--- a/modules/Reports/templates/reports/coverPage.twig.html
+++ b/modules/Reports/templates/reports/coverPage.twig.html
@@ -46,7 +46,7 @@ config:
     </tr>
     <tr>
         <td colspan=3 style="text-align:center; line-height: 1.1; font-size: 14px; font-weight: normal; color: #888888;">
-            {{- formatUsing('dateIntlReadable', report.date) -}}
+            {{- formatUsing('dateIntl', report.date) -}}
         </td>
     </tr>
     <tr>

--- a/modules/Reports/templates/reports/footers/signatureBox.twig.html
+++ b/modules/Reports/templates/reports/footers/signatureBox.twig.html
@@ -45,7 +45,7 @@ config:
             &nbsp; {{ config.signatureTitle|default("Principal") }}
         </td>
         <td class="footer border" style="width:25%;font-size: 9.5pt;line-height:4.2;">
-            &nbsp; {{ formatUsing('dateIntlReadable', reportingCycle.dateEnd) }}
+            &nbsp; {{ formatUsing('dateIntl', reportingCycle.dateEnd) }}
         </td>
     </tr>
 </table>

--- a/modules/Reports/templates/reports/footers/signatureBox.twig.html
+++ b/modules/Reports/templates/reports/footers/signatureBox.twig.html
@@ -45,7 +45,7 @@ config:
             &nbsp; {{ config.signatureTitle|default("Principal") }}
         </td>
         <td class="footer border" style="width:25%;font-size: 9.5pt;line-height:4.2;">
-            &nbsp; {{ formatUsing('dateIntl', reportingCycle.dateEnd) }}
+            &nbsp; {{ formatUsing('dateReadable', reportingCycle.dateEnd) }}
         </td>
     </tr>
 </table>

--- a/modules/Reports/templates/reports/footers/signatureLine.twig.html
+++ b/modules/Reports/templates/reports/footers/signatureLine.twig.html
@@ -40,7 +40,7 @@ config:
         </td>
         <td style="width:5%;"></td>
         <td style="width:25%; line-height: 3; font-size: 10pt; border-bottom: 1.2pt solid #000000; vertical-align: middle;">
-            {{- formatUsing('dateIntlReadable', reportingCycle.dateEnd) -}}
+            {{- formatUsing('dateIntl', reportingCycle.dateEnd) -}}
         </td>
         <td style="width:35%;"></td>
     </tr>

--- a/modules/Reports/templates/reports/footers/signatureLine.twig.html
+++ b/modules/Reports/templates/reports/footers/signatureLine.twig.html
@@ -40,7 +40,7 @@ config:
         </td>
         <td style="width:5%;"></td>
         <td style="width:25%; line-height: 3; font-size: 10pt; border-bottom: 1.2pt solid #000000; vertical-align: middle;">
-            {{- formatUsing('dateIntl', reportingCycle.dateEnd) -}}
+            {{- formatUsing('dateReadable', reportingCycle.dateEnd) -}}
         </td>
         <td style="width:35%;"></td>
     </tr>

--- a/modules/Reports/templates/reports/headers/reportInfo.twig.html
+++ b/modules/Reports/templates/reports/headers/reportInfo.twig.html
@@ -16,7 +16,7 @@ config:
 {{- stylesheet ? include(stylesheet) -}}
 <table class="w-full table" cellspacing="0">
     <tr>
-        <td style="text-align:left;width:50%;"><b>{{- report.name -}}</b> - {{ formatUsing('dateIntl', report.date) -}}</td>
+        <td style="text-align:left;width:50%;"><b>{{- report.name -}}</b> - {{ formatUsing('dateReadable', report.date) -}}</td>
         <td style="text-align:right;width:50%;"><b>{{ student.officialName }}</b>, {{ student.formGroupNameShort }}</td>
     </tr>
     {% if config.dividerLine|default('Y') == 'Y' %}

--- a/modules/Reports/templates/reports/headers/reportInfo.twig.html
+++ b/modules/Reports/templates/reports/headers/reportInfo.twig.html
@@ -16,7 +16,7 @@ config:
 {{- stylesheet ? include(stylesheet) -}}
 <table class="w-full table" cellspacing="0">
     <tr>
-        <td style="text-align:left;width:50%;"><b>{{- report.name -}}</b> - {{ formatUsing('dateIntlReadable', report.date) -}}</td>
+        <td style="text-align:left;width:50%;"><b>{{- report.name -}}</b> - {{ formatUsing('dateIntl', report.date) -}}</td>
         <td style="text-align:right;width:50%;"><b>{{ student.officialName }}</b>, {{ student.formGroupNameShort }}</td>
     </tr>
     {% if config.dividerLine|default('Y') == 'Y' %}

--- a/modules/Reports/templates/reports/studentDetails.twig.html
+++ b/modules/Reports/templates/reports/studentDetails.twig.html
@@ -20,7 +20,7 @@ sources:
                 <span style="font-size: 12pt; font-weight: bold;">{{- student.officialName -}}</span><br/><span style="font-size: 9pt;">{{- student.yearGroupName -}}</span><br/><br/><table class="w-full table" cellspacing="0" cellpadding="0" style="width: 100%; font-size: 8pt">
                     <tr>
                         <td class="border-right" style="width: 22%">{{- report.name -}}<br/>
-                            {{- formatUsing('dateIntlReadable', report.date) -}}
+                            {{- formatUsing('dateIntl', report.date) -}}
                         </td>
                         <td style="width: 4mm;"></td>
                         <td class="border-right" style="width: 22%">{{ __('Form Group') }}<br/>

--- a/modules/Reports/templates/reports/studentDetails.twig.html
+++ b/modules/Reports/templates/reports/studentDetails.twig.html
@@ -20,7 +20,7 @@ sources:
                 <span style="font-size: 12pt; font-weight: bold;">{{- student.officialName -}}</span><br/><span style="font-size: 9pt;">{{- student.yearGroupName -}}</span><br/><br/><table class="w-full table" cellspacing="0" cellpadding="0" style="width: 100%; font-size: 8pt">
                     <tr>
                         <td class="border-right" style="width: 22%">{{- report.name -}}<br/>
-                            {{- formatUsing('dateIntl', report.date) -}}
+                            {{- formatUsing('dateReadable', report.date) -}}
                         </td>
                         <td style="width: 4mm;"></td>
                         <td class="border-right" style="width: 22%">{{ __('Form Group') }}<br/>

--- a/modules/Reports/templates/ui/reportingCycleHeader.twig.html
+++ b/modules/Reports/templates/ui/reportingCycleHeader.twig.html
@@ -20,7 +20,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
         {% set dateClass = 'now'|date('Y-m-d') > milestone.milestoneDate ? 'bg-gray-400 text-gray-700' : 'text-gray-800' %}
 
         <div class="flex-1 flex flex-col justify-start p-4 {{ dateClass }} {{ not loop.last ? 'border-r' }}">
-            <div class="text-xl text-center font-light">{{ formatUsing('dateIntl', milestone.milestoneDate, Format::MEDIUM_NO_YEAR) }}</div>
+            <div class="text-xl text-center font-light">{{ formatUsing('dateReadable', milestone.milestoneDate, Format::MEDIUM_NO_YEAR) }}</div>
             <div class="mt-4 text-xs text-center text-gray-600">{{ milestone.milestoneName }}</div>
         </div>
     {% endfor %}

--- a/modules/Reports/templates/ui/reportingCycleHeader.twig.html
+++ b/modules/Reports/templates/ui/reportingCycleHeader.twig.html
@@ -20,7 +20,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
         {% set dateClass = 'now'|date('Y-m-d') > milestone.milestoneDate ? 'bg-gray-400 text-gray-700' : 'text-gray-800' %}
 
         <div class="flex-1 flex flex-col justify-start p-4 {{ dateClass }} {{ not loop.last ? 'border-r' }}">
-            <div class="text-xl text-center font-light">{{ formatUsing('dateIntlReadable', milestone.milestoneDate, 'MMM d') }}</div>
+            <div class="text-xl text-center font-light">{{ formatUsing('dateIntl', milestone.milestoneDate, Format::MEDIUM_NO_YEAR) }}</div>
             <div class="mt-4 text-xs text-center text-gray-600">{{ milestone.milestoneName }}</div>
         </div>
     {% endfor %}

--- a/modules/Staff/absences_manage.php
+++ b/modules/Staff/absences_manage.php
@@ -44,20 +44,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_manage.php'
     $staffAbsenceTypeGateway = $container->get(StaffAbsenceTypeGateway::class);
     $staffAbsenceDateGateway = $container->get(StaffAbsenceDateGateway::class);
 
-
-    // $today = date('Y-m-d', strtotime('03/02/2024'));
-
-    // echo Format::dateReadable($today, Format::FULL).'<br/>';
-    // echo Format::dateReadable($today, Format::LONG).'<br/>';
-    // echo Format::dateReadable($today, Format::MEDIUM).'<br/>';
-    // echo Format::dateReadable($today, Format::SHORT).'<br/>';
-
-    // echo Format::dateReadable($today, Format::FULL_NO_YEAR).'<br/>';
-    // echo Format::dateReadable($today, Format::LONG_NO_YEAR).'<br/>';
-    // echo Format::dateReadable($today, Format::MEDIUM_NO_YEAR).'<br/>';
-    // echo Format::dateReadable($today, Format::SHORT_NO_YEAR).'<br/>';
-
-    
     $form = Form::create('filter', $session->get('absoluteURL').'/index.php', 'get');
     $form->setTitle(__('Filter'));
     $form->setClass('noIntBorder fullWidth');

--- a/modules/Staff/absences_manage.php
+++ b/modules/Staff/absences_manage.php
@@ -47,15 +47,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_manage.php'
 
     // $today = date('Y-m-d', strtotime('03/02/2024'));
 
-    // echo Format::dateIntl($today, Format::FULL).'<br/>';
-    // echo Format::dateIntl($today, Format::LONG).'<br/>';
-    // echo Format::dateIntl($today, Format::MEDIUM).'<br/>';
-    // echo Format::dateIntl($today, Format::SHORT).'<br/>';
+    // echo Format::dateReadable($today, Format::FULL).'<br/>';
+    // echo Format::dateReadable($today, Format::LONG).'<br/>';
+    // echo Format::dateReadable($today, Format::MEDIUM).'<br/>';
+    // echo Format::dateReadable($today, Format::SHORT).'<br/>';
 
-    // echo Format::dateIntl($today, Format::FULL_NO_YEAR).'<br/>';
-    // echo Format::dateIntl($today, Format::LONG_NO_YEAR).'<br/>';
-    // echo Format::dateIntl($today, Format::MEDIUM_NO_YEAR).'<br/>';
-    // echo Format::dateIntl($today, Format::SHORT_NO_YEAR).'<br/>';
+    // echo Format::dateReadable($today, Format::FULL_NO_YEAR).'<br/>';
+    // echo Format::dateReadable($today, Format::LONG_NO_YEAR).'<br/>';
+    // echo Format::dateReadable($today, Format::MEDIUM_NO_YEAR).'<br/>';
+    // echo Format::dateReadable($today, Format::SHORT_NO_YEAR).'<br/>';
 
     
     $form = Form::create('filter', $session->get('absoluteURL').'/index.php', 'get');

--- a/modules/Staff/absences_manage.php
+++ b/modules/Staff/absences_manage.php
@@ -43,6 +43,20 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/absences_manage.php'
     $staffAbsenceGateway = $container->get(StaffAbsenceGateway::class);
     $staffAbsenceTypeGateway = $container->get(StaffAbsenceTypeGateway::class);
     $staffAbsenceDateGateway = $container->get(StaffAbsenceDateGateway::class);
+
+
+    // $today = date('Y-m-d', strtotime('03/02/2024'));
+
+    // echo Format::dateIntl($today, Format::FULL).'<br/>';
+    // echo Format::dateIntl($today, Format::LONG).'<br/>';
+    // echo Format::dateIntl($today, Format::MEDIUM).'<br/>';
+    // echo Format::dateIntl($today, Format::SHORT).'<br/>';
+
+    // echo Format::dateIntl($today, Format::FULL_NO_YEAR).'<br/>';
+    // echo Format::dateIntl($today, Format::LONG_NO_YEAR).'<br/>';
+    // echo Format::dateIntl($today, Format::MEDIUM_NO_YEAR).'<br/>';
+    // echo Format::dateIntl($today, Format::SHORT_NO_YEAR).'<br/>';
+
     
     $form = Form::create('filter', $session->get('absoluteURL').'/index.php', 'get');
     $form->setTitle(__('Filter'));

--- a/modules/Staff/coverage_availability.php
+++ b/modules/Staff/coverage_availability.php
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_availabilit
     $table->addMetaData('bulkActions', $col);
 
     $table->addColumn('date', __('Date'))
-        ->format(Format::using('dateIntl', 'date'));
+        ->format(Format::using('dateReadable', 'date'));
 
     $table->addColumn('timeStart', __('Time'))->format(function ($date) {
         if ($date['allDay'] == 'N') {

--- a/modules/Staff/coverage_availability.php
+++ b/modules/Staff/coverage_availability.php
@@ -104,7 +104,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_availabilit
     $table->addMetaData('bulkActions', $col);
 
     $table->addColumn('date', __('Date'))
-        ->format(Format::using('dateIntlReadable', 'date'));
+        ->format(Format::using('dateIntl', 'date'));
 
     $table->addColumn('timeStart', __('Time'))->format(function ($date) {
         if ($date['allDay'] == 'N') {

--- a/modules/Staff/coverage_manage_addAjax.php
+++ b/modules/Staff/coverage_manage_addAjax.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_add.
     });
 
     $table->addColumn('dateLabel', __('Date'))
-        ->format(Format::using('dateIntlReadable', 'date'));
+        ->format(Format::using('dateIntl', 'date'));
 
     $table->addCheckboxColumn('requestDates', 'date')
         ->width('15%')

--- a/modules/Staff/coverage_manage_addAjax.php
+++ b/modules/Staff/coverage_manage_addAjax.php
@@ -86,7 +86,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage_add.
     });
 
     $table->addColumn('dateLabel', __('Date'))
-        ->format(Format::using('dateIntl', 'date'));
+        ->format(Format::using('dateReadable', 'date'));
 
     $table->addCheckboxColumn('requestDates', 'date')
         ->width('15%')

--- a/modules/Staff/coverage_my.php
+++ b/modules/Staff/coverage_my.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_my.php') ==
 
         if ($coverageByTimetable) {
             $table->addColumn('date', __('Date'))
-                ->format(Format::using('dateIntlReadable', 'date'))
+                ->format(Format::using('dateIntl', 'date'))
                 ->formatDetails(function ($coverage) {
                     return Format::small(Format::dayOfWeekName($coverage['date']));
                 });

--- a/modules/Staff/coverage_my.php
+++ b/modules/Staff/coverage_my.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_my.php') ==
 
         if ($coverageByTimetable) {
             $table->addColumn('date', __('Date'))
-                ->format(Format::using('dateIntl', 'date'))
+                ->format(Format::using('dateReadable', 'date'))
                 ->formatDetails(function ($coverage) {
                     return Format::small(Format::dayOfWeekName($coverage['date']));
                 });

--- a/modules/Staff/coverage_planner.php
+++ b/modules/Staff/coverage_planner.php
@@ -96,7 +96,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_planner.php
         ->getOutput();
 
     echo '<h2>'.__(Format::dayOfWeekName($date->format('Y-m-d'))).'</h2>';
-    echo '<p>'.Format::dateIntl($date->format('Y-m-d')).'</p>';
+    echo '<p>'.Format::dateReadable($date->format('Y-m-d')).'</p>';
 
     foreach ($times as $groupBy => $timeSlot) {
 

--- a/modules/Staff/coverage_planner.php
+++ b/modules/Staff/coverage_planner.php
@@ -96,7 +96,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_planner.php
         ->getOutput();
 
     echo '<h2>'.__(Format::dayOfWeekName($date->format('Y-m-d'))).'</h2>';
-    echo '<p>'.Format::dateIntlReadable($date->format('Y-m-d')).'</p>';
+    echo '<p>'.Format::dateIntl($date->format('Y-m-d')).'</p>';
 
     foreach ($times as $groupBy => $timeSlot) {
 

--- a/modules/Staff/coverage_planner_assign.php
+++ b/modules/Staff/coverage_planner_assign.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage.php'
     // DETAILS
     $table = DataTable::createDetails('coverage');
 
-    $table->addColumn('date', __('Date'))->format(Format::using('dateIntl', ['date', Format::FULL]));
+    $table->addColumn('date', __('Date'))->format(Format::using('dateReadable', ['date', Format::FULL]));
     $table->addColumn('period', __('Period'));
     $table->addColumn('time', __('Time'))->format(Format::using('timeRange', ['timeStart', 'timeEnd']));
 

--- a/modules/Staff/coverage_planner_assign.php
+++ b/modules/Staff/coverage_planner_assign.php
@@ -78,7 +78,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/coverage_manage.php'
     // DETAILS
     $table = DataTable::createDetails('coverage');
 
-    $table->addColumn('date', __('Date'))->format(Format::using('dateIntlReadable', ['date', 'EEEE, MMM d']));
+    $table->addColumn('date', __('Date'))->format(Format::using('dateIntl', ['date', Format::FULL]));
     $table->addColumn('period', __('Period'));
     $table->addColumn('time', __('Time'))->format(Format::using('timeRange', ['timeStart', 'timeEnd']));
 

--- a/modules/Staff/report_absences_summary.php
+++ b/modules/Staff/report_absences_summary.php
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
                     $dateText = $day['date']->format($dateFormat);
                     $url = $baseURL.'&dateStart='.$dateText.'&dateEnd='.$dateText.'&gibbonStaffAbsenceTypeID='.$gibbonStaffAbsenceTypeID;
                     $title =  Format::dayOfWeekName($day['date']);
-                    $title .= '<br/>'.Format::dateIntl($day['date'], Format::MEDIUM);
+                    $title .= '<br/>'.Format::dateReadable($day['date'], Format::MEDIUM);
                     if ($day['count'] > 0) {
                         $title .= '<br/>'.__n('{count} Absence', '{count} Absences', $day['count']);
                     }

--- a/modules/Staff/report_absences_summary.php
+++ b/modules/Staff/report_absences_summary.php
@@ -64,7 +64,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
 
     // Translated array of months in the current school year
     foreach ($dateRange as $monthDate) {
-        $months[$monthDate->format('Y-m-d')] = Format::dateIntlReadable($monthDate->format('Y-m-d'), 'MMMM yyyy');
+        $months[$monthDate->format('Y-m-d')] = Format::monthName($monthDate->format('Y-m-d')).' '.$monthDate->format('Y');
     }
 
     // Setup the date range used for this report
@@ -174,7 +174,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_summ
                     $dateText = $day['date']->format($dateFormat);
                     $url = $baseURL.'&dateStart='.$dateText.'&dateEnd='.$dateText.'&gibbonStaffAbsenceTypeID='.$gibbonStaffAbsenceTypeID;
                     $title =  Format::dayOfWeekName($day['date']);
-                    $title .= '<br/>'.Format::dateIntlReadable($day['date'], 'MMM d, yyyy');
+                    $title .= '<br/>'.Format::dateIntl($day['date'], Format::MEDIUM);
                     if ($day['count'] > 0) {
                         $title .= '<br/>'.__n('{count} Absence', '{count} Absences', $day['count']);
                     }

--- a/modules/Staff/report_absences_weekly.php
+++ b/modules/Staff/report_absences_weekly.php
@@ -156,7 +156,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_week
 
         $table = DataTable::create('staffAbsences'.$date->format('D'));
         $table->setTitle(__(Format::dayOfWeekName($date->format('Y-m-d'))));
-        $table->setDescription(Format::dateIntlReadable($date->format('Y-m-d')));
+        $table->setDescription(Format::dateIntl($date->format('Y-m-d')));
 
         $canView = isActionAccessible($guid, $connection2, '/modules/Staff/absences_view_byPerson.php', 'View Absences_any');
 

--- a/modules/Staff/report_absences_weekly.php
+++ b/modules/Staff/report_absences_weekly.php
@@ -156,7 +156,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_absences_week
 
         $table = DataTable::create('staffAbsences'.$date->format('D'));
         $table->setTitle(__(Format::dayOfWeekName($date->format('Y-m-d'))));
-        $table->setDescription(Format::dateIntl($date->format('Y-m-d')));
+        $table->setDescription(Format::dateReadable($date->format('Y-m-d')));
 
         $canView = isActionAccessible($guid, $connection2, '/modules/Staff/absences_view_byPerson.php', 'View Absences_any');
 

--- a/modules/Staff/report_coverage_summary.php
+++ b/modules/Staff/report_coverage_summary.php
@@ -60,7 +60,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
 
     // Translated array of months in the current school year
     foreach ($dateRange as $monthDate) {
-        $months[$monthDate->format('Y-m-d')] = Format::dateIntlReadable($monthDate->format('Y-m-d'), 'MMMM yyyy');
+        $months[$monthDate->format('Y-m-d')] = Format::monthName($monthDate->format('Y-m-d')).' '.$monthDate->format('Y');
     }
 
     // Setup the date range used for this report
@@ -208,7 +208,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_coverage_summ
 
         $count = 0;
         foreach ($dateRange as $monthDate) {
-            $table->addColumn('month'.$count, Format::monthName($monthDate, true))->description(Format::dateIntlReadable($monthDate, 'yyyy'))
+            $table->addColumn('month'.$count, Format::monthName($monthDate, true))->description(Format::date($monthDate, 'Y'))
                 ->notSortable()
                 ->format(function ($sub) use ($monthDate) {
                     $sum =  array_sum($sub['coverage'][$monthDate->format('Y-m')] ?? []);

--- a/modules/Staff/report_subs_availability.php
+++ b/modules/Staff/report_subs_availability.php
@@ -121,7 +121,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     // DATA TABLE
     $table = DataTable::createPaginated('subsManage', $criteria);
     $table->setTitle(__('Substitute Availability'));
-    $table->setDescription(Format::dateIntl($dateObject->format('Y-m-d'), Format::FULL));
+    $table->setDescription(Format::dateReadable($dateObject->format('Y-m-d'), Format::FULL));
 
     $table->addHeaderAction('calendar', __('Weekly').' '.__('View'))
         ->setIcon('planner')

--- a/modules/Staff/report_subs_availability.php
+++ b/modules/Staff/report_subs_availability.php
@@ -121,7 +121,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
     // DATA TABLE
     $table = DataTable::createPaginated('subsManage', $criteria);
     $table->setTitle(__('Substitute Availability'));
-    $table->setDescription(Format::dateIntlReadable($dateObject->format('Y-m-d'), 'EEEE, MMM d'));
+    $table->setDescription(Format::dateIntl($dateObject->format('Y-m-d'), Format::FULL));
 
     $table->addHeaderAction('calendar', __('Weekly').' '.__('View'))
         ->setIcon('planner')

--- a/modules/Staff/report_subs_availabilityWeekly.php
+++ b/modules/Staff/report_subs_availabilityWeekly.php
@@ -142,7 +142,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
         $dayOfWeek = $daysOfWeekGateway->getDayOfWeekByDate($weekday->format('Y-m-d'));
 
         $url = './index.php?q=/modules/Staff/report_subs_availability.php&date='.Format::date($weekday->format('Y-m-d'));
-        $columnTitle = Format::link($url, Format::dateIntlReadable($weekday->format('Y-m-d'), 'EEE, MMM d'));
+        $columnTitle = Format::link($url, Format::dateIntl($weekday->format('Y-m-d'), Format::FULL_NO_YEAR));
 
         $table->addColumn($weekday->format('D'), $columnTitle)
             ->context('primary')

--- a/modules/Staff/report_subs_availabilityWeekly.php
+++ b/modules/Staff/report_subs_availabilityWeekly.php
@@ -142,7 +142,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Staff/report_subs_availabi
         $dayOfWeek = $daysOfWeekGateway->getDayOfWeekByDate($weekday->format('Y-m-d'));
 
         $url = './index.php?q=/modules/Staff/report_subs_availability.php&date='.Format::date($weekday->format('Y-m-d'));
-        $columnTitle = Format::link($url, Format::dateIntl($weekday->format('Y-m-d'), Format::FULL_NO_YEAR));
+        $columnTitle = Format::link($url, Format::dateReadable($weekday->format('Y-m-d'), Format::FULL_NO_YEAR));
 
         $table->addColumn($weekday->format('D'), $columnTitle)
             ->context('primary')

--- a/modules/Staff/src/Forms/CoverageRequestForm.php
+++ b/modules/Staff/src/Forms/CoverageRequestForm.php
@@ -221,7 +221,7 @@ class CoverageRequestForm
         });
 
         $table->addColumn('dateLabel', __('Date'))
-            ->format(Format::using('dateIntl', 'date'))
+            ->format(Format::using('dateReadable', 'date'))
             ->formatDetails(function ($coverage) {
                 return Format::small(Format::dayOfWeekName($coverage['date']));
             });

--- a/modules/Staff/src/Forms/CoverageRequestForm.php
+++ b/modules/Staff/src/Forms/CoverageRequestForm.php
@@ -221,7 +221,7 @@ class CoverageRequestForm
         });
 
         $table->addColumn('dateLabel', __('Date'))
-            ->format(Format::using('dateIntlReadable', 'date'))
+            ->format(Format::using('dateIntl', 'date'))
             ->formatDetails(function ($coverage) {
                 return Format::small(Format::dayOfWeekName($coverage['date']));
             });

--- a/modules/Staff/src/Messages/AbsenceApproval.php
+++ b/modules/Staff/src/Messages/AbsenceApproval.php
@@ -60,7 +60,7 @@ class AbsenceApproval extends Message
     public function getDetails() : array
     {
         return [
-            __($this->absence['status'])  => Format::dateTimeIntlReadable($this->absence['timestampApproval']),
+            __($this->absence['status'])  => Format::dateTimeIntl($this->absence['timestampApproval']),
             __('Reply') => $this->absence['notesApproval'],
         ];
     }

--- a/modules/Staff/src/Messages/AbsenceApproval.php
+++ b/modules/Staff/src/Messages/AbsenceApproval.php
@@ -60,7 +60,7 @@ class AbsenceApproval extends Message
     public function getDetails() : array
     {
         return [
-            __($this->absence['status'])  => Format::dateTimeIntl($this->absence['timestampApproval']),
+            __($this->absence['status'])  => Format::dateTimeReadable($this->absence['timestampApproval']),
             __('Reply') => $this->absence['notesApproval'],
         ];
     }

--- a/modules/Staff/src/Messages/CoveragePartial.php
+++ b/modules/Staff/src/Messages/CoveragePartial.php
@@ -34,7 +34,7 @@ class CoveragePartial extends Message
         $this->coverage = $coverage;
 
         $this->uncoveredDates = array_map(function ($date) {
-            return Format::dateIntl($date, Format::MEDIUM_NO_YEAR);
+            return Format::dateReadable($date, Format::MEDIUM_NO_YEAR);
         }, $uncoveredDates);
     }
 

--- a/modules/Staff/src/Messages/CoveragePartial.php
+++ b/modules/Staff/src/Messages/CoveragePartial.php
@@ -34,7 +34,7 @@ class CoveragePartial extends Message
         $this->coverage = $coverage;
 
         $this->uncoveredDates = array_map(function ($date) {
-            return Format::dateIntlReadable($date, 'MMM d');
+            return Format::dateIntl($date, Format::MEDIUM_NO_YEAR);
         }, $uncoveredDates);
     }
 

--- a/modules/Staff/src/Messages/NewAbsenceWithCoverage.php
+++ b/modules/Staff/src/Messages/NewAbsenceWithCoverage.php
@@ -70,7 +70,7 @@ class NewAbsenceWithCoverage extends Message
             if (!empty($date['period']) && !empty($date['contextName'])) {
                 $coverageDetails[$date['period']] = $date['contextName'].$notes;
             } else {
-                $dateReadable = Format::dateIntl($date['date']);
+                $dateReadable = Format::dateReadable($date['date']);
                 $coverageDetails[$dateReadable] = (!empty($date['surnameCoverage']) ? Format::name($date['titleCoverage'], $date['preferredNameCoverage'], $date['surnameCoverage'], 'Staff', false, true) : __('Any available substitute')).$notes;
             }
         }

--- a/modules/Staff/src/Messages/NewAbsenceWithCoverage.php
+++ b/modules/Staff/src/Messages/NewAbsenceWithCoverage.php
@@ -70,7 +70,7 @@ class NewAbsenceWithCoverage extends Message
             if (!empty($date['period']) && !empty($date['contextName'])) {
                 $coverageDetails[$date['period']] = $date['contextName'].$notes;
             } else {
-                $dateReadable = Format::dateIntlReadable($date['date']);
+                $dateReadable = Format::dateIntl($date['date']);
                 $coverageDetails[$dateReadable] = (!empty($date['surnameCoverage']) ? Format::name($date['titleCoverage'], $date['preferredNameCoverage'], $date['surnameCoverage'], 'Staff', false, true) : __('Any available substitute')).$notes;
             }
         }

--- a/modules/Staff/src/Tables/AbsenceCalendar.php
+++ b/modules/Staff/src/Tables/AbsenceCalendar.php
@@ -88,7 +88,7 @@ class AbsenceCalendar
                     if (empty($day) || $day['count'] <= 0) return '';
 
                     $url = 'fullscreen.php?q=/modules/Staff/absences_view_details.php&gibbonStaffAbsenceID='.$day['absence']['gibbonStaffAbsenceID'].'&width=800&height=550';
-                    $title = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateIntl($day['date'], Format::MEDIUM);
+                    $title = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateReadable($day['date'], Format::MEDIUM);
                     $title .= '<br/>'.$day['absence']['type'];
                     $classes = ['thickbox'];
                     if ($day['absence']['allDay'] == 'N') {

--- a/modules/Staff/src/Tables/AbsenceCalendar.php
+++ b/modules/Staff/src/Tables/AbsenceCalendar.php
@@ -88,7 +88,7 @@ class AbsenceCalendar
                     if (empty($day) || $day['count'] <= 0) return '';
 
                     $url = 'fullscreen.php?q=/modules/Staff/absences_view_details.php&gibbonStaffAbsenceID='.$day['absence']['gibbonStaffAbsenceID'].'&width=800&height=550';
-                    $title = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateIntlReadable($day['date'], 'MMM d, yyyy');
+                    $title = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateIntl($day['date'], Format::MEDIUM);
                     $title .= '<br/>'.$day['absence']['type'];
                     $classes = ['thickbox'];
                     if ($day['absence']['allDay'] == 'N') {

--- a/modules/Staff/src/Tables/AbsenceDates.php
+++ b/modules/Staff/src/Tables/AbsenceDates.php
@@ -94,7 +94,7 @@ class AbsenceDates
         }
 
         $table->addColumn('date', $dateLabel)
-            ->format(Format::using('dateIntlReadable', 'date'));
+            ->format(Format::using('dateIntl', 'date'));
 
         $table->addColumn('timeStart', $timeLabel)
             ->format([AbsenceFormats::class, 'timeDetails']);

--- a/modules/Staff/src/Tables/AbsenceDates.php
+++ b/modules/Staff/src/Tables/AbsenceDates.php
@@ -94,7 +94,7 @@ class AbsenceDates
         }
 
         $table->addColumn('date', $dateLabel)
-            ->format(Format::using('dateIntl', 'date'));
+            ->format(Format::using('dateReadable', 'date'));
 
         $table->addColumn('timeStart', $timeLabel)
             ->format([AbsenceFormats::class, 'timeDetails']);

--- a/modules/Staff/src/Tables/CoverageCalendar.php
+++ b/modules/Staff/src/Tables/CoverageCalendar.php
@@ -107,7 +107,7 @@ class CoverageCalendar
 
                     $url = 'fullscreen.php?q=/modules/Staff/coverage_view_details.php&gibbonStaffCoverageID='.$coverage['gibbonStaffCoverageID'].'&width=800&height=550';
 
-                    $params['title'] = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateIntl($day['date'], Format::MEDIUM);
+                    $params['title'] = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateReadable($day['date'], Format::MEDIUM);
                     $params['class'] = '';
                     if ($coverage['allDay'] == 'N') {
                         $params['class'] = $coverage['timeStart'] < '12:00:00' ? 'half-day-am' : 'half-day-pm';

--- a/modules/Staff/src/Tables/CoverageCalendar.php
+++ b/modules/Staff/src/Tables/CoverageCalendar.php
@@ -107,7 +107,7 @@ class CoverageCalendar
 
                     $url = 'fullscreen.php?q=/modules/Staff/coverage_view_details.php&gibbonStaffCoverageID='.$coverage['gibbonStaffCoverageID'].'&width=800&height=550';
 
-                    $params['title'] = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateIntlReadable($day['date'], 'MMM d, yyyy');
+                    $params['title'] = Format::dayOfWeekName($day['date']).'<br/>'.Format::dateIntl($day['date'], Format::MEDIUM);
                     $params['class'] = '';
                     if ($coverage['allDay'] == 'N') {
                         $params['class'] = $coverage['timeStart'] < '12:00:00' ? 'half-day-am' : 'half-day-pm';

--- a/modules/Staff/src/Tables/CoverageDates.php
+++ b/modules/Staff/src/Tables/CoverageDates.php
@@ -99,7 +99,7 @@ class CoverageDates
         $table->addMetaData('blankSlate', __('Coverage is required but has not been requested yet.'));
 
         $table->addColumn('date', __('Date'))
-            ->format(Format::using('dateIntlReadable', 'date'))
+            ->format(Format::using('dateIntl', 'date'))
             ->formatDetails(function ($coverage) {
                 return Format::small(Format::dayOfWeekName($coverage['date']));
             });

--- a/modules/Staff/src/Tables/CoverageDates.php
+++ b/modules/Staff/src/Tables/CoverageDates.php
@@ -99,7 +99,7 @@ class CoverageDates
         $table->addMetaData('blankSlate', __('Coverage is required but has not been requested yet.'));
 
         $table->addColumn('date', __('Date'))
-            ->format(Format::using('dateIntl', 'date'))
+            ->format(Format::using('dateReadable', 'date'))
             ->formatDetails(function ($coverage) {
                 return Format::small(Format::dayOfWeekName($coverage['date']));
             });

--- a/modules/Students/firstAidRecord.php
+++ b/modules/Students/firstAidRecord.php
@@ -102,10 +102,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.ph
         $output = '';
         if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2br($person['description']).'<br/><br/>';
         if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2br($person['actionTaken']).'<br/><br/>';
-        if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateIntlReadable($person['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
+        if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeIntl($person['timestamp'])]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
         $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
         foreach ($resultLog AS $rowLog) {
-            $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateIntlReadable($rowLog['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
+            $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeIntl($rowLog['timestamp'])]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
         }
 
         return $output;

--- a/modules/Students/firstAidRecord.php
+++ b/modules/Students/firstAidRecord.php
@@ -102,10 +102,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord.ph
         $output = '';
         if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2br($person['description']).'<br/><br/>';
         if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2br($person['actionTaken']).'<br/><br/>';
-        if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeIntl($person['timestamp'])]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
+        if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeReadable($person['timestamp'])]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
         $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
         foreach ($resultLog AS $rowLog) {
-            $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeIntl($rowLog['timestamp'])]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
+            $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeReadable($rowLog['timestamp'])]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
         }
 
         return $output;

--- a/modules/Students/firstAidRecord_edit.php
+++ b/modules/Students/firstAidRecord_edit.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
             if (!empty($values['followUp'])) {
                 $row = $form->addRow();
                     $column = $row->addColumn();
-                    $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider']), 'date' => Format::dateIntlReadable($values['timestamp'], 'HH:mm, MMM dd yyyy')]));
+                    $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider']), 'date' => Format::dateTimeIntl($values['timestamp'])]));
                     $column->addContent($values['followUp'])->setClass('fullWidth');
             }
 

--- a/modules/Students/firstAidRecord_edit.php
+++ b/modules/Students/firstAidRecord_edit.php
@@ -122,7 +122,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/firstAidRecord_ed
             if (!empty($values['followUp'])) {
                 $row = $form->addRow();
                     $column = $row->addColumn();
-                    $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider']), 'date' => Format::dateTimeIntl($values['timestamp'])]));
+                    $column->addLabel('followUp0', __("Follow Up by {name} at {date}", ['name' => Format::name('', $values['preferredNameFirstAider'], $values['surnameFirstAider']), 'date' => Format::dateTimeReadable($values['timestamp'])]));
                     $column->addContent($values['followUp'])->setClass('fullWidth');
             }
 

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1330,10 +1330,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                 $output = '';
                                 if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2br($person['description']).'<br/><br/>';
                                 if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2br($person['actionTaken']).'<br/><br/>';
-                                if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeIntl($person['timestamp'])]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
+                                if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeReadable($person['timestamp'])]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
                                 $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
                                 foreach ($resultLog AS $rowLog) {
-                                    $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeIntl($rowLog['timestamp'])]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
+                                    $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeReadable($rowLog['timestamp'])]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
                                 }
 
                                 return $output;
@@ -2114,7 +2114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                 $table->addColumn('timestampModified', __('Date'))
                                     ->width('30%')
                                     ->format(function ($report) {
-                                        $output = Format::dateIntl($report['timestampModified']);
+                                        $output = Format::dateReadable($report['timestampModified']);
                                         if ($report['status'] == 'Draft') {
                                             $output .= '<span class="tag ml-2 dull">'.__($report['status']).'</span>';
                                         }

--- a/modules/Students/student_view_details.php
+++ b/modules/Students/student_view_details.php
@@ -1330,10 +1330,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                 $output = '';
                                 if ($person['description'] != '') $output .= '<b>'.__('Description').'</b><br/>'.nl2br($person['description']).'<br/><br/>';
                                 if ($person['actionTaken'] != '') $output .= '<b>'.__('Action Taken').'</b><br/>'.nl2br($person['actionTaken']).'<br/><br/>';
-                                if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeIntlReadable($person['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
+                                if ($person['followUp'] != '') $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $person['preferredNameFirstAider'], $person['surnameFirstAider']), 'date' => Format::dateTimeIntl($person['timestamp'])]).'</b><br/>'.nl2br($person['followUp']).'<br/><br/>';
                                 $resultLog = $firstAidGateway->queryFollowUpByFirstAidID($person['gibbonFirstAidID']);
                                 foreach ($resultLog AS $rowLog) {
-                                    $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeIntlReadable($rowLog['timestamp'], 'HH:mm, MMM dd yyyy')]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
+                                    $output .= '<b>'.__("Follow Up by {name} at {date}", ['name' => Format::name('', $rowLog['preferredName'], $rowLog['surname']), 'date' => Format::dateTimeIntl($rowLog['timestamp'])]).'</b><br/>'.nl2br($rowLog['followUp']).'<br/><br/>';
                                 }
 
                                 return $output;
@@ -2114,7 +2114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Students/student_view_deta
                                 $table->addColumn('timestampModified', __('Date'))
                                     ->width('30%')
                                     ->format(function ($report) {
-                                        $output = Format::dateIntlReadable($report['timestampModified']);
+                                        $output = Format::dateIntl($report['timestampModified']);
                                         if ($report['status'] == 'Draft') {
                                             $output .= '<span class="tag ml-2 dull">'.__($report['status']).'</span>';
                                         }

--- a/modules/System Admin/import_manage.php
+++ b/modules/System Admin/import_manage.php
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_manage
             ->width('25%')
             ->format(function ($importType) use ($session) {
                 if ($log = $importType['log']) {
-                    $text = Format::dateIntl($log['timestamp']);
+                    $text = Format::dateReadable($log['timestamp']);
                     $url = $session->get('absoluteURL').'/fullscreen.php?q=/modules/System Admin/import_history_view.php&gibbonLogID='.$log['gibbonLogID'].'&width=800&height=550';
                     $title = Format::dateTime($log['timestamp']).' - '.Format::nameList([$log]);
                     return Format::link($url, $text, ['title' => $title, 'class' => 'thickbox']);

--- a/modules/System Admin/import_manage.php
+++ b/modules/System Admin/import_manage.php
@@ -99,7 +99,7 @@ if (isActionAccessible($guid, $connection2, "/modules/System Admin/import_manage
             ->width('25%')
             ->format(function ($importType) use ($session) {
                 if ($log = $importType['log']) {
-                    $text = Format::dateIntlReadable($log['timestamp']);
+                    $text = Format::dateIntl($log['timestamp']);
                     $url = $session->get('absoluteURL').'/fullscreen.php?q=/modules/System Admin/import_history_view.php&gibbonLogID='.$log['gibbonLogID'].'&width=800&height=550';
                     $title = Format::dateTime($log['timestamp']).' - '.Format::nameList([$log]);
                     return Format::link($url, $text, ['title' => $title, 'class' => 'thickbox']);

--- a/modules/Timetable/report_viewAvailableSpace_view.php
+++ b/modules/Timetable/report_viewAvailableSpace_view.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     // DATA TABLE
     $table = DataTable::create('facilityList');
-    $table->setTitle(Format::dateIntl($date). ' - '. $period);
+    $table->setTitle(Format::dateReadable($date). ' - '. $period);
     $table->setDescription(__('View Available Facilities'));
 
     $table->addColumn('name', __('Name'))

--- a/modules/Timetable/report_viewAvailableSpace_view.php
+++ b/modules/Timetable/report_viewAvailableSpace_view.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     // DATA TABLE
     $table = DataTable::create('facilityList');
-    $table->setTitle(Format::dateIntlReadable($date). ' - '. $period);
+    $table->setTitle(Format::dateIntl($date). ' - '. $period);
     $table->setDescription(__('View Available Facilities'));
 
     $table->addColumn('name', __('Name'))

--- a/modules/Timetable/report_viewAvailableTeachers_view.php
+++ b/modules/Timetable/report_viewAvailableTeachers_view.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     // DATA TABLE
     $table = DataTable::create('teacherList');
-    $table->setTitle(Format::dateIntlReadable($date). ' - '. $period);
+    $table->setTitle(Format::dateIntl($date). ' - '. $period);
     $table->setDescription(__('View Available Teachers'));
 
     // COLUMNS

--- a/modules/Timetable/report_viewAvailableTeachers_view.php
+++ b/modules/Timetable/report_viewAvailableTeachers_view.php
@@ -40,7 +40,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/report_viewAvail
 
     // DATA TABLE
     $table = DataTable::create('teacherList');
-    $table->setTitle(Format::dateIntl($date). ' - '. $period);
+    $table->setTitle(Format::dateReadable($date). ' - '. $period);
     $table->setDescription(__('View Available Teachers'));
 
     // COLUMNS

--- a/modules/User Admin/user_manage_password.php
+++ b/modules/User Admin/user_manage_password.php
@@ -150,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
 
             $row = $form->addRow();
                 $row->addLabel('lastTimestampLabel', __('Last Login: Time'));
-                $row->addTextField('lastTimestamp')->setValue(Format::dateTimeIntlReadable($values['lastTimestamp']))->setClass('w-64')->readonly();
+                $row->addTextField('lastTimestamp')->setValue(Format::dateTimeIntl($values['lastTimestamp']))->setClass('w-64')->readonly();
                 $row->addContent(!empty($values['lastTimestamp'])? $trueIcon : $falseIcon);
 
             $row = $form->addRow();

--- a/modules/User Admin/user_manage_password.php
+++ b/modules/User Admin/user_manage_password.php
@@ -150,7 +150,7 @@ if (isActionAccessible($guid, $connection2, '/modules/User Admin/user_manage_pas
 
             $row = $form->addRow();
                 $row->addLabel('lastTimestampLabel', __('Last Login: Time'));
-                $row->addTextField('lastTimestamp')->setValue(Format::dateTimeIntl($values['lastTimestamp']))->setClass('w-64')->readonly();
+                $row->addTextField('lastTimestamp')->setValue(Format::dateTimeReadable($values['lastTimestamp']))->setClass('w-64')->readonly();
                 $row->addContent(!empty($values['lastTimestamp'])? $trueIcon : $falseIcon);
 
             $row = $form->addRow();

--- a/src/Forms/Builder/View/ApplicationCheckView.php
+++ b/src/Forms/Builder/View/ApplicationCheckView.php
@@ -52,7 +52,7 @@ class ApplicationCheckView extends AbstractFormView
         $col->addSubheading($this->getName());
 
         $list[__('Status')] = $data->getStatus();
-        $list[__('Date')] = Format::dateTimeIntlReadable($data->getResult('statusDate'));
+        $list[__('Date')] = Format::dateTimeIntl($data->getResult('statusDate'));
 
         $col->addContent(Format::listDetails($list));
 

--- a/src/Forms/Builder/View/ApplicationCheckView.php
+++ b/src/Forms/Builder/View/ApplicationCheckView.php
@@ -52,7 +52,7 @@ class ApplicationCheckView extends AbstractFormView
         $col->addSubheading($this->getName());
 
         $list[__('Status')] = $data->getStatus();
-        $list[__('Date')] = Format::dateTimeIntl($data->getResult('statusDate'));
+        $list[__('Date')] = Format::dateTimeReadable($data->getResult('statusDate'));
 
         $col->addContent(Format::listDetails($list));
 

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -54,9 +54,9 @@ class Format
         'dateFormatFull'       => 'l, F j',
         'dateFormatLong'       => 'F j',
         'dateFormatMedium'     => 'M j',
-        'dateFormatIntlFull'   => 'EEEE MMMM d',
-        'dateFormatIntlLong'   => 'MMMM d',
-        'dateFormatIntlMedium' => 'MMM d',
+        'dateFormatIntlFull'   => 'EEEE, d MMMM',
+        'dateFormatIntlLong'   => 'd MMMM',
+        'dateFormatIntlMedium' => 'd MMM',
         'dateFormatGenerate'   => true,
     ];
 
@@ -78,6 +78,10 @@ class Format
             static::$settings['dateFormatIntlFull'] = $intlPatternGenerator->getBestPattern('EEEEMMMMd');
             static::$settings['dateFormatIntlLong'] = $intlPatternGenerator->getBestPattern('MMMMd');
             static::$settings['dateFormatIntlMedium'] = $intlPatternGenerator->getBestPattern('MMMd');
+        } else {
+            static::$settings['dateFormatIntlFull'] = static::$settings['code'] == 'en_GB' ? 'EEEE, d MMMM' : 'EEEE, MMMM d';
+            static::$settings['dateFormatIntlLong'] = static::$settings['code'] == 'en_GB' ? 'd MMMM' : 'MMMM d';
+            static::$settings['dateFormatIntlMedium'] = static::$settings['code'] == 'en_GB' ? 'd MMM' : 'MMM d';
         }
     }
 

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -71,7 +71,8 @@ class Format
         static::$settings = array_replace(static::$settings, $settings);
         static::$intlFormatterAvailable = class_exists('IntlDateFormatter');
 
-        if (static::$intlFormatterAvailable) {
+        // Generate best-fit date formats for this locale, if possible
+        if (static::$intlFormatterAvailable && class_exists('IntlDatePatternGenerator')) {
             $intlPatternGenerator = new \IntlDatePatternGenerator(static::$settings['code']);
             static::$settings['dateFormatIntlFull'] = $intlPatternGenerator->getBestPattern('EEEEMMMMd');
             static::$settings['dateFormatIntlLong'] = $intlPatternGenerator->getBestPattern('EEMMMMd');

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -52,14 +52,15 @@ class Format
         'dateTimeFormatPHP'    => 'd/m/Y H:i',
         'timeFormatPHP'        => 'H:i',
         'dateFormatFull'       => 'l, F j',
-        'dateFormatLong'       => 'D, M j',
+        'dateFormatLong'       => 'F j',
         'dateFormatMedium'     => 'M j',
         'dateFormatIntlFull'   => 'EEEE MMMM d',
-        'dateFormatIntlLong'   => 'EE MMMM d',
+        'dateFormatIntlLong'   => 'MMMM d',
         'dateFormatIntlMedium' => 'MMM d',
+        'dateFormatGenerate'   => true,
     ];
 
-    protected static $intlFormatterAvailable = false;
+    public static $intlFormatterAvailable = false;
 
     /**
      * Sets the internal formatting options from an array.
@@ -72,10 +73,10 @@ class Format
         static::$intlFormatterAvailable = class_exists('IntlDateFormatter');
 
         // Generate best-fit date formats for this locale, if possible
-        if (static::$intlFormatterAvailable && class_exists('IntlDatePatternGenerator')) {
+        if (static::$settings['dateFormatGenerate'] && class_exists('IntlDatePatternGenerator')) {
             $intlPatternGenerator = new \IntlDatePatternGenerator(static::$settings['code']);
             static::$settings['dateFormatIntlFull'] = $intlPatternGenerator->getBestPattern('EEEEMMMMd');
-            static::$settings['dateFormatIntlLong'] = $intlPatternGenerator->getBestPattern('EEMMMMd');
+            static::$settings['dateFormatIntlLong'] = $intlPatternGenerator->getBestPattern('MMMMd');
             static::$settings['dateFormatIntlMedium'] = $intlPatternGenerator->getBestPattern('MMMd');
         }
     }
@@ -234,7 +235,14 @@ class Format
      */
     protected static function getDateFallback($dateFormat = null, $timeFormat = null)
     {
+        if (is_null($dateFormat)) {
+            $dateFormat = static::MEDIUM;
+        }
+
         switch ($dateFormat) {
+            case static::NONE:
+                $format = '';
+                break;
             case static::FULL:
             case static::FULL_NO_YEAR:
                 $format = static::$settings['dateFormatFull'];
@@ -247,14 +255,15 @@ class Format
                 $format = static::$settings['dateFormatMedium'];
         }
 
-        if ($dateFormat < 100) {
-            $format .= ', Y'; 
+        if ($dateFormat >= 0 && $dateFormat < 100) {
+            $format .= ' Y'; 
         }
 
-        if ($timeFormat != null) {
+        if ($timeFormat != null && $timeFormat != static::NONE) {
+            $format .= !empty($format) ? ', ' : '';
             $format .= $timeFormat == static::FULL
-                ? ' H:i:s'
-                : ' H:i';
+                ? 'H:i:s'
+                : 'H:i';
         }
 
         return $format;

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -150,25 +150,24 @@ class Format
      * Formats a YYYY-MM-DD date as a readable string with month names.
      *
      * @param DateTime|string $dateString   The date string to format.
-     * @param int|string    $dateFormat     (Optional) An int to specify the date format used with IntlDateFormatter
+     * @param int|string     $dateFormat    (Optional) An int to specify the date format used with IntlDateFormatter
      *                                      If a string is passed, it will return a default format.
-     *
      *                                      See: https://www.php.net/manual/en/class.intldateformatter.php
      *                                      See: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
      *                                      Default: \IntlDateFormatter::LONG
-     * @param int|string    $timeFormat     (Optional) An int to specify the time format used with IntlDateFormatter
+     * @param int|string     $timeFormat    (Optional) An int to specify the time format used with IntlDateFormatter
      *                                      Default: \IntlDateFormatter::NONE
      *
      * @return string  The formatted date string.
      */
-    public static function dateIntl($dateString, $dateFormat = null, $timeFormat = null) : string
+    public static function dateReadable($dateString, $dateFormat = null, $timeFormat = null) : string
     {
         if (empty($dateString)) {
             return '';
         }
 
         if (!static::$intlFormatterAvailable) {
-            return static::date($dateString, static::dateReadableFallback($dateFormat, $timeFormat));
+            return static::date($dateString, static::getDateFallback($dateFormat, $timeFormat));
         }
 
         $formatter = new \IntlDateFormatter(
@@ -177,7 +176,7 @@ class Format
             is_int($timeFormat) ? $timeFormat : \IntlDateFormatter::NONE,
             null,
             null,
-            static::dateReadablePattern($dateFormat)
+            static::getDatePattern($dateFormat)
         );
 
         return mb_convert_case(
@@ -186,7 +185,26 @@ class Format
         );
     }
 
-    protected static function dateReadablePattern($dateFormat = null)
+    /**
+     * A shortcut for formatting a YYYY-MM-DD date as a readable string with month names and times.
+     *
+     * @param DateTime|string $dateString  The date string to format.
+
+     * @return string  The formatted date string.
+     */
+    public static function dateTimeReadable($dateString) : string
+    {
+        return static::dateReadable($dateString, static::LONG, static::SHORT);
+    }
+
+    /**
+     * Gets a IntlDateFormatter pattern string for a given format constant.
+     * Extends the IntlDateFormatter options by adding NO_YEAR options.
+     *
+     * @param string|int    $dateFormat
+     * @return string       The IntlDateFormatter pattern string.
+     */
+    protected static function getDatePattern($dateFormat = null)
     {
         if (is_string($dateFormat) && !empty($dateFormat)) {
             return $dateFormat;
@@ -205,7 +223,15 @@ class Format
         return null;
     }
 
-    protected static function dateReadableFallback($dateFormat = null, $timeFormat = null)
+    /**
+     * Gets a generic format for DateTime classes, to be used as a fallback
+     * when IntlDateFormatter is not avaialble.
+     *
+     * @param string|int    $dateFormat
+     * @param string|int    $timeFormat
+     * @return string       The DateTime format string.
+     */
+    protected static function getDateFallback($dateFormat = null, $timeFormat = null)
     {
         switch ($dateFormat) {
             case static::FULL:
@@ -231,55 +257,6 @@ class Format
         }
 
         return $format;
-    }
-
-    /**
-     * Formats a YYYY-MM-DD date as a readable string with month names.
-     *
-     * @deprecated v27.0.00 Use dateIntl() instead.
-     * @param DateTime|string $dateString
-     * @return string
-     */
-    public static function dateReadable($dateString, $format = '%b %e, %Y')
-    {
-        if (empty($dateString)) {
-            return '';
-        }
-        $date = static::createDateTime($dateString);
-        return mb_convert_case(strftime($format, $date->format('U')), MB_CASE_TITLE);
-    }
-
-    /**
-     * Formats a YYYY-MM-DD date as a readable string with month names and times.
-     *
-     * @param DateTime|string $dateString  The date string to format.
-     * @param string          $pattern     (Optional) The pattern string for Unicode formatting suppored by
-     *                                     IntlDateFormatter::setPattern().
-     *
-     *                                     See: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
-     *                                     Default: 'MMM d, Y'
-     *
-     * @return string  The formatted date string.
-     */
-    public static function dateTimeIntl($dateString, $dateFormat = null, $timeFormat = null): string
-    {
-        return static::dateIntl($dateString, $dateFormat ?? static::LONG, $timeFormat ?? static::SHORT);
-    }
-
-    /**
-     * Formats a YYYY-MM-DD date as a readable string with month names and times.
-     *
-     * @deprecated v27.0.00 Use dateTimeIntl() instead.
-     * @param DateTime|string $dateString
-     * @return string
-     */
-    public static function dateTimeReadable($dateString, $format = '%b %e, %Y %H:%M')
-    {
-        if (empty($dateString)) {
-            return '';
-        }
-        $date = static::createDateTime($dateString);
-        return mb_convert_case(strftime($format, $date->format('U')), MB_CASE_TITLE);
     }
 
     /**
@@ -403,7 +380,7 @@ class Format
                 break;
             default:
                 $timeDifference = 0;
-                $time = static::dateIntl($dateString);
+                $time = static::dateReadable($dateString);
         }
 
         if ($relativeString && $timeDifference > 0) {

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -152,10 +152,10 @@ class Format
      *
      * @param DateTime|string $dateString   The date string to format.
      * @param int|string     $dateFormat    (Optional) An int to specify the date format used with IntlDateFormatter
-     *                                      If a string is passed, it will return a default format.
+     *                                      If a string is passed, it will return the default format.
      *                                      See: https://www.php.net/manual/en/class.intldateformatter.php
      *                                      See: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
-     *                                      Default: \IntlDateFormatter::LONG
+     *                                      Default: \IntlDateFormatter::MEDIUM
      * @param int|string     $timeFormat    (Optional) An int to specify the time format used with IntlDateFormatter
      *                                      Default: \IntlDateFormatter::NONE
      *
@@ -207,8 +207,8 @@ class Format
      */
     protected static function getDatePattern($dateFormat = null)
     {
-        if (is_string($dateFormat) && !empty($dateFormat)) {
-            return $dateFormat;
+        if (is_string($dateFormat)) {
+            return null;
         }
         
         switch ($dateFormat) {
@@ -226,7 +226,7 @@ class Format
 
     /**
      * Gets a generic format for DateTime classes, to be used as a fallback
-     * when IntlDateFormatter is not avaialble.
+     * when IntlDateFormatter is not available.
      *
      * @param string|int    $dateFormat
      * @param string|int    $timeFormat

--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -194,7 +194,7 @@ class Format
      */
     public static function dateTimeReadable($dateString) : string
     {
-        return static::dateReadable($dateString, static::LONG, static::SHORT);
+        return static::dateReadable($dateString, static::MEDIUM, static::SHORT);
     }
 
     /**

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -30,6 +30,7 @@ class FormatTest extends TestCase
             'currency'                       => 'HKD $',
             'currencySymbol'                 => '$',
             'currencyName'                   => 'HKD',
+            'dateFormatGenerate'             => false,
         ];
 
         // Set the locale for the tests.
@@ -163,6 +164,28 @@ class FormatTest extends TestCase
 
         // modules/Attendance/attendance_take_byPerson.php
         $this->assertEquals('13:24', Format::dateReadable($dateString, Format::NONE, Format::SHORT));
+
+        Format::$intlFormatterAvailable = false;
+
+        $this->assertEquals('May 18 2018', Format::dateReadable('2018-05-18'));
+        $this->assertEquals('May 18 2018, 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
+
+        $this->assertEquals('Saturday, February 3 2018', Format::dateReadable($dateString, Format::FULL));
+        $this->assertEquals('Saturday, February 3', Format::dateReadable($dateString, Format::FULL_NO_YEAR));
+        $this->assertEquals('February 3 2018', Format::dateReadable($dateString, Format::LONG));
+        $this->assertEquals('Feb 3 2018', Format::dateReadable($dateString, Format::MEDIUM));
+        $this->assertEquals('Feb 3', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
+
+        $this->assertEquals('03', Format::date($dateString, 'd'));
+        $this->assertEquals('Saturday', Format::dayOfWeekName($dateString));
+        $this->assertEquals('Sat', Format::dayOfWeekName($dateString, true));
+        $this->assertEquals('February', Format::monthName($dateString));
+        $this->assertEquals('Feb', Format::monthName($dateString, true));
+
+        $this->assertEquals('Feb 3 2018, 13:24', Format::dateTimeReadable($dateString));
+        $this->assertEquals('February 3 2018, 13:24', Format::dateReadable($dateString, Format::LONG, Format::SHORT));
+        $this->assertEquals('13:24', Format::dateReadable($dateString, Format::NONE, Format::SHORT));
+        
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -82,12 +82,12 @@ class FormatTest extends TestCase
     public function testFormatsReadableDates()
     {
         $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
-        $this->assertEquals('May 18, 2018', Format::dateIntlReadable('2018-05-18'));
+        $this->assertEquals('18 May 2018', Format::dateIntl('2018-05-18'));
         $this->assertEquals('May 18, 2018 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
-        $this->assertEquals('May 18, 2018 13:24', Format::dateTimeIntlReadable('2018-05-18 13:24'));
+        $this->assertEquals('18 May 2018 At 13:24', Format::dateTimeIntl('2018-05-18 13:24'));
 
         //
-        // Verify fidelity of formatting output before and after dateIntlReadable refactor.
+        // Verify fidelity of formatting output before and after dateIntl refactor.
         //
 
         $dateString = '2018-02-03 13:24';
@@ -95,11 +95,11 @@ class FormatTest extends TestCase
         // modules/Planner/units_edit_deploy.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
-        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntlReadable($dateString, 'E d MMM, yyyy'));
+        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntl($dateString, 'E d MMM, yyyy'));
 
         // modules/Students/student_view_details.php
         $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, '%H:%M, %b %d %Y'));
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntlReadable($dateString, 'HH:mm, MMM dd yyyy'));
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntl($dateString, 'HH:mm, MMM dd yyyy'));
 
         // modules/Attendance/attendance.php
         // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
@@ -108,7 +108,7 @@ class FormatTest extends TestCase
         // modules/Attendance/report_formGroupsNotRegistered_byDate.php
         // modules/Attendance/src/AttendanceView.php
         $this->assertEquals('03', Format::dateReadable($dateString, '%d'));
-        $this->assertEquals('03', Format::dateIntlReadable($dateString, 'dd'));
+        $this->assertEquals('03', Format::dateIntl($dateString, 'dd'));
 
         // modules/Attendance/attendance.php
         // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
@@ -121,16 +121,16 @@ class FormatTest extends TestCase
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
         $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
-        $this->assertEquals('Feb', Format::dateIntlReadable($dateString, 'MMM'));
+        $this->assertEquals('Feb', Format::dateIntl($dateString, 'MMM'));
 
         // modules/Attendance/attendance_future_byPerson.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('February  3, 2018', Format::dateReadable($dateString, '%B %e, %Y'));
-        $this->assertEquals('February 3, 2018', Format::dateIntlReadable($dateString, 'MMMM d, yyyy'));
+        $this->assertEquals('February 3, 2018', Format::dateIntl($dateString, 'MMMM d, yyyy'));
 
         // modules/Attendance/report_graph_byType.php
         $this->assertEquals('Feb 03', Format::dateReadable($dateString, '%b %d'));
-        $this->assertEquals('Feb 03', Format::dateIntlReadable($dateString, 'MMM dd'));
+        $this->assertEquals('3 Feb', Format::dateIntl($dateString, Format::MEDIUM_NO_YEAR));
 
         // modules/Reports/reporting_my.php
         // modules/Activities/report_attendance.php
@@ -139,12 +139,12 @@ class FormatTest extends TestCase
         // modules/Reports/templates/ui/reportingCycleHeader.twig.html
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
-        $this->assertEquals('Feb 3', Format::dateIntlReadable($dateString, 'MMM d'));
+        $this->assertEquals('3 Feb', Format::dateIntl($dateString, Format::MEDIUM_NO_YEAR));
 
         // modules/Activities/report_attendance.php
         // modules/Activities/activities_attendance.php
         $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
-        $this->assertEquals('Sat', Format::dateIntlReadable($dateString, 'EEE'));
+        $this->assertEquals('Sat', Format::dateIntl($dateString, 'EEE'));
 
         // modules/Staff/src/Forms/CoverageRequestForm.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
@@ -155,50 +155,50 @@ class FormatTest extends TestCase
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_absences_weekly.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
-        $this->assertEquals('Saturday', Format::dateIntlReadable($dateString, 'EEEE'));
+        $this->assertEquals('Saturday', Format::dateIntl($dateString, 'EEEE'));
 
         // modules/Staff/src/Tables/AbsenceCalendar.php
         // modules/Staff/report_absences_summary.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
-        $this->assertEquals('Feb 3, 2018', Format::dateIntlReadable($dateString, 'MMM d, yyyy'));
+        $this->assertEquals('3 Feb 2018', Format::dateIntl($dateString, Format::MEDIUM));
 
         // modules/Staff/report_subs_availability.php
         // modules/Staff/coverage_planner_assign.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
-        $this->assertEquals('Saturday, Feb 3', Format::dateIntlReadable($dateString, 'EEEE, MMM d'));
+        $this->assertEquals('Saturday, Feb 3', Format::dateIntl($dateString, 'EEEE, MMM d'));
 
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
         $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
-        $this->assertEquals('February 2018', Format::dateIntlReadable($dateString, 'MMMM yyyy'));
+        $this->assertEquals('February 2018', Format::dateIntl($dateString, 'MMMM yyyy'));
 
         // modules/Staff/report_subs_availabilityWeekly.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat, Feb  3', Format::dateReadable($dateString, '%a, %b %e'));
-        $this->assertEquals('Sat, Feb 3', Format::dateIntlReadable($dateString, 'EEE, MMM d'));
+        $this->assertEquals('Sat, Feb 3', Format::dateIntl($dateString, 'EEE, MMM d'));
 
         // modules/Staff/report_absences_summary.php
         // modules/Planner/units_edit_working.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
-        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntlReadable($dateString, 'EEE d MMM, yyyy'));
+        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntl($dateString, 'EEE d MMM, yyyy'));
 
         // modules/Attendance/attendance_future_byPerson.php
         // modules/Attendance/attendance_take_byPerson.php
         $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%R, %b %d'));
         $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%H:%M, %b %d'));
-        $this->assertEquals('13:24, Feb 03', Format::dateIntlReadable($dateString, 'HH:mm, MMM dd'));
+        $this->assertEquals('13:24, Feb 03', Format::dateIntl($dateString, 'HH:mm, MMM dd'));
 
         // modules/Students/firstAidRecord_edit.php
         // modules/Students/firstAidRecord.php
         $this->assertEquals('13:24, Feb 03 2018', Format::dateTimeReadable($dateString, '%H:%M, %b %d %Y'));
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntlReadable($dateString, 'HH:mm, MMM dd yyyy'));
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntl($dateString, 'HH:mm, MMM dd yyyy'));
 
         // modules/Attendance/attendance_take_byPerson.php
         $this->assertEquals('13:24', Format::dateTimeReadable($dateString, '%H:%M'));
-        $this->assertEquals('13:24', Format::dateIntlReadable($dateString, 'HH:mm'));
+        $this->assertEquals('13:24', Format::dateIntl($dateString, 'HH:mm'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -81,70 +81,46 @@ class FormatTest extends TestCase
 
     public function testFormatsReadableDates()
     {
-        // $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
         $this->assertEquals('18 May 2018', Format::dateReadable('2018-05-18'));
-        // $this->assertEquals('May 18, 2018 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
         $this->assertEquals('18 May 2018, 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
 
         //
-        // Verify fidelity of formatting output before and after dateReadable refactor.
+        // Verify fidelity of formatting output after dateReadable refactor.
         //
 
         $dateString = '2018-02-03 13:24';
 
         // modules/Planner/units_edit_deploy.php
-        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        // $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
-        $this->assertEquals('Sat 3 Feb, 2018', Format::dateReadable($dateString, 'E d MMM, yyyy'));
+        // modules/Staff/report_subs_availability.php
+        // modules/Staff/coverage_planner_assign.php
+        $this->assertEquals('Saturday, 3 February 2018', Format::dateReadable($dateString, Format::FULL));
 
-        // modules/Students/student_view_details.php
-        // $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, '%H:%M, %b %d %Y'));
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, 'HH:mm, MMM dd yyyy'));
-
-        // modules/Attendance/attendance.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
-        // modules/Attendance/src/AttendanceView.php
-        // $this->assertEquals('03', Format::dateReadable($dateString, '%d'));
-        $this->assertEquals('03', Format::dateReadable($dateString, 'dd'));
-
-        // modules/Attendance/attendance.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
-        // modules/Attendance/src/AttendanceView.php
-        // modules/Staff/src/Tables/AbsenceCalendar.php
-        // modules/Staff/src/Tables/CoverageCalendar.php
-        // modules/Staff/report_absences_summary.php
-        // modules/Staff/report_coverage_summary.php
-        // $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
-        $this->assertEquals('Feb', Format::dateReadable($dateString, 'MMM'));
+        // modules/Staff/report_subs_availabilityWeekly.php
+        $this->assertEquals('Saturday, 3 February', Format::dateReadable($dateString, Format::FULL_NO_YEAR));
 
         // modules/Attendance/attendance_future_byPerson.php
-        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        // $this->assertEquals('February  3, 2018', Format::dateReadable($dateString, '%B %e, %Y'));
-        $this->assertEquals('February 3, 2018', Format::dateReadable($dateString, 'MMMM d, yyyy'));
+        $this->assertEquals('3 February 2018', Format::dateReadable($dateString, Format::LONG));
+
+        // modules/Staff/src/Tables/AbsenceCalendar.php
+        // modules/Staff/report_absences_summary.php
+        // modules/Planner/units_edit_working.php
+        $this->assertEquals('3 Feb 2018', Format::dateReadable($dateString, Format::MEDIUM));
 
         // modules/Attendance/report_graph_byType.php
-        // $this->assertEquals('Feb 03', Format::dateReadable($dateString, '%b %d'));
-        $this->assertEquals('3 Feb', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
-
         // modules/Reports/reporting_my.php
         // modules/Activities/report_attendance.php
         // modules/Activities/activities_attendance.php
         // modules/Staff/src/Messages/CoveragePartial.php
         // modules/Reports/templates/ui/reportingCycleHeader.twig.html
-        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        // $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
         $this->assertEquals('3 Feb', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
 
-        // modules/Activities/report_attendance.php
-        // modules/Activities/activities_attendance.php
-        // $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
-        $this->assertEquals('Sat', Format::dateReadable($dateString, 'EEE'));
+        // modules/Attendance/attendance.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
+        // modules/Attendance/src/AttendanceView.php
+        $this->assertEquals('03', Format::date($dateString, 'd'));
 
         // modules/Staff/src/Forms/CoverageRequestForm.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
@@ -154,50 +130,38 @@ class FormatTest extends TestCase
         // modules/Staff/coverage_planner.php
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_absences_weekly.php
-        // $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
-        $this->assertEquals('Saturday', Format::dateReadable($dateString, 'EEEE'));
+        $this->assertEquals('Saturday', Format::dayOfWeekName($dateString));
 
-        // modules/Staff/src/Tables/AbsenceCalendar.php
-        // modules/Staff/report_absences_summary.php
-        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        // $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
-        $this->assertEquals('3 Feb 2018', Format::dateReadable($dateString, Format::MEDIUM));
-
-        // modules/Staff/report_subs_availability.php
-        // modules/Staff/coverage_planner_assign.php
-        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        // $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
-        $this->assertEquals('Saturday, Feb 3', Format::dateReadable($dateString, 'EEEE, MMM d'));
+        // modules/Activities/report_attendance.php
+        // modules/Activities/activities_attendance.php
+        $this->assertEquals('Sat', Format::dayOfWeekName($dateString, true));
 
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
-        // $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
-        $this->assertEquals('February 2018', Format::dateReadable($dateString, 'MMMM yyyy'));
+        $this->assertEquals('February', Format::monthName($dateString));
 
-        // modules/Staff/report_subs_availabilityWeekly.php
-        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        // $this->assertEquals('Sat, Feb  3', Format::dateReadable($dateString, '%a, %b %e'));
-        $this->assertEquals('Sat, Feb 3', Format::dateReadable($dateString, 'EEE, MMM d'));
-
+        // modules/Attendance/attendance.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
+        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
+        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
+        // modules/Attendance/src/AttendanceView.php
+        // modules/Staff/src/Tables/AbsenceCalendar.php
+        // modules/Staff/src/Tables/CoverageCalendar.php
         // modules/Staff/report_absences_summary.php
-        // modules/Planner/units_edit_working.php
-        // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        // $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
-        $this->assertEquals('Sat 3 Feb, 2018', Format::dateReadable($dateString, 'EEE d MMM, yyyy'));
+        // modules/Staff/report_coverage_summary.php
+        $this->assertEquals('Feb', Format::monthName($dateString, true));
 
         // modules/Attendance/attendance_future_byPerson.php
         // modules/Attendance/attendance_take_byPerson.php
-        // $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%R, %b %d'));
-        // $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString));
+        // modules/Students/student_view_details.php
         $this->assertEquals('3 Feb 2018, 13:24', Format::dateTimeReadable($dateString));
 
         // modules/Students/firstAidRecord_edit.php
         // modules/Students/firstAidRecord.php
-        // $this->assertEquals('13:24, Feb 03 2018', Format::dateTimeReadable($dateString, '%H:%M, %b %d %Y'));
         $this->assertEquals('3 February 2018 At 13:24', Format::dateReadable($dateString, Format::LONG, Format::SHORT));
 
         // modules/Attendance/attendance_take_byPerson.php
-        // $this->assertEquals('13:24', Format::dateTimeReadable($dateString, '%H:%M'));
         $this->assertEquals('13:24', Format::dateReadable($dateString, Format::NONE, Format::SHORT));
     }
 

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -82,106 +82,64 @@ class FormatTest extends TestCase
 
     public function testFormatsReadableDates()
     {
-        $this->assertEquals('18 May 2018', Format::dateReadable('2018-05-18'));
-        $this->assertEquals('18 May 2018, 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
-
-        //
-        // Verify fidelity of formatting output after dateReadable refactor.
-        //
+        
 
         $dateString = '2018-02-03 13:24';
 
-        // modules/Planner/units_edit_deploy.php
-        // modules/Staff/report_subs_availability.php
-        // modules/Staff/coverage_planner_assign.php
+        // Verify fidelity of formatting output using default en_GB locale
+
+        $this->assertEquals('18 May 2018', Format::dateReadable('2018-05-18'));
+        $this->assertEquals('18 May 2018, 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
         $this->assertEquals('Saturday, 3 February 2018', Format::dateReadable($dateString, Format::FULL));
-
-        // modules/Staff/report_subs_availabilityWeekly.php
         $this->assertEquals('Saturday, 3 February', Format::dateReadable($dateString, Format::FULL_NO_YEAR));
-
-        // modules/Attendance/attendance_future_byPerson.php
         $this->assertEquals('3 February 2018', Format::dateReadable($dateString, Format::LONG));
-
-        // modules/Staff/src/Tables/AbsenceCalendar.php
-        // modules/Staff/report_absences_summary.php
-        // modules/Planner/units_edit_working.php
         $this->assertEquals('3 Feb 2018', Format::dateReadable($dateString, Format::MEDIUM));
-
-        // modules/Attendance/report_graph_byType.php
-        // modules/Reports/reporting_my.php
-        // modules/Activities/report_attendance.php
-        // modules/Activities/activities_attendance.php
-        // modules/Staff/src/Messages/CoveragePartial.php
-        // modules/Reports/templates/ui/reportingCycleHeader.twig.html
         $this->assertEquals('3 Feb', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
-
-        // modules/Attendance/attendance.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
-        // modules/Attendance/src/AttendanceView.php
         $this->assertEquals('03', Format::date($dateString, 'd'));
-
-        // modules/Staff/src/Forms/CoverageRequestForm.php
-        // modules/Staff/src/Tables/AbsenceCalendar.php
-        // modules/Staff/src/Tables/CoverageDates.php
-        // modules/Staff/src/Tables/CoverageCalendar.php
-        // modules/Staff/coverage_my.php
-        // modules/Staff/coverage_planner.php
-        // modules/Staff/report_absences_summary.php
-        // modules/Staff/report_absences_weekly.php
         $this->assertEquals('Saturday', Format::dayOfWeekName($dateString));
-
-        // modules/Activities/report_attendance.php
-        // modules/Activities/activities_attendance.php
         $this->assertEquals('Sat', Format::dayOfWeekName($dateString, true));
-
-        // modules/Staff/report_absences_summary.php
-        // modules/Staff/report_coverage_summary.php
         $this->assertEquals('February', Format::monthName($dateString));
-
-        // modules/Attendance/attendance.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
-        // modules/Attendance/report_courseClassesNotRegistered_byDate.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
-        // modules/Attendance/report_formGroupsNotRegistered_byDate.php
-        // modules/Attendance/src/AttendanceView.php
-        // modules/Staff/src/Tables/AbsenceCalendar.php
-        // modules/Staff/src/Tables/CoverageCalendar.php
-        // modules/Staff/report_absences_summary.php
-        // modules/Staff/report_coverage_summary.php
         $this->assertEquals('Feb', Format::monthName($dateString, true));
-
-        // modules/Attendance/attendance_future_byPerson.php
-        // modules/Attendance/attendance_take_byPerson.php
-        // modules/Students/student_view_details.php
         $this->assertEquals('3 Feb 2018, 13:24', Format::dateTimeReadable($dateString));
-
-        // modules/Students/firstAidRecord_edit.php
-        // modules/Students/firstAidRecord.php
         $this->assertEquals('3 February 2018 At 13:24', Format::dateReadable($dateString, Format::LONG, Format::SHORT));
-
-        // modules/Attendance/attendance_take_byPerson.php
         $this->assertEquals('13:24', Format::dateReadable($dateString, Format::NONE, Format::SHORT));
+
+        // Verify fidelity of formatting output using en_US locale
+
+        Format::setup(['code' => 'en_US']);
+
+        $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
+        $this->assertEquals('May 18, 2018, 1:24 Pm', Format::dateTimeReadable('2018-05-18 13:24'));
+        $this->assertEquals('Saturday, February 3, 2018', Format::dateReadable($dateString, Format::FULL));
+        $this->assertEquals('Saturday, February 3', Format::dateReadable($dateString, Format::FULL_NO_YEAR));
+        $this->assertEquals('February 3, 2018', Format::dateReadable($dateString, Format::LONG));
+        $this->assertEquals('Feb 3, 2018', Format::dateReadable($dateString, Format::MEDIUM));
+        $this->assertEquals('Feb 3', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
+        $this->assertEquals('03', Format::date($dateString, 'd'));
+        $this->assertEquals('Saturday', Format::dayOfWeekName($dateString));
+        $this->assertEquals('Sat', Format::dayOfWeekName($dateString, true));
+        $this->assertEquals('February', Format::monthName($dateString));
+        $this->assertEquals('Feb', Format::monthName($dateString, true));
+        $this->assertEquals('Feb 3, 2018, 1:24 Pm', Format::dateTimeReadable($dateString));
+        $this->assertEquals('February 3, 2018 At 1:24 Pm', Format::dateReadable($dateString, Format::LONG, Format::SHORT));
+        $this->assertEquals('1:24 Pm', Format::dateReadable($dateString, Format::NONE, Format::SHORT));
+
+        // Verify fidelity of formatting output using generic fallbacks 
 
         Format::$intlFormatterAvailable = false;
 
         $this->assertEquals('May 18 2018', Format::dateReadable('2018-05-18'));
         $this->assertEquals('May 18 2018, 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
-
         $this->assertEquals('Saturday, February 3 2018', Format::dateReadable($dateString, Format::FULL));
         $this->assertEquals('Saturday, February 3', Format::dateReadable($dateString, Format::FULL_NO_YEAR));
         $this->assertEquals('February 3 2018', Format::dateReadable($dateString, Format::LONG));
         $this->assertEquals('Feb 3 2018', Format::dateReadable($dateString, Format::MEDIUM));
         $this->assertEquals('Feb 3', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
-
         $this->assertEquals('03', Format::date($dateString, 'd'));
         $this->assertEquals('Saturday', Format::dayOfWeekName($dateString));
         $this->assertEquals('Sat', Format::dayOfWeekName($dateString, true));
         $this->assertEquals('February', Format::monthName($dateString));
         $this->assertEquals('Feb', Format::monthName($dateString, true));
-
         $this->assertEquals('Feb 3 2018, 13:24', Format::dateTimeReadable($dateString));
         $this->assertEquals('February 3 2018, 13:24', Format::dateReadable($dateString, Format::LONG, Format::SHORT));
         $this->assertEquals('13:24', Format::dateReadable($dateString, Format::NONE, Format::SHORT));

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -82,12 +82,12 @@ class FormatTest extends TestCase
     public function testFormatsReadableDates()
     {
         $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
-        $this->assertEquals('18 May 2018', Format::dateIntl('2018-05-18'));
+        $this->assertEquals('18 May 2018', Format::dateReadable('2018-05-18'));
         $this->assertEquals('May 18, 2018 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
-        $this->assertEquals('18 May 2018 At 13:24', Format::dateTimeIntl('2018-05-18 13:24'));
+        $this->assertEquals('18 May 2018 At 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
 
         //
-        // Verify fidelity of formatting output before and after dateIntl refactor.
+        // Verify fidelity of formatting output before and after dateReadable refactor.
         //
 
         $dateString = '2018-02-03 13:24';
@@ -95,11 +95,11 @@ class FormatTest extends TestCase
         // modules/Planner/units_edit_deploy.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
-        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntl($dateString, 'E d MMM, yyyy'));
+        $this->assertEquals('Sat 3 Feb, 2018', Format::dateReadable($dateString, 'E d MMM, yyyy'));
 
         // modules/Students/student_view_details.php
         $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, '%H:%M, %b %d %Y'));
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntl($dateString, 'HH:mm, MMM dd yyyy'));
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, 'HH:mm, MMM dd yyyy'));
 
         // modules/Attendance/attendance.php
         // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
@@ -108,7 +108,7 @@ class FormatTest extends TestCase
         // modules/Attendance/report_formGroupsNotRegistered_byDate.php
         // modules/Attendance/src/AttendanceView.php
         $this->assertEquals('03', Format::dateReadable($dateString, '%d'));
-        $this->assertEquals('03', Format::dateIntl($dateString, 'dd'));
+        $this->assertEquals('03', Format::dateReadable($dateString, 'dd'));
 
         // modules/Attendance/attendance.php
         // modules/Attendance/report_courseClassesNotRegistered_byDate_print.php
@@ -121,16 +121,16 @@ class FormatTest extends TestCase
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
         $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
-        $this->assertEquals('Feb', Format::dateIntl($dateString, 'MMM'));
+        $this->assertEquals('Feb', Format::dateReadable($dateString, 'MMM'));
 
         // modules/Attendance/attendance_future_byPerson.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('February  3, 2018', Format::dateReadable($dateString, '%B %e, %Y'));
-        $this->assertEquals('February 3, 2018', Format::dateIntl($dateString, 'MMMM d, yyyy'));
+        $this->assertEquals('February 3, 2018', Format::dateReadable($dateString, 'MMMM d, yyyy'));
 
         // modules/Attendance/report_graph_byType.php
         $this->assertEquals('Feb 03', Format::dateReadable($dateString, '%b %d'));
-        $this->assertEquals('3 Feb', Format::dateIntl($dateString, Format::MEDIUM_NO_YEAR));
+        $this->assertEquals('3 Feb', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
 
         // modules/Reports/reporting_my.php
         // modules/Activities/report_attendance.php
@@ -139,12 +139,12 @@ class FormatTest extends TestCase
         // modules/Reports/templates/ui/reportingCycleHeader.twig.html
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
-        $this->assertEquals('3 Feb', Format::dateIntl($dateString, Format::MEDIUM_NO_YEAR));
+        $this->assertEquals('3 Feb', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
 
         // modules/Activities/report_attendance.php
         // modules/Activities/activities_attendance.php
         $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
-        $this->assertEquals('Sat', Format::dateIntl($dateString, 'EEE'));
+        $this->assertEquals('Sat', Format::dateReadable($dateString, 'EEE'));
 
         // modules/Staff/src/Forms/CoverageRequestForm.php
         // modules/Staff/src/Tables/AbsenceCalendar.php
@@ -155,50 +155,50 @@ class FormatTest extends TestCase
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_absences_weekly.php
         $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
-        $this->assertEquals('Saturday', Format::dateIntl($dateString, 'EEEE'));
+        $this->assertEquals('Saturday', Format::dateReadable($dateString, 'EEEE'));
 
         // modules/Staff/src/Tables/AbsenceCalendar.php
         // modules/Staff/report_absences_summary.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
-        $this->assertEquals('3 Feb 2018', Format::dateIntl($dateString, Format::MEDIUM));
+        $this->assertEquals('3 Feb 2018', Format::dateReadable($dateString, Format::MEDIUM));
 
         // modules/Staff/report_subs_availability.php
         // modules/Staff/coverage_planner_assign.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
-        $this->assertEquals('Saturday, Feb 3', Format::dateIntl($dateString, 'EEEE, MMM d'));
+        $this->assertEquals('Saturday, Feb 3', Format::dateReadable($dateString, 'EEEE, MMM d'));
 
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
         $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
-        $this->assertEquals('February 2018', Format::dateIntl($dateString, 'MMMM yyyy'));
+        $this->assertEquals('February 2018', Format::dateReadable($dateString, 'MMMM yyyy'));
 
         // modules/Staff/report_subs_availabilityWeekly.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat, Feb  3', Format::dateReadable($dateString, '%a, %b %e'));
-        $this->assertEquals('Sat, Feb 3', Format::dateIntl($dateString, 'EEE, MMM d'));
+        $this->assertEquals('Sat, Feb 3', Format::dateReadable($dateString, 'EEE, MMM d'));
 
         // modules/Staff/report_absences_summary.php
         // modules/Planner/units_edit_working.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
         $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
-        $this->assertEquals('Sat 3 Feb, 2018', Format::dateIntl($dateString, 'EEE d MMM, yyyy'));
+        $this->assertEquals('Sat 3 Feb, 2018', Format::dateReadable($dateString, 'EEE d MMM, yyyy'));
 
         // modules/Attendance/attendance_future_byPerson.php
         // modules/Attendance/attendance_take_byPerson.php
         $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%R, %b %d'));
         $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%H:%M, %b %d'));
-        $this->assertEquals('13:24, Feb 03', Format::dateIntl($dateString, 'HH:mm, MMM dd'));
+        $this->assertEquals('13:24, Feb 03', Format::dateReadable($dateString, 'HH:mm, MMM dd'));
 
         // modules/Students/firstAidRecord_edit.php
         // modules/Students/firstAidRecord.php
         $this->assertEquals('13:24, Feb 03 2018', Format::dateTimeReadable($dateString, '%H:%M, %b %d %Y'));
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateIntl($dateString, 'HH:mm, MMM dd yyyy'));
+        $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, 'HH:mm, MMM dd yyyy'));
 
         // modules/Attendance/attendance_take_byPerson.php
         $this->assertEquals('13:24', Format::dateTimeReadable($dateString, '%H:%M'));
-        $this->assertEquals('13:24', Format::dateIntl($dateString, 'HH:mm'));
+        $this->assertEquals('13:24', Format::dateReadable($dateString, 'HH:mm'));
     }
 
     public function testFormatsDateRanges()

--- a/tests/unit/Services/FormatTest.php
+++ b/tests/unit/Services/FormatTest.php
@@ -81,10 +81,10 @@ class FormatTest extends TestCase
 
     public function testFormatsReadableDates()
     {
-        $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
+        // $this->assertEquals('May 18, 2018', Format::dateReadable('2018-05-18'));
         $this->assertEquals('18 May 2018', Format::dateReadable('2018-05-18'));
-        $this->assertEquals('May 18, 2018 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
-        $this->assertEquals('18 May 2018 At 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
+        // $this->assertEquals('May 18, 2018 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
+        $this->assertEquals('18 May 2018, 13:24', Format::dateTimeReadable('2018-05-18 13:24'));
 
         //
         // Verify fidelity of formatting output before and after dateReadable refactor.
@@ -94,11 +94,11 @@ class FormatTest extends TestCase
 
         // modules/Planner/units_edit_deploy.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
+        // $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
         $this->assertEquals('Sat 3 Feb, 2018', Format::dateReadable($dateString, 'E d MMM, yyyy'));
 
         // modules/Students/student_view_details.php
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, '%H:%M, %b %d %Y'));
+        // $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, '%H:%M, %b %d %Y'));
         $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, 'HH:mm, MMM dd yyyy'));
 
         // modules/Attendance/attendance.php
@@ -107,7 +107,7 @@ class FormatTest extends TestCase
         // modules/Attendance/report_formGroupsNotRegistered_byDate_print.php
         // modules/Attendance/report_formGroupsNotRegistered_byDate.php
         // modules/Attendance/src/AttendanceView.php
-        $this->assertEquals('03', Format::dateReadable($dateString, '%d'));
+        // $this->assertEquals('03', Format::dateReadable($dateString, '%d'));
         $this->assertEquals('03', Format::dateReadable($dateString, 'dd'));
 
         // modules/Attendance/attendance.php
@@ -120,16 +120,16 @@ class FormatTest extends TestCase
         // modules/Staff/src/Tables/CoverageCalendar.php
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
-        $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
+        // $this->assertEquals('Feb', Format::dateReadable($dateString, '%b'));
         $this->assertEquals('Feb', Format::dateReadable($dateString, 'MMM'));
 
         // modules/Attendance/attendance_future_byPerson.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        $this->assertEquals('February  3, 2018', Format::dateReadable($dateString, '%B %e, %Y'));
+        // $this->assertEquals('February  3, 2018', Format::dateReadable($dateString, '%B %e, %Y'));
         $this->assertEquals('February 3, 2018', Format::dateReadable($dateString, 'MMMM d, yyyy'));
 
         // modules/Attendance/report_graph_byType.php
-        $this->assertEquals('Feb 03', Format::dateReadable($dateString, '%b %d'));
+        // $this->assertEquals('Feb 03', Format::dateReadable($dateString, '%b %d'));
         $this->assertEquals('3 Feb', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
 
         // modules/Reports/reporting_my.php
@@ -138,12 +138,12 @@ class FormatTest extends TestCase
         // modules/Staff/src/Messages/CoveragePartial.php
         // modules/Reports/templates/ui/reportingCycleHeader.twig.html
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
+        // $this->assertEquals('Feb  3', Format::dateReadable($dateString, '%b %e'));
         $this->assertEquals('3 Feb', Format::dateReadable($dateString, Format::MEDIUM_NO_YEAR));
 
         // modules/Activities/report_attendance.php
         // modules/Activities/activities_attendance.php
-        $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
+        // $this->assertEquals('Sat', Format::dateReadable($dateString, '%a'));
         $this->assertEquals('Sat', Format::dateReadable($dateString, 'EEE'));
 
         // modules/Staff/src/Forms/CoverageRequestForm.php
@@ -154,51 +154,51 @@ class FormatTest extends TestCase
         // modules/Staff/coverage_planner.php
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_absences_weekly.php
-        $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
+        // $this->assertEquals('Saturday', Format::dateReadable($dateString, '%A'));
         $this->assertEquals('Saturday', Format::dateReadable($dateString, 'EEEE'));
 
         // modules/Staff/src/Tables/AbsenceCalendar.php
         // modules/Staff/report_absences_summary.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
+        // $this->assertEquals('Feb  3, 2018', Format::dateReadable($dateString, '%b %e, %Y'));
         $this->assertEquals('3 Feb 2018', Format::dateReadable($dateString, Format::MEDIUM));
 
         // modules/Staff/report_subs_availability.php
         // modules/Staff/coverage_planner_assign.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
+        // $this->assertEquals('Saturday, Feb  3', Format::dateReadable($dateString, '%A, %b %e'));
         $this->assertEquals('Saturday, Feb 3', Format::dateReadable($dateString, 'EEEE, MMM d'));
 
         // modules/Staff/report_absences_summary.php
         // modules/Staff/report_coverage_summary.php
-        $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
+        // $this->assertEquals('February 2018', Format::dateReadable($dateString, '%B %Y'));
         $this->assertEquals('February 2018', Format::dateReadable($dateString, 'MMMM yyyy'));
 
         // modules/Staff/report_subs_availabilityWeekly.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        $this->assertEquals('Sat, Feb  3', Format::dateReadable($dateString, '%a, %b %e'));
+        // $this->assertEquals('Sat, Feb  3', Format::dateReadable($dateString, '%a, %b %e'));
         $this->assertEquals('Sat, Feb 3', Format::dateReadable($dateString, 'EEE, MMM d'));
 
         // modules/Staff/report_absences_summary.php
         // modules/Planner/units_edit_working.php
         // Note: %e has a leading space for single digit days, but cannot do the same with intl date formats.
-        $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
+        // $this->assertEquals('Sat  3 Feb, 2018', Format::dateReadable($dateString, '%a %e %b, %Y'));
         $this->assertEquals('Sat 3 Feb, 2018', Format::dateReadable($dateString, 'EEE d MMM, yyyy'));
 
         // modules/Attendance/attendance_future_byPerson.php
         // modules/Attendance/attendance_take_byPerson.php
-        $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%R, %b %d'));
-        $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%H:%M, %b %d'));
-        $this->assertEquals('13:24, Feb 03', Format::dateReadable($dateString, 'HH:mm, MMM dd'));
+        // $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString, '%R, %b %d'));
+        // $this->assertEquals('13:24, Feb 03', Format::dateTimeReadable($dateString));
+        $this->assertEquals('3 Feb 2018, 13:24', Format::dateTimeReadable($dateString));
 
         // modules/Students/firstAidRecord_edit.php
         // modules/Students/firstAidRecord.php
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateTimeReadable($dateString, '%H:%M, %b %d %Y'));
-        $this->assertEquals('13:24, Feb 03 2018', Format::dateReadable($dateString, 'HH:mm, MMM dd yyyy'));
+        // $this->assertEquals('13:24, Feb 03 2018', Format::dateTimeReadable($dateString, '%H:%M, %b %d %Y'));
+        $this->assertEquals('3 February 2018 At 13:24', Format::dateReadable($dateString, Format::LONG, Format::SHORT));
 
         // modules/Attendance/attendance_take_byPerson.php
-        $this->assertEquals('13:24', Format::dateTimeReadable($dateString, '%H:%M'));
-        $this->assertEquals('13:24', Format::dateReadable($dateString, 'HH:mm'));
+        // $this->assertEquals('13:24', Format::dateTimeReadable($dateString, '%H:%M'));
+        $this->assertEquals('13:24', Format::dateReadable($dateString, Format::NONE, Format::SHORT));
     }
 
     public function testFormatsDateRanges()


### PR DESCRIPTION
This PR builds on @yookoala's excellent work by making some additional changes to improve backwards compatibility while aiming to keep the code maintainable.

- All readable date formats now use a constant to define which pattern to use, and these constants (nearly) mirror the exact ones used by the IntlDateFormatter class. This decouples the logic of which type of date to use from the pattern itself.
- The constants for IntlDateFormatter have been extended to add _NO_YEAR options, which matches many of the use cases for date formatting.
- Fallback date formats can now be handled internally, because the intent of the format is communicated through the constant. These can then be removed in the future when a fallback is no longer needed.
- Rather than introducing a new method name, the original method has been refactored, but is still backwards compatible if passed a non-integer value, falling back to a default date format.
- If the IntlDatePatternGenerator is present, then the date formats will be constructed on setup for the chosen locale, creating better localised date formatting.

**Motivation and Context**
Moving the implementation of date patterns/formats internally and using an enumerated constant should make the code more readable and maintainable long-term. Anything using a date class will no longer rely on concrete date patterns, enabling the Format class to handle the patterns internally, and apply fallbacks as necessary.

**How Has This Been Tested?**
Locally
