### PR TITLE
Checks emailAlternate as well as email for matching SSO credentials

### DIFF
--- a/src/Domain/User/UserGateway.php
+++ b/src/Domain/User/UserGateway.php
@@ -101,7 +101,7 @@ class UserGateway extends QueryableGateway implements ScrubbableGateway
                 FROM gibbonPerson 
                 LEFT JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) 
                 WHERE (
-                    (username=:username OR (LOCATE('@', :username)>0 AND email=:username)) 
+                    (username=:username OR (LOCATE('@', :username)>0 AND (email=:username OR emailAlternate=:username)) 
                     AND status='Full' 
                 )";
 


### PR DESCRIPTION
**Description**
Made a minor addition in \src\Domain\User\UserGateway.php function selectLoginDetailsByUsername($username) on line 104
changed from: 
(username=:username OR (LOCATE('@', :username)>0 AND email=:username)) 
to:
(username=:username OR (LOCATE('@', :username)>0 AND (email=:username OR emailAlternate=:username))

**Motivation and Context**
For (admittedly small) use case where a teacher is also a parent, and wished to have communications from Gibbon messenger to go to their home email address instead of their school email address, as messenger will only send to the primary email address and not the alternative email address supplied.
So, if you put their home email address in the primary email within Gibbon, and their work email address in the alternative email address, messenger sends to their home email address. Happy teacher!
However, this breaks the single sign on, as the SSO will only check against email, and not emailAlternate. So I need it to check against either the email field or emailAlternate field for the email address to resolve the credentials.

**How Has This Been Tested?**
Tested in our production server against Google SSO and Microsoft SSO
As this just adds an OR - none of the existing functionality is changed, but enhanced in a small but impactful way. And this means I don't need to refactor messenger code, or add a "home email" "work email" logic inside messenger or alter gibbonPerson. I thought this would be least disruptive.
