### PR TITLE
Admissions: added new options for how houses are automatically assigned when a student application is accepted

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ v31.0.00
         Activities: display overlapping calendar events next to student names on Activity Attendance page
         Admissions: added a progress bar for admissions milestones to Manage Applications
         Admissions: added a warning to Accept Application when milestones have not been completed
+        Admissions: improved the logic to automatically assign a house based on siblings or parents
         Attendance: student attendance history now ordered by timetable period
         Attendance: fixed the Consecutive Absences check to only count the final status for each day
         Attendance: added a foreign table field to attendance logs for recording target of future absences

--- a/src/Domain/School/HouseGateway.php
+++ b/src/Domain/School/HouseGateway.php
@@ -128,4 +128,39 @@ class HouseGateway extends QueryableGateway
 
         return $this->db()->select($sql, $data);
     }
+
+    /**
+     * Find an existing house assignment for a student by family
+     *
+     * @param int $gibbonFamilyID
+     * @param int $gibbonPersonIDStudent Person to exclude when checking siblings
+     * @return array|false
+     */
+    public function selectExistingHouseByFamilyID($gibbonFamilyID, $gibbonPersonIDStudent)
+    {
+        $data = ['gibbonFamilyID' => $gibbonFamilyID, 'gibbonPersonIDStudent' => $gibbonPersonIDStudent];
+
+        $sql = "SELECT gibbonHouseID, house FROM (
+                    SELECT gibbonHouse.gibbonHouseID, gibbonHouse.name AS house, 1 AS priority, gibbonFamilyAdult.contactPriority
+                    FROM gibbonFamilyAdult
+                    JOIN gibbonPerson ON (gibbonFamilyAdult.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                    JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID)
+                    JOIN gibbonHouse ON (gibbonPerson.gibbonHouseID=gibbonHouse.gibbonHouseID)
+                    WHERE gibbonFamilyAdult.gibbonFamilyID=:gibbonFamilyID
+                    AND gibbonPerson.status='Full'
+                    AND gibbonRole.category='Staff'
+                    UNION ALL
+                    SELECT gibbonHouse.gibbonHouseID, gibbonHouse.name AS house, 2 AS priority, 0 AS contactPriority
+                    FROM gibbonFamilyChild
+                    JOIN gibbonPerson ON (gibbonFamilyChild.gibbonPersonID=gibbonPerson.gibbonPersonID)
+                    JOIN gibbonHouse ON (gibbonPerson.gibbonHouseID=gibbonHouse.gibbonHouseID)
+                    WHERE gibbonFamilyChild.gibbonFamilyID=:gibbonFamilyID
+                    AND gibbonPerson.gibbonPersonID!=:gibbonPersonIDStudent
+                    AND gibbonPerson.status='Full'
+                ) AS familyHouse
+                ORDER BY priority, contactPriority
+                LIMIT 1";
+
+        return $this->db()->selectOne($sql, $data);
+    }
 }

--- a/src/Forms/Builder/Process/AssignHouse.php
+++ b/src/Forms/Builder/Process/AssignHouse.php
@@ -23,8 +23,6 @@ namespace Gibbon\Forms\Builder\Process;
 
 use Gibbon\Contracts\Services\Session;
 use Gibbon\Domain\School\HouseGateway;
-use Gibbon\Domain\User\FamilyGateway;
-use Gibbon\Domain\User\RoleGateway;
 use Gibbon\Domain\User\UserGateway;
 use Gibbon\Forms\Builder\AbstractFormProcess;
 use Gibbon\Forms\Builder\FormBuilderInterface;
@@ -38,16 +36,12 @@ class AssignHouse extends AbstractFormProcess implements ViewableProcess
     private $session;
     private $userGateway;
     private $houseGateway;
-    private $familyGateway;
-    private $roleGateway;
 
