### PR TITLE
Admissions: fix applicant not linked to admissions account on acceptance

### DIFF
--- a/modules/Admissions/applications_manage_acceptProcess.php
+++ b/modules/Admissions/applications_manage_acceptProcess.php
@@ -94,14 +94,14 @@ if (isActionAccessible($guid, $connection2, '/modules/Admissions/applications_ma
 
     // Link the admissions account to new parent and family, if they were created during this acceptance process
     if ($formData->getStatus() == 'Accepted') {
-        if ($formData->hasResult('familyCreated') && $formData->hasResult('gibbonFamilyID') && empty($account['gibbonFamilyID'])) {
+        if ($formData->has('familyCreated') && $formData->has('gibbonFamilyID') && empty($account['gibbonFamilyID'])) {
             $admissionsAccountGateway->update($account['gibbonAdmissionsAccountID'], [
-                'gibbonFamilyID' => $formData->getResult('gibbonFamilyID'),
+                'gibbonFamilyID' => $formData->get('gibbonFamilyID'),
             ]);
         }
-        if ($formData->hasResult('parent1created') && $formData->hasResult('gibbonPersonIDParent1') && empty($account['gibbonPersonID'])) {
+        if ($formData->has('parent1created') && $formData->has('gibbonPersonIDParent1') && empty($account['gibbonPersonID'])) {
             $admissionsAccountGateway->update($account['gibbonAdmissionsAccountID'], [
-                'gibbonPersonID' => $formData->getResult('gibbonPersonIDParent1'),
+                'gibbonPersonID' => $formData->get('gibbonPersonIDParent1'),
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- The acceptance process in `applications_manage_acceptProcess.php` used `hasResult()`/`getResult()` to check for parent and family records created during acceptance
- However, `CreateParents.php` and `CreateFamily.php` store these values using `set()`, not `setResult()` — so the condition always failed silently
- Changed to `has()`/`get()` to match how the data is actually stored by the form builder processes

**Impact:** Without this fix, accepting an application creates the student, parents, and family correctly, but the admissions account's `gibbonPersonID` is never updated — the applicant (parent) remains unlinked.

## Test plan
- [ ] Create a new admissions application with parent details
- [ ] Accept the application
- [ ] Verify `gibbonAdmissionsAccount.gibbonPersonID` is set to the parent's person ID
- [ ] Verify `gibbonAdmissionsAccount.gibbonFamilyID` is set to the new family ID