### PR TITLE
Fixed grammar in alarm message

### DIFF
--- a/resources/templates/ui/alarmOverlay.twig.html
+++ b/resources/templates/ui/alarmOverlay.twig.html
@@ -60,12 +60,12 @@ html, body {
             {% if alarm.gibbonPersonID != gibbonPersonID %}
             <p>
                 {% if confirmed %}
-                    <i>{{ __('You have successfully confirmed receipt of this alarm, which will continue to be displayed until an administrator has cancelled the alarm.') }}</i>
+                    <i>{{ __('You have successfully confirmed receipt of this alarm, which will continue to be displayed until an administrator cancels the alarm.') }}</i>
                 {% else %}
                     <a target="_parent" class="block text-white text-4xl sm:text-5xl font-bold p-6" href="{{ absoluteURL }}/index_notification_ajax_alarmProcess.php?gibbonAlarmID={{ alarm.gibbonAlarmID }}">
                         {{ __('Click here to confirm that you have received this alarm.') }}
                     </a>
-                    <i>{{ __('After confirming receipt, the alarm will continue to be displayed until an administrator has cancelled the alarm.') }}</i>
+                    <i>{{ __('After confirming receipt, the alarm will continue to be displayed until an administrator cancels the alarm.') }}</i>
                 {% endif %}
             </p>
             {% endif %}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
<!-- Please describe your changes in detail. -->

The message letting staff know that an alarm will stay on their screen until it is cancelled had a slight grammatical error, which was fixed.

**Motivation and Context**
<!-- Why is this change suggested? Is there a problem it helps to solve?
If this PR fixes an open issue, please link to the issue here. -->

It provides clarity into what the message meant.

**How Has This Been Tested?**
<!-- Please describe how you've tested your changes. Include details of 
your testing environment, and any tests you've run to see how your 
change affects other areas of the code. -->

Tested to work after sending an alarm

**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->
