### PR TITLE
Books without cover art are not shown + books outside "library" are not shown by default

### DIFF
--- a/modules/Library/library_browse.php
+++ b/modules/Library/library_browse.php
@@ -124,6 +124,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
         $ageArray=range(2,21);
         $col->addSelect('readerAge')->fromArray($ageArray)->setClass('fullWidth')->selected($readerAge)->placeholder();
 
+	$locationToggle = 'on';
     $col = $row->addColumn()->setClass('quarterWidth');
         $col->addCheckBox('locationToggle')->description('Include Books Outside of Library?')->checked(($locationToggle == 'on'))->setValue('on');
 
@@ -213,8 +214,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/library_browse.php
             ->fromPOST();
         
         $searchItems = $gateway->queryBrowseItems($criteria)->toArray();
-        $searchTerms = ['Everything' => $everything, 'Name' => $name, 'Producer' => $producer, 'Collection' => $collection, 'Location' => $locationName['name']];
-        
+        $searchTerms = ['Everything' => $everything, 'Name' => $name, 'Producer' => $producer, 'Collection' => $collection, 'Location' => $locationName['name'],'Reader Age' => $readerAge];	
+		
         echo $page->fetchFromTemplate('librarySearch.twig.html', [
             'searchItems' => $searchItems,
             'searchTerms' => $searchTerms,

--- a/modules/Library/templates/librarySearch.twig.html
+++ b/modules/Library/templates/librarySearch.twig.html
@@ -16,6 +16,14 @@
                 <a data-log="{{searchItemViewer.tooltip(item) }}">
                     <img src="{{ "?" in item.imageLocation ? item.imageLocation ~ "&fife=w200" : item.imageLocation }}" class="transition shadow-xl ease-out duration-300 border-2 border-transparent hover hover:border-purple-600 transform hover:-translate-y-1 hover:scale-105 hover:shadow-2xl w-40 h-64">
                 </a>
+			{% else %}
+				<a data-log="{{searchItemViewer.tooltip(item) }}">
+                    <!-- <div class="bg-gray-350 items-center justify-center transition shadow-xl ease-out duration-300 border-2 border-transparent hover hover:border-purple-600 transform hover:-translate-y-1 hover:scale-105 hover:shadow-2xl w-40 h-64"> -->
+					<div class="bg-gray-300 flex flex-col items-center justify-center transition shadow-xl ease-out duration-300 border-2 border-transparent hover hover:border-purple-600 transform hover:-translate-y-1 hover:scale-105 hover:shadow-2xl w-40 h-64">
+						<p class="text-center font-bold">{{ item.name }}</p>
+						<p class="text-center text-sm text-gray-600">{{ item.producer }}</p>
+					</div>
+                </a>
             {% endif %}
         {% endfor %}
         </div>


### PR DESCRIPTION
**Description**
1. By default, library_browse.php statically filters out all books which are not located in the location called "Library". Its not based on country or language. If the locations name is not exactly "Library" (eg Bibliothek in German), the books will get filtered out by default unless the user is attentive enough to not miss the check-box "include books outside of Library". But in that case all the books are included and not only "Library's".  My proposal for fix here is to have the check box checked by default, and the user can actively deselect it if too many unwanted results are shown. The confusion of having too many results seems better than the confusion of having no results at all.

2. The template librarySearch.twig.html silently hides books from the search results if they don't have cover art associated in the database. I think the easiest fix here would be to have a default image shown, eg, that states "image not available".

3. Abother minor and unrelated issue to the original post here but in the same file (library_browse.php) so I mention it here: Normally when a user performs a search in (or outside) library, the search criteria are displayed at the top of the results—except the criteria of readers age. I guess the feature to search on basis of readers age was added not too long ago, so this part got missed. This also seems like a straightforward fix.


**Motivation and Context**
https://ask.gibbonedu.org/t/library-browser-and-search-stop-working-after-update-to-v27/9083/5

**How Has This Been Tested?**
on a docker based testbench

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
![image](https://github.com/user-attachments/assets/fcd8e1bc-2868-4a57-aba4-85acf2a86fb2)
