### PR TITLE
Preserve newlines in proofread comments

### DIFF
--- a/modules/Reports/reporting_proofread.php
+++ b/modules/Reports/reporting_proofread.php
@@ -206,7 +206,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_proofrea
     if ($gibbonPersonID == $session->get('gibbonPersonID')) {
         $filterOptions = $form->getFactory()->createSelect('filter')
             ->fromArray($filters)
-            ->setClass('auto-submit filters float-none w-24 sm:leading-none sm:h-8 sm:text-sm border-0 ring-1 ring-inset ring-gray-400 focus:ring-gray-400 hover:bg-gray-200 rounded-md w-full min-w-16 border py-2 text-gray-900  placeholder:text-gray-500 focus:ring-1 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-5')
+            ->setClass('auto-submit filters float-none w-24 sm:leading-none sm:h-8 sm:text-sm border-0 ring-1 ring-inset ring-gray-400 focus:ring-gray-400 hover:bg-gray-200 rounded-md w-full min-w-16 border py-2 text-gray-900  placeholder:text-gray-500 focus:ring-1 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6')
             ->placeholder(__('Filters'))
             ->selected($filter)
             ->getOutput();
@@ -322,7 +322,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_proofrea
 
                 $actions = ['Accepted' => __('Accept').'&nbsp;&nbsp;', 'Declined' => __('Decline').'&nbsp;&nbsp;', 'Revised' => __('Edit Comment').'&nbsp;&nbsp;'];
             } else {
-                $section->addContent($criteria['comment'])
+                $section->addContent(nl2br(htmlPrep($criteria['comment'])))
                     ->wrap('<div class="text-base font-sans leading-tight text-gray-900 p-1 mb-6">', '</div>');
 
                 $actions = ['Revised' => __('Edit Comment').'&nbsp;&nbsp;'];
@@ -358,7 +358,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_proofrea
 
             $proofText = $proof['status'] == 'Edited'
                 ? $differ->htmlDiff(htmlPrep($criteria['comment']), htmlPrep($proof['comment']))
-                : htmlPrep($criteria['comment']);
+                : nl2br(htmlPrep($criteria['comment']));
 
             $section->addContent($proofText)
                     ->wrap('<div class="text-base font-sans leading-tight text-gray-900 p-1 mb-6">', '</div>');
@@ -410,7 +410,8 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reporting_proofrea
 $('.statusInput input[type="radio"]').change(function() {
     var details = $(this).parents('details').first();
     var textarea = details.find('textarea.commentEditor');
-    
+    console.log(textarea);
+
     if ($(this).val() == 'Done' || $(this).val() == 'Accepted') {
         details.removeClass('message bg-blue-100').removeClass('error bg-red-100').removeClass('bg-gray-100');
         details.addClass('success bg-green-100');

--- a/modules/Reports/reports_generate_single.php
+++ b/modules/Reports/reports_generate_single.php
@@ -58,10 +58,24 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
 
     $context = ContextFactory::create($templateData['context']);
 
-    $ids = $context->getIdentifiers($pdo, $report['gibbonReportID'], $contextData, true);
-    $ids = array_map(function ($report) use ($gibbonReportID, &$reportArchiveEntryGateway) {
-        $report['archive'] = $reportArchiveEntryGateway->getRecentArchiveEntryByReport($gibbonReportID, 'Single', $report['gibbonPersonID'], 'Staff', true, true);
-        return $report;
+$ids = $context->getIdentifiers($pdo, $report['gibbonReportID'], $contextData, true);
+$ids = array_map(function ($entry) use ($gibbonReportID, $report, &$reportArchiveEntryGateway) {
+    $entry['archive'] = $reportArchiveEntryGateway->getRecentArchiveEntryByReport($gibbonReportID, 'Single', $entry['gibbonPersonID'], 'Staff', true, true);
+
+    // Backward-compatibility fallback: some archived entries are linked by identifier only.
+    if (empty($entry['archive']) && !empty($report['name'])) {
+        $entry['archive'] = $reportArchiveEntryGateway->getRecentArchiveEntryByReportIdentifier(
+            $report['gibbonSchoolYearID'],
+            $report['name'],
+            'Single',
+            $entry['gibbonPersonID'],
+            'Staff',
+            true,
+            true
+        );
+    }
+
+    return $entry;
     }, $ids);
 
     // FORM
@@ -105,7 +119,9 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/reports_generate_s
         ->notSortable()
         ->format(function ($report) use ($gibbonReportID, &$reportArchiveEntryGateway) {
             if ($report['archive']) {
-                $tag = '<span class="tag ml-2 '.($report['archive']['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['archive']['status']).'</span>';
+                $tag = !empty($report['archive']['status'])
+                    ? '<span class="tag ml-2 '.($report['archive']['status'] == 'Final' ? 'success' : 'dull').'">'.__($report['archive']['status']).'</span>'
+                    : '';
                 $title = Format::dateTimeReadable($report['archive']['timestampModified']);
                 $url = './modules/Reports/archive_byStudent_download.php?gibbonReportArchiveEntryID='.$report['archive']['gibbonReportArchiveEntryID'].'&gibbonPersonID='.$report['gibbonPersonID'];
                 return Format::link($url, $title).$tag;

--- a/modules/Reports/templates/ui/writingStudentOverview.twig.html
+++ b/modules/Reports/templates/ui/writingStudentOverview.twig.html
@@ -60,7 +60,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 
                     <p class="mt-2 mb-1 ">
                         {% if criteria.comment %} 
-                            {{ criteria.comment }}
+                            {{ criteria.comment|nl2br }}
                         {% else %}
                             <span class="text-xxs text-gray-600 italic">{{ __('N/A') }} </span>
                         {% endif%}


### PR DESCRIPTION
Use nl2br when rendering proofread comments so line breaks are preserved in both PHP and Twig outputs. Also apply htmlPrep() to sanitize content before converting newlines. Small UI tweak: change sm:leading-5 to sm:leading-6 for the filter select. Added a console.log for the textarea selector to aid debugging.