### PR TITLE
System: update the timetable navigation to use AJAX reloading

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ v28.0.00
         System: added Nicaraguan Córdoba C$ as a currency option
         System: refactored the Fast Finder using HTMX and Alpine
         System: updated Core modules to have Gibbon Foundation as author
+        System: updates the timetable navigation to use AJAX reloading rather than page refresh
         Attendance: added an index to the attendance log to help speed up attendance pages
         Activities: updated Activity Attendance to always count participants for dates in the past
         Markbook: updated markbook columns to grey out students who joined after the Go Live date

--- a/index_tt_ajax.php
+++ b/index_tt_ajax.php
@@ -38,6 +38,8 @@ if (!empty($session->get('i18n')['code']) && function_exists('gettext')) {
 //Setup variables
 $output = '';
 $id = $_REQUEST['gibbonTTID'] ?? '';
+$gibbonPersonID = $_REQUEST['gibbonPersonID'] ?? $session->get('gibbonPersonID');
+$narrow = $_REQUEST['narrow'] ?? 'trim';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == false) {
     //Acess denied
@@ -54,7 +56,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == fals
         $ttDate = Format::timestamp(Format::dateConvert($_REQUEST['ttDate']));
     }
 
-    $tt = renderTT($guid, $connection2, $session->get('gibbonPersonID'), $id, false, $ttDate, '', '', 'trim');
+    $tt = renderTT($guid, $connection2, $gibbonPersonID, $id, false, $ttDate, '', '', $narrow);
     if ($tt != false) {
         $output .= $tt;
     } else {

--- a/index_tt_ajax.php
+++ b/index_tt_ajax.php
@@ -42,8 +42,8 @@ $gibbonPersonID = $_REQUEST['gibbonPersonID'] ?? $session->get('gibbonPersonID')
 $narrow = $_REQUEST['narrow'] ?? 'trim';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == false) {
-    //Acess denied
-    $page->addError(__('Your request failed because you do not have access to this action.'));
+    // Access denied
+    echo Format::alert(__('Your request failed because you do not have access to this action.'), 'error');
 } else {
     include './modules/Timetable/moduleFunctions.php';
     $ttDate = '';

--- a/index_tt_ajax.php
+++ b/index_tt_ajax.php
@@ -37,7 +37,7 @@ if (!empty($session->get('i18n')['code']) && function_exists('gettext')) {
 
 //Setup variables
 $output = '';
-$id = $_POST['gibbonTTID'] ?? '';
+$id = $_REQUEST['gibbonTTID'] ?? '';
 
 if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == false) {
     //Acess denied
@@ -45,8 +45,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') == fals
 } else {
     include './modules/Timetable/moduleFunctions.php';
     $ttDate = '';
-    if (!empty($_POST['ttDate'])) {
-        $ttDate = Format::timestamp(Format::dateConvert($_POST['ttDate']));
+
+    if (!empty($_REQUEST['ttDateNav'])) {
+        $ttDate = Format::timestamp($_REQUEST['ttDateNav']);
+    } elseif (!empty($_REQUEST['ttDateChooser'])) {
+        $ttDate = Format::timestamp($_REQUEST['ttDateChooser']);
+    } elseif (!empty($_REQUEST['ttDate'])) {
+        $ttDate = Format::timestamp(Format::dateConvert($_REQUEST['ttDate']));
     }
 
     $tt = renderTT($guid, $connection2, $session->get('gibbonPersonID'), $id, false, $ttDate, '', '', 'trim');

--- a/modules/Timetable/moduleFunctions.php
+++ b/modules/Timetable/moduleFunctions.php
@@ -382,10 +382,10 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $self = true;
             $roleCategory = $session->get('gibbonRoleIDCurrentCategory');
 
-            if (!empty($_POST['fromTT']) && $_POST['fromTT'] == 'Y') {
-                $session->set('viewCalendarSchool', !empty($_POST['schoolCalendar']) ? 'Y' : 'N');
-                $session->set('viewCalendarPersonal', !empty($_POST['personalCalendar']) ? 'Y' : 'N');
-                $session->set('viewCalendarSpaceBooking', !empty($_POST['spaceBookingCalendar']) ? 'Y' : 'N');
+            if (!empty($_REQUEST['fromTT']) && !empty($_POST['ttCheckbox'])) {
+                $session->set('viewCalendarSchool', !empty($_POST['schoolCalendar']) ? $_POST['schoolCalendar'] : 'N');
+                $session->set('viewCalendarPersonal', !empty($_POST['personalCalendar']) ? $_POST['personalCalendar'] : 'N');
+                $session->set('viewCalendarSpaceBooking', !empty($_POST['spaceBookingCalendar']) ? $_POST['spaceBookingCalendar'] : 'N');
             }
 
             //Update display choices
@@ -477,72 +477,45 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
             $row = $result->fetch();
             $gibbonTTID = $row['gibbonTTID'];
             $nameShortDisplay = $row['nameShortDisplay']; //Store day short name display setting for later
-            $thisWeek = time();
 
             if ($title != false) {
                 $output .= '<h2>'.$row['name'].'</h2>';
             }
-            $output .= "<table cellspacing='0' class='noIntBorder' style='width: 100%; margin: 10px 0 10px 0'>";
-            $output .= '<tr>';
-            $output .= "<td style='vertical-align: top;width:360px'>";
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
-            $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], ($startDayStamp - (7 * 24 * 60 * 60)))."' type='hidden'>";
-            $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-            $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-            $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-            $output .= "<input name='fromTT' value='Y' type='hidden'>";
-            $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='< ".__('Last Week')."'>";
-            $output .= '</form>';
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
-            $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'],($thisWeek))."' type='hidden'>";
-            $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-            $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-            $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-            $output .= "<input name='fromTT' value='Y' type='hidden'>";
-            $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='".__('This Week')."'>";
-            $output .= '</form>';
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
-            $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], ($startDayStamp + (7 * 24 * 60 * 60)))."' type='hidden'>";
-            $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-            $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-            $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-            $output .= "<input name='fromTT' value='Y' type='hidden'>";
-            $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='".__('Next Week')." >'>";
-            $output .= '</form>';
-            $output .= '</td>';
-            $output .= "<td style='vertical-align: top; text-align: right'>";
-            $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q&gibbonTTID=".$row['gibbonTTID']."$params'>";
-            $output .= '<span class="relative">';
-            $output .= "<input name='ttDate' id='ttDate' aria-label='".__('Choose Date')."' maxlength=10 value='".date($session->get('i18n')['dateFormatPHP'], $startDayStamp)."' type='text' style='width:120px; margin-right: 0px; float: none'> ";
-            $output .= '</span>';
-            $output .= '<script type="text/javascript">';
-            $output .= "var ttDate=new LiveValidation('ttDate');";
-            $output .= 'ttDate.add( Validate.Format, {pattern:';
-            if ($session->get('i18n')['dateFormatRegEx'] == '') {
-                $output .= "/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/i";
-            } else {
-                $output .= $session->get('i18n')['dateFormatRegEx'];
-            }
-            $output .= ', failureMessage: "Use ';
-            if ($session->get('i18n')['dateFormat'] == '') {
-                $output .= 'dd/mm/yyyy';
-            } else {
-                $output .= $session->get('i18n')['dateFormat'];
-            }
-            $output .= '." } );';
-            $output .= 'ttDate.add(Validate.Presence);';
-            $output .= '$("#ttDate").datepicker();';
-            $output .= '</script>';
 
