### PR TITLE
Timetable admin   increase the default short name length

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -1035,5 +1035,7 @@ UPDATE `gibbonAction` SET URLList='calendar_event_manage.php, calendar_event_add
 INSERT INTO `gibboni18n` (`code`, `name`, `version`, `active`, `installed`, `systemDefault`, `dateFormat`, `dateFormatRegEx`, `dateFormatPHP`, `rtl`) VALUES ('ca_CA', 'Català - Catalonia', '30.0.00', 'Y', 'N', 'N', 'dd/mm/yyyy', '/^(0[1-9]|[12][0-9]|3[01])[- /.](0[1-9]|1[012])[- /.](19|20)\\d\\d$/i', 'd/m/Y', 'N');end
 UPDATE `gibbonAction` SET description='Allows users to create and edit thier own calendar events.' WHERE name='Manage Events_my' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Calendar');end
 UPDATE `gibbonAction` SET URLList='calendar_event_manage.php, calendar_event_add.php, calendar_event_edit.php, calendar_event_delete.php, calendar_event_view.php, calendar_event_participants.php, calendar_event_participants_add.php, calendar_event_participants_edit.php, calendar_event_participants_delete.php' WHERE (name='Manage Events_all' OR name='Manage Events_my') AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Calendar');end
+ALTER TABLE `gibbonCourse` CHANGE `nameShort` `nameShort` VARCHAR(16) NOT NULL;end
+ALTER TABLE `gibbonCourseClass` CHANGE `nameShort` `nameShort` VARCHAR(16) NOT NULL;end
 
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -73,7 +73,7 @@ v30.0.00
         Timetable: added coverage details for staff duty and activities on the timetable
         Timetable: added a search field in 'Manage Bookings' and 'Mange Facility Changes'
         Timetable Admin: added an Exceptions layer to Class Enrolment by Person, to see existing exceptions
-        Timetable Admin: increased the default short name length for both courses and classses with a warning
+        Timetable Admin: increased the default short name length for both courses and classes with a warning
         User Admin: added a backup table to store person images from previous years
         User Admin: added Sibling as option to Emergency Relationship select
         User Admin: added Prof. as an option in Title select

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -73,6 +73,7 @@ v30.0.00
         Timetable: added coverage details for staff duty and activities on the timetable
         Timetable: added a search field in 'Manage Bookings' and 'Mange Facility Changes'
         Timetable Admin: added an Exceptions layer to Class Enrolment by Person, to see existing exceptions
+        Timetable Admin: increased the default short name length for both courses and classses with a warning
         User Admin: added a backup table to store person images from previous years
         User Admin: added Sibling as option to Emergency Relationship select
         User Admin: added Prof. as an option in Title select

--- a/modules/Timetable Admin/course_manage_add.php
+++ b/modules/Timetable Admin/course_manage_add.php
@@ -89,7 +89,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 			
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'));
-				$row->addTextField('nameShort')->required()->maxLength(12);
+				$row->addTextField('nameShort')->required()->maxLength(16);
 			
 			$row = $form->addRow();
 				$row->addLabel('orderBy', __('Order'))->description(__('May be used to adjust arrangement of courses in reports.'));

--- a/modules/Timetable Admin/course_manage_class_add.php
+++ b/modules/Timetable Admin/course_manage_class_add.php
@@ -87,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this course.'));
-				$row->addTextField('nameShort')->required()->maxLength(8);
+				$row->addTextField('nameShort')->required()->maxLength(16);
 
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable?'))->description(__('Should this class show in reports?'));

--- a/modules/Timetable Admin/course_manage_class_edit.php
+++ b/modules/Timetable Admin/course_manage_class_edit.php
@@ -58,7 +58,12 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
         } else {
             //Let's go!
 			$values = $result->fetch();
-
+            $courseClassName = $values['courseNameShort'].$values['nameShort'];
+            $length= mb_strlen($courseClassName);
+            if ($length> 16) {
+                $page->addWarning(__('The combined short name for this class, {courseClassName}, is longer than the recommended length of 16 characters. Please note this may cause visual issues on the timetable and in dropdown menus.', ['courseClassName' => $courseClassName]));
+            }
+            
 			$form = Form::create('action', $session->get('absoluteURL').'/modules/'.$session->get('module').'/course_manage_class_editProcess.php');
 
 			$form->addHiddenValue('address', $session->get('address'));
@@ -82,7 +87,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'))->description(__('Must be unique for this course.'));
-				$row->addTextField('nameShort')->required()->maxLength(8);
+				$row->addTextField('nameShort')->required()->maxLength(16);
 
 			$row = $form->addRow();
 				$row->addLabel('reportable', __('Reportable?'))->description(__('Should this class show in reports?'));

--- a/modules/Timetable Admin/course_manage_edit.php
+++ b/modules/Timetable Admin/course_manage_edit.php
@@ -100,7 +100,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Timetable Admin/course_man
 
 			$row = $form->addRow();
 				$row->addLabel('nameShort', __('Short Name'));
-				$row->addTextField('nameShort')->required()->maxLength(12);
+				$row->addTextField('nameShort')->required()->maxLength(16);
 
             $row = $form->addRow()->addHeading('Display Information', __('Display Information'));
 


### PR DESCRIPTION


**Description**
Timetable Admin: increased the default short name length for both courses and classes with a warning
