### PR TITLE
Activities: fix bug in activity registration by parent

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ v29.0.00
     
     Bug Fixes
         System Admin: fixed field validation for Student Default Email in Form Builder
+        Activity registration: fix issue that registration button not shown to the parent.
 
 v28.0.01
 --------

--- a/modules/Activities/activities_view.php
+++ b/modules/Activities/activities_view.php
@@ -50,12 +50,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
         //If student, set gibbonPersonID to self
         if ($roleCategory == 'Student' and $highestAction == 'View Activities_studentRegister') {
             $gibbonPersonID = $session->get('gibbonPersonID');
+        }else if ($roleCategory == 'Parent' and $highestAction == 'View Activities_studentRegisterByParent') {
+            $gibbonPersonID = $_GET['gibbonPersonID'] ?? '';
+
         }
         
         //Check access controls
         $settingGateway = $container->get(SettingGateway::class);
 
-        $canAccessRegistration = !empty($gibbonPersonID) && (($roleCategory == 'Student' && $highestAction == 'View Activities_studentRegister') || ($roleCategory == 'Parent' && $highestAction == 'View Activities_studentRegisterByParent' && $countChild > 0));
+        $canAccessRegistration = !empty($gibbonPersonID) && (($roleCategory == 'Student' && $highestAction == 'View Activities_studentRegister') || ($roleCategory == 'Parent' && $highestAction == 'View Activities_studentRegisterByParent'));
 
         $allActivityAccess = $settingGateway->getSettingByScope('Activities', 'access');
         $hideExternalProviderCost = $settingGateway->getSettingByScope('Activities', 'hideExternalProviderCost');
@@ -111,6 +114,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_view
 
                     if ($countChild == 0) {
                         echo $page->getBlankSlate();
+                        $canAccessRegistration = false;
                     }
                 }
             }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
The registration button is not shown to the parent. 
there is a variable used before creation.

**Motivation and Context**
<!-- Why is this change suggested? Is there a problem it helps to solve?
If this PR fixes an open issue, please link to the issue here. -->

**How Has This Been Tested?**
<!-- Please describe how you've tested your changes. Include details of 
your testing environment, and any tests you've run to see how your 
change affects other areas of the code. -->

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
