### PR TITLE
Batch creation for internal assessments

### DIFF
--- a/modules/Formal Assessment/internalAssessment_manage.php
+++ b/modules/Formal Assessment/internalAssessment_manage.php
@@ -75,6 +75,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
             $page->navigator->addHeaderAction('addMultiple', __('Add Multiple Columns'))
                 ->setURL('/modules/Formal Assessment/internalAssessment_manage_add.php')
                 ->addParams($params)
+                ->setIcon('page_new')
+                ->displayLabel();
+            $page->navigator->addHeaderAction('addMultipleTimes', __('添加多个考试与多个时间列'))
+                ->setURL('/modules/Formal Assessment/internalAssessment_manage_addMulti.php')
+                ->addParams($params)
                 ->setIcon('page_new_multi')
                 ->displayLabel();
 

--- a/modules/Formal Assessment/internalAssessment_manage.php
+++ b/modules/Formal Assessment/internalAssessment_manage.php
@@ -77,7 +77,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 ->addParams($params)
                 ->setIcon('page_new')
                 ->displayLabel();
-            $page->navigator->addHeaderAction('addMultipleTimes', __('添加多个考试与多个时间列'))
+            $page->navigator->addHeaderAction('addMultipleTimes', __('Add Multiple Columns & Date'))
                 ->setURL('/modules/Formal Assessment/internalAssessment_manage_addMulti.php')
                 ->addParams($params)
                 ->setIcon('page_new_multi')

--- a/modules/Formal Assessment/internalAssessment_manage_addMulti.php
+++ b/modules/Formal Assessment/internalAssessment_manage_addMulti.php
@@ -74,7 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                     ->selected($gibbonCourseClassID);
 
             $row = $form->addRow();
-                $row->addLabel('prefix', __('前缀'));
+                $row->addLabel('prefix', __('Prefix'));
                 $row->addTextField('prefix')->required()->maxLength(8);
 
             $row = $form->addRow();
@@ -82,7 +82,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $row->addTextField('name')->required()->maxLength(16);
 
             $row = $form->addRow();
-                $row->addLabel('suffix', __('后缀'));
+                $row->addLabel('suffix', __('Suffix'));
                 $row->addTextField('suffix')->required()->maxLength(8);
 
             $row = $form->addRow();
@@ -90,11 +90,11 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
                 $row->addTextField('description')->required()->maxLength(1000);
 
             $row = $form->addRow();
-                $row->addLabel('duplicate', __('重复次数'));
+                $row->addLabel('duplicate', __('Number of repetitions'));
                 $row->addSelect('duplicate')->fromString('1,2,3,4,5,6,7,8,9,10')->selected(1)->required();
 
             $row = $form->addRow();
-                $row->addLabel('interval', __('日期间隔'));
+                $row->addLabel('interval', __('Date interval'));
                 $row->addSelect('interval')->fromString('0,1,2,3,4,5,6,7')->selected(1)->required();
 
             $types = $settingGateway->getSettingByScope('Formal Assessment', 'internalAssessmentTypes');

--- a/modules/Formal Assessment/internalAssessment_manage_addMulti.php
+++ b/modules/Formal Assessment/internalAssessment_manage_addMulti.php
@@ -75,7 +75,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
 
             $row = $form->addRow();
                 $row->addLabel('prefix', __('Prefix'));
-                $row->addTextField('prefix')->required()->maxLength(8);
+                $row->addTextField('prefix')->maxLength(8);
 
             $row = $form->addRow();
                 $row->addLabel('name', __('Name'));
@@ -83,7 +83,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internal
 
             $row = $form->addRow();
                 $row->addLabel('suffix', __('Suffix'));
-                $row->addTextField('suffix')->required()->maxLength(8);
+                $row->addTextField('suffix')->maxLength(8);
 
             $row = $form->addRow();
                 $row->addLabel('description', __('Description'));

