### PR TITLE
Library: fixed the bug that was preventing exporting more than 50 rec…

### DIFF
--- a/modules/Library/report_catalogSummary.php
+++ b/modules/Library/report_catalogSummary.php
@@ -84,6 +84,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Library/report_catalogSumm
         ->filterBy('ownershipType', $ownershipType)
         ->filterBy('space', $gibbonSpaceID)
         ->filterBy('status', $status)
+        ->pageSize(!empty($viewMode) ? 0 : 50)
         ->fromPOST();
 
     $catalog = $reportGateway->queryCatalogSummary($criteria);


### PR DESCRIPTION
**Description**
When we click “export” in Catalog Summary, not all records are included in the exported file. Only 50 records are recorded, even if we change the number of records to display in the table. When we click "Print" or "export", only the first 50 records are included not all the records