-            $output .= "<input style='margin-top: 0px; margin-right: -1px; padding-left: 1rem; padding-right: 1rem;' type='submit' value='".__('Go')."'>";
-            $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-            $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-            $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-            $output .= "<input name='fromTT' value='Y' type='hidden'>";
+            $urlParams = [
+                'q'                    => $q,
+                'gibbonTTID'           => $row['gibbonTTID'],
+                'schoolCalendar'       => $session->get('viewCalendarSchool'),
+                'personalCalendar'     => $session->get('viewCalendarPersonal'),
+                'spaceBookingCalendar' => $session->get('viewCalendarSpaceBooking'),
+                'fromTT'               => 'Y',
+            ];
+
+            $apiEndpoint = Url::fromHandlerRoute('index_tt_ajax.php')->withQueryParams($urlParams);
+
+            $output .= "<form x-data='{ ttDate: \"\" }'
+                        hx-post='".$apiEndpoint."' 
+                        hx-trigger='click from:(button), change from:(#ttDateChooser)'
+                        hx-target='#tt' 
+                        hx-include='[name=\"ttDateChooser\"]'
+                        >";
+
+            $output .= "<nav id='#ttNav' cellspacing='0' class='flex justify-between items-end' style='width: 100%; margin: 10px 0 10px 0'>";
+            $output .= "<input type='hidden' name='ttDateNav' x-model='ttDate'>";
+
+            $output .= "<div>";
+            $output .= "<button type='button' class='float-left rounded-l h-8 px-3 text-xs border border-gray-500 text-gray-600 bg-gray-200 font-semibold hover:bg-gray-400 hover:text-gray-700'
+                x-on:click='ttDate=\"".date('Y-m-d', ($startDayStamp - (7 * 24 * 60 * 60)))."\"'>← <span class='hidden sm:inline'>".__('Last Week')."</span></button>";
+            $output .= "<button type='button' class='float-left h-8 px-3 text-xs border border-gray-500 text-gray-600 bg-gray-200 font-semibold hover:bg-gray-400 hover:text-gray-700 -ml-px'
+                x-on:click='ttDate=\"".date('Y-m-d', time())."\"'>".__('This Week')."</button>";
+            $output .= "<button type='button' class='float-left rounded-r h-8 px-3 text-xs border border-gray-500 text-gray-600 bg-gray-200 font-semibold hover:bg-gray-400 hover:text-gray-700 -ml-px'
+                x-on:click='ttDate=\"".date('Y-m-d', ($startDayStamp + (7 * 24 * 60 * 60)))."\"'><span class='hidden sm:inline'>".__('Next Week')."</span> →</button>";
+            $output .= "</div>";
+
+            $output .= "<input name='ttDateChooser' id='ttDateChooser' aria-label='".__('Choose Date')."' maxlength=10 value='".date('Y-m-d', $startDayStamp)."' type='date' required class='self-end border font-sans h-10 w-36 px-3'> ";
+            $output .= '</nav>';
+
             $output .= '</form>';
