### PR TITLE
Markbook: Allow user to inout decimal values in raw marks box

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -97,7 +97,7 @@ v30.0.00
         Attendance: fixed Student History display when all seven weekdays are set as school days
         Data Updater: fixed attachments being cleared when new data updates are submitted
         Library: fixed handling of SQL values in Library Browse page
-        Markbook: fixed the bug preventing to display user inputs
+        Markbook: fixed the bug preventing to display user inputs and allow decimal inputs
         Messenger: fixed missing From address on emails when using the Add Recipient action in Send Report
         Planner: fixed Teacher Notes in smart blocks not visible when using the Show Confidential Data toggle
         Planner: fixed access to class list in Edit Unit when viewing past and upcoming years

--- a/modules/Markbook/markbook_edit_data.php
+++ b/modules/Markbook/markbook_edit_data.php
@@ -461,7 +461,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Markbook/markbook_edit_dat
 
                         $col = $row->onlyIf($hasAttainment && $hasRawAttainment)->addColumn();
                         $col->addNumber($count.'-attainmentValueRaw')
-                            ->onlyInteger(false)
+                            ->decimalPlaces(2)
                             ->setClass('inline-block w-16')
                             ->setValue($student['attainmentValueRaw']);
                         $col->addContent('/ '.floatval($values['attainmentRawMax']))->setClass('inline-block ml-1');


### PR DESCRIPTION
**Description**
Fixed the issue so that a teacher can now input decimal values in the mark box.