### PR TITLE
Create studentFutureAbsence.yml

### DIFF
--- a/resources/imports/studentFutureAbsence.yml
+++ b/resources/imports/studentFutureAbsence.yml
@@ -1,0 +1,92 @@
+details:
+  type: studentFutureAbsence
+  category: Attendance
+  name: Future Absences
+  table: gibbonAttendanceLogPerson
+  modes:
+    insert: true
+    update: false
+
+access:
+  module: Attendance
+  action: Set Future Absence
+
+primaryKey: gibbonAttendanceLogPersonID
+
+table:
+  gibbonPersonID:
+    name: "Student"
+    desc: "Username"
+    args:
+      filter: nospaces
+      required: true
+    relationship:
+      table: gibbonPerson
+      key: gibbonPersonID
+      field: username
+
+  date:
+    name: "Date"
+    desc: "YYYY-MM-DD"
+    args:
+      filter: date
+      required: true
+
+  gibbonAttendanceCodeID:
+    name: "Attendance Code (short, e.g. PS, A, etc.)"
+    desc: "Looks up the code ID"
+    args:
+      filter: string
+      required: true
+    lookup:
+      table: gibbonAttendanceCode
+      key: nameShort
+      value: gibbonAttendanceCodeID
+
+  type:
+    name: "Type"
+    desc: "Eg. Absent, Excused Absence"
+    args:
+      filter: string
+      required: true
+
+  reason:
+    name: "Reason"
+    desc: "From School Admin > Attendance Settings"
+    args:
+      filter: string
+      required: false
+
+  comment:
+    name: "Comment"
+    desc: "Optional note"
+    args:
+      filter: string
+      required: false
+
+  context:
+    name: "Context"
+    desc: "Must be Future"
+    args:
+      filter: string
+      required: true
+    default: Future
+
+  direction:
+    name: "Direction"
+    desc: "Must be Out for absences"
+    args:
+      filter: string
+      required: true
+    default: Out
+
+  gibbonPersonIDTaker:
+    name: "Recorded By"
+    desc: "Username of staff recording the absence"
+    args:
+      filter: nospaces
+      required: true
+    relationship:
+      table: gibbonPerson
+      key: gibbonPersonID
+      field: username

--- a/resources/imports/studentFutureAbsence.yml
+++ b/resources/imports/studentFutureAbsence.yml
@@ -3,90 +3,50 @@ details:
   category: Attendance
   name: Future Absences
   table: gibbonAttendanceLogPerson
-  modes:
-    insert: true
-    update: false
-
+  modes: { insert: true, update: false }
 access:
   module: Attendance
   action: Set Future Absence
-
 primaryKey: gibbonAttendanceLogPersonID
-
 table:
   gibbonPersonID:
     name: "Student"
-    desc: "Username"
-    args:
-      filter: nospaces
-      required: true
-    relationship:
-      table: gibbonPerson
-      key: gibbonPersonID
-      field: username
-
+    desc: "Username, student ID, or Email (if unique)"
+    args: { filter: nospaces, required: true }
+    relationship: { table: gibbonPerson, key: gibbonPersonID, field: username|email|studentID }
   date:
     name: "Date"
-    desc: "YYYY-MM-DD"
-    args:
-      filter: date
-      required: true
-
+    desc: "Must be unique."
+    args: { filter: date, required: true }
   gibbonAttendanceCodeID:
-    name: "Attendance Code (short, e.g. PS, A, etc.)"
-    desc: "Looks up the code ID"
-    args:
-      filter: string
-      required: true
-    lookup:
-      table: gibbonAttendanceCode
-      key: nameShort
-      value: gibbonAttendanceCodeID
-
+    name: "Attendance Status"
+    desc: "Short Name"
+    args: { filter: string, required: true }
+    lookup: { table: gibbonAttendanceCode, key: nameShort, value: gibbonAttendanceCodeID }
   type:
     name: "Type"
     desc: "Eg. Absent, Excused Absence"
-    args:
-      filter: string
-      required: true
-
+    args: { filter: string, required: true }
   reason:
     name: "Reason"
     desc: "From School Admin > Attendance Settings"
-    args:
-      filter: string
-      required: false
-
+    args: { filter: string }
   comment:
     name: "Comment"
     desc: "Optional note"
-    args:
-      filter: string
-      required: false
-
+    args: { filter: string }
   context:
     name: "Context"
-    desc: "Must be Future"
-    args:
-      filter: string
-      required: true
-    default: Future
-
+    desc: ""
+    value: "Future"
+    args: { filter: string, hidden: true }
   direction:
     name: "Direction"
-    desc: "Must be Out for absences"
-    args:
-      filter: string
-      required: true
-    default: Out
-
+    desc: ""
+    value: "Out"
+    args: { filter: string, hidden: true }
   gibbonPersonIDTaker:
     name: "Recorded By"
     desc: "Username of staff recording the absence"
-    args:
-      filter: nospaces
-      required: true
-    relationship:
-      table: gibbonPerson
-      key: gibbonPersonID
-      field: username
+    args: { filter: nospaces, required: true }
+    relationship: { table: gibbonPerson, key: gibbonPersonID, field: username }


### PR DESCRIPTION
Importer for future student absences


**Description**
Import process to batch future non-consecutive absences.

**Motivation and Context**
Students are often absent for non-consecutive days, sometimes for weeks or months in advance. This allows administrators to set future absences quickly without needing to use the GUI.

**How Has This Been Tested?**
t's been run on 29.0, PHP 8.1.2, MySQL 8.0.42. No issues when testing.

**Screenshots**

<img width="1203" height="825" alt="Screenshot 2025-10-28 at 13 29 29" src="https://github.com/user-attachments/assets/faba3c3a-6a28-490c-bbf2-712bfcb69f07" />
<img width="1203" height="383" alt="Screenshot 2025-10-28 at 13 29 58" src="https://github.com/user-attachments/assets/f0e06fab-afed-4377-b20d-7f16dc44ebd8" />