-            $output .= '</td>';
-            $output .= '</tr>';
-            $output .= '</table>';
 
             //Check which days are school days
             $daysInWeek = 0;
@@ -906,42 +879,38 @@ function renderTT($guid, $connection2, $gibbonPersonID, $gibbonTTID, $title = ''
                 if ($self == true and ($session->get('calendarFeed') != '' || $session->get('calendarFeedPersonal') != '' || $session->get('viewCalendarSpaceBooking') != '')) {
                     $output .= "<tr class='head' style='height: 37px;'>";
                     $output .= "<th class='ttCalendarBar' colspan=".($daysInWeek + 1).'>';
-                    $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q".$params."' style='padding: 5px 5px 0 0'>";
+
+                    $output .= "<form class='py-2'
+                        hx-post='".$apiEndpoint->withQueryParam('ttDate', date($session->get('i18n')['dateFormatPHP'], $startDayStamp))."' 
+                        hx-trigger='change'
+                        hx-target='#tt' 
+                        hx-vals='{\"ttCheckbox\": \"true\"}'
+                        >";
 
                     $displayCalendars = ($session->has('googleAPIAccessToken') && $session->has('googleAPICalendarEnabled')) || $session->has('microsoftAPIAccessToken');
-                    if ($session->has('calendarFeed') && $session->has('googleAPIAccessToken') && $session->has('googleAPICalendarEnabled')) {
-                        $checked = '';
-                        if ($session->get('viewCalendarSchool') == 'Y') {
-                            $checked = 'checked';
-                        }
-                        $output .= "<span class='ttSchoolCalendar' style='opacity: $schoolCalendarAlpha'>".__('School Calendar');
-                        $output .= "<input $checked style='margin-left: 3px' type='checkbox' name='schoolCalendar' onclick='submit();'/>";
+                    if (true || $session->has('calendarFeed') && $session->has('googleAPIAccessToken') && $session->has('googleAPICalendarEnabled')) {
+                        $checked = $session->get('viewCalendarSchool') == 'Y' ? 'checked' : '';
+                        $output .= "<span class='ttSchoolCalendar rounded-sm'>".__('School Calendar');
+                        $output .= "<input $checked class='ml-2' type='checkbox' name='schoolCalendar' value='Y' class='ttCheckbox' />";
                         $output .= '</span>';
                     }
-                    if ($displayCalendars) {
-                        $checked = '';
-                        if ($session->get('viewCalendarPersonal') == 'Y') {
-                            $checked = 'checked';
-                        }
-                        $output .= "<span class='ttPersonalCalendar' style='opacity: $schoolCalendarAlpha'>".__('Personal Calendar');
-                        $output .= "<input $checked style='margin-left: 3px' type='checkbox' name='personalCalendar' onclick='submit();'/>";
+                    if (true || $displayCalendars) {
+                        $checked = $session->get('viewCalendarPersonal') == 'Y' ? 'checked' : '';
+                        $output .= "<span class='ttPersonalCalendar rounded-sm'>".__('Personal Calendar');
+                        $output .= "<input $checked class='ml-2' type='checkbox' name='personalCalendar' value='Y' class='ttCheckbox' />";
                         $output .= '</span>';
                     }
                     if ($spaceBookingAvailable) {
                         if ($session->get('viewCalendarSpaceBooking') != '') {
-                            $checked = '';
-                            if ($session->get('viewCalendarSpaceBooking') == 'Y') {
-                                $checked = 'checked';
-                            }
-                            $output .= "<span class='ttSpaceBookingCalendar' style='opacity: $schoolCalendarAlpha'><a style='color: #fff' href='".$session->get('absoluteURL')."/index.php?q=/modules/Timetable/spaceBooking_manage.php'>".__('Bookings').'</a> ';
-                            $output .= "<input $checked style='margin-left: 3px' type='checkbox' name='spaceBookingCalendar' aria-label='".__('Space Booking Calendar')."' onclick='submit();'/>";
+                            $checked = $session->get('viewCalendarSpaceBooking') == 'Y' ? 'checked' : '';
+                            $output .= "<span class='ttSpaceBookingCalendar rounded-sm'><a style='color: #fff' href='".$session->get('absoluteURL')."/index.php?q=/modules/Timetable/spaceBooking_manage.php'>".__('Bookings').'</a> ';
+                            $output .= "<input $checked class='ml-2' type='checkbox' name='spaceBookingCalendar' value='Y' class='ttCheckbox' aria-label='".__('Space Booking Calendar')."' />";
                             $output .= '</span>';
                         }
                     }
 
-                    $output .= "<input type='hidden' name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], $startDayStamp)."'>";
-                    $output .= "<input name='fromTT' value='Y' type='hidden'>";
                     $output .= '</form>';
+
                     $output .= '</th>';
                     $output .= '</tr>';
                 }
@@ -2069,6 +2038,9 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
 
     }
 
+    if (!empty($_REQUEST['fromTT']) && !empty($_POST['ttCheckbox'])) {
+        $session->set('viewCalendarSpaceBooking', !empty($_POST['spaceBookingCalendar']) ? $_POST['spaceBookingCalendar'] : 'N');
+    }
     
     //Get space booking array
     $eventsSpaceBooking = false;
@@ -2086,68 +2058,43 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
             $output .= '<h2>'.$row['name'].'</h2>';
         }
 
-        $output .= "<table cellspacing='0' class='noIntBorder' cellspacing='0' style='width: 100%; margin: 10px 0 10px 0'>";
-        $output .= '<tr>';
-        $output .= "<td style='vertical-align: top;width:360px;'>";
-        $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q".$params.'&gibbonTTID='.$row['gibbonTTID']."'>";
-        $output .= "<input name='ttDate' maxlength=10 value='".date($session->get('i18n')['dateFormatPHP'], ($startDayStamp - (7 * 24 * 60 * 60)))."' type='hidden'>";
-        $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-        $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-        $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-        $output .= "<input name='fromTT' value='Y' type='hidden'>";
-        $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='< ".__('Last Week')."'>";
+        $urlParams = [
+            'q'                    => $q,
+            'gibbonSpaceID'        => $gibbonSpaceID,
+            'gibbonTTID'           => $row['gibbonTTID'],
+            'schoolCalendar'       => $session->get('viewCalendarSchool'),
+            'personalCalendar'     => $session->get('viewCalendarPersonal'),
+            'spaceBookingCalendar' => $session->get('viewCalendarSpaceBooking'),
+            'fromTT'               => 'Y',
+        ];
+
+        $apiEndpoint = Url::fromHandlerRoute('index.php')->withQueryParams($urlParams);
+
+        $output .= '<div id="ttSpace">';
+        $output .= "<form x-data='{ ttDate: \"".date('Y-m-d', $startDayStamp)."\" }'
+                    hx-post='".$apiEndpoint."' 
+                    hx-trigger='click from:(button), change from:(#ttDateChooser)'
+                    hx-target='#ttSpace'
+                    hx-select='#ttSpace' 
+                    hx-include='[name=\"ttDate\"]'
+                    >";
+
+        $output .= "<nav id='#ttNav' cellspacing='0' class='flex justify-between items-end' style='width: 100%; margin: 10px 0 10px 0'>";
+        // $output .= "<input type='hidden' name='ttDate' x-model='ttDate'>";
+
+        $output .= "<div>";
+        $output .= "<button type='button' class='float-left rounded-l h-8 px-3 text-xs border border-gray-500 text-gray-600 bg-gray-200 font-semibold hover:bg-gray-400 hover:text-gray-700'
+            x-on:click='ttDate=\"".date('Y-m-d', ($startDayStamp - (7 * 24 * 60 * 60)))."\"'>← <span class='hidden sm:inline'>".__('Last Week')."</span></button>";
+        $output .= "<button type='button' class='float-left h-8 px-3 text-xs border border-gray-500 text-gray-600 bg-gray-200 font-semibold hover:bg-gray-400 hover:text-gray-700 -ml-px'
+            x-on:click='ttDate=\"".date('Y-m-d', time())."\"'>".__('This Week')."</button>";
+        $output .= "<button type='button' class='float-left rounded-r h-8 px-3 text-xs border border-gray-500 text-gray-600 bg-gray-200 font-semibold hover:bg-gray-400 hover:text-gray-700 -ml-px'
+            x-on:click='ttDate=\"".date('Y-m-d', ($startDayStamp + (7 * 24 * 60 * 60)))."\"'><span class='hidden sm:inline'>".__('Next Week')."</span> →</button>";
+        $output .= "</div>";
+
+        $output .= "<input x-model='ttDate' name='ttDate' id='ttDateChooser' aria-label='".__('Choose Date')."' maxlength=10  type='date' required class='self-end border font-sans h-10 w-36 px-3'> ";
+        $output .= '</nav>';
+
         $output .= '</form>';
-        $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q".$params.'&gibbonTTID='.$row['gibbonTTID']."'>";
-        $output .= "<input name='ttDate' maxlength=10 value='".date($session->get('i18n')['dateFormatPHP'])."' type='hidden'>";
-        $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-        $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-        $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-        $output .= "<input name='fromTT' value='Y' type='hidden'>";
-        $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='".__('This Week')."'>";
-        $output .= '</form>';
-        $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q".$params.'&gibbonTTID='.$row['gibbonTTID']."'>";
-        $output .= "<input name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], ($startDayStamp + (7 * 24 * 60 * 60)))."' type='hidden'>";
-        $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-        $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-        $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-        $output .= "<input name='fromTT' value='Y' type='hidden'>";
-        $output .= "<input class='buttonLink' style='min-width: 30px; margin-top: 0px; float: left' type='submit' value='".__('Next Week')." >'>";
-        $output .= '</form>';
-        $output .= '</td>';
-        $output .= "<td style='vertical-align: top; text-align: right'>";
-        $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q".$params.'&gibbonTTID='.$row['gibbonTTID']."'>";
-        $output .= "<input name='ttDate' id='ttDate' aria-label='".__('Choose Date')."' maxlength=10 value='".date($session->get('i18n')['dateFormatPHP'], $startDayStamp)."' type='text' style='height: 36px; width:120px; margin-right: 0px; float: none'>";
-        $output .= '<script type="text/javascript">';
-        $output .= "var ttDate=new LiveValidation('ttDate');";
-        $output .= 'ttDate.add( Validate.Format, {pattern: ';
-        if ($session->get('i18n')['dateFormatRegEx'] == '') {
-            $output .= "/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\d\d$/i";
-        } else {
-            $output .= $session->get('i18n')['dateFormatRegEx'];
-        }
-        $output .= ', failureMessage: "Use ';
-        if ($session->get('i18n')['dateFormat'] == '') {
-            $output .= 'dd/mm/yyyy';
-        } else {
-            $output .= $session->get('i18n')['dateFormat'];
-        }
-        $output .= '." } );';
-        $output .= 'ttDate.add(Validate.Presence);';
-        $output .= '</script>';
-        $output .= '<script type="text/javascript">';
-        $output .= '$(function() {';
-        $output .= '$("#ttDate").datepicker();';
-        $output .= '});';
-        $output .= '</script>';
-        $output .= "<input style='margin-top: 0px; margin-right: -1px;  padding-left: 1rem; padding-right: 1rem;' type='submit' value='".__('Go')."'>";
-        $output .= "<input name='schoolCalendar' value='".$session->get('viewCalendarSchool')."' type='hidden'>";
-        $output .= "<input name='personalCalendar' value='".$session->get('viewCalendarPersonal')."' type='hidden'>";
-        $output .= "<input name='spaceBookingCalendar' value='".$session->get('viewCalendarSpaceBooking')."' type='hidden'>";
-        $output .= "<input name='fromTT' value='Y' type='hidden'>";
-        $output .= '</form>';
-        $output .= '</td>';
-        $output .= '</tr>';
-        $output .= '</table>';
 
         //Check which days are school days
         $daysInWeek = 0;
@@ -2308,20 +2255,29 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
             if ($session->get('viewCalendarSpaceBooking') != '') {
                 $output .= "<tr class='head' style='height: 37px;'>";
                 $output .= "<th class='ttCalendarBar' colspan=".($daysInWeek + 1).'>';
-                $output .= "<form method='post' action='".$session->get('absoluteURL')."/index.php?q=$q".$params."' style='padding: 5px 5px 0 0'>";
+                $output .= "<form class='py-2'
+                        hx-post='".$apiEndpoint->withQueryParam('ttDate', date($session->get('i18n')['dateFormatPHP'], $startDayStamp))."' 
+                        hx-trigger='change'
+                        hx-target='#ttSpace' 
+                        hx-select='#ttSpace'
+                        hx-include='this'
+                        hx-vals='{\"ttCheckbox\": \"true\"}'
+                >";
+
                 if ($session->get('viewCalendarSpaceBooking') != '') {
                     $checked = '';
                     if ($session->get('viewCalendarSpaceBooking') == 'Y') {
                         $checked = 'checked';
                     }
-                    $output .= "<span class='ttSpaceBookingCalendar' style='opacity: $schoolCalendarAlpha'><a style='color: #fff' href='".$session->get('absoluteURL')."/index.php?q=/modules/Timetable/spaceBooking_manage.php'>".__('Bookings').'</a> ';
-                    $output .= "<input $checked style='margin-left: 3px' type='checkbox' name='spaceBookingCalendar' aria-label='".__('Space Booking Calendar')."' onclick='submit();'/>";
+                    $output .= "<span class='ttSpaceBookingCalendar rounded-sm my-1' style='opacity: $schoolCalendarAlpha'><a style='color: #fff' href='".$session->get('absoluteURL')."/index.php?q=/modules/Timetable/spaceBooking_manage.php'>".__('Bookings').'</a> ';
+                    $output .= "<input 
+                        $checked style='margin-left: 3px' type='checkbox' value='Y' name='spaceBookingCalendar' aria-label='".__('Space Booking Calendar')."' 
+                        />";
                     $output .= '</span>';
                 }
 
-                $output .= "<input type='hidden' name='ttDate' value='".date($session->get('i18n')['dateFormatPHP'], $startDayStamp)."'>";
-                $output .= "<input name='fromTT' value='Y' type='hidden'>";
                 $output .= '</form>';
+
                 $output .= '</th>';
                 $output .= '</tr>';
             }
@@ -2504,6 +2460,7 @@ function renderTTSpace($guid, $connection2, $gibbonSpaceID, $gibbonTTID, $title 
 
         $output .= '</tr>';
         $output .= '</table>';
+        $output .= '</div>';
         $output .= '</div>';
     }
 

--- a/src/UI/Dashboard/StaffDashboard.php
+++ b/src/UI/Dashboard/StaffDashboard.php
@@ -257,7 +257,6 @@ class StaffDashboard implements OutputableInterface, ContainerAwareInterface
             isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') and $this->session->get('username') != ''
             && $this->session->get('gibbonRoleIDCurrentCategory') == 'Staff'
         ) {
-            $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php');
             $_POST = (new Validator(''))->sanitize($_POST);
             $jsonQuery = [
                 'gibbonTTID' => $_GET['gibbonTTID'] ?? '',
@@ -267,15 +266,10 @@ class StaffDashboard implements OutputableInterface, ContainerAwareInterface
                 'schoolCalendar' => $_POST['schoolCalendar'] ?? '',
                 'spaceBookingCalendar' => $_POST['spaceBookingCalendar'] ?? '',
             ];
-            $timetable .= '
-            <script type="text/javascript">
-                $(document).ready(function(){
-                    $("#tt").load('.json_encode($apiEndpoint).', '.json_encode($jsonQuery).');
-                });
-            </script>';
+            $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php')->withQueryParams($jsonQuery);
 
             $timetable .= '<h2>'.__('My Timetable').'</h2>';
-            $timetable .= "<div id='tt' name='tt' style='width: 100%; min-height: 40px; text-align: center'>";
+            $timetable .= "<div id='tt' name='tt' hx-get='".$apiEndpoint."' hx-trigger='load' style='width: 100%; min-height: 40px; text-align: center'>";
             $timetable .= "<img style='margin: 10px 0 5px 0' src='".$this->session->get('absoluteURL')."/themes/Default/img/loading.gif' alt='".__('Loading')."' onclick='return false;' /><br/><p style='text-align: center'>".__('Loading').'</p>';
             $timetable .= '</div>';
         }

