### PR TITLE
Calendar: Email relevant staff about an event including the list of students

### DIFF
--- a/modules/Calendar/calendar_event_edit.php
+++ b/modules/Calendar/calendar_event_edit.php
@@ -65,6 +65,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
         ->setIcon('attendance')
         ->displayLabel();
 
+    $form->addHeaderAction('email', __('Notify Staff'))
+        ->setURL('/modules/Calendar/calendar_event_notify.php')
+        ->addParam('gibbonCalendarEventID', $gibbonCalendarEventID)
+        ->setIcon('run')
+        ->displayLabel();
+
     $form->addRow()->addHeading(__('Basic Information'));
 
     // Get Calendars of the current school year

--- a/modules/Calendar/calendar_event_enrolment.php
+++ b/modules/Calendar/calendar_event_enrolment.php
@@ -64,6 +64,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_en
         ->addParam('gibbonCalendarEventID', $gibbonCalendarEventID)
         ->displayLabel();
 
+    $form->addHeaderAction('email', __('Notify Staff'))
+        ->setURL('/modules/Calendar/calendar_event_notify.php')
+        ->addParam('gibbonCalendarEventID', $gibbonCalendarEventID)
+        ->setIcon('run')
+        ->displayLabel();
+
     $calendars = $calendarGateway->selectCalendarsBySchoolYear($session->get('gibbonSchoolYearID'))->fetchKeyPair();
     $row = $form->addRow();
         $row->addLabel('gibbonCalendarID', __('Calendar'));

--- a/modules/Calendar/calendar_event_enrolment_delete.php
+++ b/modules/Calendar/calendar_event_enrolment_delete.php
@@ -22,7 +22,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 use Gibbon\Forms\Prefab\DeleteForm;
 use Gibbon\Domain\Calendar\CalendarEventPersonGateway;
 
-if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_enrolment_delete.php') == false) {
+if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_enrolment_edit.php') == false) {
     // Access denied
     $page->addError(__('You do not have access to this action.'));
 } else {

--- a/modules/Calendar/calendar_event_enrolment_deleteProcess.php
+++ b/modules/Calendar/calendar_event_enrolment_deleteProcess.php
@@ -29,7 +29,7 @@ $gibbonCalendarEventID = $_POST['gibbonCalendarEventID'] ?? '';
 
 $URL = $session->get('absoluteURL').'/index.php?q=/modules/Calendar/calendar_event_enrolment.php&gibbonCalendarEventID='.$gibbonCalendarEventID;
 
-if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_enrolment_delete.php') == false) {
+if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_enrolment_edit.php') == false) {
     $URL .= '&return=error0';
     header("Location: {$URL}");
     exit;

--- a/modules/Calendar/calendar_event_notify.php
+++ b/modules/Calendar/calendar_event_notify.php
@@ -74,6 +74,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
             'HOY'      => __('Head of Year'),
             'tutors'   => __('Form Tutors'),
             'teachers' => __('Class Teachers'),
+            'INAssistant' => __('LSAs'),
         ])->checkAll()->addClass('notifyGroups');
 
     $row = $form->addRow();

