### PR TITLE
fix(ParentDashboard): Avoid undefined variable warnings in logs for p…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ v30.0.00
         Staff: fixed coverage longer than one week not including staff duty and activity cover
         Messenger: fixed missing From address on emails when using the Add Recipient action in Send Report
         Timetable Admin: fixed missing Manage Exceptions button on the timetable in Course Enrolment by Person
+		Parent Dashboard: Initialize output variables before use to avoid 'Undefined variable' warnings in error logs.
 
     Deprecations
         Removed all functions in functions.php flagged for deprecation since v25

--- a/src/UI/Dashboard/ParentDashboard.php
+++ b/src/UI/Dashboard/ParentDashboard.php
@@ -173,6 +173,11 @@ class ParentDashboard implements OutputableInterface, ContainerAwareInterface
         $alertLevelGateway = $this->getContainer()->get(AlertLevelGateway::class);
         $alert = $alertLevelGateway->getByID(AlertLevelGateway::LEVEL_MEDIUM);
         $entryCount = 0;
+		
+		//INITIALISE OUTPUT VARIABLES (to silence warnings in Apache error log)
+		$plannerOutput   = '';
+		$gradesOutput    = '';
+		$deadlinesOutput = '';
 
         //PREPARE PLANNER SUMMARY
         $classes = false;


### PR DESCRIPTION
fix(dashboard): initialize planner/deadlines output to avoid undefined variable notices

**Description**
Initializes variables used in the Parent Dashboard tab content to prevent PHP “Undefined variable” notices:
Add early initialization in src/UI/Dashboard/ParentDashboard.php:

$plannerOutput   = '';
$gradesOutput    = '';
$deadlinesOutput = '';

(placed just after $entryCount = 0;, before the “PREPARE PLANNER SUMMARY” section)

This ensures the later concatenation:
'content' => $plannerOutput.$gradesOutput.$deadlinesOutput,
always operates on defined strings, even when a given section has no data.

**Motivation and Context**
Apache logs were showing notices such as:
Warning: Undefined variable $plannerOutput
Warning: Undefined variable $deadlinesOutput

These are noisy in production and can obscure more important messages. The change is a small defensive fix with no user-facing behaviour change.

**How Has This Been Tested?**
Applied on a testing and production server.
Loaded the Parent Dashboard as a parent user with/without planner or deadlines data.
Confirmed the dashboard renders normally and Apache error log remains clean (no related notices).

**Screenshots**
N/A — no UI changes.