### PR TITLE
Fixed the issue of redirect to installer file

### DIFF
--- a/src/Gibbon/Core.php
+++ b/src/Gibbon/Core.php
@@ -126,6 +126,7 @@ class Core
      */
     public function isInstalled()
     {
+        clearstatcache(true, $this->basePath . '/config.php');    
         return (file_exists($this->basePath . '/config.php') && filesize($this->basePath . '/config.php') > 0);
     }
 


### PR DESCRIPTION
**Description**
The issue was reported here: https://ask.gibbonedu.org/t/intermittent-redirect-to-installer-install-php-v30-0-00-v30-0-01/15522

The issue may be that it may be using stale cached data, which is triggering the redirect to the installer. Thus, it is better to clear the file status cache before checking.