### PR TITLE
fix(Forms): Define default $rtl in Toggle.template.php to avoid installer warning

### DIFF
--- a/src/Forms/Input/Toggle.template.php
+++ b/src/Forms/Input/Toggle.template.php
@@ -9,6 +9,7 @@
     </label>
 
     <?php $disabledClass = $disabled || $readonly ? 'border-dashed cursor-not-allowed' : ''; ?>
+    <?php $rtl = $rtl ?? false; // During installer, $rtl may not be defined; default it to false ?>
     <?php $flip = $rtl ? '-1' : '1'; ?>
     
     <?php if ($toggleSize == 'sm') { ?>


### PR DESCRIPTION
**Description**
This updates src/Forms/Input/Toggle.template.php to ensure the $rtl variable is always defined. 
During installation, language settings (and therefore $rtl) are not yet available, which results in a PHP warning when the toggle component is rendered in the Gibbon installer. This fix adds a default value of false for $rtl, ensuring consistent behaviour in both the installer and at runtime when everything is set up.

**Motivation and Context**
Without this change, fresh installs of Gibbon trigger a warning which is rendered in the installer:
`Warning: Undefined variable $rtl in \src\Forms\Input\Toggle.template.php on line 12`
This should improve the user experience for new installs of Gibbon.

**How Has This Been Tested?**
Tested in a fresh install of Gibbon v30.0.00 on PHP 8.2 using Laragon (Windows).
Verified that the PHP warning no longer occurs.
Verified that toggles continue to render and behave correctly in both installer and normal application views.
Confirmed that RTL languages (when selected after install) still display the toggle correctly.

**Screenshots**
<img width="1445" height="1478" alt="image" src="https://github.com/user-attachments/assets/b1094c67-5569-4dd0-bec2-2b43d98c7960" />
<img width="1383" height="1284" alt="image" src="https://github.com/user-attachments/assets/1e1890dc-a506-4dee-ae22-c91230d1816e" />


