### PR TITLE
Planner: restore lesson Chat with current discussion UI

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -58,6 +58,7 @@ v31.0.00
         Messenger: creator of targeted message can now view it in Message Wall
         Planner: improved the Deploy Unit page with a drag-drop interface and new tools
         Planner: added the option to set a location for non-timetables lessons in Lesson Planner
+        Planner: restored lesson plan Chat comments using the discussion UI, keeping existing records
         Reports: added error detection while editing twig templates
         Reports: improved the file path checking while managing archives and uploading bulk reports
         Reports: added the option to set the report author in Write Reports by Student

--- a/modules/Planner/moduleFunctions.php
+++ b/modules/Planner/moduleFunctions.php
@@ -218,17 +218,14 @@ function getPlannerEntryDiscussion($gibbonPlannerEntryID, array $urlParams = [],
             $item['replies'] = $build($item['gibbonPlannerEntryDiscussID']);
 
             if ($canReply) {
-                $item['attachmentLocation'] = (string) Url::fromModuleRoute('Planner', 'planner_view_full_post')
+                $item['replyURL'] = (string) Url::fromModuleRoute('Planner', 'planner_view_full_post')
                     ->withQueryParams($urlParams + ['replyTo' => $item['gibbonPlannerEntryDiscussID']]);
-                $item['attachmentText'] = __('Reply');
-                $item['attachmentTarget'] = '';
             }
 
             if ($canDelete) {
-                $deleteURL = $session->get('absoluteURL').'/modules/Planner/planner_view_full_post_deleteProcess.php?'.http_build_query($urlParams + [
+                $item['deleteURL'] = $session->get('absoluteURL').'/modules/Planner/planner_view_full_post_deleteProcess.php?'.http_build_query($urlParams + [
                     'gibbonPlannerEntryDiscussID' => $item['gibbonPlannerEntryDiscussID'],
                 ]);
-                $item['extra'] = Format::link($deleteURL, __('Delete'));
             }
 
             $discussion[] = $item;

--- a/modules/Planner/moduleFunctions.php
+++ b/modules/Planner/moduleFunctions.php
@@ -25,7 +25,9 @@ use Gibbon\Services\Format;
 use Gibbon\Forms\DatabaseFormFactory;
 use Gibbon\Domain\Timetable\CourseGateway;
 use Gibbon\Domain\Planner\PlannerEntryGateway;
+use Gibbon\Domain\Planner\PlannerEntryDiscussGateway;
 use Gibbon\Forms\Input\Editor;
+use Gibbon\Http\Url;
 use Gibbon\Data\Validator;
 
 //Make the display for a block, according to the input provided, where $i is a unique number appended to the block's field ids.
@@ -197,6 +199,45 @@ function makeBlock($guid, $connection2, $i, $mode = 'masterAdd', $title = '', $t
     if ($outerBlock) {
         echo '</div>';
     }
+}
+
+function getPlannerEntryDiscussion($gibbonPlannerEntryID, array $urlParams = [], $canReply = false, $canDelete = false)
+{
+    global $container, $session;
+
+    $discussGateway = $container->get(PlannerEntryDiscussGateway::class);
+    $validator = $container->get(Validator::class);
+
+    $build = function ($parent) use (&$build, $discussGateway, $validator, $gibbonPlannerEntryID, $urlParams, $canReply, $canDelete, $session) {
+        $discussion = [];
+        $items = $discussGateway->selectDiscussionByPlannerEntryID($gibbonPlannerEntryID, $parent)->fetchAll();
+
+        foreach ($items as $item) {
+            $item['comment'] = $validator->sanitizeRichText($item['comment']);
+            $item['label'] = $item['category'] ?? '';
+            $item['replies'] = $build($item['gibbonPlannerEntryDiscussID']);
+
+            if ($canReply) {
+                $item['attachmentLocation'] = (string) Url::fromModuleRoute('Planner', 'planner_view_full_post')
+                    ->withQueryParams($urlParams + ['replyTo' => $item['gibbonPlannerEntryDiscussID']]);
+                $item['attachmentText'] = __('Reply');
+                $item['attachmentTarget'] = '';
+            }
+
+            if ($canDelete) {
+                $deleteURL = $session->get('absoluteURL').'/modules/Planner/planner_view_full_post_deleteProcess.php?'.http_build_query($urlParams + [
+                    'gibbonPlannerEntryDiscussID' => $item['gibbonPlannerEntryDiscussID'],
+                ]);
+                $item['extra'] = Format::link($deleteURL, __('Delete'));
+            }
+
+            $discussion[] = $item;
+        }
+
+        return $discussion;
+    };
+
+    return $build(0);
 }
 
 function getThread($guid, $connection2, $gibbonPlannerEntryID, $parent, $level, $self, $viewBy, $subView, $date, $class, $gibbonCourseClassID, $search, $role, $links = true, $narrow = false)

--- a/modules/Planner/planner_unitOverview.php
+++ b/modules/Planner/planner_unitOverview.php
@@ -437,8 +437,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_unitOvervi
                                     $discussion = getPlannerEntryDiscussion($rowLessons['gibbonPlannerEntryID']);
                                     if (!empty($discussion)) {
                                         echo '<h5>'.__('Chat').'</h5>';
-                                        echo $page->fetchFromTemplate('ui/discussion.twig.html', [
-                                            'compact' => true,
+                                        echo $page->fetchFromTemplate('ui/plannerChat.twig.html', [
                                             'discussion' => $discussion,
                                         ]);
                                     }

--- a/modules/Planner/planner_unitOverview.php
+++ b/modules/Planner/planner_unitOverview.php
@@ -434,19 +434,13 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_unitOvervi
                                     }
 
 									//Print chats
-                                    try {
-                                        $dataDiscuss = array('gibbonPlannerEntryID' => $rowLessons['gibbonPlannerEntryID']);
-                                        $sqlDiscuss = 'SELECT gibbonPlannerEntryDiscuss.*, title, surname, preferredName, category FROM gibbonPlannerEntryDiscuss JOIN gibbonPerson ON (gibbonPlannerEntryDiscuss.gibbonPersonID=gibbonPerson.gibbonPersonID) JOIN gibbonRole ON (gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID) WHERE gibbonPlannerEntryID=:gibbonPlannerEntryID ORDER BY timestamp';
-                                        $resultDiscuss = $connection2->prepare($sqlDiscuss);
-                                        $resultDiscuss->execute($dataDiscuss);
-                                    } catch (PDOException $e) {}
-
-                                    if ($resultDiscuss->rowCount() > 0) {
-                                        echo "<h5 style='font-size: 85%'>".__('Chat').'</h5>';
-                                        echo '<style type="text/css">';
-                                        echo 'table.chatbox { width: 90%!important }';
-                                        echo '</style>';
-                                        echo getThread($guid, $connection2, $rowLessons['gibbonPlannerEntryID'], null, 0, null, null, null, null, null, $class[1] ?? '', $session->get('gibbonPersonID'), 'Teacher', false, true);
+                                    $discussion = getPlannerEntryDiscussion($rowLessons['gibbonPlannerEntryID']);
+                                    if (!empty($discussion)) {
+                                        echo '<h5>'.__('Chat').'</h5>';
+                                        echo $page->fetchFromTemplate('ui/discussion.twig.html', [
+                                            'compact' => true,
+                                            'discussion' => $discussion,
+                                        ]);
                                     }
                                 }
                             }

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -1129,26 +1129,32 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                         }
                         echo '</table>';
 
-                        // Temporarily disabled
-                        if (false && $highestAction != 'Lesson Planner_viewOnly') {
+                        $canReply = $highestAction != 'Lesson Planner_viewOnly';
+                        $canDelete = ($values['role'] ?? '') == 'Teacher';
+                        $chatParams = [
+                            'gibbonPlannerEntryID' => $gibbonPlannerEntryID,
+                            'viewBy' => $viewBy,
+                            'subView' => $subView,
+                            'gibbonCourseClassID' => $gibbonCourseClassID,
+                            'date' => $date,
+                            'search' => $gibbonPersonID,
+                        ];
+                        $discussion = getPlannerEntryDiscussion($gibbonPlannerEntryID, $chatParams, $canReply, $canDelete);
 
-                          echo "<a name='chat'></a>";
-                          echo "<h2 style='padding-top: 30px'>".__('Chat').'</h2>';
-                          echo "<table class='smallIntBorder' cellspacing='0' style='width: 100%;'>";
-                          echo '<tr>';
-                          echo "<td style='text-align: justify; padding-top: 5px; width: 33%; vertical-align: top; max-width: 752px!important;' colspan=3>";
+                        echo '<a name="chat"></a>';
+                        echo '<h2>'.__('Chat').'</h2>';
 
-                              echo "<div style='margin: 0px' class='linkTop'>";
-                              echo "<a href='".$session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_GET['q'])."/planner_view_full.php$paramsVar#chat'>".__('Refresh')."<img style='margin-left: 5px' title='".__('Refresh')."' src='./themes/".$session->get('gibbonThemeName')."/img/refresh.png'/></a> <a href='".$session->get('absoluteURL')."/index.php?q=/modules/Planner/planner_view_full_post.php&gibbonPlannerEntryID=$gibbonPlannerEntryID&viewBy=$viewBy&subView=$subView&gibbonCourseClassID=$gibbonCourseClassID&date=$date&search=".$gibbonPersonID."'>".__('Add')."<img style='margin-left: 5px' title='".__('Add')."' src='./themes/".$session->get('gibbonThemeName')."/img/page_new.png'/></a> ";
-                              echo '</div>';
-
-                              //Get discussion
-                              echo getThread($guid, $connection2, $gibbonPlannerEntryID, null, 0, null, $viewBy, $subView, $date, @$class, $gibbonCourseClassID, $gibbonPersonID, $values['role']);
-
-                          echo '</td>';
-                          echo '</tr>';
+                        if ($canReply) {
+                            echo '<div class="linkTop">';
+                            echo Format::link((string) Url::fromModuleRoute('Planner', 'planner_view_full_post')->withQueryParams($chatParams), __('Add'));
+                            echo '</div>';
                         }
-                        echo '</table>';
+
+                        echo $page->fetchFromTemplate('ui/discussion.twig.html', [
+                            'compact' => true,
+                            'discussion' => $discussion,
+                            'blankSlate' => __('There are no records to display.'),
+                        ]);
 
                         //Participants & Attendance
                         $gibbonCourseClassID = $values['gibbonCourseClassID'];

--- a/modules/Planner/planner_view_full.php
+++ b/modules/Planner/planner_view_full.php
@@ -1142,19 +1142,22 @@ if (isActionAccessible($guid, $connection2, '/modules/Planner/planner_view_full.
                         $discussion = getPlannerEntryDiscussion($gibbonPlannerEntryID, $chatParams, $canReply, $canDelete);
 
                         echo '<a name="chat"></a>';
-                        echo '<h2>'.__('Chat').'</h2>';
+
+                        $chatForm = Form::createBlank('plannerChat', '');
+                        $chatForm->setTitle(__('Chat'));
 
                         if ($canReply) {
-                            echo '<div class="linkTop">';
-                            echo Format::link((string) Url::fromModuleRoute('Planner', 'planner_view_full_post')->withQueryParams($chatParams), __('Add'));
-                            echo '</div>';
+                            $chatForm->addHeaderAction('add', __('Add'))
+                                ->setURL('/modules/Planner/planner_view_full_post.php')
+                                ->addParams($chatParams)
+                                ->displayLabel();
                         }
 
-                        echo $page->fetchFromTemplate('ui/discussion.twig.html', [
-                            'compact' => true,
+                        $chatForm->addRow()->addContent($page->fetchFromTemplate('ui/plannerChat.twig.html', [
                             'discussion' => $discussion,
-                            'blankSlate' => __('There are no records to display.'),
-                        ]);
+                        ]));
+
+                        echo $chatForm->getOutput();
 
                         //Participants & Attendance
                         $gibbonCourseClassID = $values['gibbonCourseClassID'];

--- a/resources/templates/ui/plannerChat.twig.html
+++ b/resources/templates/ui/plannerChat.twig.html
@@ -1,0 +1,70 @@
+{#<!--
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This is a Gibbon template file, written in HTML and Twig syntax.
+For info about editing, see: https://twig.symfony.com/doc/2.x/
+-->#}
+
+{% if discussion is empty %}
+    <div class="rounded border bg-gray-50 text-gray-600 text-sm font-sans p-6 text-center">
+        {{ __('There are no records to display.') }}
+    </div>
+{% endif %}
+
+{% for item in discussion %}
+<div class="flex gap-3 sm:gap-4 mb-4 font-sans">
+    <div class="flex-none">
+        <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden bg-gray-200 border">
+            {% if item.image_240 %}
+                <img class="w-full h-full object-cover" src="{{ absoluteURL }}/{{ item.image_240 }}" alt="" />
+            {% else %}
+                <img class="w-full h-full object-cover" src="{{ absoluteURL }}/themes/{{ gibbonThemeName }}/img/anonymous_240.jpg" alt="" />
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="flex-1 min-w-0">
+        <div class="rounded-sm border bg-white shadow-sm overflow-hidden">
+            <div class="px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 bg-gray-50 border-b">
+                <div class="text-sm text-gray-800">
+                    <span class="font-bold">
+                        {{- formatUsing('name', item.title, item.preferredName, item.surname, item.category ?? 'Staff', false, true) -}}
+                    </span>
+                    {% if item.label %}
+                        <span class="ml-2 tag dull">{{ item.label }}</span>
+                    {% endif %}
+                    {% if item.timestamp %}
+                        <span class="ml-2 text-xs text-gray-500 whitespace-no-wrap">{{ formatUsing('relativeTime', item.timestamp) }}</span>
+                    {% endif %}
+                </div>
+
+                {% if item.replyURL or item.deleteURL %}
+                <div class="flex items-center gap-2">
+                    {% if item.replyURL %}
+                        <a class="tag dull" href="{{ item.replyURL }}">{{ __('Reply') }}</a>
+                    {% endif %}
+                    {% if item.deleteURL %}
+                        <a class="tag dull" href="{{ item.deleteURL }}">{{ __('Delete') }}</a>
+                    {% endif %}
+                </div>
+                {% endif %}
+            </div>
+
+            {% if item.comment %}
+            <div class="p-4 text-sm text-gray-700 leading-relaxed">
+                {{ item.comment|raw }}
+            </div>
+            {% endif %}
+        </div>
+
+        {% if item.replies %}
+            <div class="mt-3 ml-1 pl-4 border-l-2 border-gray-200">
+                {{ include('ui/plannerChat.twig.html', {discussion: item.replies}) }}
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endfor %}

--- a/resources/templates/ui/plannerChat.twig.html
+++ b/resources/templates/ui/plannerChat.twig.html
@@ -9,7 +9,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 -->#}
 
 {% if discussion is empty %}
-    <div class="rounded border bg-gray-50 text-gray-600 text-sm font-sans p-6 text-center">
+    <div class="rounded-lg bg-blue-50 text-gray-600 text-sm font-sans p-6 text-center">
         {{ __('There are no records to display.') }}
     </div>
 {% endif %}
@@ -17,7 +17,7 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
 {% for item in discussion %}
 <div class="flex gap-3 sm:gap-4 mb-4 font-sans">
     <div class="flex-none">
-        <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden bg-gray-200 border">
+        <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full overflow-hidden bg-blue-100">
             {% if item.image_240 %}
                 <img class="w-full h-full object-cover" src="{{ absoluteURL }}/{{ item.image_240 }}" alt="" />
             {% else %}
@@ -27,9 +27,9 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
     </div>
 
     <div class="flex-1 min-w-0">
-        <div class="rounded-sm border bg-white shadow-sm overflow-hidden">
-            <div class="px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 bg-gray-50 border-b">
-                <div class="text-sm text-gray-800">
+        <div class="rounded-lg bg-blue-50 overflow-hidden">
+            <div class="px-4 py-3 flex flex-row items-center justify-between gap-3 bg-blue-100">
+                <div class="text-sm text-gray-800 min-w-0">
                     <span class="font-bold">
                         {{- formatUsing('name', item.title, item.preferredName, item.surname, item.category ?? 'Staff', false, true) -}}
                     </span>
@@ -42,26 +42,26 @@ For info about editing, see: https://twig.symfony.com/doc/2.x/
                 </div>
 
                 {% if item.replyURL or item.deleteURL %}
-                <div class="flex items-center gap-2">
+                <div class="flex-none flex items-center justify-end gap-2 ml-auto">
                     {% if item.replyURL %}
-                        <a class="tag dull" href="{{ item.replyURL }}">{{ __('Reply') }}</a>
+                        <a class="tag message no-underline" href="{{ item.replyURL }}">{{ __('Reply') }}</a>
                     {% endif %}
                     {% if item.deleteURL %}
-                        <a class="tag dull" href="{{ item.deleteURL }}">{{ __('Delete') }}</a>
+                        <a class="tag message no-underline" href="{{ item.deleteURL }}">{{ __('Delete') }}</a>
                     {% endif %}
                 </div>
                 {% endif %}
             </div>
 
             {% if item.comment %}
-            <div class="p-4 text-sm text-gray-700 leading-relaxed">
+            <div class="px-4 py-4 text-sm text-gray-700 leading-relaxed">
                 {{ item.comment|raw }}
             </div>
             {% endif %}
         </div>
 
         {% if item.replies %}
-            <div class="mt-3 ml-1 pl-4 border-l-2 border-gray-200">
+            <div class="mt-3 ml-2 pl-4">
                 {{ include('ui/plannerChat.twig.html', {discussion: item.replies}) }}
             </div>
         {% endif %}

--- a/src/Domain/Planner/PlannerEntryDiscussGateway.php
+++ b/src/Domain/Planner/PlannerEntryDiscussGateway.php
@@ -1,0 +1,68 @@
+<?php
+/*
+Gibbon: the flexible, open school platform
+Founded by Ross Parker at ICHK Secondary. Built by Ross Parker, Sandra Kuipers and the Gibbon community (https://gibbonedu.org/about/)
+Copyright © 2010, Gibbon Foundation
+Gibbon™, Gibbon Education Ltd. (Hong Kong)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Gibbon\Domain\Planner;
+
+use Gibbon\Domain\Traits\TableAware;
+use Gibbon\Domain\QueryableGateway;
+
+/**
+ * Planner Entry Discuss Gateway
+ *
+ * @version v31
+ * @since   v31
+ */
+class PlannerEntryDiscussGateway extends QueryableGateway
+{
+    use TableAware;
+
+    private static $tableName = 'gibbonPlannerEntryDiscuss';
+    private static $primaryKey = 'gibbonPlannerEntryDiscussID';
+    private static $searchableColumns = [];
+
+    public function selectDiscussionByPlannerEntryID($gibbonPlannerEntryID, $parent = null)
+    {
+        $query = $this
+            ->newSelect()
+            ->cols([
+                'gibbonPlannerEntryDiscuss.*',
+                'gibbonPerson.title',
+                'gibbonPerson.surname',
+                'gibbonPerson.preferredName',
+                'gibbonPerson.image_240',
+                'gibbonRole.category',
+            ])
+            ->from($this->getTableName())
+            ->innerJoin('gibbonPerson', 'gibbonPlannerEntryDiscuss.gibbonPersonID=gibbonPerson.gibbonPersonID')
+            ->innerJoin('gibbonRole', 'gibbonPerson.gibbonRoleIDPrimary=gibbonRole.gibbonRoleID')
+            ->where('gibbonPlannerEntryID=:gibbonPlannerEntryID')
+            ->bindValue('gibbonPlannerEntryID', $gibbonPlannerEntryID)
+            ->orderBy(['gibbonPlannerEntryDiscuss.timestamp']);
+
+        if ($parent === 0) {
+            $query->where('gibbonPlannerEntryDiscussIDReplyTo IS NULL');
+        } elseif ($parent != null) {
+            $query->where('gibbonPlannerEntryDiscussIDReplyTo=:parent', ['parent' => $parent]);
+        }
+
+        return $this->runSelect($query);
+    }
+}


### PR DESCRIPTION
## Summary
- Restores lesson plan Chat, which was temporarily disabled in v31, using existing `gibbonPlannerEntryDiscuss` records.
- Renders comments with card style (blue header/body, rounded corners, no borders) instead of the old table thread.
- View-only users can read past comments; add/reply stay off for that action. Teachers can still delete.

## Tested locally and on production v31.0.00