### PR TITLE
System: added a system log when a password reset is initiated and changed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ v29.0.00
         System: removed Date of Birth field from Public Registration when no minimum registration age is set
         System: improved the colour picker to add a pre-set colour palette
         System: added IDD country codes to all countries in the database
+        System: added a log entry for resetting password through 'Forgot Password"
         Admissions: added the ability to re-send the submission email from the Process tab in Edit Applicaiton
         Attendance: updated Student History view to display Off Timetable days
         Behaviour: added an 'Observation' type to track neutral records

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -90,6 +90,8 @@ else {
         $gibbonPersonID = $row['gibbonPersonID'];
         $email = $row['email'];
         $username = $row['username'];
+        $preferredName = $row['preferredName'];
+        $surname = $row['surname'];
 
         if ($step == 1) { //This is the request phase
             // Use password policy to generate random string
@@ -150,12 +152,10 @@ else {
                 // Log this password reset request
                 $details = [
                     'gibbonPersonID' => $gibbonPersonID,
-                    'name' => Format::name('', $row['preferredName'], $row['surname'], 'Staff', false, true),
-                    'changedByID' => $session->get('gibbonPersonID'),
-                    'changedBy' => Format::name('', $session->get('preferredName'), $session->get('surname'), 'Staff', false, true),
+                    'name' => Format::name('', $preferredName, $surname, 'Staff', false, true),
+                    'IPAddress' => $_SERVER['REMOTE_ADDR'],
                 ];
-
-                $container->get(LogGateway::class)->addLog($session->get('gibbonSchoolYearID'), null, $session->get('gibbonPersonID'), 'User - Forgot Password Request Initiated ', $details, $_SERVER['REMOTE_ADDR']);
+                $container->get(LogGateway::class)->addLog($session->get('gibbonSchoolYearID'), null, null, 'User - Forgot Password Request Initiated ', $details, $_SERVER['REMOTE_ADDR']);
 
                 header("Location: {$URL->withReturn('success0')}");
             } else {
@@ -234,11 +234,10 @@ else {
                                 // Log this password change
                                 $details = [
                                     'gibbonPersonID' => $gibbonPersonID,
-                                    'name' => Format::name('', $row['preferredName'], $row['surname'], 'Staff', false, true),
-                                    'changedByID' => $session->get('gibbonPersonID'),
-                                    'changedBy' => Format::name('', $session->get('preferredName'), $session->get('surname'), 'Staff', false, true),
+                                    'name' => Format::name('', $preferredName, $surname, 'Staff', false, true),
+                                    'IPAddress' => $_SERVER['REMOTE_ADDR'],
                                 ];
-                                $gibbonLogID = $container->get(LogGateway::class)->addLog($session->get('gibbonSchoolYearID'), null, $session->get('gibbonPersonID'), 'User - Password Changed Through Forgot Password', $details, $_SERVER['REMOTE_ADDR']);
+                                $container->get(LogGateway::class)->addLog($session->get('gibbonSchoolYearID'), null, null, 'User - Password Changed Through Forgot Password', $details, $_SERVER['REMOTE_ADDR']);
 
                                 //Return
                                 header("Location: {$URL->withReturn('success1')}");

--- a/passwordResetProcess.php
+++ b/passwordResetProcess.php
@@ -155,7 +155,7 @@ else {
                     'changedBy' => Format::name('', $session->get('preferredName'), $session->get('surname'), 'Staff', false, true),
                 ];
 
-                $container->get(LogGateway::class)->addLog($session->get('gibbonSchoolYearID'), null, $session->get('gibbonPersonID'), 'Forgot User - Password Request Initiated ', $details, $_SERVER['REMOTE_ADDR']);
+                $container->get(LogGateway::class)->addLog($session->get('gibbonSchoolYearID'), null, $session->get('gibbonPersonID'), 'User - Forgot Password Request Initiated ', $details, $_SERVER['REMOTE_ADDR']);
 
                 header("Location: {$URL->withReturn('success0')}");
             } else {


### PR DESCRIPTION
**Description**
In the Forgot Password page, users can initiate a password reset. For security purposes, this request should be logged with the IP address, so that false requests can be more easily caught. Added a log entry every time a request is initiated and a password is changed via clicking the link in the email
