### PR TITLE
Fixed the issue of updating attainment percentage values from raw values

### DIFF
--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -58,7 +58,6 @@ echo "<script type='text/javascript'>";
 ?>
     $(document).ready(function(){
         autosize($('textarea'));
-    });
 
     // Map [Enter] key to work like the [Tab] key
     // Daniel P. Clark 2014
@@ -110,8 +109,9 @@ echo "<script type='text/javascript'>";
         // We need to capture the [Shift] key and check the [Enter] key either way.
         if (e.shiftKey) { enterKey() } else { enterKey() }
     });
+});
 
-    <?php
+<?php
 echo '</script>';
 
 if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_data.php') == false) {


### PR DESCRIPTION
**Description**
When Raw Attainment is enabled, it’s possible to set a total value for a column, so teachers can enter arbitrary grades for that column. If they also have Percent set as the Attainment Scale, when they type a number and press enter, it is automatically calculating the percent.