--- a/src/UI/Dashboard/StaffDashboard.php
+++ b/src/UI/Dashboard/StaffDashboard.php
@@ -261,15 +261,11 @@ class StaffDashboard implements OutputableInterface, ContainerAwareInterface
             $jsonQuery = [
                 'gibbonTTID' => $_GET['gibbonTTID'] ?? '',
                 'ttDate' => $_POST['ttDate'] ?? '',
-                'fromTT' => $_POST['fromTT'] ?? '',
-                'personalCalendar' => $_POST['personalCalendar'] ?? '',
-                'schoolCalendar' => $_POST['schoolCalendar'] ?? '',
-                'spaceBookingCalendar' => $_POST['spaceBookingCalendar'] ?? '',
             ];
             $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php')->withQueryParams($jsonQuery);
 
             $timetable .= '<h2>'.__('My Timetable').'</h2>';
-            $timetable .= "<div id='tt' name='tt' hx-get='".$apiEndpoint."' hx-trigger='load' style='width: 100%; min-height: 40px; text-align: center'>";
+            $timetable .= "<div hx-get='".$apiEndpoint."' hx-trigger='load' style='width: 100%; min-height: 40px; text-align: center'>";
             $timetable .= "<img style='margin: 10px 0 5px 0' src='".$this->session->get('absoluteURL')."/themes/Default/img/loading.gif' alt='".__('Loading')."' onclick='return false;' /><br/><p style='text-align: center'>".__('Loading').'</p>';
             $timetable .= '</div>';
         }

