### PR TITLE
Update main.css

### DIFF
--- a/themes/Default/css/main.css
+++ b/themes/Default/css/main.css
@@ -857,7 +857,7 @@ table.smallIntBorder td.noPadding {
     height: 1.2rem;
     position: absolute;
     top: 30%;
-    right: 6px;
+    right: 0;
 }
 
 .dataTable .sortable:not(.sorting):hover:after,


### PR DESCRIPTION
Fixes an issue where the sorting indicators crash into the column title.

Before:
<img width="326" height="262" alt="Screenshot 2025-08-25 at 2 08 43 AM" src="https://github.com/user-attachments/assets/b841c70a-8d82-4cbb-a608-c7628c055e1b" />

After:
<img width="280" height="252" alt="Screenshot 2025-08-25 at 2 08 15 AM" src="https://github.com/user-attachments/assets/ed7a0593-1e9c-4843-8b6d-92d540b57b59" />
