### PR TITLE
System Admin: apply string replacements to specific users

### DIFF
--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -446,5 +446,7 @@ INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, 
 INSERT INTO `gibbonPermission` (`gibbonRoleID`, `gibbonActionID`) VALUES (001, (SELECT gibbonActionID FROM gibbonAction WHERE name='View Timetable by Facility_editLocation' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Timetable')));end
 UPDATE `gibbonReportingCycle` SET `milestones`='[]' WHERE TRIM(`milestones`) IN ('Array', '\"Array\"') OR `milestones` IS NULL;end
 ALTER TABLE `gibbonString` ADD `gibbonPersonID` INT(10) UNSIGNED ZEROFILL DEFAULT NULL AFTER `priority`;end
+ALTER TABLE `gibbonString` CHANGE `gibbonPersonID` `gibbonPersonIDList` TEXT DEFAULT NULL;end
+UPDATE `gibbonString` SET `gibbonPersonIDList` = CAST(`gibbonPersonIDList` AS UNSIGNED) WHERE `gibbonPersonIDList` IS NOT NULL AND `gibbonPersonIDList` != '' AND `gibbonPersonIDList` NOT LIKE '%,%';end
 
 ";

--- a/CHANGEDB.php
+++ b/CHANGEDB.php
@@ -445,5 +445,6 @@ UPDATE `gibbonAction` SET name='View Timetable by Facility_viewOnly' WHERE name=
 INSERT INTO `gibbonAction` (`gibbonModuleID`, `name`, `precedence`, `category`, `description`, `URLList`, `entryURL`, `defaultPermissionAdmin`, `defaultPermissionTeacher`, `defaultPermissionStudent`, `defaultPermissionParent`, `defaultPermissionSupport`, `categoryPermissionStaff`, `categoryPermissionStudent`, `categoryPermissionParent`, `categoryPermissionOther`, `menuShow`, `entrySidebar`) VALUES ((SELECT gibbonModuleID FROM gibbonModule WHERE name='Timetable'), 'View Timetable by Facility_editLocation', 1, 'View Timetables', 'View facility usage and edit class facilities.', 'tt_space.php,tt_space_view.php,tt_space_edit.php', 'tt_space.php', 'Y', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N', 'Y', 'Y');end
 INSERT INTO `gibbonPermission` (`gibbonRoleID`, `gibbonActionID`) VALUES (001, (SELECT gibbonActionID FROM gibbonAction WHERE name='View Timetable by Facility_editLocation' AND gibbonModuleID=(SELECT gibbonModuleID FROM gibbonModule WHERE name='Timetable')));end
 UPDATE `gibbonReportingCycle` SET `milestones`='[]' WHERE TRIM(`milestones`) IN ('Array', '\"Array\"') OR `milestones` IS NULL;end
+ALTER TABLE `gibbonString` ADD `gibbonPersonID` INT(10) UNSIGNED ZEROFILL DEFAULT NULL AFTER `priority`;end
 
 ";

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -71,7 +71,7 @@ v31.0.00
         Students: added an indicator at the top of view student profile to indicate attendance status and current location of the student
         Students: Added a checkbox to the Medical Data Summary to exclude students with no medical conditions
         System Admin: added a validation to check for error in email twig templates
-        System Admin: added the option to apply a string replacement to a specific user
+        System Admin: added the option to apply a string replacement to specific users
         System Admin: added new Marks By Term importer for Markbook Column
         System Admin: added new importer to import Internal Assessment Columns
         Timetable: added class and location details to non-timetabled lessons in the Timetable

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -71,6 +71,7 @@ v31.0.00
         Students: added an indicator at the top of view student profile to indicate attendance status and current location of the student
         Students: Added a checkbox to the Medical Data Summary to exclude students with no medical conditions
         System Admin: added a validation to check for error in email twig templates
+        System Admin: added the option to apply a string replacement to a specific user
         System Admin: added new Marks By Term importer for Markbook Column
         System Admin: added new importer to import Internal Assessment Columns
         Timetable: added class and location details to non-timetabled lessons in the Timetable

--- a/gibbon.sql
+++ b/gibbon.sql
@@ -6317,7 +6317,8 @@ CREATE TABLE `gibbonString` (
   `replacement` varchar(255) NOT NULL,
   `mode` enum('Whole','Partial') NOT NULL,
   `caseSensitive` enum('Y','N') NOT NULL,
-  `priority` int NOT NULL DEFAULT '0'
+  `priority` int NOT NULL DEFAULT '0',
+  `gibbonPersonID` int(10) UNSIGNED ZEROFILL DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -7933,7 +7934,8 @@ ALTER TABLE `gibbonStaffUpdate`
 -- Indexes for table `gibbonString`
 --
 ALTER TABLE `gibbonString`
-  ADD PRIMARY KEY (`gibbonStringID`);
+  ADD PRIMARY KEY (`gibbonStringID`),
+  ADD KEY `gibbonPersonID` (`gibbonPersonID`);
 
 --
 -- Indexes for table `gibbonStudentEnrolment`

--- a/gibbon.sql
+++ b/gibbon.sql
@@ -6318,7 +6318,7 @@ CREATE TABLE `gibbonString` (
   `mode` enum('Whole','Partial') NOT NULL,
   `caseSensitive` enum('Y','N') NOT NULL,
   `priority` int NOT NULL DEFAULT '0',
-  `gibbonPersonID` int(10) UNSIGNED ZEROFILL DEFAULT NULL
+  `gibbonPersonIDList` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -7934,8 +7934,7 @@ ALTER TABLE `gibbonStaffUpdate`
 -- Indexes for table `gibbonString`
 --
 ALTER TABLE `gibbonString`
-  ADD PRIMARY KEY (`gibbonStringID`),
-  ADD KEY `gibbonPersonID` (`gibbonPersonID`);
+  ADD PRIMARY KEY (`gibbonStringID`);
 
 --
 -- Indexes for table `gibbonStudentEnrolment`

--- a/modules/System Admin/stringReplacement_manage.php
+++ b/modules/System Admin/stringReplacement_manage.php
@@ -78,13 +78,13 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     $table->addColumn('replacement', __('Replacement String'));
     $table->addColumn('mode', __('Mode'))->translatable();
     $table->addColumn('caseSensitive', __('Case Sensitive'))->format(Format::using('yesNo', 'caseSensitive'));
-    $table->addColumn('user', __('User'))
+    $table->addColumn('userList', __('Users'))
         ->format(function ($row) {
-            if (empty($row['gibbonPersonID'])) {
+            if (empty($row['gibbonPersonIDList'])) {
                 return __('All Users');
             }
 
-            return Format::name($row['title'] ?? '', $row['preferredName'], $row['surname'], 'Staff', true, true);
+            return $row['userList'] ?? $row['gibbonPersonIDList'];
         });
     $table->addColumn('priority', __('Priority'));
 

--- a/modules/System Admin/stringReplacement_manage.php
+++ b/modules/System Admin/stringReplacement_manage.php
@@ -78,6 +78,14 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     $table->addColumn('replacement', __('Replacement String'));
     $table->addColumn('mode', __('Mode'))->translatable();
     $table->addColumn('caseSensitive', __('Case Sensitive'))->format(Format::using('yesNo', 'caseSensitive'));
+    $table->addColumn('user', __('User'))
+        ->format(function ($row) {
+            if (empty($row['gibbonPersonID'])) {
+                return __('All Users');
+            }
+
+            return Format::name($row['title'] ?? '', $row['preferredName'], $row['surname'], 'Staff', true, true);
+        });
     $table->addColumn('priority', __('Priority'));
 
     $table->addActionColumn()

--- a/modules/System Admin/stringReplacement_manage_add.php
+++ b/modules/System Admin/stringReplacement_manage_add.php
@@ -21,6 +21,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Http\Url;
 use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplacement_manage_add.php') == false) {
     // Access denied
@@ -47,6 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     }
 
     $form = Form::create('addString', $session->get('absoluteURL').'/modules/'.$session->get('module').'/stringReplacement_manage_addProcess.php?search='.$search);
+    $form->setFactory(DatabaseFormFactory::create($pdo));
 
     $form->addHiddenValue('address', $session->get('address'));
 
@@ -70,6 +72,10 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     $row = $form->addRow();
         $row->addLabel('caseSensitive', __('Case Sensitive'));
         $row->addYesNo('caseSensitive')->selected('N')->required();
+
+    $row = $form->addRow();
+        $row->addLabel('gibbonPersonID', __('User'))->description(__('Leave blank to apply to all users.'));
+        $row->addSelectUsers('gibbonPersonID', $session->get('gibbonSchoolYearID'))->placeholder();
 
     $row = $form->addRow();
         $row->addLabel('priority', __('Priority'))->description(__('Higher priorities are substituted first.'));

--- a/modules/System Admin/stringReplacement_manage_add.php
+++ b/modules/System Admin/stringReplacement_manage_add.php
@@ -74,8 +74,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
         $row->addYesNo('caseSensitive')->selected('N')->required();
 
     $row = $form->addRow();
-        $row->addLabel('gibbonPersonID', __('User'))->description(__('Leave blank to apply to all users.'));
-        $row->addSelectUsers('gibbonPersonID', $session->get('gibbonSchoolYearID'))->placeholder();
+        $row->addLabel('gibbonPersonIDList', __('Users'))->description(__('Leave blank to apply to all users.'));
+        $row->addSelectUsers('gibbonPersonIDList', $session->get('gibbonSchoolYearID'))->selectMultiple();
 
     $row = $form->addRow();
         $row->addLabel('priority', __('Priority'))->description(__('Higher priorities are substituted first.'));

--- a/modules/System Admin/stringReplacement_manage_addProcess.php
+++ b/modules/System Admin/stringReplacement_manage_addProcess.php
@@ -37,6 +37,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     $mode = $_POST['mode'] ?? '';
     $caseSensitive = $_POST['caseSensitive'] ?? '';
     $priority = $_POST['priority'] ?? '';
+    $gibbonPersonID = !empty($_POST['gibbonPersonID']) ? $_POST['gibbonPersonID'] : null;
 
     //Validate Inputs
     if ($original == '' or $replacement == '' or $mode == '' or $caseSensitive == '' or $priority == '') {
@@ -45,8 +46,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     } else {
         //Write to database
         try {
-            $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority);
-            $sql = 'INSERT INTO gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority';
+            $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonID' => $gibbonPersonID);
+            $sql = 'INSERT INTO gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonID=:gibbonPersonID';
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {

--- a/modules/System Admin/stringReplacement_manage_addProcess.php
+++ b/modules/System Admin/stringReplacement_manage_addProcess.php
@@ -51,8 +51,14 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     } else {
         //Write to database
         try {
-            $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonIDList' => $gibbonPersonIDList);
-            $sql = 'INSERT INTO gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonIDList=:gibbonPersonIDList';
+            $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority);
+            $sql = 'INSERT INTO gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority';
+
+            $columnCheck = $pdo->select("SHOW COLUMNS FROM gibbonString LIKE 'gibbonPersonIDList'");
+            if ($columnCheck && $columnCheck->rowCount() > 0) {
+                $data['gibbonPersonIDList'] = $gibbonPersonIDList;
+                $sql .= ', gibbonPersonIDList=:gibbonPersonIDList';
+            }
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {

--- a/modules/System Admin/stringReplacement_manage_addProcess.php
+++ b/modules/System Admin/stringReplacement_manage_addProcess.php
@@ -37,7 +37,12 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     $mode = $_POST['mode'] ?? '';
     $caseSensitive = $_POST['caseSensitive'] ?? '';
     $priority = $_POST['priority'] ?? '';
-    $gibbonPersonID = !empty($_POST['gibbonPersonID']) ? $_POST['gibbonPersonID'] : null;
+    $gibbonPersonIDList = $_POST['gibbonPersonIDList'] ?? [];
+    if (!is_array($gibbonPersonIDList)) {
+        $gibbonPersonIDList = empty($gibbonPersonIDList) ? [] : [$gibbonPersonIDList];
+    }
+    $gibbonPersonIDList = array_filter(array_map('intval', $gibbonPersonIDList));
+    $gibbonPersonIDList = empty($gibbonPersonIDList) ? null : implode(',', $gibbonPersonIDList);
 
     //Validate Inputs
     if ($original == '' or $replacement == '' or $mode == '' or $caseSensitive == '' or $priority == '') {
@@ -46,8 +51,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
     } else {
         //Write to database
         try {
-            $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonID' => $gibbonPersonID);
-            $sql = 'INSERT INTO gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonID=:gibbonPersonID';
+            $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonIDList' => $gibbonPersonIDList);
+            $sql = 'INSERT INTO gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonIDList=:gibbonPersonIDList';
             $result = $connection2->prepare($sql);
             $result->execute($data);
         } catch (PDOException $e) {

--- a/modules/System Admin/stringReplacement_manage_edit.php
+++ b/modules/System Admin/stringReplacement_manage_edit.php
@@ -21,6 +21,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Http\Url;
 use Gibbon\Forms\Form;
+use Gibbon\Forms\DatabaseFormFactory;
 
 if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplacement_manage_edit.php') == false) {
     // Access denied
@@ -56,6 +57,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             }
 
             $form = Form::create('editString', $session->get('absoluteURL').'/modules/'.$session->get('module').'/stringReplacement_manage_editProcess.php?gibbonStringID='.$values['gibbonStringID'].'&search='.$search);
+            $form->setFactory(DatabaseFormFactory::create($pdo));
 
             $form->addHiddenValue('address', $session->get('address'));
 
@@ -83,6 +85,10 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             $row = $form->addRow();
                 $row->addLabel('caseSensitive', __('Case Sensitive'));
                 $row->addYesNo('caseSensitive')->selected('N')->required()->selected($values['caseSensitive']);
+
+            $row = $form->addRow();
+                $row->addLabel('gibbonPersonID', __('User'))->description(__('Leave blank to apply to all users.'));
+                $row->addSelectUsers('gibbonPersonID', $session->get('gibbonSchoolYearID'))->placeholder()->selected($values['gibbonPersonID']);
 
             $row = $form->addRow();
                 $row->addLabel('priority', __('Priority'))->description(__('Higher priorities are substituted first.'));

--- a/modules/System Admin/stringReplacement_manage_edit.php
+++ b/modules/System Admin/stringReplacement_manage_edit.php
@@ -87,8 +87,10 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
                 $row->addYesNo('caseSensitive')->selected('N')->required()->selected($values['caseSensitive']);
 
             $row = $form->addRow();
-                $row->addLabel('gibbonPersonID', __('User'))->description(__('Leave blank to apply to all users.'));
-                $row->addSelectUsers('gibbonPersonID', $session->get('gibbonSchoolYearID'))->placeholder()->selected($values['gibbonPersonID']);
+                $row->addLabel('gibbonPersonIDList', __('Users'))->description(__('Leave blank to apply to all users.'));
+                $row->addSelectUsers('gibbonPersonIDList', $session->get('gibbonSchoolYearID'))
+                    ->selectMultiple()
+                    ->selected(array_filter(explode(',', $values['gibbonPersonIDList'] ?? '')));
 
             $row = $form->addRow();
                 $row->addLabel('priority', __('Priority'))->description(__('Higher priorities are substituted first.'));

--- a/modules/System Admin/stringReplacement_manage_editProcess.php
+++ b/modules/System Admin/stringReplacement_manage_editProcess.php
@@ -58,6 +58,7 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             $mode = $_POST['mode'] ?? '';
             $caseSensitive = $_POST['caseSensitive'] ?? '';
             $priority = $_POST['priority'] ?? '';
+            $gibbonPersonID = !empty($_POST['gibbonPersonID']) ? $_POST['gibbonPersonID'] : null;
 
             if ($original == '' or $replacement == '' or $mode == '' or $caseSensitive == '' or $priority == '') {
                 $URL .= '&return=error3';
@@ -65,8 +66,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             } else {
                 //Write to database
                 try {
-                    $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonStringID' => $gibbonStringID);
-                    $sql = 'UPDATE gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority WHERE gibbonStringID=:gibbonStringID';
+                    $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonID' => $gibbonPersonID, 'gibbonStringID' => $gibbonStringID);
+                    $sql = 'UPDATE gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonID=:gibbonPersonID WHERE gibbonStringID=:gibbonStringID';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/modules/System Admin/stringReplacement_manage_editProcess.php
+++ b/modules/System Admin/stringReplacement_manage_editProcess.php
@@ -71,8 +71,16 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             } else {
                 //Write to database
                 try {
-                    $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonIDList' => $gibbonPersonIDList, 'gibbonStringID' => $gibbonStringID);
-                    $sql = 'UPDATE gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonIDList=:gibbonPersonIDList WHERE gibbonStringID=:gibbonStringID';
+                    $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonStringID' => $gibbonStringID);
+                    $sql = 'UPDATE gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority';
+
+                    $columnCheck = $pdo->select("SHOW COLUMNS FROM gibbonString LIKE 'gibbonPersonIDList'");
+                    if ($columnCheck && $columnCheck->rowCount() > 0) {
+                        $data['gibbonPersonIDList'] = $gibbonPersonIDList;
+                        $sql .= ', gibbonPersonIDList=:gibbonPersonIDList';
+                    }
+
+                    $sql .= ' WHERE gibbonStringID=:gibbonStringID';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/modules/System Admin/stringReplacement_manage_editProcess.php
+++ b/modules/System Admin/stringReplacement_manage_editProcess.php
@@ -58,7 +58,12 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             $mode = $_POST['mode'] ?? '';
             $caseSensitive = $_POST['caseSensitive'] ?? '';
             $priority = $_POST['priority'] ?? '';
-            $gibbonPersonID = !empty($_POST['gibbonPersonID']) ? $_POST['gibbonPersonID'] : null;
+            $gibbonPersonIDList = $_POST['gibbonPersonIDList'] ?? [];
+            if (!is_array($gibbonPersonIDList)) {
+                $gibbonPersonIDList = empty($gibbonPersonIDList) ? [] : [$gibbonPersonIDList];
+            }
+            $gibbonPersonIDList = array_filter(array_map('intval', $gibbonPersonIDList));
+            $gibbonPersonIDList = empty($gibbonPersonIDList) ? null : implode(',', $gibbonPersonIDList);
 
             if ($original == '' or $replacement == '' or $mode == '' or $caseSensitive == '' or $priority == '') {
                 $URL .= '&return=error3';
@@ -66,8 +71,8 @@ if (isActionAccessible($guid, $connection2, '/modules/System Admin/stringReplace
             } else {
                 //Write to database
                 try {
-                    $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonID' => $gibbonPersonID, 'gibbonStringID' => $gibbonStringID);
-                    $sql = 'UPDATE gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonID=:gibbonPersonID WHERE gibbonStringID=:gibbonStringID';
+                    $data = array('original' => $original, 'replacement' => $replacement, 'mode' => $mode, 'caseSensitive' => $caseSensitive, 'priority' => $priority, 'gibbonPersonIDList' => $gibbonPersonIDList, 'gibbonStringID' => $gibbonStringID);
+                    $sql = 'UPDATE gibbonString SET original=:original, replacement=:replacement, mode=:mode, caseSensitive=:caseSensitive, priority=:priority, gibbonPersonIDList=:gibbonPersonIDList WHERE gibbonStringID=:gibbonStringID';
                     $result = $connection2->prepare($sql);
                     $result->execute($data);
                 } catch (PDOException $e) {

--- a/resources/imports/stringReplacements.yml
+++ b/resources/imports/stringReplacements.yml
@@ -9,7 +9,7 @@ access:
 primaryKey:
     gibbonStringID
 uniqueKeys:
-    - [ original, mode ]
+    - [ original, mode, gibbonPersonID ]
 table:
     original: 
         name: "Original String"
@@ -31,3 +31,8 @@ table:
         name: "Priority"
         desc: "Higher priorities are substituted first."
         args: { filter: numeric, required: true, custom: true }
+    gibbonPersonID:
+        name: "User"
+        desc: "Username or Email (if unique). Leave blank to apply to all users."
+        args: { filter: nospaces, required: false, custom: true }
+        relationship: { table: gibbonPerson, key: gibbonPersonID, field: username|email  }

--- a/resources/imports/stringReplacements.yml
+++ b/resources/imports/stringReplacements.yml
@@ -9,7 +9,7 @@ access:
 primaryKey:
     gibbonStringID
 uniqueKeys:
-    - [ original, mode, gibbonPersonID ]
+    - [ original, mode ]
 table:
     original: 
         name: "Original String"
@@ -31,8 +31,7 @@ table:
         name: "Priority"
         desc: "Higher priorities are substituted first."
         args: { filter: numeric, required: true, custom: true }
-    gibbonPersonID:
-        name: "User"
-        desc: "Username or Email (if unique). Leave blank to apply to all users."
-        args: { filter: nospaces, required: false, custom: true }
-        relationship: { table: gibbonPerson, key: gibbonPersonID, field: username|email  }
+    gibbonPersonIDList:
+        name: "Users"
+        desc: "Comma-separated person IDs. Leave blank to apply to all users."
+        args: { filter: string, required: false, custom: true }

--- a/src/Domain/System/StringGateway.php
+++ b/src/Domain/System/StringGateway.php
@@ -52,9 +52,15 @@ class StringGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonString.gibbonStringID', 'gibbonString.original', 'gibbonString.replacement', 'gibbonString.mode', 'gibbonString.caseSensitive', 'gibbonString.priority', 'gibbonString.gibbonPersonID', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonPerson.username', 'gibbonPerson.title'
-            ])
-            ->leftJoin('gibbonPerson', 'gibbonString.gibbonPersonID=gibbonPerson.gibbonPersonID');
+                'gibbonString.gibbonStringID',
+                'gibbonString.original',
+                'gibbonString.replacement',
+                'gibbonString.mode',
+                'gibbonString.caseSensitive',
+                'gibbonString.priority',
+                'gibbonString.gibbonPersonIDList',
+                "(SELECT GROUP_CONCAT(DISTINCT CONCAT(gibbonPerson.surname, ', ', gibbonPerson.preferredName) ORDER BY gibbonPerson.surname, gibbonPerson.preferredName SEPARATOR '; ') FROM gibbonPerson WHERE FIND_IN_SET(gibbonPerson.gibbonPersonID, gibbonString.gibbonPersonIDList)) as userList",
+            ]);
 
         return $this->runQuery($query, $criteria);
     }

--- a/src/Domain/System/StringGateway.php
+++ b/src/Domain/System/StringGateway.php
@@ -48,19 +48,25 @@ class StringGateway extends QueryableGateway
      */
     public function queryStrings(QueryCriteria $criteria)
     {
+        $cols = [
+            'gibbonString.gibbonStringID',
+            'gibbonString.original',
+            'gibbonString.replacement',
+            'gibbonString.mode',
+            'gibbonString.caseSensitive',
+            'gibbonString.priority',
+        ];
+
+        $columnCheck = $this->db()->select("SHOW COLUMNS FROM gibbonString LIKE 'gibbonPersonIDList'");
+        if ($columnCheck && $columnCheck->rowCount() > 0) {
+            $cols[] = 'gibbonString.gibbonPersonIDList';
+            $cols[] = "(SELECT GROUP_CONCAT(DISTINCT CONCAT(gibbonPerson.surname, ', ', gibbonPerson.preferredName) ORDER BY gibbonPerson.surname, gibbonPerson.preferredName SEPARATOR '; ') FROM gibbonPerson WHERE FIND_IN_SET(gibbonPerson.gibbonPersonID, gibbonString.gibbonPersonIDList)) as userList";
+        }
+
         $query = $this
             ->newQuery()
             ->from($this->getTableName())
-            ->cols([
-                'gibbonString.gibbonStringID',
-                'gibbonString.original',
-                'gibbonString.replacement',
-                'gibbonString.mode',
-                'gibbonString.caseSensitive',
-                'gibbonString.priority',
-                'gibbonString.gibbonPersonIDList',
-                "(SELECT GROUP_CONCAT(DISTINCT CONCAT(gibbonPerson.surname, ', ', gibbonPerson.preferredName) ORDER BY gibbonPerson.surname, gibbonPerson.preferredName SEPARATOR '; ') FROM gibbonPerson WHERE FIND_IN_SET(gibbonPerson.gibbonPersonID, gibbonString.gibbonPersonIDList)) as userList",
-            ]);
+            ->cols($cols);
 
         return $this->runQuery($query, $criteria);
     }

--- a/src/Domain/System/StringGateway.php
+++ b/src/Domain/System/StringGateway.php
@@ -52,8 +52,9 @@ class StringGateway extends QueryableGateway
             ->newQuery()
             ->from($this->getTableName())
             ->cols([
-                'gibbonStringID', 'original', 'replacement', 'mode', 'caseSensitive', 'priority'
-            ]);
+                'gibbonString.gibbonStringID', 'gibbonString.original', 'gibbonString.replacement', 'gibbonString.mode', 'gibbonString.caseSensitive', 'gibbonString.priority', 'gibbonString.gibbonPersonID', 'gibbonPerson.surname', 'gibbonPerson.preferredName', 'gibbonPerson.username', 'gibbonPerson.title'
+            ])
+            ->leftJoin('gibbonPerson', 'gibbonString.gibbonPersonID=gibbonPerson.gibbonPersonID');
 
         return $this->runQuery($query, $criteria);
     }

--- a/src/Gibbon/Locale.php
+++ b/src/Gibbon/Locale.php
@@ -164,11 +164,23 @@ class Locale implements LocaleInterface
 
             if ($pdo->getConnection() != null) {
                 $data = array();
-                $sql = "SELECT original, replacement, mode, caseSensitive FROM gibbonString WHERE (gibbonPersonIDList IS NULL OR gibbonPersonIDList='')";
+                $sql = "SELECT original, replacement, mode, caseSensitive FROM gibbonString";
 
-                if (!empty($gibbonPersonID)) {
-                    $data['gibbonPersonID'] = (string) intval($gibbonPersonID);
-                    $sql .= " OR FIND_IN_SET(:gibbonPersonID, gibbonPersonIDList)";
+                // Keep working before System Admin > Update adds gibbonPersonIDList
+                $hasPersonIDList = $session->get('gibbonStringHasPersonIDList');
+                if ($hasPersonIDList !== true) {
+                    $columnCheck = $pdo->select("SHOW COLUMNS FROM gibbonString LIKE 'gibbonPersonIDList'");
+                    $hasPersonIDList = $columnCheck && $columnCheck->rowCount() > 0;
+                    $session->set('gibbonStringHasPersonIDList', $hasPersonIDList);
+                }
+
+                if ($hasPersonIDList) {
+                    $sql .= " WHERE (gibbonPersonIDList IS NULL OR gibbonPersonIDList='')";
+
+                    if (!empty($gibbonPersonID)) {
+                        $data['gibbonPersonID'] = (string) intval($gibbonPersonID);
+                        $sql .= " OR FIND_IN_SET(:gibbonPersonID, gibbonPersonIDList)";
+                    }
                 }
 
                 $sql .= " ORDER BY priority DESC, original";

--- a/src/Gibbon/Locale.php
+++ b/src/Gibbon/Locale.php
@@ -164,11 +164,11 @@ class Locale implements LocaleInterface
 
             if ($pdo->getConnection() != null) {
                 $data = array();
-                $sql = "SELECT original, replacement, mode, caseSensitive FROM gibbonString WHERE gibbonPersonID IS NULL";
+                $sql = "SELECT original, replacement, mode, caseSensitive FROM gibbonString WHERE (gibbonPersonIDList IS NULL OR gibbonPersonIDList='')";
 
                 if (!empty($gibbonPersonID)) {
-                    $data['gibbonPersonID'] = $gibbonPersonID;
-                    $sql .= " OR gibbonPersonID=:gibbonPersonID";
+                    $data['gibbonPersonID'] = (string) intval($gibbonPersonID);
+                    $sql .= " OR FIND_IN_SET(:gibbonPersonID, gibbonPersonIDList)";
                 }
 
                 $sql .= " ORDER BY priority DESC, original";

--- a/src/Gibbon/Locale.php
+++ b/src/Gibbon/Locale.php
@@ -154,15 +154,24 @@ class Locale implements LocaleInterface
     public function setStringReplacementList(Session $session, Connection $pdo, $forceRefresh = false)
     {
         $stringReplacements = $session->get('stringReplacement', null);
+        $gibbonPersonID = $session->get('gibbonPersonID');
+        $stringReplacementPersonID = $session->get('stringReplacementPersonID');
 
-        // Do this once per session, only if the value doesn't exist
-        if ($forceRefresh || $stringReplacements === null) {
+        // Do this once per session, only if the value doesn't exist or the current user has changed
+        if ($forceRefresh || $stringReplacements === null || $stringReplacementPersonID !== $gibbonPersonID) {
 
             $stringReplacements = array();
 
             if ($pdo->getConnection() != null) {
                 $data = array();
-                $sql="SELECT original, replacement, mode, caseSensitive FROM gibbonString ORDER BY priority DESC, original";
+                $sql = "SELECT original, replacement, mode, caseSensitive FROM gibbonString WHERE gibbonPersonID IS NULL";
+
+                if (!empty($gibbonPersonID)) {
+                    $data['gibbonPersonID'] = $gibbonPersonID;
+                    $sql .= " OR gibbonPersonID=:gibbonPersonID";
+                }
+
+                $sql .= " ORDER BY priority DESC, original";
 
                 $result = $pdo->select($sql, $data);
 
@@ -171,7 +180,8 @@ class Locale implements LocaleInterface
                 }
             }
 
-            $session->set('stringReplacement', $stringReplacements );
+            $session->set('stringReplacement', $stringReplacements);
+            $session->set('stringReplacementPersonID', $gibbonPersonID);
         }
 
         $this->stringReplacements = $stringReplacements;


### PR DESCRIPTION
I had a need to apply string replacements for a single user.

## Summary
- Adds an optional Users field on Add/Edit String Replacement so a replacement can apply to one or more people, or to everyone if left blank.
- Stores selected people as `gibbonPersonIDList` and loads only global rows plus rows that include the current user.
- Checks whether the new column exists before querying it, so the site keeps working until System Admin → Update is run.

## To install
-  Run System Admin → Update so `gibbonPersonIDList` is added.

 Tested in production (not the best idea I know but it is a minor change). No gibbons were harmed in the production of this PR!