### PR TITLE
Timetable Admin: fixed the issue of text not being visible when background and font are both white color by default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -58,6 +58,7 @@ v30.0.00
         Planner: fixed access to class list in Edit Unit when viewing past and upcoming years
         Staff: fixed coverage longer than one week not including staff duty and activity cover
         Timetable Admin: fixed missing Manage Exceptions button on the timetable in Course Enrolment by Person
+        Timetable Admin: fixed the issue of setting white as the default color for both background and font
 
     Deprecations
         Removed all functions in functions.php flagged for deprecation since v25

--- a/src/Forms/Input/Color.php
+++ b/src/Forms/Input/Color.php
@@ -81,7 +81,7 @@ class Color extends Input
     protected function getElement()
     {
         return Component::render(Color::class, $this->getAttributeArray() + [
-            'color'     => !empty($this->getValue()) ? $this->getValue() : '#ffffff',
+            'color'     => !empty($this->getValue()) ? $this->getValue() : '',
             'showField' => $this->showField,
             'palette'   => $this->palette,
         ]);


### PR DESCRIPTION
**Description**

The issue was that the Timetable day colours were #FFFFFF for both background and text by default. Fixed the logic to assign no colour by default.