--- a/src/UI/Dashboard/StudentDashboard.php
+++ b/src/UI/Dashboard/StudentDashboard.php
@@ -227,16 +227,12 @@ class StudentDashboard implements OutputableInterface, ContainerAwareInterface
             $jsonQuery = [
                 'gibbonTTID' => $_GET['gibbonTTID'] ?? '',
                 'ttDate' => $_POST['ttDate'] ?? '',
-                'fromTT' => $_POST['fromTT'] ?? '',
-                'personalCalendar' => $_POST['personalCalendar'] ?? '',
-                'schoolCalendar' => $_POST['schoolCalendar'] ?? '',
-                'spaceBookingCalendar' => $_POST['spaceBookingCalendar'] ?? '',
             ];
 
             $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php')->withQueryParams($jsonQuery);
             
             $timetable .= '<h2>'.__('My Timetable').'</h2>';
-            $timetable .= "<div id='tt' name='tt' hx-get='".$apiEndpoint."' hx-trigger='load' style='width: 100%; min-height: 40px; text-align: center'>";
+            $timetable .= "<div hx-get='".$apiEndpoint."' hx-trigger='load' style='width: 100%; min-height: 40px; text-align: center'>";
             $timetable .= "<img style='margin: 10px 0 5px 0' src='".$this->session->get('absoluteURL')."/themes/Default/img/loading.gif' alt='".__('Loading')."' onclick='return false;' /><br/><p style='text-align: center'>".__('Loading').'</p>';
             $timetable .= '</div>';
         }