--- a/modules/Formal Assessment/internalAssessment_manage_addMulti.php
+++ b/modules/Formal Assessment/internalAssessment_manage_addMulti.php
@@ -1,0 +1,168 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Domain\System\SettingGateway;
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+
+//Module includes
+require_once __DIR__ . '/moduleFunctions.php';
+
+//Get alternative header names
+$settingGateway = $container->get(SettingGateway::class);
+$attainmentAlternativeName = $settingGateway->getSettingByScope('Markbook', 'attainmentAlternativeName');
+$effortAlternativeName = $settingGateway->getSettingByScope('Markbook', 'effortAlternativeName');
+
+if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internalAssessment_manage_add.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    $gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
+    if ($gibbonCourseClassID == '') {
+        $page->addError(__('You have not specified one or more required parameters.'));
+    } else {
+
+            $data = array('gibbonCourseClassID' => $gibbonCourseClassID);
+            $sql = 'SELECT gibbonCourse.nameShort AS course, gibbonCourseClass.nameShort AS class, gibbonCourseClass.gibbonCourseClassID, gibbonCourse.gibbonDepartmentID, gibbonYearGroupIDList FROM gibbonCourse, gibbonCourseClass WHERE gibbonCourse.gibbonCourseID=gibbonCourseClass.gibbonCourseID AND gibbonCourseClass.gibbonCourseClassID=:gibbonCourseClassID ORDER BY course, class';
+            $result = $connection2->prepare($sql);
+            $result->execute($data);
+
+        if ($result->rowCount() != 1) {
+            $page->addError(__('The selected record does not exist, or you do not have access to it.'));
+        } else {
+            $row = $result->fetch();
+
+            $page->breadcrumbs
+                ->add(__('Manage {courseClass} Internal Assessments', ['courseClass' => $row['course'].'.'.$row['class']]), 'internalAssessment_manage.php', ['gibbonCourseClassID' => $gibbonCourseClassID])
+                ->add(__('Add Multiple Columns'));
+
+            $page->return->addReturns(['error3' => __('Your request failed due to an attachment error.')]);
+
+            $form = Form::create('internalAssessment', $session->get('absoluteURL').'/modules/'.$session->get('module').'/internalAssessment_manage_addMultiProcess.php?gibbonCourseClassID='.$gibbonCourseClassID.'&address='.$session->get('address'));
+            $form->setFactory(DatabaseFormFactory::create($pdo));
+            $form->addHiddenValue('address', $session->get('address'));
+
+            $form->addRow()->addHeading('Basic Information', __('Basic Information'));
+
+            $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'));
+            $sql = "SELECT gibbonYearGroup.name as groupBy, gibbonCourseClassID as value, CONCAT(gibbonCourse.nameShort, '.', gibbonCourseClass.nameShort) AS name FROM gibbonCourseClass JOIN gibbonCourse ON (gibbonCourseClass.gibbonCourseID=gibbonCourse.gibbonCourseID) JOIN gibbonYearGroup ON (gibbonCourse.gibbonYearGroupIDList LIKE concat( '%', gibbonYearGroup.gibbonYearGroupID, '%' )) WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND gibbonCourseClass.reportable='Y' ORDER BY gibbonYearGroup.sequenceNumber, name";
+
+            $row = $form->addRow();
+                $row->addLabel('gibbonCourseClassIDMulti', __('Class'));
+                $row->addSelect('gibbonCourseClassIDMulti')
+                    ->fromQuery($pdo, $sql, $data, 'groupBy')
+                    ->selectMultiple()
+                    ->required()
+                    ->selected($gibbonCourseClassID);
+
+            $row = $form->addRow();
+                $row->addLabel('prefix', __('前缀'));
+                $row->addTextField('prefix')->required()->maxLength(8);
+
+            $row = $form->addRow();
+                $row->addLabel('name', __('Name'));
+                $row->addTextField('name')->required()->maxLength(16);
+
+            $row = $form->addRow();
+                $row->addLabel('suffix', __('后缀'));
+                $row->addTextField('suffix')->required()->maxLength(8);
+
+            $row = $form->addRow();
+                $row->addLabel('description', __('Description'));
+                $row->addTextField('description')->required()->maxLength(1000);
+
+            $row = $form->addRow();
+                $row->addLabel('duplicate', __('重复次数'));
+                $row->addSelect('duplicate')->fromString('1,2,3,4,5,6,7,8,9,10')->selected(1)->required();
+
+            $row = $form->addRow();
+                $row->addLabel('interval', __('日期间隔'));
+                $row->addSelect('interval')->fromString('0,1,2,3,4,5,6,7')->selected(1)->required();
+
+            $types = $settingGateway->getSettingByScope('Formal Assessment', 'internalAssessmentTypes');
+            if (!empty($types)) {
+                $row = $form->addRow();
+                    $row->addLabel('type', __('Type'));
+                    $row->addSelect('type')->fromString($types)->required()->placeholder();
+            }
+
+            $row = $form->addRow();
+                $row->addLabel('file', __('Attachment'));
+                $row->addFileUpload('file');
+
+            $form->addRow()->addHeading('Assessment', __('Assessment'));
+
+            $attainmentLabel = !empty($attainmentAlternativeName)? sprintf(__('Assess %1$s?'), $attainmentAlternativeName) : __('Assess Attainment?');
+            $row = $form->addRow();
+                $row->addLabel('attainment', $attainmentLabel);
+                $row->addYesNoRadio('attainment')->required();
+
+            $form->toggleVisibilityByClass('attainmentRow')->onRadio('attainment')->when('Y');
+
+            $attainmentScaleLabel = !empty($attainmentAlternativeName)? $attainmentAlternativeName.' '.__('Scale') : __('Attainment Scale');
+            $row = $form->addRow()->addClass('attainmentRow');
+                $row->addLabel('gibbonScaleIDAttainment', $attainmentScaleLabel);
+                $row->addSelectGradeScale('gibbonScaleIDAttainment')->required()->selected($session->get('defaultAssessmentScale'));
+
+            $effortLabel = !empty($effortAlternativeName)? sprintf(__('Assess %1$s?'), $effortAlternativeName) : __('Assess Effort?');
+            $row = $form->addRow();
+                $row->addLabel('effort', $effortLabel);
+                $row->addYesNoRadio('effort')->required();
+
+            $form->toggleVisibilityByClass('effortRow')->onRadio('effort')->when('Y');
+
+            $effortScaleLabel = !empty($effortAlternativeName)? $effortAlternativeName.' '.__('Scale') : __('Effort Scale');
+            $row = $form->addRow()->addClass('effortRow');
+                $row->addLabel('gibbonScaleIDEffort', $effortScaleLabel);
+                $row->addSelectGradeScale('gibbonScaleIDEffort')->required()->selected($session->get('defaultAssessmentScale'));
+
+            $row = $form->addRow();
+                $row->addLabel('comment', __('Include Comment?'));
+                $row->addYesNoRadio('comment')->required();
+
+            $row = $form->addRow();
+                $row->addLabel('uploadedResponse', __('Include Uploaded Response?'));
+                $row->addYesNoRadio('uploadedResponse')->required();
+
+            $form->addRow()->addHeading('Access', __('Access'));
+
+            $row = $form->addRow();
+                $row->addLabel('viewableStudents', __('Viewable to Students'));
+                $row->addYesNo('viewableStudents')->required();
+
+            $row = $form->addRow();
+                $row->addLabel('viewableParents', __('Viewable to Parents'));
+                $row->addYesNo('viewableParents')->required();
+
+            $row = $form->addRow();
+                $row->addLabel('completeDate', __('Go Live Date'))->prepend('1. ')->append('<br/>'.__('2. Column is hidden until date is reached.'));
+                $row->addDate('completeDate');
+
+            $row = $form->addRow();
+                $row->addFooter();
+                $row->addSubmit();
+
+            echo $form->getOutput();
+        }
+    }
+    //Print sidebar
+    $session->set('sidebarExtra', sidebarExtra($guid, $connection2, $gibbonCourseClassID));
+}

