### PR TITLE
Stream: Fixed the error of "File not supported" with exif checking

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ v28.0.00
     Bug Fixes
         Admissions: fixed "Do not include a second parent" being accidentally checked by default
         Messenger: fixed error redirect for New Message sending users to a non-existing page
+        FileUploader: fixed the error shown when the FileUploader did an exif data check for some images
 
 v27.0.00
 --------

--- a/src/Gibbon/FileUploader.php
+++ b/src/Gibbon/FileUploader.php
@@ -277,7 +277,7 @@ class FileUploader
         }
 
         $this->resizeImage($file['tmp_name'], $file['tmp_name'], $maxSize, $quality);
-
+        
         return $this->uploadFromPost($file, $filenameChange);
     }
 
@@ -350,8 +350,8 @@ class FileUploader
             imagecopyresampled($dst, $src, $destX, $destY, $srcX, $srcY, $destWidth, $destHeight, $srcWidth, $srcHeight);
 
             // Handle Exif rotation
-            if (function_exists('exif_read_data')) {
-                $exif = exif_read_data($sourcePath);
+            if (function_exists('exif_read_data') && in_array($extension, ['jpg', 'jpeg'])) {
+                $exif = @exif_read_data($sourcePath);
                 if (!empty($exif['Orientation'])) {
                     switch ($exif['Orientation']) {
                         case 3:


### PR DESCRIPTION
**Description**
When uploading images, the FileUploader does an exif data check, which is an extra step to check the orientation of an image that came from a mobile device. Without this step, the image is often rotated the wrong direction. However, for some temporary files especially in the Stream module, there was a File not supported error related to exif:

Fixed the FileUploader script so that no error is given even when different types of images are uploaded,.