### PR TITLE
System: Secured uploaded file downloads via session-based access control

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ v31.0.00
         System: added Peruvian Sol as a currency option
         System: ensured Twig cache is turned off for Development installs
         System: added a new fileHandler class to track and monitor file uploads
+        System: secured uploaded file downloads via session-based access control (requires Apache mod_rewrite)
         Activities: display overlapping calendar events next to student names on Activity Attendance page
         Admissions: added a progress bar for admissions milestones to Manage Applications
         Admissions: added a warning to Accept Application when milestones have not been completed

--- a/file.php
+++ b/file.php
@@ -1,0 +1,77 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+require_once './gibbon.php';
+
+$path = ltrim((string) ($_GET['path'] ?? ''), '/');
+if ($path === '' || str_contains($path, '..')) {
+    http_response_code(403);
+    exit;
+}
+
+// Rewrite from uploads/ passes a path relative to that directory
+if (!str_starts_with($path, 'uploads/')) {
+    $path = 'uploads/'.$path;
+}
+
+$absolutePath = $session->get('absolutePath');
+$uploadsRoot = realpath($absolutePath.'/uploads');
+$filePath = realpath($absolutePath.'/'.$path);
+
+if ($uploadsRoot === false || $filePath === false || !str_starts_with($filePath, $uploadsRoot) || !is_file($filePath)) {
+    http_response_code(403);
+    exit;
+}
+
+$publicPaths = array_filter([
+    ltrim((string) $session->get('organisationLogo'), '/'),
+    ltrim((string) $session->get('organisationBackground'), '/'),
+]);
+
+$isPublic = in_array($path, $publicPaths, true);
+$allowedUploads = $session->get('allowedUploads', []);
+$isAllowed = $session->has('gibbonPersonID')
+    && isset($allowedUploads[$path])
+    && (time() - (int) $allowedUploads[$path]) <= 7200;
+
+if (!$isPublic && !$isAllowed) {
+    http_response_code(403);
+    exit;
+}
+
+$mimeType = mime_content_type($filePath) ?: 'application/octet-stream';
+$filename = basename($filePath);
+
+header('Content-Type: '.$mimeType);
+header('Content-Disposition: inline; filename="'.$filename.'"');
+header('Content-Length: '.filesize($filePath));
+header('Cache-Control: private');
+
+$hasXSendfile = function_exists('apache_get_modules')
+    && in_array('mod_xsendfile', apache_get_modules() ?: []);
+
+if ($hasXSendfile) {
+    header('X-Sendfile: '.$filePath);
+} else {
+    readfile($filePath);
+}
+
+exit;

--- a/functions.php
+++ b/functions.php
@@ -785,6 +785,57 @@ function isCommandLineInterface()
 }
 
 /**
+ * Register an uploads path in the current session so file.php may serve it.
+ * @version  v31
+ * @param string $path
+ */
+function allowSecureFileAccess($path)
+{
+    global $session;
+
+    if (empty($session)) {
+        return;
+    }
+
+    $path = ltrim(trim((string) $path), '/');
+    if ($path === '' || !str_starts_with($path, 'uploads/')) {
+        return;
+    }
+
+    $now = time();
+    $allowed = $session->get('allowedUploads', []);
+
+    foreach ($allowed as $allowedPath => $timestamp) {
+        if ($now - (int) $timestamp > 7200) {
+            unset($allowed[$allowedPath]);
+        }
+    }
+
+    $allowed[$path] = $now;
+    $session->set('allowedUploads', $allowed);
+}
+
+/**
+ * Find uploads/ paths in rendered output and grant this session access to them.
+ *
+ * @param string $content
+ */
+function registerSecureUploadsInContent($content)
+{
+    if (!is_string($content) || $content === '') {
+        return;
+    }
+
+    if (!preg_match_all('#\buploads/[^\s"\'<>\\\\?]+#', $content, $matches)) {
+        return;
+    }
+
+    foreach (array_unique($matches[0]) as $path) {
+        allowSecureFileAccess(rawurldecode($path));
+    }
+}
+
+/**
  * @deprecated in v22. Use Page's ReturnMessage.
  */
 function returnProcess($guid, $return, $editLink = null, $customReturns = null)

--- a/gibbon.php
+++ b/gibbon.php
@@ -120,6 +120,14 @@ $session = $container->get('session');
 $gibbon->session = $session;
 $container->share(\Gibbon\Contracts\Services\Session::class, $session);
 