--- a/modules/Calendar/calendar_event_notify.php
+++ b/modules/Calendar/calendar_event_notify.php
@@ -1,0 +1,92 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Domain\Calendar\CalendarEventGateway;
+use Gibbon\Domain\Calendar\CalendarEventPersonGateway;
+
+if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_edit.php') == false) {
+    // Access denied
+    $page->addError(__('You do not have access to this action.'));
+} else {
+    // Proceed!
+    $page->breadcrumbs
+        ->add(__('Manage Events'), 'calendar_event_manage.php')
+        ->add(__('Notify Event'));
+
+    $gibbonCalendarEventID = $_GET['gibbonCalendarEventID'] ?? '';
+
+    $calendarEventGateway = $container->get(CalendarEventGateway::class);
+    $calendarEventPersonGateway = $container->get(CalendarEventPersonGateway::class);
+
+    // Get event details
+    $values = $calendarEventGateway->getByID($gibbonCalendarEventID);
+    if (!empty($gibbonCalendarEventID) && empty($values)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+    $form = Form::create('eventNotification', $session->get('absoluteURL').'/modules/Calendar/calendar_event_notifyProcess.php');
+    $form->setFactory(DatabaseFormFactory::create($pdo));
+
+    $form->addHiddenValue('address', $session->get('address'));
+    $form->addHiddenValue('gibbonCalendarEventID', $gibbonCalendarEventID);
+
+    // NOTES
+    $form->addRow()->addHeading('notes', __('Notes'));
+
+    $col = $form->addRow()->addColumn();
+        $col->addLabel('notes', __('Add Notes to the Email'))->description(__('If provided, this note will be shared with all the email recipients.'));
+        $col->addTextArea('notes');
+
+    // NOTIFICATIONS
+    $form->addRow()->addHeading('Notifications', __('Notifications'));
+
+    $form->toggleVisibilityByClass('notifyGroups')->onCheckbox('allStaff')->whenNot('Y');
+    
+    $row = $form->addRow();
+        $row->addLabel('notify', __('Automatically Notify'));
+        $row->addCheckbox('allStaff')
+            ->description(__('All staff'))
+            ->setValue('Y');
+
+    $row = $form->addRow();
+        $row->addCheckbox('notifyGroups')->fromArray([
+            'HOY'      => __('Head of Year'),
+            'tutors'   => __('Form Tutors'),
+            'teachers' => __('Class Teachers'),
+        ])->checkAll()->addClass('notifyGroups');
+
+    $row = $form->addRow();
+        $row->addLabel('notificationList', __('Notify Additional People'))->addClass('notifyGroups');
+        $row->addFinder('notificationList')
+            ->addClass('notifyGroups')
+            ->fromAjax($session->get('absoluteURL').'/modules/Staff/staff_searchAjax.php')
+            ->setParameter('resultsLimit', 10)
+            ->resultsFormatter('function(item){ return "<li class=\'\'><div class=\'inline-block bg-cover w-12 h-12 ml-2 rounded-full bg-gray-200 border border-gray-400 bg-no-repeat\' style=\'background-image: url(" + item.image + ");\'></div><div class=\'inline-block px-4 truncate\'>" + item.name + "<br/><span class=\'inline-block opacity-75 truncate text-xxs\'>" + item.jobTitle + "</span></div></li>"; }');
+
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
+
+    echo $form->getOutput();
+}

--- a/modules/Calendar/calendar_event_notifyProcess.php
+++ b/modules/Calendar/calendar_event_notifyProcess.php
@@ -19,11 +19,10 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-use Gibbon\Comms\Mailer;
+use Gibbon\View\View;
 use Gibbon\Data\Validator;
 use Gibbon\Services\Format;
-use Gibbon\Comms\EmailTemplate;
-use Gibbon\Comms\NotificationEvent;
+use Gibbon\Contracts\Comms\Mailer;
 use Gibbon\Domain\User\UserGateway;
 use Gibbon\Domain\Staff\StaffGateway;
 use Gibbon\Domain\School\YearGroupGateway;
@@ -121,99 +120,55 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
     $staffDetails = $container->get(UserGateway::class)->selectNotificationDetailsByPerson($staffPersonIDs)->fetchAll();
     $sender = $container->get(UserGateway::class)->getByID($session->get('gibbonPersonID'));
 
-
-
-
-                                    ///. /-/-/-/-/-/-/-/-/-/-/-/-/-/- LEFT TO DO
-
-    // Create the email Template
-    $template = $container->get(EmailTemplate::class)->setTemplate('Calendar Event Notification');
-
+    $view = $container->get(View::class);
     $mail = $container->get(Mailer::class);
     $mail->SMTPKeepAlive = true;
 
-    $emailIndex = 1;
-    $emails = [];
+    $content = $view->fetchFromTemplate('calendarEvents.twig.html', [
+        'students' => $students->toArray(),
+        'event' => $event ?? [],
+        'notes' => $notes ?? '',
+    ]);
+    
+    $sender = $container->get(UserGateway::class)->getByID($session->get('gibbonPersonID'));
+    $replyTo = $sender['email'];
+    $replyToName = Format::name($sender['title'], $sender['preferredName'], $sender['surname'], 'Staff');
 
     foreach ($staffDetails as $staffDetail) {
+        $buttonURL = "index.php?q=/modules/Calendar/calendar_event_view.php&gibbonCalendarEventID=".$gibbonCalendarEventID;
+        $subject = sprintf(__('Event Summary - %1$s (%2$s - %3$s'), $event['name'], Format::date($event['dateStart']), Format::date($event['dateEnd']). ')', $session->get('systemName'), $session->get('organisationNameShort'));
 
-        // Setup the email recipients
-        $mail->ClearAddresses();
-        $mail->AddAddress($staffDetail['email']);
+        $body = sprintf(__('Dear %1$s'), $staffDetail['preferredName'].' '.$staffDetail['surname']).',<br/><br/>';
+        $body .= $content;
 
-        $mail->SetFrom($sender['email'], $sender['preferredName'].' '.$sender['surname']);
-        $mail->AddReplyTo($sender['email'],);
-        $mail->setDefaultSender($template->renderSubject($templateData));
+        $mail->AddReplyTo($replyTo ?? $session->get('organisationEmail'), $replyToName ?? '');
+        $mail->AddAddress($staffDetail['email'], $staffDetail['surname'].', '.$staffDetail['preferredName']);
 
+        $mail->setDefaultSender($subject);
         $mail->renderBody('mail/message.twig.html', [
-            'title'  => $template->renderSubject($templateData),
-            'body'   => $template->renderBody($templateData),
+            'title'  => __('Event Summary'),
+            'body'   => $body,
+            'button' => [
+                'url'  => $buttonURL,
+                'text' => __('Click Here to View Event'),
+            ],
         ]);
 
-        // Send email and record the result
-        $sent = $mail->Send();
+        // Send
+        if ($mail->Send()) {
+            $sendReport['emailSent']++;
+        } else {
+            $sendReport['emailFailed']++;
+            $sendReport['emailErrors'] .= sprintf(__('An error (%1$s) occurred sending an email to %2$s.'), 'email send failed', $staffDetail['preferredName'].' '.$staffDetail['surname']).'<br/>';
+        }
 
-        $emails[$emailIndex] = Format::name($staffDetail['title'], $staffDetail['preferredName'], $staffDetail['surname'], 'Staff').': '.$staffDetail['email'].($sent ? __('Sent') : __('Failed') );
-        $emailIndex++;
+        $mail->ClearAllRecipients();
+        $mail->clearReplyTos();
     }
+
+    // Close SMTP connection
+    $mail->smtpClose();
         
-
-        // $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, true);
-            
-        // $today = date("Y-m-d"); 
-        // if ($today > $data['dateEnd']) {
-        //     $notificationString = __('{student} {formGroup} has withdrawn from {school} on {date}.', [
-        //         'student'   => $studentName,
-        //         'formGroup'   => $student['formGroup'],
-        //         'school'    => $session->get('organisationNameShort'),
-        //         'date'      => Format::date($data['dateEnd']),
-        //     ]);
-        // } else {
-        //     $notificationString = __('{student} {formGroup} will withdraw from {school}, effective from {date}.', [
-        //         'student'   => $studentName,
-        //         'formGroup'   => $student['formGroup'],
-        //         'school'    => $session->get('organisationNameShort'),
-        //         'date'      => Format::date($data['dateEnd']),
-        //     ]);
-        // }
-        
-        // if (!empty($withdrawNote)) {
-        //     $notificationString .= '<br/><br/>'.__('Withdraw Note').': '.$withdrawNote;
-        // }
-
-        // Raise a new notification event
-        // $event = new NotificationEvent('Admissions', 'Student Withdrawn');
-        // $event->addScope('gibbonPersonIDStudent', $gibbonPersonID);
-        // $event->addScope('gibbonYearGroupID', $student['gibbonYearGroupID']);
-        // $event->setNotificationText($notificationString);
-        // $event->setActionLink('/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID.'&search=&sort=&allStudents=on');
-
-        // Notify Additional People
-
-        // Head of Year
-        // if (in_array('HOY', $notify)) {
-        //     $yearGroup = $container->get(YearGroupGateway::class)->getByID($student['gibbonYearGroupID']);
-        //     $event->addRecipient($yearGroup['gibbonPersonIDHOY']);
-        // }
-
-        // Form Tutors
-        // if (in_array('tutors', $notify)) {
-        //     $formGroup = $container->get(FormGroupGateway::class)->getByID($student['gibbonFormGroupID']);
-        //     $event->addRecipient($formGroup['gibbonPersonIDTutor']);
-        //     $event->addRecipient($formGroup['gibbonPersonIDTutor2']);
-        //     $event->addRecipient($formGroup['gibbonPersonIDTutor3']);
-        // }
-
-        // // Class Teachers
-        // if (in_array('teachers', $notify)) {
-        //     $teachers = $container->get(CourseEnrolmentGateway::class)->selectClassTeachersByStudent($session->get('gibbonSchoolYearID'), $gibbonPersonID);
-        //     foreach ($teachers as $teacher) {
-        //         $event->addRecipient($teacher['gibbonPersonID']);
-        //     }
-        // }
-
-        // Add event listeners to the notification sender
-        // $event->sendNotifications($pdo, $session);
 
     
     $URL .= $partialFail

--- a/modules/Calendar/calendar_event_notifyProcess.php
+++ b/modules/Calendar/calendar_event_notifyProcess.php
@@ -124,7 +124,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
 
 
 
-                                    // LEFT TO DO
+                                    ///. /-/-/-/-/-/-/-/-/-/-/-/-/-/- LEFT TO DO
 
     // Create the email Template
     $template = $container->get(EmailTemplate::class)->setTemplate('Calendar Event Notification');
@@ -216,7 +216,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
         // $event->sendNotifications($pdo, $session);
 
     
-
     $URL .= $partialFail
         ? "&return=warning1"
         : "&return=success0";

--- a/modules/Calendar/calendar_event_notifyProcess.php
+++ b/modules/Calendar/calendar_event_notifyProcess.php
@@ -1,0 +1,232 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+use Gibbon\Comms\Mailer;
+use Gibbon\Data\Validator;
+use Gibbon\Services\Format;
+use Gibbon\Comms\EmailTemplate;
+use Gibbon\Comms\NotificationEvent;
+use Gibbon\Domain\User\UserGateway;
+use Gibbon\Domain\Staff\StaffGateway;
+use Gibbon\Domain\School\YearGroupGateway;
+use Gibbon\Domain\FormGroups\FormGroupGateway;
+use Gibbon\Domain\Calendar\CalendarEventGateway;
+use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
+use Gibbon\Domain\Calendar\CalendarEventPersonGateway;
+
+require_once '../../gibbon.php';
+
+$_POST = $container->get(Validator::class)->sanitize($_POST);
+
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/Calendar/calendar_event_notify.php';
+$gibbonCalendarEventID = $_POST['gibbonCalendarEventID'] ?? '';
+
+if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_edit.php') == false) {
+    $URL .= '&return=error0';
+    header("Location: {$URL}");
+    exit;
+} else {
+    // Proceed!
+    $calendarEventGateway = $container->get(CalendarEventGateway::class);
+    $calendarEventPersonGateway = $container->get(CalendarEventPersonGateway::class);
+
+    // Get event details
+    $values = $calendarEventGateway->getByID($gibbonCalendarEventID);
+    if (!empty($gibbonCalendarEventID) && empty($values)) {
+        $page->addError(__('The specified record cannot be found.'));
+        return;
+    }
+
+    // Get all student participants
+    $criteria = $calendarEventPersonGateway->newQueryCriteria()
+        ->sortBy(['surname', 'preferredName', 'category'])
+        ->fromPOST();
+    $students = $calendarEventPersonGateway->queryEnrolledAttendees($criteria, $gibbonCalendarEventID);
+
+    if (empty($students)) {
+        $page->addError(__('The specified record does not have any enrolled attendees.'));
+        return;
+    }
+
+    $notes = $_POST['notes'] ?? '';
+    $notifyGroups = $_POST['notifyGroups'] ?? [];
+    $allStaff = $_POST['allStaff'] ?? 'N';
+    $notificationList = isset($_POST['notificationList']) ? explode(',', $_POST['notificationList']) : [];
+    $staff = [];
+
+    if ($allStaff == 'Y') {
+         // All Staff
+        $staffGateway = $container->get(StaffGateway::class);
+        $criteria = $staffGateway->newQueryCriteria();
+
+        $results = $staffGateway->queryAllStaff($criteria);
+        foreach ($results as $result) {
+            $staff[] = $result['gibbonPersonID'];
+        }
+    } elseif (!empty($notifyGroups)) {
+        foreach ($students as $student) {
+            // Head of Year
+            if (in_array('HOY', $notifyGroups)) {
+                $yearGroup = $container->get(YearGroupGateway::class)->getByID($student['gibbonYearGroupID']);
+                if (!empty($yearGroup['gibbonPersonIDHOY'])) {
+                    $staff[] = $yearGroup['gibbonPersonIDHOY'];
+                }
+            }
+
+            // Form Tutors
+            if (in_array('tutors', $notifyGroups)) {
+                $formGroup = $container->get(FormGroupGateway::class)->getByID($student['gibbonFormGroupID']);
+                $staff[] = $formGroup['gibbonPersonIDTutor'];
+                $staff[] = $formGroup['gibbonPersonIDTutor2'];
+                $staff[] = $formGroup['gibbonPersonIDTutor3'];
+            }
+
+            // Class Teachers
+            if (in_array('teachers', $notifyGroups)) {
+                $teachers = $container->get(CourseEnrolmentGateway::class)->selectClassTeachersByStudent($session->get('gibbonSchoolYearID'), $student['gibbonPersonID']);
+                foreach ($teachers as $teacher) {
+                    $staff[] = $teacher['gibbonPersonID'];
+                }
+            }
+        }
+
+        if (!empty($notificationList)) {
+            foreach ($notificationList as $gibbonPersonIDNotify) {
+                // Add the staff
+                $staff[] = $gibbonPersonIDNotify;
+            }
+        }
+    }
+
+    $staffPersonIDs = isset($staff) ? array_values(array_filter(array_unique($staff))) : [];
+
+    $staffDetails = $container->get(UserGateway::class)->selectNotificationDetailsByPerson($staffPersonIDs)->fetchAll();
+    $sender = $container->get(UserGateway::class)->getByID($session->get('gibbonPersonID'));
+
+    echo '<pre>';
+    print_r($staffDetails);
+    echo '</pre>';
+    die();
+
+    // Create the email Template
+    $template = $container->get(EmailTemplate::class)->setTemplate('Calendar Event Notification');
+
+    $mail = $container->get(Mailer::class);
+    $mail->SMTPKeepAlive = true;
+
+    $emailIndex = 1;
+    $emails = [];
+
+
+    foreach ($staffDetails as $staffDetail) {
+
+        // Setup the email recipients
+        $mail->ClearAddresses();
+        $mail->AddAddress($staffDetail['email']);
+
+        $mail->SetFrom($sender['email'], $sender['preferredName'].' '.$sender['surname']);
+        $mail->AddReplyTo($sender['email'],);
+        $mail->setDefaultSender($template->renderSubject($templateData));
+
+        $mail->renderBody('mail/message.twig.html', [
+            'title'  => $template->renderSubject($templateData),
+            'body'   => $template->renderBody($templateData),
+        ]);
+
+        // Send email and record the result
+        $sent = $mail->Send();
+
+        $emails[$emailIndex] = Format::name($templateData['title'], $templateData['preferredName'], $templateData['surname'], 'Staff').': '.$templateData['email'].' ($'.$templateData['amount'].') - '. ($sent ? __('Sent') : __('Failed') );
+        $emailIndex++;
+    }
+
+        
+    // echo '<pre>';
+    // print_r($emailStaff);
+    // echo '</pre>';
+    // die();
+        
+
+        // $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, true);
+            
+        // $today = date("Y-m-d"); 
+        // if ($today > $data['dateEnd']) {
+        //     $notificationString = __('{student} {formGroup} has withdrawn from {school} on {date}.', [
+        //         'student'   => $studentName,
+        //         'formGroup'   => $student['formGroup'],
+        //         'school'    => $session->get('organisationNameShort'),
+        //         'date'      => Format::date($data['dateEnd']),
+        //     ]);
+        // } else {
+        //     $notificationString = __('{student} {formGroup} will withdraw from {school}, effective from {date}.', [
+        //         'student'   => $studentName,
+        //         'formGroup'   => $student['formGroup'],
+        //         'school'    => $session->get('organisationNameShort'),
+        //         'date'      => Format::date($data['dateEnd']),
+        //     ]);
+        // }
+        
+        // if (!empty($withdrawNote)) {
+        //     $notificationString .= '<br/><br/>'.__('Withdraw Note').': '.$withdrawNote;
+        // }
+
+        // Raise a new notification event
+        // $event = new NotificationEvent('Admissions', 'Student Withdrawn');
+        // $event->addScope('gibbonPersonIDStudent', $gibbonPersonID);
+        // $event->addScope('gibbonYearGroupID', $student['gibbonYearGroupID']);
+        // $event->setNotificationText($notificationString);
+        // $event->setActionLink('/index.php?q=/modules/Students/student_view_details.php&gibbonPersonID='.$gibbonPersonID.'&search=&sort=&allStudents=on');
+
+        // Notify Additional People
+
+        // Head of Year
+        // if (in_array('HOY', $notify)) {
+        //     $yearGroup = $container->get(YearGroupGateway::class)->getByID($student['gibbonYearGroupID']);
+        //     $event->addRecipient($yearGroup['gibbonPersonIDHOY']);
+        // }
+
+        // Form Tutors
+        // if (in_array('tutors', $notify)) {
+        //     $formGroup = $container->get(FormGroupGateway::class)->getByID($student['gibbonFormGroupID']);
+        //     $event->addRecipient($formGroup['gibbonPersonIDTutor']);
+        //     $event->addRecipient($formGroup['gibbonPersonIDTutor2']);
+        //     $event->addRecipient($formGroup['gibbonPersonIDTutor3']);
+        // }
+
+        // // Class Teachers
+        // if (in_array('teachers', $notify)) {
+        //     $teachers = $container->get(CourseEnrolmentGateway::class)->selectClassTeachersByStudent($session->get('gibbonSchoolYearID'), $gibbonPersonID);
+        //     foreach ($teachers as $teacher) {
+        //         $event->addRecipient($teacher['gibbonPersonID']);
+        //     }
+        // }
+
+        // Add event listeners to the notification sender
+        // $event->sendNotifications($pdo, $session);
+
+    
+
+    $URL .= $partialFail
+        ? "&return=warning1"
+        : "&return=success0";
+
+    header("Location: {$URL}");
+}

