### PR TITLE
Bug fix: Add max and min limits  to form values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@ v29.0.00
     
     Bug Fixes
         System: fixed issue with search terms containing a : full colon (special character) 
+        System: Add max and min limits to form values
         Sidebar: fixed localization of Roles menu items.
         Activities: fixed activity missing from the timetable if it doesn't have a category
         Activities: fixed missing registration button for parents on View Activities page

--- a/src/Forms/Input/Number.php
+++ b/src/Forms/Input/Number.php
@@ -110,6 +110,6 @@ class Number extends TextField
      */
     protected function getElement()
     {
-        return Component::render(Number::class, $this->getAttributeArray() + []);
+        return Component::render(Number::class, $this->getAttributeArray() + ["min" => $this->min, "max" => $this->max]);
     }
 }

--- a/src/Forms/Input/Number.template.php
+++ b/src/Forms/Input/Number.template.php
@@ -1,5 +1,6 @@
 <div class="flex-grow relative flex" >
-    <input type="text" <?= $attributes; ?> 
-    class="w-full rounded-md border py-2 text-gray-900  placeholder:text-gray-500 
+    <input type="number" <?= $attributes; ?> 
+    min=<?= $min; ?> max=<?= $max; ?>
+    class="w-full rounded-md border py-2 text-gray-900 placeholder:text-gray-500 
     focus:ring-1 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6" />
 </div>


### PR DESCRIPTION
**Description**

Came from this forum request: https://ask.gibbonedu.org/t/how-to-restrict-numeric-input-range/15191

Fixed the bug to change the input type to "number" and add a max and min value limit


