### PR TITLE
Reports: fixed a typo bug to return the correct the array

### DIFF
--- a/modules/Reports/src/ReportSection.php
+++ b/modules/Reports/src/ReportSection.php
@@ -48,7 +48,7 @@ class ReportSection
     {
         $sources = is_string($sources)
             ? json_decode($sources) ?? []
-            : $source ?? [];
+            : $sources ?? [];
 
         foreach ($sources as $alias => $className) {
             $this->addDataSource($alias, $className);


### PR DESCRIPTION
**Description**
Fixed a typo bug to return the correct the array, reported here: [Gibbon Forum](https://ask.gibbonedu.org/t/bug-reportsection-php-adddatasources-uses-undefined-variable-source-instead-of-sources-v30-0-01/15591)