+// Auto-register any uploads/ paths present in this response for the current session.
+if (basename($_SERVER['SCRIPT_FILENAME'] ?? '') !== 'file.php') {
+    ob_start(function ($buffer) {
+        registerSecureUploadsInContent($buffer);
+        return $buffer;
+    });
+}
+
 // Setup global absoluteURL for all urls.
 if ($gibbon->isInstalled() && $session->has('absoluteURL')) {
     Url::setBaseUrl($session->get('absoluteURL'));

--- a/modules/System Admin/moduleFunctions.php
+++ b/modules/System Admin/moduleFunctions.php
@@ -446,19 +446,22 @@ function camelToWords($name)
  * Performs a HTTP GET request on the uploads folder 
  *
  * @param string $absoluteURL
- * @return string
+ * @return bool true when uploads do not appear publicly accessible
  */
 function checkUploadsFolderStatus($absoluteURL) : bool
 {
+    global $session;
+
     $statusCode = '';
     $responseBody = '';
     try {
         $client = new Client();
         $response = $client->request('GET', $absoluteURL.'/uploads', [
             'headers' => ['Referer' => $absoluteURL.'/index.php'],
+            'http_errors' => false,
         ]);
-        $statusCode = $response->getStatusCode();
-        $responseBody = $response->getBody();
+        $statusCode = (string) $response->getStatusCode();
+        $responseBody = (string) $response->getBody();
     } catch (GuzzleHttp\Exception\ClientException $e) {
         $responseBody = $e->getMessage();
     } catch (\GuzzleHttp\Exception\GuzzleException $e) {
@@ -467,6 +470,30 @@ function checkUploadsFolderStatus($absoluteURL) : bool
 
     if (stripos($responseBody, 'Index of') !== false || stripos($responseBody, 'Parent Directory') !== false) {
         return false;
+    }
+
+    // Anonymous file probe: a direct 200 means uploads are still statically public
+    // (e.g. mod_rewrite disabled/ignored). Gateway-secured installs should return 4xx.
+    $canaryName = '.gibbon_upload_access_check';
+    $absolutePath = $session->get('absolutePath') ?? '';
+    if ($absolutePath !== '') {
+        $canaryPath = $absolutePath.'/uploads/'.$canaryName;
+        if (!is_file($canaryPath)) {
+            @file_put_contents($canaryPath, 'gibbon-upload-access-check');
+        }
+
+        if (is_file($canaryPath)) {
+            try {
+                $fileResponse = (new Client())->request('GET', $absoluteURL.'/uploads/'.$canaryName, [
+                    'headers' => ['Referer' => $absoluteURL.'/index.php'],
+                    'http_errors' => false,
+                ]);
+                if ((int) $fileResponse->getStatusCode() === 200) {
+                    return false;
+                }
+            } catch (\GuzzleHttp\Exception\GuzzleException $e) {
+            }
+        }
     }
 
     if (substr($statusCode, 0, 1) == '4') {

--- a/modules/System Admin/moduleFunctions.php
+++ b/modules/System Admin/moduleFunctions.php
@@ -460,8 +460,8 @@ function checkUploadsFolderStatus($absoluteURL) : bool
             'headers' => ['Referer' => $absoluteURL.'/index.php'],
             'http_errors' => false,
         ]);
-        $statusCode = (string) $response->getStatusCode();
-        $responseBody = (string) $response->getBody();
+        $statusCode = $response->getStatusCode();
+        $responseBody = $response->getBody();
     } catch (GuzzleHttp\Exception\ClientException $e) {
         $responseBody = $e->getMessage();
     } catch (\GuzzleHttp\Exception\GuzzleException $e) {
@@ -472,8 +472,7 @@ function checkUploadsFolderStatus($absoluteURL) : bool
         return false;
     }
 
-    // Anonymous file probe: a direct 200 means uploads are still statically public
-    // (e.g. mod_rewrite disabled/ignored). Gateway-secured installs should return 4xx.
+    // Check if uploads folder is publicly accessible
     $canaryName = '.gibbon_upload_access_check';
     $absolutePath = $session->get('absolutePath') ?? '';
     if ($absolutePath !== '') {

--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,4 +1,19 @@
+Options -Indexes
+
 <FilesMatch "\.(js|htm|html|css|php|php3|php4|php5|php7|phtml|asp|jsp|py|DS_Store)$">
     Order Allow,Deny
     Deny from all
 </FilesMatch>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    # Route existing upload files through the auth gateway
+    RewriteCond %{REQUEST_FILENAME} -f
+    RewriteRule ^(.*)$ ../file.php?path=$1 [L,QSA]
+</IfModule>
+
+# Fail closed: if mod_rewrite is not available, never serve uploads statically
+<IfModule !mod_rewrite.c>
+    Order Allow,Deny
+    Deny from all
+</IfModule>


### PR DESCRIPTION
**Description**
The request came from here: [Public Access to uploaded documents via URL](https://ask.gibbonedu.org/t/public-access-to-uploaded-personal-documents-via-direct-url/15585)

Before, Once the URL is known, the document can be accessed directly without requiring authentication or an active user session. So anyone with the link may be able to access the file.

After the current changes, a user has to be logged-in to be able to open a link. Secondly, a user can only access the file if they have the access permission to view the page. This ensure role based controls for the files.
