### PR TITLE
Fix code-type custom fields becoming uneditable in course context

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -1054,4 +1054,5 @@ ALTER TABLE `gibbonCalendarEventType` CHANGE `color` `color` VARCHAR(7) NULL, CH
 //v30.0.01
 ++$count;
 $sql[$count][0] = '30.0.01';
-$sql[$count][1] = "";
+$sql[$count][1] = "
+UPDATE `gibbonAction` SET URLList='calendar_view.php,calendar_event_view.php' WHERE name='View Calendar' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Calendar');end";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ v30.0.01
     Bug Fixes
         System: fixed default collation in gibbon.sql causing installation issues for MariaDB systems
         System: added a upper character limit of 2048 to translation strings, to prevent gettext errors
+        System: fixed validation of Number fields not allowing decimal places for non-integer values
         Attendance: fixed empty list in Set Future Absence when using Select Students for Multiple Students
         Calendar: fixed access to View Event when users only have View Calendar access
         Planner: fixed an error on the Year Overview of the Lesson Planner

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ v30.0.01
         System: fixed default collation in gibbon.sql causing installation issues for MariaDB systems
         System: added a upper character limit of 2048 to translation strings, to prevent gettext errors
         Attendance: fixed empty list in Set Future Absence when using Select Students for Multiple Students
+        Calendar: fixed access to View Event when users only have View Calendar access
         Planner: fixed an error on the Year Overview of the Lesson Planner
 
 v30.0.00

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,8 @@ v30.0.01
         Attendance: fixed empty list in Set Future Absence when using Select Students for Multiple Students
         Calendar: fixed access to View Event when users only have View Calendar access
         Planner: fixed an error on the Year Overview of the Lesson Planner
+        Reports: improved sanitization of file paths in Manage Archive
+        Tracking: improved validation of user inputs in Graphing page
 
 v30.0.00
 --------

