### PR TITLE
Bug: Fixed the issue of correctly extracting a URL Link from text.

### DIFF
--- a/src/Services/Format.php
+++ b/src/Services/Format.php
@@ -653,7 +653,7 @@ class Format
      */
     public static function hyperlinkAll(string $value)
     {
-        $pattern = '/([^">]|^)(https?:\/\/[^"<>\s]+)/';
+        $pattern = '/([^">]|^)(https?:\/\/[^"<>\s]+?)(?=[.,;:!]*(?:\s|$))/';
         return preg_replace($pattern, '$1<a target="_blank" rel="noopener noreferrer" href="$2">$2</a>', $value);
     }
 


### PR DESCRIPTION
**Description**

If there was a full stop at the end of an url (not part of the link), the full stop is added to the url link and this breaks the link.

For example: "there is the link [https://www.w3schools.com/php/func_string_nl2br.asp. Very helpful."

Now the link is actually https://www.w3schools.com/php/func_string_nl2br.asp and the full stop is added to finish the sentence. However, the link is displayed as https://www.w3schools.com/php/func_string_nl2br.asp. 
which is broken and when you click it, it gives a 404 error.


