### PR TITLE
Planner: Visual fix to remove extra space between date and month in

### DIFF
--- a/modules/Planner/src/Tables/LessonTable.php
+++ b/modules/Planner/src/Tables/LessonTable.php
@@ -316,8 +316,7 @@ class LessonTable
             ->format(function ($values) {
                 if (!empty($values['closure'])) return $values['closure'];
 
-                $output = Format::bold(Format::date($values['date'])).'<br/><br/>'
-                    .Format::monthName($values['date']);
+                $output = Format::bold(Format::date($values['date'])).'<br/>'.Format::monthName($values['date']);
                 
                 return $output;
             });


### PR DESCRIPTION
**Description**
Planner: Visual fix to remove extra space between date and month in lesson planner year view