--- a/composer.lock
+++ b/composer.lock
@@ -1817,16 +1817,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -1865,7 +1865,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -1873,7 +1873,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T12:36:36+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "myclabs/php-enum",
@@ -5245,16 +5245,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -5297,9 +5297,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5798,16 +5798,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.23",
+            "version": "9.6.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95"
+                "reference": "fea06253ecc0a32faf787bd31b261f56f351d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
-                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fea06253ecc0a32faf787bd31b261f56f351d049",
+                "reference": "fea06253ecc0a32faf787bd31b261f56f351d049",
                 "shasum": ""
             },
             "require": {
@@ -5818,7 +5818,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.1",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -5829,11 +5829,11 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
                 "sebastian/type": "^3.2.1",
@@ -5881,7 +5881,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.23"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.33"
             },
             "funding": [
                 {
@@ -5905,7 +5905,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T06:40:34+00:00"
+            "time": "2026-01-27T05:25:09+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -6126,16 +6126,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -6188,15 +6188,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -6386,16 +6398,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
@@ -6451,28 +6463,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -6515,15 +6539,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -6696,16 +6732,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -6747,15 +6783,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -7961,16 +8009,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -7999,7 +8047,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -8007,7 +8055,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [

--- a/modules/Calendar/calendar_event_view.php
+++ b/modules/Calendar/calendar_event_view.php
@@ -30,7 +30,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_v
 } else {
     // Proceed!
     $page->breadcrumbs
-        ->add(__('Manage Events'), 'calendar_event_manage.php')
+        ->add(__('View Calendar'), 'calendar_view.php')
         ->add(__('View Event'));
 
     $gibbonCalendarEventID = $_GET['gibbonCalendarEventID'] ?? '';
@@ -45,12 +45,14 @@ if (!isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_v
         return;
     }
 
-    $canEditEvent = $event['editor'] == 'Y' && Access::allows('Calendar', 'calendar_event_edit');
+    $canManageCalendars = Access::allows('Calendar', 'calendar_event_edit');
+    $canEditEvent = $event['editor'] == 'Y' && $canManageCalendars;
 
     // DATA TABLE TO VIEW EVENT DETAILS
     $table = DataTable::createDetails('viewEvent');
 
     $table->setTitle(__('View'));
+    $table->addMetaData('allowHTML', ['description']);
 
     if ($canEditEvent) {
         $table->addHeaderAction('edit', __('Edit Event'))
@@ -111,6 +113,8 @@ if (!isActionAccessible($guid, $connection2, '/modules/Calendar/calendar_event_v
         ->fromPOST();
         
     $participants = $calendarEventPersonGateway->queryAllEventParticipants($criteria, $gibbonCalendarEventID);
+
+    if (!$canManageCalendars || count($participants) <= 0) return;
 
     // DATA TABLE FOR ALL PARTICIPANTS
     $table = DataTable::createPaginated('participants', $criteria)->withData($participants);

--- a/modules/Reports/archive_manage_addProcess.php
+++ b/modules/Reports/archive_manage_addProcess.php
@@ -37,18 +37,26 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_add
     // Proceed!
     $reportArchiveGateway = $container->get(ReportArchiveGateway::class);
 
+    $requestedPath = $_POST['path'] ?? '';
+    $requestedPathFiltered = str_replace(['..', './', '..\\'], '', $requestedPath);
+    $requestedPathFiltered = trim($requestedPathFiltered, '/');
+
+    if (strpos($requestedPathFiltered, 'uploads') !== 0) {
+        $requestedPathFiltered = 'uploads/' . $requestedPathFiltered;
+    }
+
+    $securePath = '/' . $requestedPathFiltered;
+
     $data = [
         'name'             => $_POST['name'] ?? '',
-        'path'             => $_POST['path'] ?? '',
+        'path'             => $securePath ?? '',
         'readonly'         => $_POST['readonly'] ?? 'Y',
         'viewableStaff'    => $_POST['viewableStaff'] ?? 'N',
         'viewableStudents' => $_POST['viewableStudents'] ?? 'N',
         'viewableParents'  => $_POST['viewableParents'] ?? 'N',
         'viewableOther'    => $_POST['viewableOther'] ?? 'N',
     ];
-
-    $data['path'] = '/'.trim($data['path'], '/');
-
+    
     // Validate the required values are present
     if (empty($data['name']) || empty($data['path'])) {
         $URL .= '&return=error1';

--- a/modules/Reports/archive_manage_addProcess.php
+++ b/modules/Reports/archive_manage_addProcess.php
@@ -25,7 +25,8 @@ use Gibbon\Data\Validator;
 
 require_once '../../gibbon.php';
 
-$_POST = $container->get(Validator::class)->sanitize($_POST);
+$validator = $container->get(Validator::class);
+$_POST = $validator->sanitize($_POST);
 
 $URL = $session->get('absoluteURL').'/index.php?q=/modules/Reports/archive_manage_add.php';
 
@@ -37,15 +38,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_add
     // Proceed!
     $reportArchiveGateway = $container->get(ReportArchiveGateway::class);
 
-    $requestedPath = $_POST['path'] ?? '';
-    $requestedPathFiltered = str_replace(['..', './', '..\\'], '', $requestedPath);
-    $requestedPathFiltered = trim($requestedPathFiltered, '/');
-
-    if (strpos($requestedPathFiltered, 'uploads') !== 0) {
-        $requestedPathFiltered = 'uploads/' . $requestedPathFiltered;
+    $path = $_POST['path'] ?? '';
+    if (substr($path, 0, 8) != '/uploads') {
+        $path = '/uploads/' . trim($path, ' /');
     }
 
-    $securePath = '/' . $requestedPathFiltered;
+    $securePath = $validator->sanitizeFilePath($path, $session->get('absolutePath'));
+    if (empty($securePath)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
 
     $data = [
         'name'             => $_POST['name'] ?? '',

--- a/modules/Reports/archive_manage_editProcess.php
+++ b/modules/Reports/archive_manage_editProcess.php
@@ -25,7 +25,8 @@ use Gibbon\Data\Validator;
 
 require_once '../../gibbon.php';
 
-$_POST = $container->get(Validator::class)->sanitize($_POST);
+$validator = $container->get(Validator::class);
+$_POST = $validator->sanitize($_POST);
 
 $gibbonReportArchiveID = $_POST['gibbonReportArchiveID'] ?? '';
 
@@ -39,15 +40,17 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_edi
     // Proceed!
     $reportArchiveGateway = $container->get(ReportArchiveGateway::class);
     
-    $requestedPath = $_POST['path'] ?? '';
-    $requestedPathFiltered = str_replace(['..', './', '..\\'], '', $requestedPath);
-    $requestedPathFiltered = trim($requestedPathFiltered, '/');
-
-    if (strpos($requestedPathFiltered, 'uploads') !== 0) {
-        $requestedPathFiltered = 'uploads/' . $requestedPathFiltered;
+    $path = $_POST['path'] ?? '';
+    if (substr($path, 0, 8) != '/uploads') {
+        $path = '/uploads/' . trim($path, ' /');
     }
 
-    $securePath = '/' . $requestedPathFiltered;
+    $securePath = $validator->sanitizeFilePath($path, $session->get('absolutePath'));
+    if (empty($securePath)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
 
     $data = [
         'name'             => $_POST['name'] ?? '',

--- a/modules/Reports/archive_manage_editProcess.php
+++ b/modules/Reports/archive_manage_editProcess.php
@@ -38,18 +38,26 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_edi
 } else {
     // Proceed!
     $reportArchiveGateway = $container->get(ReportArchiveGateway::class);
+    
+    $requestedPath = $_POST['path'] ?? '';
+    $requestedPathFiltered = str_replace(['..', './', '..\\'], '', $requestedPath);
+    $requestedPathFiltered = trim($requestedPathFiltered, '/');
+
+    if (strpos($requestedPathFiltered, 'uploads') !== 0) {
+        $requestedPathFiltered = 'uploads/' . $requestedPathFiltered;
+    }
+
+    $securePath = '/' . $requestedPathFiltered;
 
     $data = [
         'name'             => $_POST['name'] ?? '',
-        'path'             => $_POST['path'] ?? '',
+        'path'             => $securePath ?? '',
         'readonly'         => $_POST['readonly'] ?? 'Y',
         'viewableStaff'    => $_POST['viewableStaff'] ?? 'N',
         'viewableStudents' => $_POST['viewableStudents'] ?? 'N',
         'viewableParents'  => $_POST['viewableParents'] ?? 'N',
         'viewableOther'    => $_POST['viewableOther'] ?? 'N',
     ];
-
-    $data['path'] = '/'.trim($data['path'], '/');
 
     // Validate the required values are present
     if (empty($gibbonReportArchiveID) || empty($data['name'])) {

--- a/modules/Reports/archive_manage_uploadProcess.php
+++ b/modules/Reports/archive_manage_uploadProcess.php
@@ -46,25 +46,28 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
     $fileSeparator = $_POST['fileSeparator'] ?? '';
     $fileSection = $_POST['fileSection'] ?? '';
 
-    if (empty($file) || empty($gibbonReportArchiveID) || empty($gibbonSchoolYearID) || empty($reportIdentifier) || empty($reportDate)) {
+    if (empty($gibbonReportArchiveID) || empty($gibbonSchoolYearID) || empty($reportIdentifier) || empty($reportDate)) {
         $URL .= '&return=error1';
         header("Location: {$URL}");
         exit;
     }
 
-    $absolutePath = $session->get('absolutePath');
-    if (!is_file($absolutePath.'/'.$file)) {
-        $URL .= '&return=error1';
-        header("Location: {$URL}");
-        exit;
-    }
-    
     $reportArchiveGateway = $container->get(ReportArchiveGateway::class);
     $reportArchiveEntryGateway = $container->get(ReportArchiveEntryGateway::class);
     $studentGateway = $container->get(StudentGateway::class);
 
     $archive = $reportArchiveGateway->getByID($gibbonReportArchiveID);
     if (empty($archive)) {
+        $URL .= '&return=error1';
+        header("Location: {$URL}");
+        exit;
+    }
+
+    $secureFileName = basename($file);
+    $allowedPath = $archive['path'] . '/temp/' . $secureFileName;
+
+    $absolutePath = $session->get('absolutePath');
+    if (empty($secureFileName) || !is_file($absolutePath.'/'.$allowedPath)) {
         $URL .= '&return=error1';
         header("Location: {$URL}");
         exit;
@@ -77,7 +80,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
     }
 
     $fileUploader = new FileUploader($pdo, $session);
-    $reports = $fileUploader->uploadFromZIP($absolutePath.'/'.$file, $destinationFolder, ['pdf']);
+    $reports = $fileUploader->uploadFromZIP($absolutePath.'/'.$allowedPath, $destinationFolder, ['pdf']);
 
     $partialFail = false;
     $count = 0;
@@ -137,7 +140,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
         }
     }
 
-    unlink($absolutePath.'/'.$file);
+    if (file_exists($absolutePath.'/'.$allowedPath)) {
+        unlink($absolutePath.'/'.$allowedPath);
+    }
 
     $URL .= $partialFail
         ? "&return=warning1"

--- a/modules/Reports/archive_manage_uploadProcess.php
+++ b/modules/Reports/archive_manage_uploadProcess.php
@@ -27,7 +27,8 @@ use Gibbon\Data\Validator;
 
 require_once '../../gibbon.php';
 
-$_POST = $container->get(Validator::class)->sanitize($_POST);
+$validator = $container->get(Validator::class);
+$_POST = $validator->sanitize($_POST);
 
 $URL = $session->get('absoluteURL').'/index.php?q=/modules/Reports/archive_manage_upload.php';
 
@@ -63,18 +64,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/archive_manage_upl
         exit;
     }
 
-    $secureFileName = basename($file);
-    $allowedPath = $archive['path'] . '/temp/' . $secureFileName;
+    $file = $validator->sanitizeFilename($file);
+    $allowedPath = $archive['path'] . '/temp/' . $file;
 
     $absolutePath = $session->get('absolutePath');
-    if (empty($secureFileName) || !is_file($absolutePath.'/'.$allowedPath)) {
+    if (empty($file) || !is_file($absolutePath.'/'.$allowedPath)) {
         $URL .= '&return=error1';
         header("Location: {$URL}");
         exit;
     }
 
-    $reportFolder = $gibbonSchoolYearID.'-'.preg_replace('[/~`!@%#$%^&*()+={}\[\]|\\:;"\'<>,.?\/]', '', $reportIdentifier);
-    $destinationFolder = $archive['path'].'/'.$reportFolder;
+    $gibbonSchoolYearID = $validator->sanitizeNumeric($gibbonSchoolYearID);
+    $reportIdentifier = $validator->sanitizeAlphaNumeric($reportIdentifier, true);
+    $reportFolder = $gibbonSchoolYearID.'-'.$reportIdentifier;
+
+    $destinationFolder = $archive['path'].'/'.$gibbonSchoolYearID.'-'.$reportIdentifier;
     if (!is_dir($absolutePath.$destinationFolder)) {
         mkdir($absolutePath.$destinationFolder, 0755, true);
     }

--- a/modules/Tracking/graphing.php
+++ b/modules/Tracking/graphing.php
@@ -19,12 +19,16 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Data\Validator;
 use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
+
+$validator = $container->get(Validator::class);
+$_POST = $validator->sanitize($_POST);
 
 if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') == false) {
     // Access denied
@@ -42,22 +46,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') ==
         echo __('Filter');
         echo '</h2>';
         
-        $gibbonPersonIDs = (isset($_POST['gibbonPersonIDs'])) ? $_POST['gibbonPersonIDs'] : null;
-        $gibbonDepartmentIDs = (isset($_POST['gibbonDepartmentIDs'])) ? $_POST['gibbonDepartmentIDs'] : null;
-        $dataType = (isset($_POST['dataType']))? $_POST['dataType'] : null;
+        $gibbonPersonIDs = $_POST['gibbonPersonIDs'] ?? [];
+        $gibbonDepartmentIDs =  $_POST['gibbonDepartmentIDs'] ?? [];
+        $dataType = $_POST['dataType'] ?? null;
 
         // Sanitize the gibbonPersonIDs and gibbonDepartmentIDs List
-        if (!empty($gibbonPersonIDs)) {
-            $gibbonPersonIDs = array_filter($gibbonPersonIDs, function($gibbonPersonID) {
-                return is_numeric($gibbonPersonID) && ctype_digit((string)$gibbonPersonID);
-            });
-        }
-
-        if (!empty($gibbonDepartmentIDs)) {
-            $gibbonDepartmentIDs = array_filter($gibbonDepartmentIDs, function($gibbonDepartmentID) {
-                return is_numeric($gibbonDepartmentID) && ctype_digit((string)$gibbonDepartmentID);
-            });
-        }
+        $gibbonPersonIDs = $validator->sanitizeArrayIDs($gibbonPersonIDs);
+        $gibbonDepartmentIDs = $validator->sanitizeArrayIDs($gibbonDepartmentIDs);
 
         $settingGateway = $container->get(SettingGateway::class);
         $attainmentAlt = $settingGateway->getSettingByScope('Markbook', 'attainmentAlternativeName');
@@ -146,6 +141,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') ==
                         $personExtra_IA = 'AND ('.substr($personExtra_IA, 0, -4).')';
                     }
 
+                    $dataType = $validator->sanitizeAlphaNumeric($dataType);
                     $sqlDepartments = '(SELECT DISTINCT gibbonDepartment.name AS department
                         FROM gibbonMarkbookEntry
                         JOIN gibbonMarkbookColumn ON (gibbonMarkbookEntry.gibbonMarkbookColumnID=gibbonMarkbookColumn.gibbonMarkbookColumnID)

--- a/modules/Tracking/graphing.php
+++ b/modules/Tracking/graphing.php
@@ -41,10 +41,23 @@ if (isActionAccessible($guid, $connection2, '/modules/Tracking/graphing.php') ==
         echo '<h2>';
         echo __('Filter');
         echo '</h2>';
-
-        $gibbonPersonIDs = (isset($_POST['gibbonPersonIDs']))? $_POST['gibbonPersonIDs'] : null;
-        $gibbonDepartmentIDs = (isset($_POST['gibbonDepartmentIDs']))? $_POST['gibbonDepartmentIDs'] : null;
+        
+        $gibbonPersonIDs = (isset($_POST['gibbonPersonIDs'])) ? $_POST['gibbonPersonIDs'] : null;
+        $gibbonDepartmentIDs = (isset($_POST['gibbonDepartmentIDs'])) ? $_POST['gibbonDepartmentIDs'] : null;
         $dataType = (isset($_POST['dataType']))? $_POST['dataType'] : null;
+
+        // Sanitize the gibbonPersonIDs and gibbonDepartmentIDs List
+        if (!empty($gibbonPersonIDs)) {
+            $gibbonPersonIDs = array_filter($gibbonPersonIDs, function($gibbonPersonID) {
+                return is_numeric($gibbonPersonID) && ctype_digit((string)$gibbonPersonID);
+            });
+        }
+
+        if (!empty($gibbonDepartmentIDs)) {
+            $gibbonDepartmentIDs = array_filter($gibbonDepartmentIDs, function($gibbonDepartmentID) {
+                return is_numeric($gibbonDepartmentID) && ctype_digit((string)$gibbonDepartmentID);
+            });
+        }
 
         $settingGateway = $container->get(SettingGateway::class);
         $attainmentAlt = $settingGateway->getSettingByScope('Markbook', 'attainmentAlternativeName');

--- a/src/Data/Validator.php
+++ b/src/Data/Validator.php
@@ -234,6 +234,75 @@ class Validator
     }
 
     /**
+     * Sanitize a string so that it may only contain alphanumeric values
+     *
+     * @param string $value
+     * @return string
+     */
+    public function sanitizeAlphaNumeric(string $value, bool $allowDashes = false)
+    {
+        return preg_replace($allowDashes ? '/[^a-zA-Z0-9-_]/' : '/[^a-zA-Z0-9]/', '', $value);
+    }
+
+    /**
+     * Sanitize a string so that it may only contain numeric values.
+     *
+     * @param string $value
+     * @return string
+     */
+    public function sanitizeNumeric(string $value, bool $allowDecimals = false)
+    {
+        return preg_replace($allowDecimals ? '/[^0-9,.]/' : '/[^0-9]/', '', $value);
+    }
+
+    /**
+     * Sanitize an array of values that may only contain numeric IDs.
+     *
+     * @param array $value
+     * @return array
+     */
+    public function sanitizeArrayIDs(array $values)
+    {
+        return array_map(function($value) {
+            return preg_replace('/[^0-9]/', '', $value);
+        }, $values);
+    }
+
+    /**
+     * Sanitize a file name to remove special characters and directories.
+     *
+     * @param string $value
+     * @return string
+     */
+    public function sanitizeFilename(string $filename)
+    {
+        $filename = basename($filename);
+        return preg_replace('/[\\\~`!@%#\$%\^&\*\(\)\+=\{\}\[\]\|\:;"\'<>,\?\\/\s]/', '', $filename);
+    }
+
+    /**
+     * Sanitize a file path to prevent path traversal and invalid characters.
+     *
+     * @param string $value
+     * @return string
+     */
+    public function sanitizeFilePath(string $filePath, string $basePath, bool $relative = true)
+    {
+        $filePath = trim(preg_replace('[~`!@%#$%^&*()+={}\[\]|\\:;"\'<>,.?]', '', $filePath), ' /');
+        $fullPath = $basePath . '/' . $filePath;
+
+        $fullPath = realpath($fullPath);
+
+        if ($fullPath === false || substr($fullPath, 0, strlen($basePath)) != $basePath) {
+            return false;
+        }
+
+        return $relative
+            ? substr($fullPath, strlen($basePath))
+            : $fullPath;
+    }
+
+    /**
      * Wrapper for strip_tags, accepts an array of tags rather than a string.
      *
      * @param    string  &$value

--- a/src/Forms/Input/CodeEditor.template.php
+++ b/src/Forms/Input/CodeEditor.template.php
@@ -3,32 +3,48 @@
 <div id="editor<?= $id; ?>" class="w-full" style="height: <?= $height; ?>px;"><?= htmlentities($text, ENT_QUOTES, 'UTF-8'); ?></div>
 
 <script type="text/javascript">
-    function setupEditor () {
-        var useAutocomplete = <?= !empty($autocomplete) ? 'true' : 'false'; ?>;
+    (async () => {
+        const editorId = "editor<?= $id; ?>";
+        const textareaId = "<?= $id; ?>";
+        const useAutocomplete = <?= !empty($autocomplete) ? 'true' : 'false'; ?>;
+
+        await import("./lib/ace/ace.js");
+
         if (useAutocomplete) {
-            var languageTools = ace.require("ace/ext/language_tools");
+            await import("./lib/ace/ext-language_tools.js");
         }
 
         ace.config.set('basePath', './lib/ace/');
-        
-        var editor = ace.edit("editor<?= $id; ?>");
+
+        const editorElement = document.getElementById(editorId);
+        const textareaElement = document.getElementById(textareaId);
+
+        if (!editorElement || !textareaElement) return;
+
+        // Avoid duplicate initialization on the same DOM node
+        if (editorElement.env && editorElement.env.editor) return;
+
+        const editor = ace.edit(editorId);
+
         editor.getSession().setUseWrapMode(true);
-        editor.getSession().on("change", function(e) {
-            $("#<?= $id; ?>").val(editor.getSession().getValue());
+        editor.getSession().setMode("ace/mode/<?= !empty($mode) ? $mode : 'html'; ?>");
+
+        editor.getSession().on("change", function () {
+            textareaElement.value = editor.getSession().getValue();
         });
 
-        editor.getSession().setMode("ace/mode/<?= !empty($mode)? $mode : 'html'; ?>");
-
         if (useAutocomplete) {
+            const languageTools = ace.require("ace/ext/language_tools");
+
             editor.setOptions({
                 enableBasicAutocompletion: false,
                 enableSnippets: true,
                 enableLiveAutocompletion: true
             });
 
-            var staticWordCompleter = {
+            const staticWordCompleter = {
                 getCompletions: function(editor, session, pos, prefix, callback) {
-                    var wordList = <?= json_encode($autocomplete ?? []); ?>;
+                    const wordList = <?= json_encode($autocomplete ?? []); ?>;
                     callback(null, wordList.map(function(word) {
                         return {
                             caption: word,
@@ -37,23 +53,19 @@
                         };
                     }));
                 }
-            }
-            
+            };
+
             languageTools.addCompleter(staticWordCompleter);
         }
-    }
 
-    // Ensure the scripts load in the correct order
-    (async () => {
-        await import("./lib/ace/ace.js")
-        await import("./lib/ace/ext-language_tools.js")
-        await setupEditor();
+        // Sync initial editor content back to the hidden textarea
+        textareaElement.value = editor.getSession().getValue();
+
+        // Clean up before HTMX swaps the page
+        document.addEventListener('htmx:beforeRequest', function () {
+            if (editorElement.env && editorElement.env.editor) {
+                editorElement.env.editor.destroy();
+            }
+        }, { once: true });
     })();
-
-    // Remove the existing editor before htmx swaps to a new page
-    document.addEventListener('htmx:beforeRequest', function (event) {
-        ace.edit("editor<?= $id; ?>").destroy();
-        $editor = $("#editor<?= $id; ?>")
-        $editor.remove();
-    }, { once: true });
 </script>

--- a/src/Forms/Input/Number.php
+++ b/src/Forms/Input/Number.php
@@ -110,7 +110,7 @@ class Number extends TextField
     protected function getElement()
     {
         
-        $stepValue = $this->onlyInteger ? "1" : ($this->decimalPlaces > 0 ? "0." . str_repeat("0", $this->decimalPlaces - 1) . "1" : "1");
+        $stepValue = $this->onlyInteger ? "1" : ($this->decimalPlaces > 0 ? "0." . str_repeat("0", $this->decimalPlaces - 1) . "1" : "any");
 
         $attributes = $this->getAttributeArray() + ["min" => $this->min, "max" => $this->max, "step" => $stepValue];
         return Component::render(Number::class, $attributes);

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -444,7 +444,7 @@ class Page extends View
      */
     public function isAddressValid($address, bool $strictPHP = true) : bool
     {
-        if ($strictPHP && stripos($address, '.php') === false) {
+        if ($strictPHP && strtolower(substr($address, -4)) !== '.php') {
             return false;
         }
 


### PR DESCRIPTION
**Summary**
Fixes an issue where code-type custom fields could become uneditable in course context.

**What changed**

* Refactored ACE editor setup into a single async initialization block
* Load `ext-language_tools` only when autocomplete is enabled
* Added a guard to prevent duplicate editor initialization on the same DOM node
* Synced the hidden textarea with the editor value immediately on load
* Updated HTMX cleanup to safely destroy the editor before page swaps

**Why**
In course context, repeated initialization or HTMX swap behavior could leave the code editor in a broken or uneditable state. This change makes initialization and teardown more reliable.

**Testing**

* Opened a code-type custom field in course context
* Confirmed the editor loads correctly
* Confirmed content changes sync back to the hidden textarea
* Confirmed duplicate editor initialization is prevented
* Confirmed editor teardown occurs cleanly before HTMX navigation

**Related discussion**
https://ask.gibbonedu.org/t/code-type-custom-fields-become-uneditable-in-course-context/15539/4

**Notes**
Tested on Gibbon v31.0.00