--- a/modules/Calendar/calendar_event_notifyProcess.php
+++ b/modules/Calendar/calendar_event_notifyProcess.php
@@ -29,6 +29,7 @@ use Gibbon\Domain\School\YearGroupGateway;
 use Gibbon\Domain\FormGroups\FormGroupGateway;
 use Gibbon\Domain\Calendar\CalendarEventGateway;
 use Gibbon\Domain\Timetable\CourseEnrolmentGateway;
+use Gibbon\Domain\IndividualNeeds\INAssistantGateway;
 use Gibbon\Domain\Calendar\CalendarEventPersonGateway;
 
 require_once '../../gibbon.php';
@@ -46,12 +47,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
     // Proceed!
     $calendarEventGateway = $container->get(CalendarEventGateway::class);
     $calendarEventPersonGateway = $container->get(CalendarEventPersonGateway::class);
+    $userGateway = $container->get(UserGateway::class);
 
     $notes = $_POST['notes'] ?? '';
     $notifyGroups = $_POST['notifyGroups'] ?? [];
     $allStaff = $_POST['allStaff'] ?? 'N';
     $notificationList = isset($_POST['notificationList']) ? explode(',', $_POST['notificationList']) : [];
     $staff = [];
+    $staffStudentContext = [];
 
     // Get event details
     $event = $calendarEventGateway->getByID($gibbonCalendarEventID);