-    public function __construct(Session $session, UserGateway $userGateway, HouseGateway $houseGateway, FamilyGateway $familyGateway, RoleGateway $roleGateway)
+    public function __construct(Session $session, UserGateway $userGateway, HouseGateway $houseGateway)
     {
         $this->session = $session;
         $this->userGateway = $userGateway;
         $this->houseGateway = $houseGateway;
-        $this->familyGateway = $familyGateway;
-        $this->roleGateway = $roleGateway;
     }
 
     public function getViewClass() : string
@@ -68,51 +62,8 @@ class AssignHouse extends AbstractFormProcess implements ViewableProcess
         $gibbonFamilyID = $formData->get('gibbonFamilyID');
         $gibbonPersonIDStudent = $formData->get('gibbonPersonIDStudent');
 
-        // Try family-based house assignment if family ID exists
         if (!empty($gibbonFamilyID)) {
-
-            // Check parents first
-            $adults = $this->familyGateway->selectAdultsByFamily($gibbonFamilyID, true);
-            foreach ($adults as $adult) {
-                // Check if parent is staff and has a house assignment
-                if ($adult['status'] == 'Full' && !empty($adult['gibbonHouseID'])) {
-                    // Staff members have roles in Staff category
-                    $roleCategory = $this->roleGateway->getRoleCategory($adult['gibbonRoleIDPrimary']);
-                    if ($roleCategory == 'Staff') {
-                        $house = $this->houseGateway->getByID($adult['gibbonHouseID']);
-                        if (!empty($house)) {
-                            $assignedHouse = [
-                                'gibbonHouseID' => $adult['gibbonHouseID'],
-                                'house' => $house['name'],
-                            ];
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // If no staff parent found, check enrolled siblings
-            if (empty($assignedHouse)) {
-                $children = $this->familyGateway->selectChildrenByFamily($gibbonFamilyID, true);
-                foreach ($children as $child) {
-                    // Skip the current student
-                    if ($child['gibbonPersonID'] == $gibbonPersonIDStudent) {
-                        continue;
-                    }
-                    
-                    // Check if sibling is enrolled and has a house
-                    if ($child['status'] == 'Full' && !empty($child['gibbonHouseID'])) {
-                        $house = $this->houseGateway->getByID($child['gibbonHouseID']);
-                        if (!empty($house)) {
-                            $assignedHouse = [
-                                'gibbonHouseID' => $child['gibbonHouseID'],
-                                'house' => $house['name'],
-                            ];
-                            break;
-                        }
-                    }
-                }
-            }
+            $assignedHouse = $this->houseGateway->selectExistingHouseByFamilyID($gibbonFamilyID, $gibbonPersonIDStudent);
         }
 
         // Fallback to gender-based assignment if no family assignment found

--- a/src/Forms/Builder/Process/AssignHouse.php
+++ b/src/Forms/Builder/Process/AssignHouse.php
@@ -22,12 +22,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 namespace Gibbon\Forms\Builder\Process;
 
 use Gibbon\Contracts\Services\Session;
+use Gibbon\Domain\School\HouseGateway;
+use Gibbon\Domain\User\FamilyGateway;
+use Gibbon\Domain\User\RoleGateway;
+use Gibbon\Domain\User\UserGateway;
 use Gibbon\Forms\Builder\AbstractFormProcess;
 use Gibbon\Forms\Builder\FormBuilderInterface;
 use Gibbon\Forms\Builder\Storage\FormDataInterface;
 use Gibbon\Forms\Builder\View\AssignHouseView;
-use Gibbon\Domain\School\HouseGateway;
-use Gibbon\Domain\User\UserGateway;
 
 class AssignHouse extends AbstractFormProcess implements ViewableProcess
 {
@@ -36,12 +38,16 @@ class AssignHouse extends AbstractFormProcess implements ViewableProcess
     private $session;
     private $userGateway;
     private $houseGateway;
+    private $familyGateway;
+    private $roleGateway;
 
-    public function __construct(Session $session, UserGateway $userGateway, HouseGateway $houseGateway)
+    public function __construct(Session $session, UserGateway $userGateway, HouseGateway $houseGateway, FamilyGateway $familyGateway, RoleGateway $roleGateway)
     {
         $this->session = $session;
         $this->userGateway = $userGateway;
         $this->houseGateway = $houseGateway;
+        $this->familyGateway = $familyGateway;
+        $this->roleGateway = $roleGateway;
     }
 
     public function getViewClass() : string
@@ -58,15 +64,68 @@ class AssignHouse extends AbstractFormProcess implements ViewableProcess
     {
         if (!$formData->has('gibbonPersonIDStudent')) return;
 
-        // Get pseudo-randomly assigned house
-        $assignedHouse = $this->houseGateway->selectAssignedHouseByGender($this->session->get('gibbonSchoolYearIDCurrent'), $formData->get('gibbonYearGroupIDEntry'), $formData->get('gender'))->fetch();
+        $assignedHouse = null;
+        $gibbonFamilyID = $formData->get('gibbonFamilyID');
+        $gibbonPersonIDStudent = $formData->get('gibbonPersonIDStudent');
+
+        // Try family-based house assignment if family ID exists
+        if (!empty($gibbonFamilyID)) {
+
+            // Check parents first
+            $adults = $this->familyGateway->selectAdultsByFamily($gibbonFamilyID, true);
+            foreach ($adults as $adult) {
+                // Check if parent is staff and has a house assignment
+                if ($adult['status'] == 'Full' && !empty($adult['gibbonHouseID'])) {
+                    // Staff members have roles in Staff category
+                    $roleCategory = $this->roleGateway->getRoleCategory($adult['gibbonRoleIDPrimary']);
+                    if ($roleCategory == 'Staff') {
+                        $house = $this->houseGateway->getByID($adult['gibbonHouseID']);
+                        if (!empty($house)) {
+                            $assignedHouse = [
+                                'gibbonHouseID' => $adult['gibbonHouseID'],
+                                'house' => $house['name'],
+                            ];
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // If no staff parent found, check enrolled siblings
+            if (empty($assignedHouse)) {
+                $children = $this->familyGateway->selectChildrenByFamily($gibbonFamilyID, true);
+                foreach ($children as $child) {
+                    // Skip the current student
+                    if ($child['gibbonPersonID'] == $gibbonPersonIDStudent) {
+                        continue;
+                    }
+                    
+                    // Check if sibling is enrolled and has a house
+                    if ($child['status'] == 'Full' && !empty($child['gibbonHouseID'])) {
+                        $house = $this->houseGateway->getByID($child['gibbonHouseID']);
+                        if (!empty($house)) {
+                            $assignedHouse = [
+                                'gibbonHouseID' => $child['gibbonHouseID'],
+                                'house' => $house['name'],
+                            ];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback to gender-based assignment if no family assignment found
+        if (empty($assignedHouse)) {
+            $assignedHouse = $this->houseGateway->selectAssignedHouseByGender($this->session->get('gibbonSchoolYearIDCurrent'), $formData->get('gibbonYearGroupIDEntry'), $formData->get('gender'))->fetch();
+        }
 
         if (empty($assignedHouse)) return;
 
         $formData->set('gibbonHouseID', $assignedHouse['gibbonHouseID']);
 
         // Update the user data for this student
-        $this->userGateway->update($formData->has('gibbonPersonIDStudent'), [
+        $this->userGateway->update($gibbonPersonIDStudent, [
             'gibbonHouseID' => $formData->get('gibbonHouseID'),
         ]);
 
@@ -77,7 +136,7 @@ class AssignHouse extends AbstractFormProcess implements ViewableProcess
     {
         if (!$formData->has('gibbonPersonIDStudent')) return;
 
-        $this->userGateway->update($formData->has('gibbonPersonIDStudent'), [
+        $this->userGateway->update($formData->get('gibbonPersonIDStudent'), [
             'gibbonHouseID' => null,
         ]);
 


### PR DESCRIPTION
**Description**
 Improved the logic to automatically assign a house based on siblings or parents.
 When a new student is accepted, the system checks if their parents are staff member and assigns the same house as them. If not, the system checks if they have siblings and assigns the student to the same house as their siblings. If not, the system automatically assigns them to a house based on old logic.



