### PR TITLE
Only add tinymcesetup event listener once

### DIFF
--- a/resources/templates/components/editor.twig.html
+++ b/resources/templates/components/editor.twig.html
@@ -120,34 +120,40 @@ Rich Text Editor
 </div>
 
 <script type="text/javascript">
-document.addEventListener('tinymceSetup', function (event) {
-
-    {% if tinymceInit %}
+    function tinymceSetupListener(event) {
+        {% if tinymceInit %}
         tinyMCE.execCommand('mceAddControl', false, '{{ id }}');
-    {% endif %}
+        {% endif %}
 
-    {% if onKeyDownSubmitUrl %}
-    setTimeout(function() {
-        tinyMCE.get('{{ id }}').on('keydown', function (){
-            tinyMCE.triggerSave();
-            gibbonFormSubmitQuiet($('#{{ onKeyDownSubmitFormId }}'), '{{ onKeyDownSubmitUrl }}')
-        })
-    }, 100);
-    {% endif %}
+        {% if onKeyDownSubmitUrl %}
+        setTimeout(function () {
+            tinyMCE.get('{{ id }}').on('keydown', function () {
+                tinyMCE.triggerSave();
+                gibbonFormSubmitQuiet($('#{{ onKeyDownSubmitFormId }}'), '{{ onKeyDownSubmitUrl }}')
+            })
+        }, 100);
+        {% endif %}
 
-    $('#{{ id }}edButtonPreview').addClass('active') ;
-    $('#{{ id }}edButtonHTML').click(function(){
-        tinyMCE.execCommand('mceRemoveEditor', false, '{{ id }}');
-        $('#{{ id }}edButtonHTML').addClass('active') ;
-        $('#{{ id }}edButtonPreview').removeClass('active') ;
-        $(".{{ id }}resourceSlider").hide();
-        $("#{{ id }}mediaInner").hide();
-    }) ;
-    $('#{{ id }}edButtonPreview').click(function(){
-        tinyMCE.execCommand('mceAddEditor', false, '{{ id }}');
         $('#{{ id }}edButtonPreview').addClass('active');
-        $('#{{ id }}edButtonHTML').removeClass('active'); 
-        $("#{{ id }}mediaInner").show();
-    });
-});
+        $('#{{ id }}edButtonHTML').click(function () {
+            tinyMCE.execCommand('mceRemoveEditor', false, '{{ id }}');
+            $('#{{ id }}edButtonHTML').addClass('active');
+            $('#{{ id }}edButtonPreview').removeClass('active');
+            $(".{{ id }}resourceSlider").hide();
+            $("#{{ id }}mediaInner").hide();
+        });
+        $('#{{ id }}edButtonPreview').click(function () {
+            tinyMCE.execCommand('mceAddEditor', false, '{{ id }}');
+            $('#{{ id }}edButtonPreview').addClass('active');
+            $('#{{ id }}edButtonHTML').removeClass('active');
+            $("#{{ id }}mediaInner").show();
+        });
+    }
+
+    if (!document.tinymceSetupListenerAdded) {
+        document.tinymceSetupListenerAdded = true;
+        document.addEventListener('tinymceSetup', tinymceSetupListener);
+    } else {
+        tinymceSetupListener()
+    }
 </script>


### PR DESCRIPTION
**Description**

When editing a Freelearning Unit (Home > Free Learning > Manage Units > Edit Unit), if there multiple smartblocks in the unit, the html tab in the tinymce editor does not _always_ work. Upon investigation, it seems that the event listener was not always correctly added for all of the `#{{ id }}edButtonHTML` elements. 

**Motivation and Context**
By only adding the eventlistener once, tinymce is set up correctly, and after that the click event listeners is added for each `#{{ id }}edButtonHTML` by loopindirectly, rather than through the `tinymceSetup` event listener.

**How Has This Been Tested?**
Tested on the MOS environment and confirmed by users that fix resolved the issue. Each of the smartblocks are not editable consistently.