@@ -64,7 +67,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
     $criteria = $calendarEventPersonGateway->newQueryCriteria()
         ->sortBy(['surname', 'preferredName', 'category'])
         ->fromPOST();
-    $students = $calendarEventPersonGateway->queryEnrolledAttendees($criteria, $gibbonCalendarEventID);
+    $students = $calendarEventPersonGateway->queryEnrolledAttendees($criteria, $gibbonCalendarEventID)->toArray();
 
     if (empty($students)) {
         $page->addError(__('The specified record does not have any enrolled attendees.'));
@@ -80,29 +83,74 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
         foreach ($results as $result) {
             $staff[] = $result['gibbonPersonID'];
         }
-    } elseif (!empty($notifyGroups)) {
-        foreach ($students as $student) {
-            // Head of Year
-            if (in_array('HOY', $notifyGroups)) {
-                $yearGroup = $container->get(YearGroupGateway::class)->getByID($student['gibbonYearGroupID']);
-                if (!empty($yearGroup['gibbonPersonIDHOY'])) {
-                    $staff[] = $yearGroup['gibbonPersonIDHOY'];
+    } else {
+        if (!empty($notifyGroups)) {
+            foreach ($students as $student) {
+                $gibbonPersonIDStudent = $student['gibbonPersonID'];
+
+                // Head of Year
+                if (in_array('HOY', $notifyGroups)) {
+                    $yearGroup = $container->get(YearGroupGateway::class)->getByID($student['gibbonYearGroupID']);
+                    $gibbonPersonIDHOY = $yearGroup['gibbonPersonIDHOY'] ?? null;
+                    if (!empty($gibbonPersonIDHOY)) {
+                        $staff[] = $gibbonPersonIDHOY;
+
+                        // Record Relation
+                        if (!isset($staffStudentContext[$gibbonPersonIDHOY][$gibbonPersonIDStudent]['context']) || !in_array('HOY', $staffStudentContext[$gibbonPersonIDHOY][$gibbonPersonIDStudent]['context'])) {
+                            $staffStudentContext[$gibbonPersonIDHOY][$gibbonPersonIDStudent]['context'][] = 'HOY';
+                        }
+                    }
                 }
-            }
 
-            // Form Tutors
-            if (in_array('tutors', $notifyGroups)) {
-                $formGroup = $container->get(FormGroupGateway::class)->getByID($student['gibbonFormGroupID']);
-                $staff[] = $formGroup['gibbonPersonIDTutor'];
-                $staff[] = $formGroup['gibbonPersonIDTutor2'];
-                $staff[] = $formGroup['gibbonPersonIDTutor3'];
-            }
+                // Form Tutors
+                if (in_array('tutors', $notifyGroups)) {
+                    $formGroup = $container->get(FormGroupGateway::class)->getByID($student['gibbonFormGroupID']);
+                    $tutorIDs = [
+                        $formGroup['gibbonPersonIDTutor'] ?? null,
+                        $formGroup['gibbonPersonIDTutor2'] ?? null,
+                        $formGroup['gibbonPersonIDTutor3'] ?? null,
+                    ];
 
-            // Class Teachers
-            if (in_array('teachers', $notifyGroups)) {
-                $teachers = $container->get(CourseEnrolmentGateway::class)->selectClassTeachersByStudent($session->get('gibbonSchoolYearID'), $student['gibbonPersonID']);
-                foreach ($teachers as $teacher) {
-                    $staff[] = $teacher['gibbonPersonID'];
+                    foreach ($tutorIDs as $gibbonPersonIDTutor) {
+                        if (empty($gibbonPersonIDTutor)) continue;
+                        $staff[] = $gibbonPersonIDTutor;
+
+                        // Record Relation
+                        if (!isset($staffStudentContext[$gibbonPersonIDTutor][$gibbonPersonIDStudent]['context']) || !in_array('Form Tutor', $staffStudentContext[$gibbonPersonIDTutor][$gibbonPersonIDStudent]['context'])) {
+                            $staffStudentContext[$gibbonPersonIDTutor][$gibbonPersonIDStudent]['context'][] = 'Form Tutor';
+                        }
+                    }
+                }
+
+                // Class Teachers
+                if (in_array('teachers', $notifyGroups)) {
+                    $teachers = $container->get(CourseEnrolmentGateway::class)->selectClassTeachersByStudent($session->get('gibbonSchoolYearID'), $gibbonPersonIDStudent);
+                    foreach ($teachers as $teacher) {
+                        $gibbonPersonIDTeacher = $teacher['gibbonPersonID'] ?? null;
+
+                        if (empty($gibbonPersonIDTeacher)) continue;
+                        $staff[] = $gibbonPersonIDTeacher;
+
+                        // Record relation
+                        if (!isset($staffStudentContext[$gibbonPersonIDTeacher][$gibbonPersonIDStudent]['context']) || !in_array('Class Teacher', $staffStudentContext[$gibbonPersonIDTeacher][$gibbonPersonIDStudent]['context'])) {
+                            $staffStudentContext[$gibbonPersonIDTeacher][$gibbonPersonIDStudent]['context'][] = 'Class Teacher';
+                        }
+                    }
+                }
+
+                if (in_array('INAssistant', $notifyGroups)) {
+                    $assistants = $container->get(INAssistantGateway::class)->selectINAssistantsByStudent($gibbonPersonIDStudent);
+                    foreach ($assistants as $assistant) {
+                        $gibbonPersonIDAssistant = $assistant['gibbonPersonID'] ?? null;
+
+                        if (empty($gibbonPersonIDAssistant)) continue; 
+                        $staff[] = $gibbonPersonIDAssistant;
+
+                        // Record Relation
+                        if (!isset($staffStudentContext[$gibbonPersonIDAssistant][$gibbonPersonIDStudent]['context']) || !in_array('LSA', $staffStudentContext[$gibbonPersonIDAssistant][$gibbonPersonIDStudent]['context'])) {
+                            $staffStudentContext[$gibbonPersonIDAssistant][$gibbonPersonIDStudent]['context'][] = 'LSA';
+                        }
+                    }
                 }
             }
         }
@@ -116,27 +164,46 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
     }
 
     $staffPersonIDs = isset($staff) ? array_values(array_filter(array_unique($staff))) : [];
-
-    $staffDetails = $container->get(UserGateway::class)->selectNotificationDetailsByPerson($staffPersonIDs)->fetchAll();
-    $sender = $container->get(UserGateway::class)->getByID($session->get('gibbonPersonID'));
+    $staffDetails = $userGateway->selectNotificationDetailsByPerson($staffPersonIDs)->fetchAll();
 
     $view = $container->get(View::class);
     $mail = $container->get(Mailer::class);
     $mail->SMTPKeepAlive = true;
 
-    $content = $view->fetchFromTemplate('calendarEvents.twig.html', [
-        'students' => $students->toArray(),
-        'event' => $event ?? [],
-        'notes' => $notes ?? '',
-    ]);
-    
-    $sender = $container->get(UserGateway::class)->getByID($session->get('gibbonPersonID'));
+    $sender = $userGateway->getByID($session->get('gibbonPersonID'));
     $replyTo = $sender['email'];
     $replyToName = Format::name($sender['title'], $sender['preferredName'], $sender['surname'], 'Staff');
 
     foreach ($staffDetails as $staffDetail) {
+        $gibbonPersonIDTeacher = $staffDetail['gibbonPersonID'];
+
+        // Get the relevant students of this staff
+        $relevantStudents = [];
+        foreach ($students as $student) {
+            $gibbonPersonIDStudent = $student['gibbonPersonID'];
+            if (isset($staffStudentContext[$gibbonPersonIDTeacher][$gibbonPersonIDStudent]['context'])) {
+                
+                // Get all the roles for this student-teacher pair
+                $contextLabels = implode(', ', $staffStudentContext[$gibbonPersonIDTeacher][$gibbonPersonIDStudent]['context']);
+                $relevantStudents[] = array_merge($student, [
+                    'context' => $contextLabels
+                ]);
+            } else {
+                $relevantStudents[] = array_merge($student, [
+                    'context' => $allStaff == 'Y' ? 'All Staff' : 'Other',
+                ]);
+            }
+        }
+
         $buttonURL = "index.php?q=/modules/Calendar/calendar_event_view.php&gibbonCalendarEventID=".$gibbonCalendarEventID;
         $subject = sprintf(__('Event Summary - %1$s (%2$s - %3$s'), $event['name'], Format::date($event['dateStart']), Format::date($event['dateEnd']). ')', $session->get('systemName'), $session->get('organisationNameShort'));
+
+         // Generate content from template
+        $content = $view->fetchFromTemplate('calendarEvents.twig.html', [
+            'students' => $relevantStudents,
+            'event' => $event ?? [],
+            'notes' => $notes ?? '',
+        ]);
 
         $body = sprintf(__('Dear %1$s'), $staffDetail['preferredName'].' '.$staffDetail['surname']).',<br/><br/>';
         $body .= $content;
@@ -146,7 +213,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
 
         $mail->setDefaultSender($subject);
         $mail->renderBody('mail/message.twig.html', [
-            'title'  => __('Event Summary'),
+            'title'  => __('Event'),
             'body'   => $body,
             'button' => [
                 'url'  => $buttonURL,
@@ -169,8 +236,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
     // Close SMTP connection
     $mail->smtpClose();
         
-
-    
     $URL .= $partialFail
         ? "&return=warning1"
         : "&return=success0";

--- a/modules/Calendar/calendar_event_notifyProcess.php
+++ b/modules/Calendar/calendar_event_notifyProcess.php
@@ -48,9 +48,15 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
     $calendarEventGateway = $container->get(CalendarEventGateway::class);
     $calendarEventPersonGateway = $container->get(CalendarEventPersonGateway::class);
 
+    $notes = $_POST['notes'] ?? '';
+    $notifyGroups = $_POST['notifyGroups'] ?? [];
+    $allStaff = $_POST['allStaff'] ?? 'N';
+    $notificationList = isset($_POST['notificationList']) ? explode(',', $_POST['notificationList']) : [];
+    $staff = [];
+
     // Get event details
-    $values = $calendarEventGateway->getByID($gibbonCalendarEventID);
-    if (!empty($gibbonCalendarEventID) && empty($values)) {
+    $event = $calendarEventGateway->getByID($gibbonCalendarEventID);
+    if (!empty($gibbonCalendarEventID) && empty($event)) {
         $page->addError(__('The specified record cannot be found.'));
         return;
     }
@@ -65,12 +71,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
         $page->addError(__('The specified record does not have any enrolled attendees.'));
         return;
     }
-
-    $notes = $_POST['notes'] ?? '';
-    $notifyGroups = $_POST['notifyGroups'] ?? [];
-    $allStaff = $_POST['allStaff'] ?? 'N';
-    $notificationList = isset($_POST['notificationList']) ? explode(',', $_POST['notificationList']) : [];
-    $staff = [];
 
     if ($allStaff == 'Y') {
          // All Staff
@@ -121,10 +121,10 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
     $staffDetails = $container->get(UserGateway::class)->selectNotificationDetailsByPerson($staffPersonIDs)->fetchAll();
     $sender = $container->get(UserGateway::class)->getByID($session->get('gibbonPersonID'));
 
-    echo '<pre>';
-    print_r($staffDetails);
-    echo '</pre>';
-    die();
+
+
+
+                                    // LEFT TO DO
 
     // Create the email Template
     $template = $container->get(EmailTemplate::class)->setTemplate('Calendar Event Notification');
@@ -134,7 +134,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
 
     $emailIndex = 1;
     $emails = [];
-
 
     foreach ($staffDetails as $staffDetail) {
 
@@ -154,15 +153,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_ed
         // Send email and record the result
         $sent = $mail->Send();
 
-        $emails[$emailIndex] = Format::name($templateData['title'], $templateData['preferredName'], $templateData['surname'], 'Staff').': '.$templateData['email'].' ($'.$templateData['amount'].') - '. ($sent ? __('Sent') : __('Failed') );
+        $emails[$emailIndex] = Format::name($staffDetail['title'], $staffDetail['preferredName'], $staffDetail['surname'], 'Staff').': '.$staffDetail['email'].($sent ? __('Sent') : __('Failed') );
         $emailIndex++;
     }
-
-        
-    // echo '<pre>';
-    // print_r($emailStaff);
-    // echo '</pre>';
-    // die();
         
 
         // $studentName = Format::name('', $student['preferredName'], $student['surname'], 'Student', false, true);

--- a/modules/Calendar/calendar_event_view.php
+++ b/modules/Calendar/calendar_event_view.php
@@ -56,11 +56,17 @@ if (!isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_v
     $form->setFactory(DatabaseFormFactory::create($pdo));
 
     $form->addHeaderAction('enrolment', __('Enrolment'))
-    ->setURL('/modules/Calendar/calendar_event_enrolment.php')
-    ->addParam('gibbonCalendarEventID', $gibbonCalendarEventID)
-      ->setIcon('attendance')
-    ->displayLabel();
+        ->setURL('/modules/Calendar/calendar_event_enrolment.php')
+        ->addParam('gibbonCalendarEventID', $gibbonCalendarEventID)
+        ->setIcon('attendance')
+        ->displayLabel();
 
+    $form->addHeaderAction('email', __('Notify Staff'))
+        ->setURL('/modules/Calendar/calendar_event_notify.php')
+        ->addParam('gibbonCalendarEventID', $gibbonCalendarEventID)
+        ->setIcon('run')
+        ->displayLabel();
+        
     $form->addRow()->addHeading(__('Basic Information'));
 
     // Get Calendars of the current school year

--- a/modules/Calendar/templates/calendarEvents.twig.html
+++ b/modules/Calendar/templates/calendarEvents.twig.html
@@ -1,0 +1,41 @@
+{#<!--
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+{{ __('Please find below the list of the partipants for the Event - {eventName}, happening on {eventDate}, {eventTime}.', {'eventName': event.name , 'eventDate': formatUsing('dateRangeReadable', event.dateStart, event.dateEnd), 'eventTime': event.allDay == 'Y' ? 'All Day' : formatUsing('timeRange', event.timeStart, event.timeEnd) }) }}<br/>
+
+<p>
+    <strong>Notes:</strong><br>
+    {{ notes }}
+</p>
+
+<p><h2>Student Participants</h2></p>
+
+{% if students is defined and students is not empty %}
+    <table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse;">
+        <thead>
+            <tr>
+                <th>Student</th>
+                <th>Form group</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for student in students %}
+                <tr>
+                    <td>{{ formatUsing('name', '', student.preferredName, student.surname, 'Student', false) }}</td>
+                    <td>{{  student.formGroup }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+{% else %}
+    <p> No students enrolled </p>
+{% endif %}

--- a/modules/Calendar/templates/calendarEvents.twig.html
+++ b/modules/Calendar/templates/calendarEvents.twig.html
@@ -10,10 +10,12 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
 {{ __('Please find below the list of the partipants for the Event - {eventName}, happening on {eventDate}, {eventTime}.', {'eventName': event.name , 'eventDate': formatUsing('dateRangeReadable', event.dateStart, event.dateEnd), 'eventTime': event.allDay == 'Y' ? 'All Day' : formatUsing('timeRange', event.timeStart, event.timeEnd) }) }}<br/>
 
-<p>
-    <strong>Notes:</strong><br>
-    {{ notes }}
-</p>
+{% if notes is defined and notes is not empty %}
+    <p>
+        <strong>Notes:</strong><br>
+        {{ notes }}
+    </p>
+{% endif %}
 
 <p><h2>Student Participants</h2></p>
 
@@ -23,14 +25,22 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
             <tr>
                 <th>Student</th>
                 <th>Form group</th>
+                <th>Context</th>
             </tr>
         </thead>
-
+        
         <tbody>
             {% for student in students %}
                 <tr>
                     <td>{{ formatUsing('name', '', student.preferredName, student.surname, 'Student', false) }}</td>
                     <td>{{  student.formGroup }}</td>
+                    <td>
+                        {% if student.context is defined and student.context is not empty %}
+                            {{ student.context }}
+                        {% else %}
+                            Other
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/src/Domain/Calendar/CalendarEventPersonGateway.php
+++ b/src/Domain/Calendar/CalendarEventPersonGateway.php
@@ -40,7 +40,7 @@ class CalendarEventPersonGateway extends QueryableGateway
     public function queryEnrolledAttendees($criteria, $gibbonCalendarEventID) {
         $query = $this
             ->newQuery()
-            ->cols(['gibbonCalendarEventPerson.*', 'surname', 'preferredName', 'gibbonRole.category', 'gibbonFormGroup.nameShort as formGroup'])
+            ->cols(['gibbonCalendarEventPerson.*', 'surname', 'preferredName', 'gibbonRole.category', 'gibbonStudentEnrolment.gibbonYearGroupID', 'gibbonStudentEnrolment.gibbonFormGroupID', 'gibbonFormGroup.nameShort as formGroup'])
             ->from($this->getTableName())
             ->innerJoin('gibbonCalendarEvent', 'gibbonCalendarEvent.gibbonCalendarEventID=gibbonCalendarEventPerson.gibbonCalendarEventID')
             ->innerJoin('gibbonCalendar', 'gibbonCalendarEvent.gibbonCalendarID=gibbonCalendar.gibbonCalendarID')


### PR DESCRIPTION
**Description**
Now, when an event is created or updated, add the option to email relevant staff about the event, including the description, date and times, and list of participants including the context of how you are related to the student.


