### PR TITLE
fix style on behaviour form

### DIFF
--- a/modules/Behaviour/css/module.css
+++ b/modules/Behaviour/css/module.css
@@ -18,3 +18,16 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 */
+
+#gibbonPersonIDMultiContainer {
+    display: flex;
+    flex-wrap: wrap; 
+    gap: 1rem; 
+    align-items: flex-start;
+}
+
+#gibbonPersonIDMultiContainer > .w-full.sm\:w-1\/3 {
+    flex: 2;
+    min-width: 250px; 
+    padding: 0px;
+}

--- a/modules/Behaviour/css/module.css
+++ b/modules/Behaviour/css/module.css
@@ -18,16 +18,3 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 */
-
-#gibbonPersonIDMultiContainer {
-    display: flex;
-    flex-wrap: wrap; 
-    gap: 1rem; 
-    align-items: flex-start;
-}
-
-#gibbonPersonIDMultiContainer > .w-full.sm\:w-1\/3 {
-    flex: 2;
-    min-width: 250px; 
-    padding: 0px;
-}

--- a/src/Forms/Input/MultiSelect.php
+++ b/src/Forms/Input/MultiSelect.php
@@ -64,9 +64,9 @@ class MultiSelect implements OutputableInterface, ValidatableInterface
             ->wrap('<div class="w-full">', '</div>');
 
         $this->addButton = $factory->createButton(__("Add"), '', $name . 'Add')->setIcon('add', 'text-green-600')
-            ->addClass("flex-1");
+            ->addClass("w-full sm:w-auto");
         $this->removeButton = $factory->createButton(__("Remove"), '', $name . 'Remove')->setIcon('cross', 'text-red-700')
-            ->addClass("flex-1");
+            ->addClass("w-full sm:w-auto");
 
         $this->searchBox = $factory->createTextField($name . "Search")
             ->placeholder(__("Search"))
@@ -180,7 +180,7 @@ class MultiSelect implements OutputableInterface, ValidatableInterface
 
         $output .= '<div class="w-full sm:w-1/3 flex flex-col items-center px-4 py-2 sm:py-0 gap-2">';
 
-            $output .= '<div class="flex w-full items-center justify-between gap-2">';
+            $output .= '<div class="flex w-full items-center justify-center gap-2 flex-wrap sm:flex-col sm:gap-2">';
                 $output .= $this->addButton->getOutput();
                 $output .= $this->removeButton->getOutput();
             $output .= '</div>';


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Pull Request title.
Be sure to check out our contributor docs for more info about pull requests.
https://github.com/GibbonEdu/core/blob/master/docs/CONTRIBUTING.md#how-to-submit-a-pull-request -->

**Description**
<!-- Please describe your changes in detail. -->

This PR fixes an issue where, when adding multiple behaviour records, the Remove button would disappear behind the second select at certain browser window widths.

**Motivation and Context**
<!-- Why is this change suggested? Is there a problem it helps to solve?
If this PR fixes an open issue, please link to the issue here. -->
@rossdotparker noticed the Remove button was playing hide-and-seek behind the second select at certain widths. This change makes sure it stays visible and behaves.

**How Has This Been Tested?**
<!-- Please describe how you've tested your changes. Include details of 
your testing environment, and any tests you've run to see how your 
change affects other areas of the code. -->

To test locally navigate to this page  [Home ](http://localhost:8888/core/index.php)> [Behaviour ](http://localhost:8888/core/index.php?q=/modules/Behaviour/behaviour_manage.php)> [Manage Behaviour Records ](http://localhost:8888/core/index.php?q=/modules/Behaviour/behaviour_manage.php)> Add Multiple


	1.	Open Inspect mode.
	2.	Switch to the device toolbar and set the dimension to Responsive.
	3.	Drag the width of the page narrower and wider.
	4.	 Confirm that the Remove button remains visible and does not disappear behind the second select.


**Screenshots**
<!-- If applicable, add screenshots to help illustrate your changes. -->

# Before 
<img width="697" height="556" alt="Screenshot 2025-09-03 at 10 26 05 PM" src="https://github.com/user-attachments/assets/049012c5-961c-4d9c-a971-71e881013d21" />



# After 
<img width="732" height="477" alt="Screenshot 2025-09-03 at 10 26 21 PM" src="https://github.com/user-attachments/assets/ab095158-c3b2-405a-bc30-139169a1a0e8" />