--- a/modules/Formal Assessment/internalAssessment_manage_addMultiProcess.php
+++ b/modules/Formal Assessment/internalAssessment_manage_addMultiProcess.php
@@ -1,0 +1,187 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Services\Format;
+use Gibbon\Data\Validator;
+
+include '../../gibbon.php';
+
+$_POST = $container->get(Validator::class)->sanitize($_POST);
+
+$gibbonCourseClassID = $_GET['gibbonCourseClassID'] ?? '';
+$address = $_GET['address'] ?? '';
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address)."/internalAssessment_manage_addMulti.php&gibbonCourseClassID=$gibbonCourseClassID";
+
+if (isActionAccessible($guid, $connection2, '/modules/Formal Assessment/internalAssessment_manage_add.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+} else {
+    if (empty($_POST)) {
+        $URL .= '&return=error3';
+        header("Location: {$URL}");
+    } else {
+        //Proceed!
+        //Validate Inputs
+        $gibbonCourseClassIDMulti = $_POST['gibbonCourseClassIDMulti'] ?? [];
+
+        $name = ($_POST['prefix'] ?? '') . ($_POST['name'] ?? '') . ($_POST['suffix'] ?? '');
+        $description = $_POST['description'] ?? '';
+        $duplicate = $_POST['duplicate'] ?? '';
+        $interval = $_POST['interval'] ?? '';
+        
+        $type = $_POST['type'] ?? '';
+        //Sort out attainment
+        $attainment = $_POST['attainment'] ?? '';
+        if ($attainment == 'N') {
+            $gibbonScaleIDAttainment = null;
+        } else {
+            if ($_POST['gibbonScaleIDAttainment'] == '') {
+                $gibbonScaleIDAttainment = null;
+            } else {
+                $gibbonScaleIDAttainment = $_POST['gibbonScaleIDAttainment'] ?? '';
+            }
+        }
+        //Sort out effort
+        $effort = $_POST['effort'] ?? '';
+        if ($effort == 'N') {
+            $gibbonScaleIDEffort = null;
+        } else {
+            if ($_POST['gibbonScaleIDEffort'] == '') {
+                $gibbonScaleIDEffort = null;
+            } else {
+                $gibbonScaleIDEffort = $_POST['gibbonScaleIDEffort'] ?? '';
+            }
+        }
+        $comment = $_POST['comment'] ?? '';
+        $uploadedResponse = $_POST['uploadedResponse'] ?? '';
+        $completeDate = $_POST['completeDate'] ?? '';
+        if ($completeDate == '') {
+            $completeDate = null;
+            $complete = 'N';
+        } else {
+            $completeDate = Format::dateConvert($completeDate);
+            $complete = 'Y';
+        }
+        $viewableStudents = $_POST['viewableStudents'] ?? '';
+        $viewableParents = $_POST['viewableParents'] ?? '';
+        $gibbonPersonIDCreator = $session->get('gibbonPersonID');
+        $gibbonPersonIDLastEdit = $session->get('gibbonPersonID');
+
+        $fileUploader = new Gibbon\FileUploader($pdo, $session);
+        $fileUploader->getFileExtensions();
+
+        //Lock markbook column table
+        try {
+            $sqlLock = 'LOCK TABLES gibbonInternalAssessmentColumn WRITE';
+            $resultLock = $connection2->query($sqlLock);
+        } catch (PDOException $e) {
+            $URL .= '&return=error2';
+            header("Location: {$URL}");
+            exit();
+        }
+
+        //Get next groupingID
+        try {
+            $sqlGrouping = 'SELECT DISTINCT groupingID FROM gibbonInternalAssessmentColumn WHERE NOT groupingID IS NULL ORDER BY groupingID DESC';
+            $resultGrouping = $connection2->query($sqlGrouping);
+        } catch (PDOException $e) {
+            $URL .= '&return=error2';
+            header("Location: {$URL}");
+            exit();
+        }
+
+        $rowGrouping = $resultGrouping->fetch();
+        if (is_null($rowGrouping['groupingID'])) {
+            $groupingID = 1;
+        } else {
+            $groupingID = ($rowGrouping['groupingID'] + 1);
+        }
+
+        $time = time();
+        //Move attached file, if there is one
+        if (!empty($_FILES['file']['tmp_name'])) {
+            $file = (isset($_FILES['file']))? $_FILES['file'] : null;
+
+            // Upload the file, return the /uploads relative path
+            $attachment = $fileUploader->uploadFromPost($file, $name);
+
+            if (empty($attachment)) {
+                $partialFail = true;
+            }
+        } else {
+            $attachment = '';
+        }
+
+        if (is_array($gibbonCourseClassIDMulti) == false or is_numeric($groupingID) == false or $groupingID < 1 or $name == '' or $description == '' or $type == '' or $viewableStudents == '' or $viewableParents == '' or $duplicate == '' or !ctype_digit($duplicate) or $interval == '' or !ctype_digit($interval)) {
+            $URL .= '&return=error1';
+            header("Location: {$URL}");
+        } else {
+            $partialFail = false;
+            $duplicate = (int)$duplicate;
+            if ($duplicate <= 0 || $duplicate > 10) {
+                $duplicate = 1;
+            }
+            $interval = (int)$interval;
+            if ($interval < 0 || $interval > 7) {
+                $interval = 1;
+            }
+
+            // Prevent duplicate classes selected if courses span multiple year groups
+            $gibbonCourseClassIDMulti = array_unique($gibbonCourseClassIDMulti);
+            if (!empty($completeDate)) { $dateExam = new DateTime($completeDate); }
+            
+            for ($i = 1; $i <= $duplicate; $i++) {
+                $newDateExamStr = $completeDate;
+                if (!empty($completeDate)) {
+                    $newDateExam = clone $dateExam;
+                    $newDateExamStr = $newDateExam->modify("+" . ($i * $interval) . " days")->format('Y-m-d');
+                }
+                
+                foreach ($gibbonCourseClassIDMulti as $gibbonCourseClassIDSingle) {
+                    //Write to database
+                    try {
+                        $data = array('groupingID' => $groupingID, 'gibbonCourseClassID' => $gibbonCourseClassIDSingle, 'name' => $name, 'description' => $description, 'type' => $type, 'attainment' => $attainment, 'gibbonScaleIDAttainment' => $gibbonScaleIDAttainment, 'effort' => $effort, 'gibbonScaleIDEffort' => $gibbonScaleIDEffort, 'comment' => $comment, 'uploadedResponse' => $uploadedResponse, 'completeDate' => $newDateExamStr, 'complete' => $complete, 'viewableStudents' => $viewableStudents, 'viewableParents' => $viewableParents, 'attachment' => $attachment, 'gibbonPersonIDCreator' => $gibbonPersonIDCreator, 'gibbonPersonIDLastEdit' => $gibbonPersonIDLastEdit);
+                        $sql = 'INSERT INTO gibbonInternalAssessmentColumn SET groupingID=:groupingID, gibbonCourseClassID=:gibbonCourseClassID, name=:name, description=:description, type=:type, attainment=:attainment, gibbonScaleIDAttainment=:gibbonScaleIDAttainment, effort=:effort, gibbonScaleIDEffort=:gibbonScaleIDEffort, comment=:comment, uploadedResponse=:uploadedResponse, completeDate=:completeDate, complete=:complete, viewableStudents=:viewableStudents, viewableParents=:viewableParents, attachment=:attachment, gibbonPersonIDCreator=:gibbonPersonIDCreator, gibbonPersonIDLastEdit=:gibbonPersonIDLastEdit';
+                        $result = $connection2->prepare($sql);
+                        $result->execute($data);
+                    } catch (PDOException $e) {
+                        exit();
+                        $partialFail = true;
+                    }
+                }
+            }
+
+
+            //Unlock module table
+
+                $sql = 'UNLOCK TABLES';
+                $result = $connection2->query($sql);
+
+            if ($partialFail == true) {
+                $URL .= '&return=warning1';
+                header("Location: {$URL}");
+            } else {
+                $URL .= '&return=success0';
+                header("Location: {$URL}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
Added batch creation function for internal assessments.

**Motivation and Context**
Internal assessments cannot be added in bulk, which is very time-consuming. We may have some routine daily inspections, and this method allows batch additions. (The downside is that the corresponding tests need to be manually renamed, though duplication is possible).

**How Has This Been Tested?**
This is a minor change.

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