--- a/src/UI/Dashboard/StudentDashboard.php
+++ b/src/UI/Dashboard/StudentDashboard.php
@@ -223,7 +223,6 @@ class StudentDashboard implements OutputableInterface, ContainerAwareInterface
             isActionAccessible($guid, $connection2, '/modules/Timetable/tt.php') and $this->session->get('username') != ''
             && $this->session->get('gibbonRoleIDCurrentCategory')
         ) {
-            $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php');
             $_POST = (new Validator(''))->sanitize($_POST);
             $jsonQuery = [
                 'gibbonTTID' => $_GET['gibbonTTID'] ?? '',
@@ -233,15 +232,11 @@ class StudentDashboard implements OutputableInterface, ContainerAwareInterface
                 'schoolCalendar' => $_POST['schoolCalendar'] ?? '',
                 'spaceBookingCalendar' => $_POST['spaceBookingCalendar'] ?? '',
             ];
-            $timetable .= '
-            <script type="text/javascript">
-                $(document).ready(function(){
-                    $("#tt").load('.json_encode($apiEndpoint).', '.json_encode($jsonQuery).');
-                });
-            </script>';
 
+            $apiEndpoint = (string)Url::fromHandlerRoute('index_tt_ajax.php')->withQueryParams($jsonQuery);
+            
             $timetable .= '<h2>'.__('My Timetable').'</h2>';
-            $timetable .= "<div id='tt' name='tt' style='width: 100%; min-height: 40px; text-align: center'>";
+            $timetable .= "<div id='tt' name='tt' hx-get='".$apiEndpoint."' hx-trigger='load' style='width: 100%; min-height: 40px; text-align: center'>";
             $timetable .= "<img style='margin: 10px 0 5px 0' src='".$this->session->get('absoluteURL')."/themes/Default/img/loading.gif' alt='".__('Loading')."' onclick='return false;' /><br/><p style='text-align: center'>".__('Loading').'</p>';
             $timetable .= '</div>';
         }


### PR DESCRIPTION
Currently, navigating the timetable causes the whole page to reload. This PR implements HTMX to reload only the timetable itself, and improves the function of the navigation buttons. Changing calendar or bookings checkboxes also no longer reloads the whole timetable.

**Motivation and Context**
UI Improvements

**How Has This Been Tested?**
Locally

**Screenshots**
<img width="935" alt="Screenshot 2024-09-28 at 5 58 03 PM" src="https://github.com/user-attachments/assets/b1dfe6ec-b52a-4e26-abdd-7a88b809a471">

