### PR TITLE
Bug: Using non-English characters in the term short name

### DIFF
--- a/src/Forms/Input/Checkbox.php
+++ b/src/Forms/Input/Checkbox.php
@@ -228,7 +228,7 @@ class Checkbox extends Input
             $this->options = [$this->getValue() => $this->description];
         }
 
-        $identifier = preg_replace('/[^a-zA-Z0-9]/', '', $this->getID());
+        $identifier = preg_replace('[/~`!@%#$%^&*()+={}\[\]|\\:;"\'<>,.?\/]', '', $this->getID());
         $hasMultiple = $this->getOptionCount() > 1;
         $options = [];
 


### PR DESCRIPTION
**Description**
Fixed the issue of using non-English characters in the school term short name prevents bulk selection of SchoolDays. The request came from: https://github.com/GibbonEdu/core/issues/1921
