### PR TITLE
Messenger: add a warning if [confirmLink] is in text but read receipts are not turned on

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,7 @@ v29.0.00
         Markbook: implemented default grade from Manage Grade Scales in Markbook data entry view
         Markbook: enabled filtering by term even if Group Columns by Term is off
         Messenger: added the ability to add new recipients to a sent message and enable easier re-sending
+        Messenger: added a warning if [confirmLink] is in text but read receipts are not turned on
         Planner: added an attendance indicator to the Today's Lessons list for teachers
         Reports: updated Template Builder to select mPDF renderer by default
         Reports: added the option to archive unused assets and templates intead of deleting them

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,7 +50,7 @@ v29.0.00
         Markbook: implemented default grade from Manage Grade Scales in Markbook data entry view
         Markbook: enabled filtering by term even if Group Columns by Term is off
         Messenger: added the ability to add new recipients to a sent message and enable easier re-sending
-        Messenger: added a warning if [confirmLink] is in text but read receipts are not turned on
+        Messenger: added the feature to warn and remove [confirmLink] tag from the message body if read receipts are not turned on
         Planner: added an attendance indicator to the Today's Lessons list for teachers
         Reports: updated Template Builder to select mPDF renderer by default
         Reports: added the option to archive unused assets and templates intead of deleting them

--- a/modules/Messenger/messenger_send.php
+++ b/modules/Messenger/messenger_send.php
@@ -83,6 +83,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Messenger/messenger_send.p
 
     $sent = $values['status'] == 'Sent' || (!empty($_GET['return']) && $_GET['return'] == 'success1');
 
+     // Display a warning if the [confirmLink] tag exists in the body when read receipts are not enabled
+    if (!$sent && !empty($values['body']) && $values['emailReceipt'] == 'N') {
+        if (strpos($values['body'], '[confirmLink]') !== false) {
+            $page->addError(__('Warning: You have included [confirmLink] in your message text, however read receipts have not been turned on for this message. Please enable read receipts to use the [confirmLink] feature, otherwise this tag will be automatically removed from your email.'));
+        }
+    }
+
     // QUERY
     $criteria = $messengerReceiptGateway->newQueryCriteria()
         ->sortBy(['targetType', 'role',  'surname', 'preferredName'])

--- a/modules/Messenger/messenger_sendProcess.php
+++ b/modules/Messenger/messenger_sendProcess.php
@@ -82,6 +82,16 @@ if (isActionAccessible($guid, $connection2, "/modules/Messenger/messenger_post.p
 
     // Remove recipients who have been manually unchecked
     $messengerReceiptGateway->deleteRecipientsByID($gibbonMessengerID, $unselected);
+    
+    // Remove the [confirmLink] tag if read receipts are not enabled
+    if (!empty($values['body']) && $values['emailReceipt'] == 'N') {
+        if (strpos($values['body'], '[confirmLink]') !== false) {
+            $values['body'] = str_replace('[confirmLink]', '', $values['body']);
+            
+            // Update the body text in the database after the [confirmLink] tag has been removed
+            $messengerGateway->update($gibbonMessengerID, ['body' => $values['body']]);
+        }
+    }
 
     // Set the status of the message
     $messengerGateway->update($gibbonMessengerID, ['status' => 'Sending']);


### PR DESCRIPTION
**Description**

This is aimed to prevent people from sending a message with [confirmLink] in the text. On the Messenger Preview page, added a big red warning message to the top of the page if there is [confirmLink] in the message body, but read receipts are not turned on. Then added the feature to remove [confirmLink] from the body text if read receipts are not turned on.
